### PR TITLE
Pass first DB path to child process

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -156,8 +156,14 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 			return fmt.Errorf("cannot parse exec command: %w", err)
 		}
 
+		// Pass first database path to child process.
+		env := os.Environ()
+		if dbs := c.server.DBs(); len(dbs) > 0 {
+			env = append(env, fmt.Sprintf("LITESTREAM_DB_PATH=%s", dbs[0].Path()))
+		}
+
 		c.cmd = exec.CommandContext(ctx, execArgs[0], execArgs[1:]...)
-		c.cmd.Env = os.Environ()
+		c.cmd.Env = env
 		c.cmd.Stdout = os.Stdout
 		c.cmd.Stderr = os.Stderr
 		if err := c.cmd.Start(); err != nil {


### PR DESCRIPTION
This pull request injects the path of the database into the child process's environment variables. If more than one database is specified, only the first one is used. This works for both config files and when specifying the database & replica URL from the command line.

```
# Using a config file
$ litestream replicate -config /path/to/litestream.yml  -exec env
...
LITESTREAM_DB_PATH=/path/to/db
```

```
# Using command line arguments
$ litestream replicate -exec env /path/to/db s3://mybkt/db
...
LITESTREAM_DB_PATH=/path/to/db
```

Fixes https://github.com/benbjohnson/litestream/issues/216