### PR TITLE
Add -addr flag to replicate command

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -51,6 +51,7 @@ func NewReplicateCommand(stdin io.Reader, stdout, stderr io.Writer) *ReplicateCo
 func (c *ReplicateCommand) ParseFlags(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-replicate", flag.ContinueOnError)
 	execFlag := fs.String("exec", "", "execute subcommand")
+	addr := fs.String("addr", "", "HTTP bind address (host:port)")
 	registerConfigFlag(fs, &c.configPath, &c.noExpandEnv)
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -83,7 +84,10 @@ func (c *ReplicateCommand) ParseFlags(ctx context.Context, args []string) (err e
 		}
 	}
 
-	// Override config exec command, if specified.
+	// Override config with flags, if specified.
+	if *addr != "" {
+		c.Config.Addr = *addr
+	}
 	if *execFlag != "" {
 		c.Config.Exec = *execFlag
 	}
@@ -147,6 +151,7 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 		if err := c.httpServer.Open(); err != nil {
 			return fmt.Errorf("cannot start http server: %w", err)
 		}
+		log.Printf("http server running at %s", c.httpServer.URL())
 	}
 
 	// Parse exec commands args & start subprocess.


### PR DESCRIPTION
This pull request adds an `-addr HOSTPORT` flag to set the bind address for the HTTP server. Previously,  this could only be specified by the `addr` field in the configuration file.  Specifying the flag on the command line will override any value in the config.

This PR also adds a log message to indicate that the HTTP server is running and on what port.

```
$ litestream replicate -addr :8080
```

Fixes https://github.com/benbjohnson/litestream/issues/243