### PR TITLE
Allow DB.MetaPath to be configured

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -247,6 +247,7 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 // DBConfig represents the configuration for a single database.
 type DBConfig struct {
 	Path               string         `yaml:"path"`
+	MetaPath           *string        `yaml:"meta-path"`
 	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
 	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
 	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
@@ -266,6 +267,9 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	db := litestream.NewDB(path)
 
 	// Override default database settings if specified in configuration.
+	if dbc.MetaPath != nil {
+		db.SetMetaPath(*dbc.MetaPath)
+	}
 	if dbc.MonitorInterval != nil {
 		db.MonitorInterval = *dbc.MonitorInterval
 	}


### PR DESCRIPTION
Litestream is not currently able to be used with Litefs because the fuse filesystem doesn't allow directories. This allows the database metadata path to be configured to be elsewhere.

If breaking changes to the API are okay, it would be cleaner to have `DB.MetaPath` be a struct field rather than a method.