### PR TITLE
Add WAL overrun validation

### DIFF
--- a/litestream.go
+++ b/litestream.go
@@ -302,7 +302,7 @@ func (p Pos) String() string {
 	if p.IsZero() {
 		return ""
 	}
-	return fmt.Sprintf("%s/%08x:%d", p.Generation, p.Index, p.Offset)
+	return fmt.Sprintf("%s/%08x:%08x", p.Generation, p.Index, p.Offset)
 }
 
 // IsZero returns true if p is the zero value.


### PR DESCRIPTION
Under high write load, it is possible for write transactions from another process to overrun the WAL between the time when Litestream performs a RESTART checkpoint and when it obtains the write lock immediately after. This change adds validation that an overrun has not occurred and, if it has, it will start a new generation.