### PR TITLE
Fix FindMinSnapshotByGeneration() loop ref bug

### DIFF
--- a/litestream.go
+++ b/litestream.go
@@ -207,11 +207,13 @@ func FilterSnapshotsAfter(a []SnapshotInfo, t time.Time) []SnapshotInfo {
 // FindMinSnapshotByGeneration finds the snapshot with the lowest index in a generation.
 func FindMinSnapshotByGeneration(a []SnapshotInfo, generation string) *SnapshotInfo {
 	var min *SnapshotInfo
-	for _, snapshot := range a {
+	for i := range a {
+		snapshot := &a[i]
+
 		if snapshot.Generation != generation {
 			continue
 		} else if min == nil || snapshot.Index < min.Index {
-			min = &snapshot
+			min = snapshot
 		}
 	}
 	return min

--- a/litestream_test.go
+++ b/litestream_test.go
@@ -128,6 +128,16 @@ func TestWALSegmentPath(t *testing.T) {
 	})
 }
 
+func TestFindMinSnapshotByGeneration(t *testing.T) {
+	infos := []litestream.SnapshotInfo{
+		{Generation: "29cf4bced74e92ab", Index: 0},
+		{Generation: "5dfeb4aa03232553", Index: 24},
+	}
+	if got, want := litestream.FindMinSnapshotByGeneration(infos, "29cf4bced74e92ab"), &infos[0]; got != want {
+		t.Fatalf("info=%#v, want %#v", got, want)
+	}
+}
+
 func MustDecodeHexString(s string) []byte {
 	b, err := hex.DecodeString(s)
 	if err != nil {


### PR DESCRIPTION
## Overview

This pull request fixes a bug where the wrong snapshot can be selected for retention enforcement. The `FindMinSnapshotByGeneration()` function obtains a reference to the loop variable instead of the slice element which means it can change during iteration. This commit fixes it so that the loop variable is assigned to the reference of the slice element.

Fixes #251 