### PR TITLE
Dispatch test runner in CI

### DIFF
--- a/.github/workflows/release.linux.yml
+++ b/.github/workflows/release.linux.yml
@@ -21,6 +21,7 @@ jobs:
           - arch:   amd64
             cc:     gcc
             static: true
+            deploy_test_runner: true
 
           - arch: arm64
             cc:   aarch64-linux-gnu-gcc
@@ -123,3 +124,10 @@ jobs:
           asset_path: ./dist/litestream-${{ env.VERSION }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}${{ env.SUFFIX }}.deb
           asset_name: litestream-${{ env.VERSION }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}${{ env.SUFFIX }}.deb
           asset_content_type: application/octet-stream
+
+      - name: Dispatch test runner
+        if: matrix.deploy_test_runner
+        run: sleep 60 && gh workflow run deploy.yml -R benbjohnson/litestream-test-runner -f run_id=${{ github.run_id }} -f litestream_version=${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+


### PR DESCRIPTION
This pull request adds a dispatch to a separate workflow in the `litestream-test-runner` repository. This repo is currently closed source but it will be opened once it's cleaned up and the kinks are worked out. The test runner is a long-running program that executes various "profiles" continuously and Litestream runs in the background replicating to an external replica. Currently there is just a profile for a moderate read and write workload but others will be added in the future. 

The test runner is built as a Dockerfile and deployed as an application on [fly.io](https://fly.io). All metrics are scraped via Prometheus and displayed in a Grafana dashboard so I can monitor changes in cost & performance. Byte-for-byte database verification is performed after each profile is run. I'll open up the Grafana dashboards if I can figure out how to secure it.

Huge thanks to the folks at [fly.io](https://fly.io) for providing free credits for running Litestream's test infrastructure. 🙏