### PR TITLE
Add Windows Service & MSI builds

### DIFF
--- a/cmd/litestream/main_notwindows.go
+++ b/cmd/litestream/main_notwindows.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+package main
+
+import (
+	"context"
+)
+
+const defaultConfigPath = "/etc/litestream.yml"
+
+func isWindowsService() (bool, error) {
+	return false, nil
+}
+
+func runWindowsService(ctx context.Context) error {
+	panic("cannot run windows service as unix process")
+}

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -1,0 +1,105 @@
+// +build windows
+
+package main
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+const defaultConfigPath = `C:\Litestream\litestream.yml`
+
+// serviceName is the Windows Service name.
+const serviceName = "Litestream"
+
+// isWindowsService returns true if currently executing within a Windows service.
+func isWindowsService() (bool, error) {
+	return svc.IsWindowsService()
+}
+
+func runWindowsService(ctx context.Context) error {
+	// Attempt to install new log service. This will fail if already installed.
+	// We don't log the error because we don't have anywhere to log until we open the log.
+	_ = eventlog.InstallAsEventCreate(serviceName, eventlog.Error|eventlog.Warning|eventlog.Info)
+
+	elog, err := eventlog.Open(serviceName)
+	if err != nil {
+		return err
+	}
+	defer elog.Close()
+
+	// Set eventlog as log writer while running.
+	log.SetOutput((*eventlogWriter)(elog))
+	defer log.SetOutput(os.Stderr)
+
+	log.Print("Litestream service starting")
+
+	if err := svc.Run(serviceName, &windowsService{ctx: ctx}); err != nil {
+		return errStop
+	}
+
+	log.Print("Litestream service stopped")
+	return nil
+}
+
+// windowsService is an interface adapter for svc.Handler.
+type windowsService struct {
+	ctx context.Context
+}
+
+func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, statusCh chan<- svc.Status) (svcSpecificEC bool, exitCode uint32) {
+	var err error
+
+	// Notify Windows that the service is starting up.
+	statusCh <- svc.Status{State: svc.StartPending}
+
+	// Instantiate replication command and load configuration.
+	c := NewReplicateCommand()
+	if c.Config, err = ReadConfigFile(DefaultConfigPath()); err != nil {
+		log.Printf("cannot load configuration: %s", err)
+		return true, 1
+	}
+
+	// Execute replication command.
+	if err := c.Run(s.ctx); err != nil {
+		log.Printf("cannot replicate: %s", err)
+		statusCh <- svc.Status{State: svc.StopPending}
+		return true, 2
+	}
+
+	// Notify Windows that the service is now running.
+	statusCh <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop}
+
+	for {
+		select {
+		case req := <-r:
+			switch req.Cmd {
+			case svc.Stop:
+				c.Close()
+				statusCh <- svc.Status{State: svc.StopPending}
+				return false, windows.NO_ERROR
+			case svc.Interrogate:
+				statusCh <- req.CurrentStatus
+			default:
+				log.Printf("Litestream service received unexpected change request cmd: %d", req.Cmd)
+			}
+		}
+	}
+}
+
+// Ensure implementation implements io.Writer interface.
+var _ io.Writer = (*eventlogWriter)(nil)
+
+// eventlogWriter is an adapter for using eventlog.Log as an io.Writer.
+type eventlogWriter eventlog.Log
+
+func (w *eventlogWriter) Write(p []byte) (n int, err error) {
+	elog := (*eventlog.Log)(w)
+	return 0, elog.Info(1, string(p))
+}

--- a/etc/build.ps1
+++ b/etc/build.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+Param (
+    [Parameter(Mandatory = $true)]
+    [String] $Version
+)
+$ErrorActionPreference = "Stop"
+
+# Update working directory.
+Push-Location $PSScriptRoot
+Trap {
+    Pop-Location
+}
+
+Invoke-Expression "candle.exe -nologo -arch x64 -ext WixUtilExtension -out litestream.wixobj -dVersion=`"$Version`" litestream.wxs"
+Invoke-Expression "light.exe  -nologo -spdb -ext WixUtilExtension -out `"litestream-${Version}.msi`" litestream.wixobj"
+
+Pop-Location

--- a/etc/litestream.wxs
+++ b/etc/litestream.wxs
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix
+	xmlns="http://schemas.microsoft.com/wix/2006/wi"
+	xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
+>
+	<?if $(sys.BUILDARCH)=x64 ?>
+		<?define PlatformProgramFiles = "ProgramFiles64Folder" ?>
+	<?else ?>
+		<?define PlatformProgramFiles = "ProgramFilesFolder" ?>
+	<?endif ?>
+
+	<Product
+		Id="*"
+		UpgradeCode="5371367e-58b3-4e52-be0d-46945eb71ce6"
+		Name="Litestream"
+		Version="$(var.Version)"
+		Manufacturer="Litestream"
+		Language="1033"
+		Codepage="1252"
+	>
+		<Package
+			Id="*"
+			Manufacturer="Litestream"
+			InstallScope="perMachine"
+			InstallerVersion="500"
+			Description="Litestream $(var.Version) installer"
+			Compressed="yes"
+		/>
+		
+		<Media Id="1" Cabinet="litestream.cab" EmbedCab="yes"/>
+		
+		<MajorUpgrade
+			Schedule="afterInstallInitialize"
+			DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit."
+		/>
+
+		<Directory Id="TARGETDIR" Name="SourceDir">
+			<Directory Id="$(var.PlatformProgramFiles)">
+				<Directory Id="APPLICATIONROOTDIRECTORY" Name="Litestream"/>
+			</Directory>
+		</Directory>
+
+		<ComponentGroup Id="Files">
+			<Component Directory="APPLICATIONROOTDIRECTORY">
+				<File
+					Id="litestream.exe"
+					Name="litestream.exe"
+					Source="litestream.exe"
+					KeyPath="yes"
+				/>
+
+				<ServiceInstall
+					Id="InstallService"
+					Name="Litestream"
+					DisplayName="Litestream"
+					Description="Replicates SQLite databases"
+					ErrorControl="normal"
+					Start="auto"
+					Type="ownProcess"
+				>
+					<util:ServiceConfig
+						FirstFailureActionType="restart"
+						SecondFailureActionType="restart"
+						ThirdFailureActionType="restart"
+						RestartServiceDelayInSeconds="60"
+					/>
+					<ServiceDependency Id="wmiApSrv" />
+				</ServiceInstall>
+
+				<ServiceControl
+					Id="ServiceStateControl"
+					Name="Litestream"
+					Remove="uninstall"
+					Start="install"
+					Stop="both"
+				/>
+				<util:EventSource
+					Log="Application"
+					Name="Litestream"
+					EventMessageFile="%SystemRoot%\System32\EventCreate.exe"
+				/>
+			</Component>
+		</ComponentGroup>
+
+		<Feature Id="DefaultFeature" Level="1">
+			<ComponentGroupRef Id="Files" />
+		</Feature>
+	</Product>
+</Wix>

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.5
 	github.com/pierrec/lz4/v4 v4.1.3
 	github.com/prometheus/client_golang v1.9.0
+	golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
## Overview

This pull request adds support for a Windows Service along with a signed executable and signed MSI installer. The MSI installer installs into `C:\Program Files\Litestream` and the configuration path defaults to `C:\Litestream\litestream.yml`.

Please note that I am not a Windows developer so I welcome feedback on the implementation. Please file an issue if you have any problems and I'll do my best to help.

Closes #7 


## Logging

The service logs out to the Windows Event Log and can be viewed with the following in PowerShell:

```sh
> Get-EventLog -LogName Application -Source Litestream
```

