### PR TITLE
Fix read replication stream restart position

### DIFF
--- a/db.go
+++ b/db.go
@@ -1444,6 +1444,8 @@ func (db *DB) readPositionFile() (Pos, error) {
 		return Pos{}, err
 	}
 
+	println("dbg/posfile", strings.TrimSpace(string(buf)))
+
 	// Treat invalid format as a non-existent file so we return an empty position.
 	pos, _ := ParsePos(strings.TrimSpace(string(buf)))
 	return pos, nil
@@ -1711,6 +1713,8 @@ func (db *DB) stream(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("read position file: %w", err)
 	}
+
+	println("dbg/newstream", pos.String())
 
 	// Continuously stream and apply records from client.
 	sr, err := db.StreamClient.Stream(ctx, pos)

--- a/http/client.go
+++ b/http/client.go
@@ -48,6 +48,7 @@ func (c *Client) Stream(ctx context.Context, pos litestream.Pos) (litestream.Str
 	if !pos.IsZero() {
 		q.Set("generation", pos.Generation)
 		q.Set("index", litestream.FormatIndex(pos.Index))
+		q.Set("offset", litestream.FormatOffset(pos.Offset))
 	}
 
 	// Strip off everything but the scheme & host.

--- a/http/server.go
+++ b/http/server.go
@@ -134,15 +134,30 @@ func (s *Server) handleGetStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	generationStr := q.Get("generation")
+	indexStr := q.Get("index")
+	offsetStr := q.Get("offset")
+
 	// Parse current client position, if available.
 	var pos litestream.Pos
-	if generation, index := q.Get("generation"), q.Get("index"); generation != "" && index != "" {
-		pos.Generation = generation
+	if generationStr != "" && indexStr != "" && offsetStr != "" {
 
-		var err error
-		if pos.Index, err = litestream.ParseIndex(index); err != nil {
+		index, err := litestream.ParseIndex(indexStr)
+		if err != nil {
 			s.writeError(w, r, "Invalid index query parameter", http.StatusBadRequest)
 			return
+		}
+
+		offset, err := litestream.ParseOffset(offsetStr)
+		if err != nil {
+			s.writeError(w, r, "Invalid offset query parameter", http.StatusBadRequest)
+			return
+		}
+
+		pos = litestream.Pos{
+			Generation: generationStr,
+			Index:      index,
+			Offset:     offset,
 		}
 	}
 
@@ -162,7 +177,6 @@ func (s *Server) handleGetStream(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, r, "No generation available", http.StatusServiceUnavailable)
 		return
 	}
-	dbPos.Offset = 0
 
 	// Use database position if generation has changed.
 	var snapshotRequired bool

--- a/integration/cmd_test.go
+++ b/integration/cmd_test.go
@@ -481,7 +481,7 @@ func TestCmd_Replicate_HTTP_PartialRecovery(t *testing.T) {
 		t.Fatal(err)
 	} else if _, err := db0.ExecContext(ctx, `PRAGMA journal_mode = wal`); err != nil {
 		t.Fatal(err)
-	} else if _, err := db0.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+	} else if _, err := db0.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY, DATA TEXT)`); err != nil {
 		t.Fatal(err)
 	}
 	defer db0.Close()
@@ -489,8 +489,8 @@ func TestCmd_Replicate_HTTP_PartialRecovery(t *testing.T) {
 	var index int
 	insertAndWait := func() {
 		index++
-		t.Logf("[exec] INSERT INTO t (id) VALUES (%d)", index)
-		if _, err := db0.ExecContext(ctx, `INSERT INTO t (id) VALUES (?)`, index); err != nil {
+		t.Logf("[exec] INSERT INTO t (id, data) VALUES (%d, '...')", index)
+		if _, err := db0.ExecContext(ctx, `INSERT INTO t (id, data) VALUES (?, ?)`, index, strings.Repeat("x", 512)); err != nil {
 			t.Fatal(err)
 		}
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Previously, a reconnecting replica would reset its position's "offset" to the beginning of a given WAL file in an effort to be more conservative about what was replayed. However, the client replays each segment one-at-at-time which causes the database to get in an inconsistent state during this replay since it is being replayed from the beginning instead of the current position. The SQLite sometimes detects this inconsistent state and prevents the replica WAL from checkpointing which caused all replication to stop.

This pull request removes this "offset reset" and simply replays from the last position.