### PR TITLE
Remove Docker linux/arm64 for PR builds only

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -15,7 +15,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     env:
-      PLATFORMS: "${{ github.event_name == 'release' && 'linux/amd64,linux/arm64,linux/arm/v7' || 'linux/amd64,linux/arm64' }}"
+      PLATFORMS: "${{ github.event_name == 'release' && 'linux/amd64,linux/arm64,linux/arm/v7' || 'linux/amd64' }}"
       VERSION: "${{ github.event_name == 'release' && github.event.release.name || github.sha }}"
 
     steps:


### PR DESCRIPTION
Currently, Docker builds are created for every PR for `linux/amd64` and `linux/arm64`. While the `amd64` build only takes a minute, the `arm64` build takes closer to 10 minutes because of QEMU emulation. This pull request changes the build process so the ARM builds no longer happen for PRs. They will still be built for releases.