### PR TITLE
Stringify S3 delete errors

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -763,9 +763,9 @@ func deleteOutputError(out *s3.DeleteObjectsOutput) error {
 	case 0:
 		return nil
 	case 1:
-		return fmt.Errorf("deleting object %s: %s - %s", *out.Errors[0].Key, *out.Errors[0].Code, *out.Errors[0].Message)
+		return fmt.Errorf("deleting object: %s", out.Errors[0].String())
 	default:
-		return fmt.Errorf("%d errors occurred deleting objects, %s: %s - (%s (and %d others)",
-			len(out.Errors), *out.Errors[0].Key, *out.Errors[0].Code, *out.Errors[0].Message, len(out.Errors)-1)
+		return fmt.Errorf("%d errors occurred deleting objects: %s (and %d others)",
+			len(out.Errors), out.Errors[0].String(), len(out.Errors)-1)
 	}
 }


### PR DESCRIPTION
The error doesn't necessary have all fields and we can end up dereferencing a nil pointer causing a panic.

An example of such error after this commit:

```
time=2024-01-05T09:37:07.100+02:00 level=ERROR msg="retainer error" db=/home/hifi/git/beeper/litestream/restore.db replica=backblaze-eu error="delete wal segments before index: delete wal segments: deleting object: {\n  Code: \"MalformedXML\",\n  Messa
ge: \"The XML you provided was not well-formed or did not validate against our published schema\"\n}"
```

In this instance, B2 is having issues but doesn't provide a Key in the error which the code assumes to always exist. Since the struct has a `String()` method the safe solution and is only used in errors so the formatting isn't critical.