### PR TITLE
Add support for DigitalOcean Spaces replica URLs

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1138,6 +1138,10 @@ func ParseHost(s string) (bucket, region, endpoint string, forcePathStyle bool) 
 	} else if a := gcsRegex.FindStringSubmatch(host); a != nil {
 		bucket, region = a[1], "us-east-1"
 		endpoint = "storage.googleapis.com"
+	} else if a := digitalOceanRegex.FindStringSubmatch(host); a != nil {
+		bucket = a[1]
+		region = a[2]
+		endpoint = fmt.Sprintf("%s.digitaloceanspaces.com", a[2])
 	} else if a := backblazeRegex.FindStringSubmatch(host); a != nil {
 		bucket = a[1]
 		region = a[2]
@@ -1161,9 +1165,10 @@ func ParseHost(s string) (bucket, region, endpoint string, forcePathStyle bool) 
 }
 
 var (
-	localhostRegex = regexp.MustCompile(`^(?:(.+)\.)?localhost$`)
-	backblazeRegex = regexp.MustCompile(`^(?:(.+)\.)?s3.([^.]+)\.backblazeb2.com$`)
-	gcsRegex       = regexp.MustCompile(`^(?:(.+)\.)?storage.googleapis.com$`)
+	localhostRegex    = regexp.MustCompile(`^(?:(.+)\.)?localhost$`)
+	digitalOceanRegex = regexp.MustCompile(`^(?:(.+)\.)?([^.]+)\.digitaloceanspaces.com$`)
+	backblazeRegex    = regexp.MustCompile(`^(?:(.+)\.)?s3.([^.]+)\.backblazeb2.com$`)
+	gcsRegex          = regexp.MustCompile(`^(?:(.+)\.)?storage.googleapis.com$`)
 )
 
 // S3 metrics.


### PR DESCRIPTION
This commit adds the ability to specify DigitalOcean Spaces as replica URLs in the command line and configuration file.

Example:

```
s3://BUCKETNAME.nyc3.digitaloceanspaces.com/PATH
```

Closes #106 