### PR TITLE
Tolerate file deletion race on CurrentShadowWALIndex

### DIFF
--- a/db.go
+++ b/db.go
@@ -216,7 +216,9 @@ func (db *DB) CurrentShadowWALIndex(generation string) (index int, size int64, e
 	// Find highest wal index.
 	for _, de := range des {
 		fi, err := de.Info()
-		if err != nil {
+		if os.IsNotExist(err) {
+			continue // file was deleted after os.ReadDir returned
+		} else if err != nil {
 			return 0, 0, err
 		}
 


### PR DESCRIPTION
Commit e0493f979a8269a53b83b35939d0820f0a3a4fc1 exposed a race between CurrentShadowWALIndex and copyToShadowWAL where the temp file could exist during os.ReadDir but not when actually checking the file size.

Said race is quite uncommon and should be mostly harmless as the monitor will retry soon anyway but not having locking around these operations might cause other undesired effects.

This commit fixes the immediate issue of failing for the wrong reason.