### PR TITLE
Re-add arm/v7 build to Docker

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -15,7 +15,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     env:
-      PLATFORMS: "linux/amd64,linux/arm64"
+      PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
       VERSION: "${{ github.event_name == 'release' && github.event.release.name || github.sha }}"
 
     steps:


### PR DESCRIPTION
This was accidentally removed while debugging CI issues.

Fixes https://github.com/benbjohnson/litestream/issues/501