### PR TITLE
Add replicate flags to pump Litestream manually

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -92,19 +92,19 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 
 		// Wait for signal to stop program.
 		select {
-		case err = <-c.execCh:
+		case err = <-c.runCh:
 			slog.Info("subprocess exited, litestream shutting down")
 		case sig := <-signalCh:
 			slog.Info("signal received, litestream shutting down")
 
-			if c.cmd != nil {
+			if c.runSignal != nil {
 				slog.Info("sending signal to exec process")
-				if err := c.cmd.Process.Signal(sig); err != nil {
+				if err := c.runSignal(sig); err != nil {
 					return fmt.Errorf("cannot signal exec process: %w", err)
 				}
 
 				slog.Info("waiting for exec process to close")
-				if err := <-c.execCh; err != nil && !strings.HasPrefix(err.Error(), "signal:") {
+				if err := <-c.runCh; err != nil && !strings.HasPrefix(err.Error(), "signal:") {
 					return fmt.Errorf("cannot wait for exec process: %w", err)
 				}
 			}

--- a/db.go
+++ b/db.go
@@ -775,7 +775,7 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		checkpoint, checkpointMode = true, CheckpointModeTruncate
 	} else if db.MaxCheckpointPageN > 0 && newWALSize >= calcWALSize(db.pageSize, db.MaxCheckpointPageN) {
 		checkpoint, checkpointMode = true, CheckpointModeRestart
-	} else if newWALSize >= calcWALSize(db.pageSize, db.MinCheckpointPageN) {
+	} else if db.MinCheckpointPageN > 0 && newWALSize >= calcWALSize(db.pageSize, db.MinCheckpointPageN) {
 		checkpoint = true
 	} else if db.CheckpointInterval > 0 && !info.dbModTime.IsZero() && time.Since(info.dbModTime) > db.CheckpointInterval && newWALSize > calcWALSize(db.pageSize, 1) {
 		checkpoint = true


### PR DESCRIPTION
For some special setups it is sometimes useful to run Litestream manually instead of letting it replicate in the background.

This commit implements the following flags for replicate:

  * -once for doing synchronous replication and then exit
  * -force-snapshot to force a snapshot during -once
  * -enforce-retention to enforce retention rules during -once

Because running once does not respect the snapshot interval the caller is expected to use -force-snapshot and -enforce-retention regularly to ensure the replication targets stay clean.

For this to work correctly with a live database it needs to be opened with auto checkpointing disabled and SQLITE_FCNTL_PERSIST_WAL.

Other uses include only using -force-snapshot to create regular backups of the database instead of live replication.

Fixes #486

---

This PR is still WIP but it'd be nice to hear suggestions around the implementation and leveraging the exec stuff. Screwing around checkpointing by changing the values feels quite dirty. `MinCheckpointPageN` is checked on `Open()` so in most normal runs the added check for it to be non-zero doesn't make a difference.