### PR TITLE
fix(restore): not defined verbose flag

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -36,6 +36,8 @@ var (
 // errStop is a terminal error for indicating program should quit.
 var errStop = errors.New("stop")
 
+var loggerLevel slog.LevelVar
+
 func main() {
 	m := NewMain()
 	if err := m.Run(context.Background(), os.Args[1:]); err == flag.ErrHelp || err == errStop {
@@ -256,16 +258,16 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 	}
 
 	logOptions := slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: &loggerLevel,
 	}
 
 	switch strings.ToUpper(config.Logging.Level) {
 	case "DEBUG":
-		logOptions.Level = slog.LevelDebug
+		loggerLevel.Set(slog.LevelDebug)
 	case "WARN", "WARNING":
-		logOptions.Level = slog.LevelWarn
+		loggerLevel.Set(slog.LevelWarn)
 	case "ERROR":
-		logOptions.Level = slog.LevelError
+		loggerLevel.Set(slog.LevelError)
 	}
 
 	var logHandler slog.Handler

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -30,6 +30,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
+	verbose := fs.Bool("v", false, "verbose output")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -78,6 +79,11 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 			return nil
 		}
 		return fmt.Errorf("no matching backups found")
+	}
+
+	if *verbose {
+		slog.Warn("DEPRECATED -v argument! Please use the configuration file to change the log level.")
+		loggerLevel.Set(slog.LevelDebug)
 	}
 
 	return r.Restore(ctx, opt)
@@ -199,6 +205,7 @@ Arguments:
 
 	-v
 	    Verbose output.
+	    DEPRECATED! Please use the configuration file to change the log level.
 
 
 Examples:


### PR DESCRIPTION


I was originally using v0.3.11, but recently I upgraded to v0.3.13 and found that a previously working program is now throwing an exception. My execution command is:

```shell
litestream restore -v -if-db-not-exists -if-replica-exists /data/test.db
```

This command exits with an error in v0.3.13. You can reproduce the issue as follows:

```shell
root@bd9b09db6031:/# litestream version
v0.3.13
root@bd9b09db6031:/# litestream restore -v
flag provided but not defined: -v

...

Arguments:

...

	-v
	    Verbose output.

...

2023/11/07 12:19:26 ERROR failed to run error="flag provided but not defined: -v"
```

This breaking change was introduced in [this](https://github.com/benbjohnson/litestream/commit/b1abd6bd993b2b1ee2e9c3a7271a3f523b9be97f#diff-141fdde90cba111ee365dcbb51f4be7f2871ba982d5c22a13e90a799898d0ef2L34). In my commit, I restored the `-v` flag and added relevant warnings.
