### PR TITLE
Revert sync lock removal

### DIFF
--- a/db.go
+++ b/db.go
@@ -738,6 +738,27 @@ func (db *DB) Sync() (err error) {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
+	// Start a transaction. This will be promoted immediately after.
+	tx, err := db.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+
+	// Ensure write transaction rolls back before returning.
+	defer func() {
+		if e := rollback(tx); e != nil && err == nil {
+			err = e
+		}
+	}()
+
+	// Insert into the lock table to promote to a write tx. The lock table
+	// insert will never actually occur because our tx will be rolled back,
+	// however, it will ensure our tx grabs the write lock. Unfortunately,
+	// we can't call "BEGIN IMMEDIATE" as we are already in a transaction.
+	if _, err := tx.ExecContext(db.ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+		return fmt.Errorf("_litestream_lock: %w", err)
+	}
+
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that we have an existing generation & that the last sync
 	// position of the real WAL hasn't been overwritten by another process.
@@ -782,6 +803,11 @@ func (db *DB) Sync() (err error) {
 		checkpoint = true
 	} else if db.CheckpointInterval > 0 && !info.dbModTime.IsZero() && time.Since(info.dbModTime) > db.CheckpointInterval && newWALSize > calcWALSize(db.pageSize, 1) {
 		checkpoint = true
+	}
+
+	// Release write lock before checkpointing & exiting.
+	if err := tx.Rollback(); err != nil {
+		return fmt.Errorf("rollback write tx: %w", err)
 	}
 
 	// Issue the checkpoint.


### PR DESCRIPTION
## Overview

This commit reverts the removal of the SQLite write lock during WAL sync (#104). The change caused validation mismatch errors during the long-running test although the restored database did not appear to be corrupted so perhaps it's simply a locking issue during validation.

Reopens https://github.com/benbjohnson/litestream/issues/99