### PR TITLE
Always release long-running fd on db close

### DIFF
--- a/db.go
+++ b/db.go
@@ -355,6 +355,12 @@ func (db *DB) Close() (err error) {
 		}
 	}
 
+	if db.f != nil {
+		if e := db.f.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
If Litestream is used as a library and it can be closed and re-opened against the same database this leaking fd can break SQLite database file locking. During normal cli operation this race cannot happen as the whole process will exit after closing databases.

Closing Litestream and opening again right after will leave the unclosed file handle out-of-scope and free to garbage collect. Go tries to be helpful and closes the file handle during GC to prevent it leaking permanently but that will cause a race with POSIX advisory locks.

This order of operations will release the _real_ lock the embedded SQLite of Litestream is holding while leaving it clueless. That will allow the main application to take a new lock on the file and eventually both may be checkpointing the same WAL into the main database file causing permanent corruption.

https://www.sqlite.org/howtocorrupt.html#_posix_advisory_locks_canceled_by_a_separate_thread_doing_close_

Fixes #510