### PR TITLE
Enable test runner approval workflow

### DIFF
--- a/.github/workflows/release.linux.yml
+++ b/.github/workflows/release.linux.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
       - reopened
 
-name: Release (Linux)
+name: Release Linux
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -17,11 +17,11 @@ jobs:
         include:
           - arch:   amd64
             cc:     gcc
+            request_test_runner: true
 
           - arch:   amd64
             cc:     gcc
             static: true
-            deploy_test_runner: true
 
           - arch: arm64
             cc:   aarch64-linux-gnu-gcc
@@ -125,9 +125,9 @@ jobs:
           asset_name: litestream-${{ env.VERSION }}-${{ env.GOOS }}-${{ env.GOARCH }}${{ env.GOARM }}${{ env.SUFFIX }}.deb
           asset_content_type: application/octet-stream
 
-      - name: Dispatch test runner
-        if: matrix.deploy_test_runner
-        run: sleep 60 && gh workflow run deploy.yml -R benbjohnson/litestream-test-runner -f run_id=${{ github.run_id }} -f litestream_version=${{ github.sha }}
+      - name: Request test runner
+        if: matrix.request_test_runner
+        run: gh workflow run request_test_runner.yml -R benbjohnson/litestream -f run_id=${{ github.run_id }} -f litestream_version=${{ env.VERSION }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/request_test_runner.yml
+++ b/.github/workflows/request_test_runner.yml
@@ -1,0 +1,23 @@
+name: Request Test Runner
+on: 
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+        type: string
+      litestream_version:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    environment: 
+      name: test
+      url: http://litestream-test-runner-${{ github.sha }}.fly.dev
+    steps:
+      - name: Dispatch test runner
+        run: gh workflow run deploy.yml -R benbjohnson/litestream-test-runner -f run_id=${{ github.event.inputs.run_id }} -f litestream_version=${{ github.event.inputs.litestream_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+


### PR DESCRIPTION
This pull request adds a "test" environment to GitHub Actions so that the test runner deployment can be behind a deployment approval. This is so the test runner does not need to be deployed for CI changes or non-code related changes.