### PR TITLE
Reduce S3 sync interval

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -323,8 +323,6 @@ func NewReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *litestream.Re
 	}
 	if v := c.SyncInterval; v != nil {
 		r.SyncInterval = *v
-	} else if c.ReplicaType() == "s3" {
-		r.SyncInterval = 10 * time.Second // default s3 to 10s for configs
 	}
 	if v := c.SnapshotInterval; v != nil {
 		r.SnapshotInterval = *v


### PR DESCRIPTION
Previously, S3 would default to sync every 10s when using a config file but only every 1s when using the replica URL on the command line. Obviously, this is confusing.

A sync interval of 1s could incur a cost of $1.30/month, however, in practice applications are not receiving a constant stream of writes so the cost is typically only a few pennies. This lower sync interval will provide a smaller window for data loss in the event of a catastrophic failure at a neglible cost.

Fixes #189 