### PR TITLE
Prevent user from specifying replica URL & config flag

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -15,9 +14,8 @@ type DatabasesCommand struct{}
 
 // Run executes the command.
 func (c *DatabasesCommand) Run(ctx context.Context, args []string) (err error) {
-	var configPath string
 	fs := flag.NewFlagSet("litestream-databases", flag.ContinueOnError)
-	registerConfigFlag(fs, &configPath)
+	configPath := registerConfigFlag(fs)
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -26,10 +24,10 @@ func (c *DatabasesCommand) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	// Load configuration.
-	if configPath == "" {
-		return errors.New("-config required")
+	if *configPath == "" {
+		*configPath = DefaultConfigPath()
 	}
-	config, err := ReadConfigFile(configPath)
+	config, err := ReadConfigFile(*configPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -429,8 +429,8 @@ func DefaultConfigPath() string {
 	return defaultConfigPath
 }
 
-func registerConfigFlag(fs *flag.FlagSet, p *string) {
-	fs.StringVar(p, "config", DefaultConfigPath(), "config path")
+func registerConfigFlag(fs *flag.FlagSet) *string {
+	return fs.String("config", "", "config path")
 }
 
 // expand returns an absolute path for s.


### PR DESCRIPTION
## Overview

Previously, if a replica URL was specified then the `-config` flag was silently ignored. This commit changes this behavior so that specifying both the URL & config flag will now return an error.

Fixes #85