### PR TITLE
Replica.Restore fallback to DB.path

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -955,7 +955,10 @@ func (r *Replica) CalcRestoreTarget(ctx context.Context, opt RestoreOptions) (ge
 func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Validate options.
 	if opt.OutputPath == "" {
-		return fmt.Errorf("output path required")
+		if r.db.path == "" {
+			return fmt.Errorf("output path required")
+		}
+		opt.OutputPath = r.db.path
 	} else if opt.Generation == "" && opt.Index != math.MaxInt32 {
 		return fmt.Errorf("must specify generation when restoring to index")
 	} else if opt.Index != math.MaxInt32 && !opt.Timestamp.IsZero() {


### PR DESCRIPTION
Per the godoc on Replica.Restore and RestoreOptions.OutputPath,
Replica.db.path should be used when RestoreOptions.OutputPath is empty.

Fixes #233