### PR TITLE
Fix missing imports and out-of-date call for Windows-specific code.

### DIFF
--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -5,6 +5,8 @@ package main
 import (
 	"context"
 	"io"
+	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -69,7 +69,7 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 	}
 
 	// Execute replication command.
-	if err := c.Run(s.ctx); err != nil {
+	if err := c.Run(); err != nil {
 		slog.Error("cannot replicate", "error", err)
 		statusCh <- svc.Status{State: svc.StopPending}
 		return true, 2


### PR DESCRIPTION
This Pull Request adds missing imports in `cmd/litestream/main_windows.go` to the `log` and `log/slog` packages, ref. #475, and removes the context from a method call to `ReplicateCommand.Run`, as the Context argument was removed in 2045363cd12a2f8d099eebc63fde046347aa135b.