### PR TITLE
Add docker multiarch build and push to release

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -1,0 +1,43 @@
+on:
+  release:
+    types:
+      - published
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches-ignore:
+      - "dependabot/**"
+
+name: Release (Docker)
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+
+      - uses: docker/login-action@v1
+        with:
+          username: benbjohnson
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: litestream/litestream
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.linux.yml
+++ b/.github/workflows/release.linux.yml
@@ -1,7 +1,7 @@
 on:
   release:
     types:
-      - created
+      - published
   pull_request:
     types:
       - opened
@@ -132,4 +132,3 @@ jobs:
         run: sleep 60 && gh workflow run deploy.yml -R benbjohnson/litestream-test-runner -f run_id=${{ github.run_id }} -f litestream_version=${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
+
 WORKDIR /src/litestream
 COPY . .
+
 ARG LITESTREAM_VERSION=latest
+
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
 	go build -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
+
 
 FROM alpine
 COPY --from=builder /usr/local/bin/litestream /usr/local/bin/litestream


### PR DESCRIPTION
I added the buildx to the end of the release pipeline. 

- I'm not 100% this is where you want it to happen. Why does this pipeline run on every PR? Maybe it's better to split this out.
- this won't work until the appropriate secrets and permissions are configured, and I don't have access to do that on your repo. Have a look at the [details in the doco](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
- There are other platforms available if you want to add to the list. I included a build step to list the currently available platforms. Here's the list at the moment: `linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6`

closes #310 