### PR TITLE
Remove built-in validation option

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -112,51 +112,6 @@ func TestDB_UpdatedAt(t *testing.T) {
 	})
 }
 
-// Ensure we can compute a checksum on the real database.
-func TestDB_CRC64(t *testing.T) {
-	t.Run("ErrNotExist", func(t *testing.T) {
-		db := MustOpenDB(t)
-		defer MustCloseDB(t, db)
-		if _, _, err := db.CRC64(context.Background()); !os.IsNotExist(err) {
-			t.Fatalf("unexpected error: %#v", err)
-		}
-	})
-
-	t.Run("DB", func(t *testing.T) {
-		db, sqldb := MustOpenDBs(t)
-		defer MustCloseDBs(t, db, sqldb)
-
-		if err := db.Sync(context.Background()); err != nil {
-			t.Fatal(err)
-		}
-
-		chksum0, _, err := db.CRC64(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Issue change that is applied to the WAL. Checksum should not change.
-		if _, err := sqldb.Exec(`CREATE TABLE t (id INT);`); err != nil {
-			t.Fatal(err)
-		} else if chksum1, _, err := db.CRC64(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if chksum0 == chksum1 {
-			t.Fatal("expected different checksum event after WAL change")
-		}
-
-		// Checkpoint change into database. Checksum should change.
-		if err := db.Checkpoint(context.Background(), litestream.CheckpointModeTruncate); err != nil {
-			t.Fatal(err)
-		}
-
-		if chksum2, _, err := db.CRC64(context.Background()); err != nil {
-			t.Fatal(err)
-		} else if chksum0 == chksum2 {
-			t.Fatal("expected different checksums after checkpoint")
-		}
-	})
-}
-
 // Ensure we can sync the real WAL to the shadow WAL.
 func TestDB_Sync(t *testing.T) {
 	// Ensure sync is skipped if no database exists.


### PR DESCRIPTION
Previously, Litestream had a validator that worked most of the time but also caused some false positives. It is difficult to provide validation from with Litestream without controlling outside processes that can also affect the database. As such, validation has been moved out to the external CI test runner which provides a more consistent validation process.