### PR TITLE
Add snapshot interval

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -243,6 +243,7 @@ type ReplicaConfig struct {
 	Retention              time.Duration `yaml:"retention"`
 	RetentionCheckInterval time.Duration `yaml:"retention-check-interval"`
 	SyncInterval           time.Duration `yaml:"sync-interval"` // s3 only
+	SnapshotInterval       time.Duration `yaml:"snapshot-interval"`
 	ValidationInterval     time.Duration `yaml:"validation-interval"`
 
 	// S3 settings
@@ -303,6 +304,9 @@ func newFileReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *litestrea
 	}
 	if v := c.RetentionCheckInterval; v > 0 {
 		r.RetentionCheckInterval = v
+	}
+	if v := c.SnapshotInterval; v > 0 {
+		r.SnapshotInterval = v
 	}
 	if v := c.ValidationInterval; v > 0 {
 		r.ValidationInterval = v
@@ -371,6 +375,9 @@ func newS3ReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *s3.Replica,
 	}
 	if v := c.SyncInterval; v > 0 {
 		r.SyncInterval = v
+	}
+	if v := c.SnapshotInterval; v > 0 {
+		r.SnapshotInterval = v
 	}
 	if v := c.ValidationInterval; v > 0 {
 		r.ValidationInterval = v

--- a/litestream.go
+++ b/litestream.go
@@ -36,6 +36,7 @@ const (
 
 // Litestream errors.
 var (
+	ErrNoGeneration     = errors.New("no generation available")
 	ErrNoSnapshots      = errors.New("no snapshots available")
 	ErrChecksumMismatch = errors.New("invalid replica, checksum mismatch")
 )


### PR DESCRIPTION
## Overview

This commit adds the ability to periodically perform snapshots on an interval that is separate from retention. For example, this lets you retain backups for 24 hours but you can snapshot your database every six hours to improve recovery time.

This also fixes a bug where the retention check interval can be longer than the retention time which causes retention to not be enforced often enough.

Fixes #3 