### PR TITLE
Expose additional DB configuration settings

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -208,7 +208,12 @@ func ReadConfigFile(filename string) (_ Config, err error) {
 
 // DBConfig represents the configuration for a single database.
 type DBConfig struct {
-	Path     string           `yaml:"path"`
+	Path               string         `yaml:"path"`
+	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
+	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
+	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
+	MaxCheckpointPageN *int           `yaml:"max-checkpoint-page-count"`
+
 	Replicas []*ReplicaConfig `yaml:"replicas"`
 }
 
@@ -221,6 +226,20 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 
 	// Initialize database with given path.
 	db := litestream.NewDB(path)
+
+	// Override default database settings if specified in configuration.
+	if dbc.MonitorInterval != nil {
+		db.MonitorInterval = *dbc.MonitorInterval
+	}
+	if dbc.CheckpointInterval != nil {
+		db.CheckpointInterval = *dbc.CheckpointInterval
+	}
+	if dbc.MinCheckpointPageN != nil {
+		db.MinCheckpointPageN = *dbc.MinCheckpointPageN
+	}
+	if dbc.MaxCheckpointPageN != nil {
+		db.MaxCheckpointPageN = *dbc.MaxCheckpointPageN
+	}
 
 	// Instantiate and attach replicas.
 	for _, rc := range dbc.Replicas {

--- a/db.go
+++ b/db.go
@@ -260,6 +260,11 @@ func (db *DB) PageSize() int {
 
 // Open initializes the background monitoring goroutine.
 func (db *DB) Open() (err error) {
+	// Validate fields on database.
+	if db.MinCheckpointPageN <= 0 {
+		return fmt.Errorf("minimum checkpoint page count required")
+	}
+
 	// Validate that all replica names are unique.
 	m := make(map[string]struct{})
 	for _, r := range db.Replicas {


### PR DESCRIPTION
## Overview

This commit exposes the monitor interval, checkpoint interval, minimum checkpoint page count, and maximum checkpoint page count via the YAML configuration file. It also adds validation of the `min-checkpoint-page-count` field. The other fields can be zero or negative to disable them.

Fixes https://github.com/benbjohnson/litestream/issues/100


## Usage

```yaml
dbs:
  - path: /path/to/db
    monitor-interval: 1s
    checkpoint-interval: 1m
    min-checkpoint-page-count: 1000
    max-checkpoint-page-count: 10000
```