### PR TITLE
Support Azure account key via environment variable

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -56,8 +56,14 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		return nil
 	}
 
+	// Read account key from environment, if available.
+	accountKey := c.AccountKey
+	if accountKey == "" {
+		accountKey = os.Getenv("LITESTREAM_AZURE_ACCOUNT_KEY")
+	}
+
 	// Authenticate to ACS.
-	credential, err := azblob.NewSharedKeyCredential(c.AccountName, c.AccountKey)
+	credential, err := azblob.NewSharedKeyCredential(c.AccountName, accountKey)
 	if err != nil {
 		return err
 	}
@@ -487,6 +493,7 @@ func (itr *walSegmentIterator) fetch() error {
 		}
 		marker = resp.NextMarker
 
+		println("dbg/wal.fetch", len(resp.Segment.BlobItems))
 		for _, item := range resp.Segment.BlobItems {
 			key := path.Base(item.Name)
 			index, offset, err := litestream.ParseWALSegmentPath(key)


### PR DESCRIPTION
This pull request allows the user to set the account key on an Azure Blob Storage (ABS) replica via the `LITESTREAM_AZURE_ACCOUNT_KEY` environment variable. This makes it possible to specify the rest of the replica details via a replica URL in the format:

```
abs://STORAGEACCOUNT@CONTAINER/PATH
```