### PR TITLE
Add skip-verify flag for using self-signed certificates

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -276,6 +276,7 @@ type ReplicaConfig struct {
 	Bucket          string `yaml:"bucket"`
 	Endpoint        string `yaml:"endpoint"`
 	ForcePathStyle  *bool  `yaml:"force-path-style"`
+	SkipVerify      bool   `yaml:"skip-verify"`
 }
 
 // NewReplicaFromConfig instantiates a replica for a DB based on a config.
@@ -347,7 +348,7 @@ func newS3ReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *s3.Replica,
 	}
 
 	bucket, path := c.Bucket, c.Path
-	region, endpoint := c.Region, c.Endpoint
+	region, endpoint, skipVerify := c.Region, c.Endpoint, c.SkipVerify
 
 	// Use path style if an endpoint is explicitly set. This works because the
 	// only service to not use path style is AWS which does not use an endpoint.
@@ -396,6 +397,7 @@ func newS3ReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *s3.Replica,
 	r.Region = region
 	r.Endpoint = endpoint
 	r.ForcePathStyle = forcePathStyle
+	r.SkipVerify = skipVerify
 
 	if v := c.Retention; v > 0 {
 		r.Retention = v

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -3,11 +3,13 @@ package s3
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"path"
 	"regexp"
@@ -79,6 +81,7 @@ type Replica struct {
 	Path           string
 	Endpoint       string
 	ForcePathStyle bool
+	SkipVerify     bool
 
 	// Time between syncs with the shadow WAL.
 	SyncInterval time.Duration
@@ -769,6 +772,12 @@ func (r *Replica) config() *aws.Config {
 	if r.ForcePathStyle {
 		config.S3ForcePathStyle = aws.Bool(r.ForcePathStyle)
 	}
+	if r.SkipVerify {
+		config.HTTPClient = &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+	}
+
 	return config
 }
 


### PR DESCRIPTION
This commit adds a `skip-verify` flag to the replica configuration so that it can be used with self-signed certificates. This is useful when running a local instance of MinIO with TLS for testing.

Fixes https://github.com/benbjohnson/litestream/issues/126