### PR TITLE
Build release builds on Ubuntu 18.04

### DIFF
--- a/.github/workflows/release.linux.yml
+++ b/.github/workflows/release.linux.yml
@@ -6,7 +6,7 @@ on:
 name: release (linux)
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.linux_static.yml
+++ b/.github/workflows/release.linux_static.yml
@@ -6,7 +6,7 @@ on:
 name: release (linux/static)
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ on: push
 name: test
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Litestream was previously built on Ubuntu 20.04, however, this made it unusable on Ubuntu 18.04 because of a newer GLIBC version:

```sh
litestream: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by litestream)
```

This pull request changes the release builds to run on Ubuntu 18.04 so that Litestream will run on 18.04 & 20.04.

Fixes https://github.com/benbjohnson/litestream/issues/198