### PR TITLE
Default upstream path if not specified

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -309,10 +309,12 @@ func NewDBFromConfigWithPath(dbc *DBConfig, path string) (*litestream.DB, error)
 
 	// Attach upstream HTTP client if specified.
 	if upstreamURL := dbc.Upstream.URL; upstreamURL != "" {
-		if dbc.Upstream.Path == "" {
-			return nil, fmt.Errorf("upstream path required")
+		// Use local database path if upstream path is not specified.
+		upstreamPath := dbc.Upstream.Path
+		if upstreamPath == "" {
+			upstreamPath = db.Path()
 		}
-		db.StreamClient = http.NewClient(upstreamURL, dbc.Upstream.Path)
+		db.StreamClient = http.NewClient(upstreamURL, upstreamPath)
 	}
 
 	// Override default database settings if specified in configuration.


### PR DESCRIPTION
This pull request changes the DB upstream configuration to use the database path if the upstream path is not specified for read replication.

```yml
dbs:
  - path: /path/to/db
    upstream:
    - url: http://$HOSTPORT
```

This configuration will use `/path/to/db` as the remote upstream path to replicate from. This is a common setup as most replicas share nearly identical code and structure to the primary.