### PR TITLE
Disable prometheus metrics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ dbs:
       - path: /path/to/replica
 ```
 
+### Monitoring replication
+
+You can also enable a Prometheus metrics endpoint to monitor replication by
+specifying a bind address with the `addr` field:
+
+```yml
+addr: ":9090"
+```
+
+This will make metrics available at: http://localhost:9090/metrics
+
 
 ### Other configuration options
 
@@ -117,6 +128,7 @@ These replica options are only available for S3 replicas:
 - `bucket`—S3 bucket name. Derived from `"path"`.
 - `region`—S3 bucket region. Looked up on startup if unspecified.
 - `sync-interval`—Replication sync frequency.
+
 
 
 ## Usage

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -97,11 +97,6 @@ The commands are:
 `[1:])
 }
 
-// Default configuration settings.
-const (
-	DefaultAddr = ":9090"
-)
-
 // Config represents a configuration file for the litestream daemon.
 type Config struct {
 	// Bind address for serving metrics.
@@ -129,9 +124,7 @@ func (c *Config) Normalize() error {
 
 // DefaultConfig returns a new instance of Config with defaults set.
 func DefaultConfig() Config {
-	return Config{
-		Addr: DefaultAddr,
-	}
+	return Config{}
 }
 
 // DBConfig returns database configuration by path.


### PR DESCRIPTION
The HTTP server should only be enabled if a user explicitly sets a port for it.

Closes #16