### PR TITLE
Add two environments for overriding endpoint and region

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -703,6 +703,13 @@ func ParseHost(s string) (bucket, region, endpoint string, forcePathStyle bool) 
 		endpoint = net.JoinHostPort(endpoint, port)
 	}
 
+	if e := os.Getenv("LITESTREAM_ENDPOINT"); e != "" {
+		endpoint = e
+	}
+	if r := os.Getenv("LITESTREAM_REGION"); r != "" {
+		region = r
+	}
+
 	// Prepend scheme to endpoint.
 	if endpoint != "" {
 		endpoint = scheme + "://" + endpoint


### PR DESCRIPTION
If [Support SAKURA internet Object Storage by hnakamur · Pull Request #373 · benbjohnson/litestream](https://github.com/benbjohnson/litestream/pull/373) is not acceptable, could you merge this pull request instead? I think this is more general and can support other S3 compatible object storages too.

Usage example:
```
export LITESTREAM_ACCESS_KEY_ID=your_key_id
export LITESTREAM_SECRET_ACCESS_KEY=your_access_key
export LITESTREAM_ENDPOINT=your_endpoint
export LITESTREAM_REGION=your_region
litestream replicate fruits.db s3://mybkt/fruits.db
```