### PR TITLE
Add static release builds

### DIFF
--- a/.github/workflows/release.linux_amd64.yml
+++ b/.github/workflows/release.linux_amd64.yml
@@ -3,7 +3,7 @@ on:
     types:
       - created
 
-name: release
+name: release (linux/amd64-static)
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -26,11 +26,10 @@ jobs:
           mkdir -p dist
           cp etc/litestream.yml etc/litestream.service dist
           cat etc/nfpm.yml | LITESTREAM_VERSION=${{ steps.release.outputs.tag_name }} envsubst > dist/nfpm.yml
-          go build -ldflags "-X 'main.Version=${{ steps.release.outputs.tag_name }}'" -o dist/litestream ./cmd/litestream
-          
+          go build -ldflags "-w -extldflags "-static" -X 'main.Version=${{ steps.release.outputs.tag_name }}'" -o dist/litestream ./cmd/litestream
           cd dist
-          tar -czvf litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.tar.gz litestream
-          ../nfpm pkg --config nfpm.yml --packager deb --target litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.deb 
+          tar -czvf litestream-${{ steps.release.outputs.tag_name }}-linux-amd64-static.tar.gz litestream
+          ../nfpm pkg --config nfpm.yml --packager deb --target litestream-${{ steps.release.outputs.tag_name }}-linux-amd64-static.deb 
 
       - name: Upload release binary
         uses: actions/upload-release-asset@v1.0.2
@@ -38,8 +37,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./dist/litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.tar.gz
-          asset_name: litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.tar.gz
+          asset_path: ./dist/litestream-${{ steps.release.outputs.tag_name }}-linux-amd64-static.tar.gz
+          asset_name: litestream-${{ steps.release.outputs.tag_name }}-linux-amd64-static.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload debian package
@@ -48,6 +47,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./dist/litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.deb
-          asset_name: litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.deb
+          asset_path: ./dist/litestream-${{ steps.release.outputs.tag_name }}-linux-amd64-static.deb
+          asset_name: litestream-${{ steps.release.outputs.tag_name }}-linux-amd64-static.deb
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.linux_amd64_static.yml
+++ b/.github/workflows/release.linux_amd64_static.yml
@@ -1,0 +1,53 @@
+on:
+  release:
+    types:
+      - created
+
+name: release (linux/amd64)
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+
+      - id: release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install nfpm
+        run: |
+          wget https://github.com/goreleaser/nfpm/releases/download/v2.2.3/nfpm_2.2.3_Linux_x86_64.tar.gz
+          tar zxvf nfpm_2.2.3_Linux_x86_64.tar.gz
+
+      - name: Build litestream
+        run: |
+          mkdir -p dist
+          cp etc/litestream.yml etc/litestream.service dist
+          cat etc/nfpm.yml | LITESTREAM_VERSION=${{ steps.release.outputs.tag_name }} envsubst > dist/nfpm.yml
+          go build -ldflags "-X 'main.Version=${{ steps.release.outputs.tag_name }}'" -o dist/litestream ./cmd/litestream
+          
+          cd dist
+          tar -czvf litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.tar.gz litestream
+          ../nfpm pkg --config nfpm.yml --packager deb --target litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.deb 
+
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: ./dist/litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.tar.gz
+          asset_name: litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload debian package
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: ./dist/litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.deb
+          asset_name: litestream-${{ steps.release.outputs.tag_name }}-linux-amd64.deb
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request adds a separate GitHub Action to produce a Linux/amd64 statically-compiled release build.