### PR TITLE
Sort output of snapshots in descending timestamp order

### DIFF
--- a/cmd/litestream/snapshots.go
+++ b/cmd/litestream/snapshots.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"text/tabwriter"
 	"time"
 
@@ -85,6 +86,8 @@ func (c *SnapshotsCommand) Run(ctx context.Context, args []string) (err error) {
 			log.Printf("cannot determine snapshots: %s", err)
 			continue
 		}
+		// Sort snapshots by creation time from newest to oldest.
+		sort.Slice(infos, func(i, j int) bool { return infos[i].CreatedAt.After(infos[j].CreatedAt) })
 		for _, info := range infos {
 			fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\n",
 				r.Name(),


### PR DESCRIPTION
By default, the snapshots command seems to output in alphabetical order of hash, which isn't meaningful, as far as I can tell.

This change modifies the order of the command output so that `litestream snapshots` returns snapshots from newest to oldest.

### Output before

```text
$ ./dist/litestream snapshots "${DB_PATH}"
replica  generation        index  size     created
s3       0d1c14e2b911a876  0      1385757  2021-11-28T15:13:46Z
s3       2ca19d08fc51ec80  0      1385667  2021-11-28T03:35:45Z
s3       42ead572f43df38f  0      1385667  2021-11-28T03:36:37Z
s3       489d0b0c6230b641  0      1385703  2021-11-28T15:41:07Z
s3       4f5449b4a3a72ad3  0      1386505  2021-11-27T23:21:28Z
s3       504a3137bbfdd9ee  0      1386477  2021-11-28T14:53:51Z
s3       5baa35c6c2a34509  0      1386471  2021-11-28T14:57:45Z
s3       677d90f83b124883  0      1384279  2021-11-27T16:08:27Z
s3       699c42662c022a9c  0      1386467  2021-11-28T11:51:59Z
s3       6ddc5d92dc2501a2  0      1382871  2021-11-27T16:05:28Z
s3       8e77288f304b61cb  0      1386787  2021-11-28T04:04:08Z
s3       9bf2c520778ad7e8  0      1386116  2021-11-27T19:59:55Z
s3       d661892a63534919  0      1385667  2021-11-28T03:34:28Z
s3       d92a85987a8e00b9  0      1385150  2021-11-27T16:49:49Z
s3       e08cfb27067dbf9b  0      1385018  2021-11-27T16:28:40Z
s3       f222678df9b44170  0      1386527  2021-11-28T11:37:40Z
```

### Output after

```text
$ ./dist/litestream snapshots "${DB_PATH}"
replica  generation        index  size     created
s3       489d0b0c6230b641  0      1385703  2021-11-28T15:41:07Z
s3       0d1c14e2b911a876  0      1385757  2021-11-28T15:13:46Z
s3       5baa35c6c2a34509  0      1386471  2021-11-28T14:57:45Z
s3       504a3137bbfdd9ee  0      1386477  2021-11-28T14:53:51Z
s3       699c42662c022a9c  0      1386467  2021-11-28T11:51:59Z
s3       f222678df9b44170  0      1386527  2021-11-28T11:37:40Z
s3       8e77288f304b61cb  0      1386787  2021-11-28T04:04:08Z
s3       42ead572f43df38f  0      1385667  2021-11-28T03:36:37Z
s3       2ca19d08fc51ec80  0      1385667  2021-11-28T03:35:45Z
s3       d661892a63534919  0      1385667  2021-11-28T03:34:28Z
s3       4f5449b4a3a72ad3  0      1386505  2021-11-27T23:21:28Z
s3       9bf2c520778ad7e8  0      1386116  2021-11-27T19:59:55Z
s3       d92a85987a8e00b9  0      1385150  2021-11-27T16:49:49Z
s3       e08cfb27067dbf9b  0      1385018  2021-11-27T16:28:40Z
s3       677d90f83b124883  0      1384279  2021-11-27T16:08:27Z
s3       6ddc5d92dc2501a2  0      1382871  2021-11-27T16:05:28Z
```
