### PR TITLE
Sync on close

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -37,6 +37,9 @@ type Replica interface {
 	// Stops all replication processing. Blocks until processing stopped.
 	Stop(hard bool) error
 
+	// Performs a backup of outstanding WAL frames to the replica.
+	Sync(ctx context.Context) error
+
 	// Returns the last replication position.
 	LastPos() Pos
 
@@ -1164,7 +1167,7 @@ func ValidateReplica(ctx context.Context, r Replica) error {
 
 	// Compute checksum of primary database under lock. This prevents a
 	// sync from occurring and the database will not be written.
-	chksum0, pos, err := db.CRC64()
+	chksum0, pos, err := db.CRC64(ctx)
 	if err != nil {
 		return fmt.Errorf("cannot compute checksum: %w", err)
 	}

--- a/replica_test.go
+++ b/replica_test.go
@@ -15,7 +15,7 @@ func TestFileReplica_Sync(t *testing.T) {
 		r := NewTestFileReplica(t, db)
 
 		// Sync database & then sync replica.
-		if err := db.Sync(); err != nil {
+		if err := db.Sync(context.Background()); err != nil {
 			t.Fatal(err)
 		} else if err := r.Sync(context.Background()); err != nil {
 			t.Fatal(err)
@@ -47,7 +47,7 @@ func TestFileReplica_Sync(t *testing.T) {
 
 			// Sync periodically.
 			if i%100 == 0 || i == n-1 {
-				if err := db.Sync(); err != nil {
+				if err := db.Sync(context.Background()); err != nil {
 					t.Fatal(err)
 				} else if err := r.Sync(context.Background()); err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
This commit changes the `replicate` command so that it performs a final DB sync & replica sync before it exits to ensure it has backed up all WAL frames at the time of exit.