### PR TITLE
Configurable monitor-delay-interval

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -266,10 +266,11 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 
 // DBConfig represents the configuration for a single database.
 type DBConfig struct {
-	Path               string         `yaml:"path"`
-	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
-	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
-	MaxCheckpointPageN *int           `yaml:"max-checkpoint-page-count"`
+	Path                 string         `yaml:"path"`
+	MonitorDelayInterval *time.Duration `yaml:"monitor-delay-interval"`
+	CheckpointInterval   *time.Duration `yaml:"checkpoint-interval"`
+	MinCheckpointPageN   *int           `yaml:"min-checkpoint-page-count"`
+	MaxCheckpointPageN   *int           `yaml:"max-checkpoint-page-count"`
 
 	Replicas []*ReplicaConfig `yaml:"replicas"`
 }
@@ -289,6 +290,9 @@ func NewDBFromConfigWithPath(dbc *DBConfig, path string) (*litestream.DB, error)
 	db := litestream.NewDB(path)
 
 	// Override default database settings if specified in configuration.
+	if dbc.MonitorDelayInterval != nil {
+		db.MonitorDelayInterval = *dbc.MonitorDelayInterval
+	}
 	if dbc.CheckpointInterval != nil {
 		db.CheckpointInterval = *dbc.CheckpointInterval
 	}

--- a/integration/testdata/replicate/high-load/litestream.yml
+++ b/integration/testdata/replicate/high-load/litestream.yml
@@ -3,5 +3,4 @@ dbs:
     replicas:
       - path: $LITESTREAM_TEMPDIR/replica
 
-    monitor-interval: 100ms
     max-checkpoint-page-count: 20

--- a/integration/testdata/replicate/no-monitor-delay-interval/litestream.yml
+++ b/integration/testdata/replicate/no-monitor-delay-interval/litestream.yml
@@ -1,6 +1,5 @@
 dbs:
   - path: $LITESTREAM_TEMPDIR/db
+    monitor-delay-interval: 0
     replicas:
       - path: $LITESTREAM_TEMPDIR/replica
-
-    max-checkpoint-page-count: 10

--- a/integration/testdata/replicate/ok/litestream.yml
+++ b/integration/testdata/replicate/ok/litestream.yml
@@ -3,5 +3,4 @@ dbs:
     replicas:
       - path: $LITESTREAM_TEMPDIR/replica
 
-    monitor-interval: 100ms
     max-checkpoint-page-count: 20


### PR DESCRIPTION
The `monitor-delay-interval` has been added to the DB config so that users can change the time period between WAL checks after a file change notification has occurred. This can be useful to batch up changes in larger files in the shadow WAL or to reduce or eliminate the delay in propagating changes during read replication.

Setting the interval to zero or less will disable it.