### PR TITLE
Remove uncompressed release binary

### DIFF
--- a/.github/workflows/release.linux.yml
+++ b/.github/workflows/release.linux.yml
@@ -58,16 +58,6 @@ jobs:
           tar -czvf litestream-${{ steps.release.outputs.tag_name }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}.tar.gz litestream
           ../nfpm pkg --config nfpm.yml --packager deb --target litestream-${{ steps.release.outputs.tag_name }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}.deb 
 
-      - name: Upload release binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./dist/litestream
-          asset_name: litestream-${{ steps.release.outputs.tag_name }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}
-          asset_content_type: application/octet-stream
-
       - name: Upload release tarball
         uses: actions/upload-release-asset@v1.0.2
         env:

--- a/.github/workflows/release.linux_static.yml
+++ b/.github/workflows/release.linux_static.yml
@@ -49,16 +49,6 @@ jobs:
           cd dist
           tar -czvf litestream-${{ steps.release.outputs.tag_name }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}-static.tar.gz litestream
 
-      - name: Upload release binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./dist/litestream
-          asset_name: litestream-${{ steps.release.outputs.tag_name }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}-static
-          asset_content_type: application/octet-stream
-
       - name: Upload release tarball
         uses: actions/upload-release-asset@v1.0.2
         env:


### PR DESCRIPTION
This commit removes the uncompressed binary from the release page. It was originally added to simplify Docker but it turns out that having to chmod the binary will double its size.