### PR TITLE
Fix release of non-OFD locks

### DIFF
--- a/litestream.go
+++ b/litestream.go
@@ -152,8 +152,9 @@ func readWALHeader(filename string) ([]byte, error) {
 	return buf[:n], err
 }
 
-// readFileAt reads a slice from a file.
-func readFileAt(filename string, offset, n int64) ([]byte, error) {
+// readWALFileAt reads a slice from a file. Do not use this with database files
+// as it causes problems with non-OFD locks.
+func readWALFileAt(filename string, offset, n int64) ([]byte, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Overview

This pull request removes short-lived `os.Open()` calls on the database file because this can cause locks to be released when `os.File.Close()` is later called if the operating system does not support [OFD (Open File Descriptor)](https://www.gnu.org/software/libc/manual/html_node/Open-File-Description-Locks.html) locks.

The SQLite source provides a lengthy rant on the brokenness of locks that's worth reading as well.

Fixes #79