### PR TITLE
Catch sigterm & add shutdown logging

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -79,8 +79,7 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 
 		// Setup signal handler.
 		ctx, cancel := context.WithCancel(ctx)
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt)
+		ch := signalChan()
 		go func() { <-ch; cancel() }()
 
 		if err := c.Run(ctx); err != nil {
@@ -90,9 +89,14 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		// Wait for signal to stop program.
 		<-ctx.Done()
 		signal.Reset()
+		fmt.Println("signal received, litestream shutting down")
 
 		// Gracefully close.
-		return c.Close()
+		if err := c.Close(); err != nil {
+			return err
+		}
+		fmt.Println("litestream shut down")
+		return nil
 
 	case "restore":
 		return (&RestoreCommand{}).Run(ctx, args)

--- a/cmd/litestream/main_notwindows.go
+++ b/cmd/litestream/main_notwindows.go
@@ -4,6 +4,9 @@ package main
 
 import (
 	"context"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 const defaultConfigPath = "/etc/litestream.yml"
@@ -14,4 +17,10 @@ func isWindowsService() (bool, error) {
 
 func runWindowsService(ctx context.Context) error {
 	panic("cannot run windows service as unix process")
+}
+
+func signalChan() <-chan os.Signal {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	return ch
 }

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/signal"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
@@ -102,4 +103,10 @@ type eventlogWriter eventlog.Log
 func (w *eventlogWriter) Write(p []byte) (n int, err error) {
 	elog := (*eventlog.Log)(w)
 	return 0, elog.Info(1, string(p))
+}
+
+func signalChan() <-chan os.Signal {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	return ch
 }


### PR DESCRIPTION
This commit changes the signal handler for `replicate` to catch `syscall.SIGTERM` for non-Windows installations. It also adds some logging to indicat when a shutdown has been initiated and when it has finished.