### PR TITLE
Don't kill exec process immediately

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -86,20 +86,17 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		}
 
 		// Setup signal handler.
-		ctx, cancel := context.WithCancel(ctx)
 		signalCh := signalChan()
 
-		if err := c.Run(ctx); err != nil {
+		if err := c.Run(); err != nil {
 			return err
 		}
 
 		// Wait for signal to stop program.
 		select {
 		case err = <-c.execCh:
-			cancel()
 			fmt.Println("subprocess exited, litestream shutting down")
 		case sig := <-signalCh:
-			cancel()
 			fmt.Println("signal received, litestream shutting down")
 
 			if c.cmd != nil {

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -94,7 +94,7 @@ func (c *ReplicateCommand) ParseFlags(ctx context.Context, args []string) (err e
 }
 
 // Run loads all databases specified in the configuration.
-func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
+func (c *ReplicateCommand) Run() (err error) {
 	// Display version information.
 	log.Printf("litestream %s", Version)
 
@@ -162,7 +162,7 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 			return fmt.Errorf("cannot parse exec command: %w", err)
 		}
 
-		c.cmd = exec.CommandContext(ctx, execArgs[0], execArgs[1:]...)
+		c.cmd = exec.Command(execArgs[0], execArgs[1:]...)
 		c.cmd.Env = os.Environ()
 		c.cmd.Stdout = os.Stdout
 		c.cmd.Stderr = os.Stderr


### PR DESCRIPTION
I might be missing something, but the docs make it sound like cancelling the context that was passed to `exec.CommandContext()` will immediately kill the child process. This prevents us from forwarding the received signal to the exec'ed process and letting it shutdown gracefully.