### PR TITLE
Build darwin-arm64 build during `make dist-macos`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ endif
 	mv dist/litestream.zip dist/litestream-${LITESTREAM_VERSION}-darwin-amd64.zip
 	openssl dgst -sha256 dist/litestream-${LITESTREAM_VERSION}-darwin-amd64.zip
 
+	GOOS=darwin GOARCH=arm64 CC="gcc -target arm64-apple-macos11" CGO_ENABLED=1 go build -v -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}'"  -o dist/litestream ./cmd/litestream
+	gon etc/gon.hcl
+	mv dist/litestream.zip dist/litestream-${LITESTREAM_VERSION}-darwin-arm64.zip
+	openssl dgst -sha256 dist/litestream-${LITESTREAM_VERSION}-darwin-arm64.zip
+
 clean:
 	rm -rf dist
 


### PR DESCRIPTION
The PR edits the `make dist-macos` script to also compile a `darwin-arm64` build of litestream. 

It works by applying the appropriate `GOOS`/`GOARCH`/`CGO_ENABLED` env vars. But the `CC="gcc -target arm64-apple-macos11"` env var does the real heavy lifting. The `-target` is an apple clang-specific flag that allows you to cross compile `arm64` M1/M2 targets from a `x86_64` computer. I've used it in the past to cross compile Go binaries from a MacOS Github Action runner, in [this `sqlite-http` workflow](https://github.com/asg017/sqlite-http/blob/cffd28c93fbb2e29b9040d3da4c13e3f404eacad/.github/workflows/release.yaml#L84) (binaries [available here](https://github.com/asg017/sqlite-http/releases/tag/v0.1.1)). 

I tested this manually on my MacOS 12.3.1 x86_64 laptop. I then `scp`'ed the compiled file to my Mac M1 Mini, and was able to successfully run it. Running `file litestream` on the `darwin-arm64` output shows it's a `"Mach-O 64-bit executable arm64"`, while the previous "normal" compiler reports `"Mach-O 64-bit executable x86_64"`.

More than happy to move it to a separate `dist-macos-arm64` Makefile target if you'd like. I re-used the `gon` and `openssl` from the `amd64` target, so I think it will work?





