### PR TITLE
Remove reference to "wal" in first db init command

### DIFF
--- a/db.go
+++ b/db.go
@@ -452,7 +452,7 @@ func (db *DB) init() (err error) {
 	// https://www.sqlite.org/pragma.html#pragma_journal_mode
 	var mode string
 	if err := db.db.QueryRow(`PRAGMA journal_mode = wal;`).Scan(&mode); err != nil {
-		return fmt.Errorf("enable wal: %w", err)
+		return err
 	} else if mode != "wal" {
 		return fmt.Errorf("enable wal failed, mode=%q", mode)
 	}


### PR DESCRIPTION
## Overview

This commit changes the error message of the first SQL command executed during initialization. Typically, it wraps the error with a message of "enable wal" since it is enabling the WAL mode but that can be confusing if the DB connection or file is invalid.

Instead, the error is returned as-is and we can determine the source of the error since it is the only unwrapped DB-related error.

Fixes #152