### PR TITLE
Implement streaming WAL segment iterator

### DIFF
--- a/litestream.go
+++ b/litestream.go
@@ -39,10 +39,12 @@ const (
 
 // Litestream errors.
 var (
-	ErrNoGeneration     = errors.New("no generation available")
-	ErrNoSnapshots      = errors.New("no snapshots available")
-	ErrNoWALSegments    = errors.New("no wal segments available")
-	ErrChecksumMismatch = errors.New("invalid replica, checksum mismatch")
+	ErrDBClosed          = errors.New("database closed")
+	ErrNoGeneration      = errors.New("no generation available")
+	ErrGenerationChanged = errors.New("generation changed")
+	ErrNoSnapshots       = errors.New("no snapshots available")
+	ErrNoWALSegments     = errors.New("no wal segments available")
+	ErrChecksumMismatch  = errors.New("invalid replica, checksum mismatch")
 )
 
 var (

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -489,8 +489,6 @@ func TestFindMaxIndexByGeneration(t *testing.T) {
 	})
 }
 
-func TestRestoreSnapshot(t *testing.T) { t.Skip("TODO") }
-
 func TestRestore(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		testDir := filepath.Join("testdata", "restore", "ok")


### PR DESCRIPTION
Currently, `WALSegmentIterator` implementations read to the end of the end of their list of segments and return EOF. This commit adds the ability to push additional segments to in-process iterators and notify their callers that new segments are available. This is only implemented for the file-based iterator but other segment iterators may get this implementation in the future or have a wrapping iterator provide a polling-based implementation.