### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.16 as builder
+WORKDIR /src/litestream
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+	--mount=type=cache,target=/go/pkg \
+	go build -ldflags '-w -extldflags "-static"' -o /usr/local/bin/litestream ./cmd/litestream
+
+FROM alpine
+COPY --from=builder /usr/local/bin/litestream /usr/local/bin/litestream
+ENTRYPOINT ["/usr/local/bin/litestream"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 default:
 
+docker:
+	docker build -t litestream .
+
 dist-linux:
 	mkdir -p dist
 	cp etc/litestream.yml dist/litestream.yml


### PR DESCRIPTION
This pull request adds a `Dockerfile` and adds an official image at https://hub.docker.com/r/litestream/litestream

```sh
$ docker run litestream/litestream
litestream is a tool for replicating SQLite databases.

Usage:

	litestream <command> [arguments]

The commands are:

	databases    list databases specified in config file
	generations  list available generations for a database
	replicate    runs a server to replicate databases
	restore      recovers database backup from a replica
	snapshots    list available snapshots for a database
	version      prints the binary version
	wal          list available WAL files for a database
```