### PR TITLE
Fix Docker arch mismatch

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -14,14 +14,8 @@ name: Release (Docker)
 jobs:
   docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-          - platform: linux/arm64
-          - platform: linux/arm/v7
-
     env:
+      PLATFORMS: "${{ github.event_name == 'release' && 'linux/amd64,linux/arm64,linux/arm/v7' || 'linux/amd64,linux/arm64' }}"
       VERSION: "${{ github.event_name == 'release' && github.event.release.name || github.sha }}"
 
     steps:
@@ -50,7 +44,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Unfortunately, running `docker/build-push-action` in a matrix doesn't work. Each build replaces the other ones entirely. This pull request changes it to run them serially within one `docker/build-push-action` step.

PRs are only being built for `linux/amd64` & `linux/arm64` since running under QEMU is very slow. Release builds also add `linux/arm/v7`.