### PR TITLE
Remove Defer

### DIFF
--- a/file_replica_client.go
+++ b/file_replica_client.go
@@ -450,10 +450,10 @@ func (itr *FileWALSegmentIterator) Next() bool {
 			itr.err = err
 			return false
 		}
-		defer f.Close()
 
 		fis, err := f.Readdir(-1)
 		if err != nil {
+			f.Close()
 			itr.err = err
 			return false
 		} else if err := f.Close(); err != nil {


### PR DESCRIPTION
This patch removes the defer statement inside of the loop and instead closes the directory if an error occurs.

I'm not sure if you want to capture the error in this case too as opposed to the error that is causing the early return. I'm happy to change it if need be.

I found it by running [this tool](https://github.com/gsquire/dll).