### PR TITLE
Fix FindMinSnapshotByGeneration() loop ref bug

### DIFF
--- a/litestream.go
+++ b/litestream.go
@@ -213,11 +213,13 @@ func FilterSnapshotsAfter(a []SnapshotInfo, t time.Time) []SnapshotInfo {
 // FindMinSnapshotByGeneration finds the snapshot with the lowest index in a generation.
 func FindMinSnapshotByGeneration(a []SnapshotInfo, generation string) *SnapshotInfo {
 	var min *SnapshotInfo
-	for _, snapshot := range a {
+	for i := range a {
+		snapshot := &a[i]
+
 		if snapshot.Generation != generation {
 			continue
 		} else if min == nil || snapshot.Index < min.Index {
-			min = &snapshot
+			min = snapshot
 		}
 	}
 	return min

--- a/litestream_test.go
+++ b/litestream_test.go
@@ -40,6 +40,16 @@ func TestChecksum(t *testing.T) {
 	})
 }
 
+func TestFindMinSnapshotByGeneration(t *testing.T) {
+	infos := []litestream.SnapshotInfo{
+		{Generation: "29cf4bced74e92ab", Index: 0},
+		{Generation: "5dfeb4aa03232553", Index: 24},
+	}
+	if got, want := litestream.FindMinSnapshotByGeneration(infos, "29cf4bced74e92ab"), &infos[0]; got != want {
+		t.Fatalf("info=%#v, want %#v", got, want)
+	}
+}
+
 func MustDecodeHexString(s string) []byte {
 	b, err := hex.DecodeString(s)
 	if err != nil {

--- a/replica.go
+++ b/replica.go
@@ -266,7 +266,9 @@ func (r *Replica) writeIndexSegments(ctx context.Context, segments []WALSegmentI
 	zw := lz4.NewWriter(pw)
 
 	// Write each segment out to the replica.
-	for _, info := range segments {
+	for i := range segments {
+		info := &segments[i]
+
 		if err := func() error {
 			// Ensure segments are in order and no bytes are skipped.
 			if pos != info.Pos() {


### PR DESCRIPTION
This commit fixes an issue where the reference is taken on the loop variable rather than the slice element when computing the minimum snapshot within a generation so it can cause the wrong snapshot to be chosen.

This change has already been backported to `0.3.x`.