### PR TITLE
Ensure minimum wait time for TestDB_UpdatedAt/WAL test

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -100,9 +100,12 @@ func TestDB_UpdatedAt(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		sleepTime := 100 * time.Millisecond
 		if os.Getenv("CI") != "" {
-			time.Sleep(1 * time.Second)
+			sleepTime = 1 * time.Second
 		}
+		time.Sleep(sleepTime)
+
 		if _, err := sqldb.Exec(`CREATE TABLE t (id INT);`); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This commit fixes an issue where the test can be flakey if run on a system with a higher time resolution. It now waits a minimum of at least 100ms.

Fixes #116 