### PR TITLE
Use microsecond resolution for logging

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -70,7 +70,7 @@ func (c *ReplicateCommand) ParseFlags(ctx context.Context, args []string) (err e
 			return err
 		}
 		defer f.Close()
-		litestream.Tracef = log.New(f, "", log.LstdFlags|log.LUTC|log.Lshortfile).Printf
+		litestream.Tracef = log.New(f, "", log.LstdFlags|log.Lmicroseconds|log.LUTC|log.Lshortfile).Printf
 	}
 
 	return nil

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -53,7 +53,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Instantiate logger if verbose output is enabled.
 	if *verbose {
-		opt.Logger = log.New(os.Stderr, "", log.LstdFlags)
+		opt.Logger = log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds)
 	}
 
 	// Determine replica & generation to restore from.


### PR DESCRIPTION
This commit changes `log` from second to microsecond resolution to improve debugging when restoring WAL files.