### PR TITLE
Add osusergo & netgo tags for static builds

### DIFF
--- a/.github/workflows/release.linux_static.yml
+++ b/.github/workflows/release.linux_static.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           rm -rf dist
           mkdir -p dist
-          CGO_ENABLED=1 go build -ldflags "-s -w -extldflags "-static" -X 'main.Version=${{ steps.release.outputs.tag_name }}'" -tags sqlite_omit_load_extension -o dist/litestream ./cmd/litestream
+          CGO_ENABLED=1 go build -ldflags "-s -w -extldflags "-static" -X 'main.Version=${{ steps.release.outputs.tag_name }}'" -tags osusergo,netgo,sqlite_omit_load_extension -o dist/litestream ./cmd/litestream
           cd dist
           tar -czvf litestream-${{ steps.release.outputs.tag_name }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}-static.tar.gz litestream
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src/litestream
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
-	go build -ldflags '-s -w -extldflags "-static"' -tags sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
+	go build -ldflags '-s -w -extldflags "-static"' -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
 
 FROM alpine
 COPY --from=builder /usr/local/bin/litestream /usr/local/bin/litestream


### PR DESCRIPTION
This pull request adds the `osusergo` & `netgo` build tags when compiling static builds.
