### PR TITLE
Use hex encoding for restore's index flag

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -496,4 +497,25 @@ func expand(s string) (string, error) {
 		return u.HomeDir, nil
 	}
 	return filepath.Join(u.HomeDir, strings.TrimPrefix(s, prefix)), nil
+}
+
+// indexVar allows the flag package to parse index flags as 4-byte hexadecimal values.
+type indexVar int
+
+// Ensure type implements interface.
+var _ flag.Value = (*indexVar)(nil)
+
+// String returns an 8-character hexadecimal value.
+func (v *indexVar) String() string {
+	return fmt.Sprintf("%08x", int(*v))
+}
+
+// Set parses s into an integer from a hexadecimal value.
+func (v *indexVar) Set(s string) error {
+	i, err := strconv.ParseInt(s, 16, 32)
+	if err != nil {
+		return fmt.Errorf("invalid hexadecimal format")
+	}
+	*v = indexVar(i)
+	return nil
 }

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -25,7 +25,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	fs.StringVar(&opt.OutputPath, "o", "", "output path")
 	fs.StringVar(&opt.ReplicaName, "replica", "", "replica name")
 	fs.StringVar(&opt.Generation, "generation", "", "generation name")
-	fs.IntVar(&opt.Index, "index", opt.Index, "wal index")
+	fs.Var((*indexVar)(&opt.Index), "index", "wal index")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
 	verbose := fs.Bool("v", false, "verbose output")
@@ -156,7 +156,7 @@ Arguments:
 	    Defaults to generation with latest data.
 
 	-index NUM
-	    Restore up to a specific WAL index (inclusive).
+	    Restore up to a specific hex-encoded WAL index (inclusive).
 	    Defaults to use the highest available index.
 
 	-timestamp TIMESTAMP


### PR DESCRIPTION
This pull request changes the `-index` flag on the `restore` command by parsing it as a hex number instead of a decimal number. This is done because the index is represented in hex form everywhere else in the application.
