### PR TITLE
Never expect the replica iterators to be sorted

### DIFF
--- a/cmd/litestream/generations.go
+++ b/cmd/litestream/generations.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"text/tabwriter"
 	"time"
 
@@ -89,6 +90,8 @@ func (c *GenerationsCommand) Run(ctx context.Context, args []string) (err error)
 			r.Logger().Error("cannot list generations", "error", err)
 			continue
 		}
+
+		sort.Strings(generations)
 
 		// Iterate over each generation for the replica.
 		for _, generation := range generations {

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/internal"
@@ -180,8 +179,6 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (lites
 		})
 	}
 
-	sort.Sort(litestream.SnapshotInfoSlice(infos))
-
 	return litestream.NewSnapshotInfoSliceIterator(infos), nil
 }
 
@@ -296,8 +293,6 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (lit
 			CreatedAt:  fi.ModTime().UTC(),
 		})
 	}
-
-	sort.Sort(litestream.WALSegmentInfoSlice(infos))
 
 	return litestream.NewWALSegmentInfoSliceIterator(infos), nil
 }

--- a/replica.go
+++ b/replica.go
@@ -1302,10 +1302,15 @@ func (r *Replica) walSegmentMap(ctx context.Context, generation string, minIndex
 	}
 	defer itr.Close()
 
-	m := make(map[int][]int64)
+	a := []WALSegmentInfo{}
 	for itr.Next() {
-		info := itr.WALSegment()
+		a = append(a, itr.WALSegment())
+	}
 
+	sort.Sort(WALSegmentInfoSlice(a))
+
+	m := make(map[int][]int64)
+	for _, info := range a {
 		// Exit if we go past the max timestamp or index.
 		if !maxTimestamp.IsZero() && info.CreatedAt.After(maxTimestamp) {
 			break // after max timestamp, skip

--- a/replica_client.go
+++ b/replica_client.go
@@ -10,13 +10,13 @@ type ReplicaClient interface {
 	// Returns the type of client.
 	Type() string
 
-	// Returns a list of available generations.
+	// Returns a list of available generations. Order is undefined.
 	Generations(ctx context.Context) ([]string, error)
 
 	// Deletes all snapshots & WAL segments within a generation.
 	DeleteGeneration(ctx context.Context, generation string) error
 
-	// Returns an iterator of all snapshots within a generation on the replica.
+	// Returns an iterator of all snapshots within a generation on the replica. Order is undefined.
 	Snapshots(ctx context.Context, generation string) (SnapshotIterator, error)
 
 	// Writes LZ4 compressed snapshot data to the replica at a given index
@@ -31,7 +31,7 @@ type ReplicaClient interface {
 	// the snapshot does not exist.
 	SnapshotReader(ctx context.Context, generation string, index int) (io.ReadCloser, error)
 
-	// Returns an iterator of all WAL segments within a generation on the replica.
+	// Returns an iterator of all WAL segments within a generation on the replica. Order is undefined.
 	WALSegments(ctx context.Context, generation string) (WALSegmentIterator, error)
 
 	// Writes an LZ4 compressed WAL segment at a given position.

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"path"
-	"sort"
 	"sync"
 	"time"
 
@@ -141,8 +140,6 @@ func (c *ReplicaClient) Generations(ctx context.Context) (_ []string, err error)
 		generations = append(generations, name)
 	}
 
-	sort.Strings(generations)
-
 	return generations, nil
 }
 
@@ -228,8 +225,6 @@ func (c *ReplicaClient) Snapshots(ctx context.Context, generation string) (_ lit
 			CreatedAt:  fi.ModTime().UTC(),
 		})
 	}
-
-	sort.Sort(litestream.SnapshotInfoSlice(infos))
 
 	return litestream.NewSnapshotInfoSliceIterator(infos), nil
 }
@@ -362,8 +357,6 @@ func (c *ReplicaClient) WALSegments(ctx context.Context, generation string) (_ l
 			CreatedAt:  fi.ModTime().UTC(),
 		})
 	}
-
-	sort.Sort(litestream.WALSegmentInfoSlice(infos))
 
 	return litestream.NewWALSegmentInfoSliceIterator(infos), nil
 }


### PR DESCRIPTION
We will never trust the order of anything anymore and always sort them on use when it matters. When it doesn't we can use the potentially unsorted iterator. Documentation for replica interface has been updated to match.

Some S3 implementations, like Storj, don't return objects in order unlike the real S3 API. It's against AWS documentation but they have their reasons not to pre-sort them.

Since there's only one place where the order matters and we're going to iterate all of them anyway and there's a sort implementation for a WAL segment slice we can do just that to add compatibility without any meaningful performance hit.

This also helps implementing new native replica implementations where sorting may not be available.

Fixes #535