### PR TITLE
Add missing slog calls to commands

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -93,17 +93,17 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		// Wait for signal to stop program.
 		select {
 		case err = <-c.execCh:
-			fmt.Println("subprocess exited, litestream shutting down")
+			slog.Info("subprocess exited, litestream shutting down")
 		case sig := <-signalCh:
-			fmt.Println("signal received, litestream shutting down")
+			slog.Info("signal received, litestream shutting down")
 
 			if c.cmd != nil {
-				fmt.Println("sending signal to exec process")
+				slog.Info("sending signal to exec process")
 				if err := c.cmd.Process.Signal(sig); err != nil {
 					return fmt.Errorf("cannot signal exec process: %w", err)
 				}
 
-				fmt.Println("waiting for exec process to close")
+				slog.Info("waiting for exec process to close")
 				if err := <-c.execCh; err != nil && !strings.HasPrefix(err.Error(), "signal:") {
 					return fmt.Errorf("cannot wait for exec process: %w", err)
 				}
@@ -114,7 +114,7 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		if e := c.Close(); e != nil && err == nil {
 			err = e
 		}
-		fmt.Println("litestream shut down")
+		slog.Info("litestream shut down")
 		return err
 
 	case "restore":

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"time"
@@ -52,7 +53,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
 		}
 		if r, err = c.loadFromURL(ctx, fs.Arg(0), *ifDBNotExists, &opt); err == errSkipDBExists {
-			fmt.Println("database already exists, skipping")
+			slog.Info("database already exists, skipping")
 			return nil
 		} else if err != nil {
 			return err
@@ -62,7 +63,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 			*configPath = DefaultConfigPath()
 		}
 		if r, err = c.loadFromConfig(ctx, fs.Arg(0), *configPath, !*noExpandEnv, *ifDBNotExists, &opt); err == errSkipDBExists {
-			fmt.Println("database already exists, skipping")
+			slog.Info("database already exists, skipping")
 			return nil
 		} else if err != nil {
 			return err
@@ -73,7 +74,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	// If optional flag set, return success. Useful for automated recovery.
 	if opt.Generation == "" {
 		if *ifReplicaExists {
-			fmt.Println("no matching backups found")
+			slog.Info("no matching backups found")
 			return nil
 		}
 		return fmt.Errorf("no matching backups found")


### PR DESCRIPTION
Previously these were not part of logging but when using slog it's nicer to have them formatted like the rest of the output. Missed these when I did the initial slog conversion and I didn't notice they were not using the logger.

There are some cases where we don't read the config file at all but a separate small refactor to reorder would be needed like when restoring from a plain URL but the config file exists.