### PR TITLE
Print WAL index in hex

### DIFF
--- a/cmd/litestream/wal.go
+++ b/cmd/litestream/wal.go
@@ -101,7 +101,7 @@ func (c *WALCommand) Run(ctx context.Context, args []string) (err error) {
 				for itr.Next() {
 					info := itr.WALSegment()
 
-					fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%s\n",
+					fmt.Fprintf(w, "%s\t%s\t%x\t%d\t%d\t%s\n",
 						r.Name(),
 						info.Generation,
 						info.Index,


### PR DESCRIPTION
The `restore` command's `-index` option expects a hex-encoded WAL index, so listing the indices in hex would be a better UX.

This has tripped me up when copy-pasting an index from the `wal` command output since it is still a valid hex number, but it is much bigger than what I think I'm fetching.

### Before
```
replica  generation        index  offset  size   created
s3       dea5c913895763b5  903    0       119    2024-02-04T03:59:27Z
s3       dea5c913895763b5  903    4152    7524   2024-02-04T16:59:57Z
s3       dea5c913895763b5  904    0       119    2024-02-04T16:59:57Z
s3       dea5c913895763b5  904    4152    7638   2024-02-04T17:00:27Z
s3       dea5c913895763b5  905    0       119    2024-02-04T17:00:57Z
s3       dea5c913895763b5  905    4152    7669   2024-02-04T17:41:06Z
s3       dea5c913895763b5  906    0       7757   2024-02-04T17:41:06Z
s3       dea5c913895763b5  907    0       119    2024-02-04T17:42:06Z
s3       dea5c913895763b5  907    4152    7681   2024-02-04T17:44:06Z
s3       dea5c913895763b5  908    0       7929   2024-02-04T17:44:06Z
s3       dea5c913895763b5  909    0       10319  2024-02-04T17:45:06Z

```

### After
```
replica  generation        index  offset  size   created
s3       dea5c913895763b5  387    0       119    2024-02-04T03:59:27Z
s3       dea5c913895763b5  387    4152    7524   2024-02-04T16:59:57Z
s3       dea5c913895763b5  388    0       119    2024-02-04T16:59:57Z
s3       dea5c913895763b5  388    4152    7638   2024-02-04T17:00:27Z
s3       dea5c913895763b5  389    0       119    2024-02-04T17:00:57Z
s3       dea5c913895763b5  389    4152    7669   2024-02-04T17:41:06Z
s3       dea5c913895763b5  38a    0       7757   2024-02-04T17:41:06Z
s3       dea5c913895763b5  38b    0       119    2024-02-04T17:42:06Z
s3       dea5c913895763b5  38b    4152    7681   2024-02-04T17:44:06Z
s3       dea5c913895763b5  38c    0       7929   2024-02-04T17:44:06Z
s3       dea5c913895763b5  38d    0       10319  2024-02-04T17:45:06Z
```