### PR TITLE
Fix global settings propagation

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -149,10 +149,10 @@ type Config struct {
 func (c *Config) propagateGlobalSettings() {
 	for _, dbc := range c.DBs {
 		for _, rc := range dbc.Replicas {
-			if rc.AccessKeyID != "" {
+			if rc.AccessKeyID == "" {
 				rc.AccessKeyID = c.AccessKeyID
 			}
-			if rc.SecretAccessKey != "" {
+			if rc.SecretAccessKey == "" {
 				rc.SecretAccessKey = c.SecretAccessKey
 			}
 		}

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -1,12 +1,45 @@
 package main_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
 	main "github.com/benbjohnson/litestream/cmd/litestream"
 	"github.com/benbjohnson/litestream/s3"
 )
+
+func TestReadConfigFile(t *testing.T) {
+	// Ensure global AWS settings are propagated down to replica configurations.
+	t.Run("PropagateGlobalSettings", func(t *testing.T) {
+		filename := filepath.Join(t.TempDir(), "litestream.yml")
+		if err := ioutil.WriteFile(filename, []byte(`
+access-key-id: XXX
+secret-access-key: YYY
+
+dbs:
+  - path: /path/to/db
+    replicas:
+      - url: s3://foo/bar
+`[1:]), 0666); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := main.ReadConfigFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		} else if got, want := config.AccessKeyID, `XXX`; got != want {
+			t.Fatalf("AccessKeyID=%v, want %v", got, want)
+		} else if got, want := config.SecretAccessKey, `YYY`; got != want {
+			t.Fatalf("SecretAccessKey=%v, want %v", got, want)
+		} else if got, want := config.DBs[0].Replicas[0].AccessKeyID, `XXX`; got != want {
+			t.Fatalf("Replica.AccessKeyID=%v, want %v", got, want)
+		} else if got, want := config.DBs[0].Replicas[0].SecretAccessKey, `YYY`; got != want {
+			t.Fatalf("Replica.SecretAccessKey=%v, want %v", got, want)
+		}
+	})
+}
 
 func TestNewFileReplicaFromConfig(t *testing.T) {
 	r, err := main.NewReplicaFromConfig(&main.ReplicaConfig{Path: "/foo"}, nil)


### PR DESCRIPTION
This commit fixes an issue caused by a refactor where setting global or local AWS credentials in a config file fails. See https://github.com/benbjohnson/litestream/pull/66#issuecomment-782925729 for original report.