### PR TITLE
feat: add config param SessionToken

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -169,6 +169,7 @@ type Config struct {
 	// Global S3 settings
 	AccessKeyID     string `yaml:"access-key-id"`
 	SecretAccessKey string `yaml:"secret-access-key"`
+	SessionToken    string `yaml:"session-token"`
 
 	// Logging
 	Logging LoggingConfig `yaml:"logging"`
@@ -190,6 +191,9 @@ func (c *Config) propagateGlobalSettings() {
 			}
 			if rc.SecretAccessKey == "" {
 				rc.SecretAccessKey = c.SecretAccessKey
+			}
+			if rc.SessionToken == "" {
+				rc.SessionToken = c.SessionToken
 			}
 		}
 	}
@@ -347,6 +351,7 @@ type ReplicaConfig struct {
 	// S3 settings
 	AccessKeyID     string `yaml:"access-key-id"`
 	SecretAccessKey string `yaml:"secret-access-key"`
+	SessionToken    string `yaml:"session-token"`
 	Region          string `yaml:"region"`
 	Bucket          string `yaml:"bucket"`
 	Endpoint        string `yaml:"endpoint"`
@@ -525,6 +530,7 @@ func newS3ReplicaClientFromConfig(c *ReplicaConfig, r *litestream.Replica) (_ *s
 	client := s3.NewReplicaClient()
 	client.AccessKeyID = c.AccessKeyID
 	client.SecretAccessKey = c.SecretAccessKey
+	client.SessionToken = c.SessionToken
 	client.Bucket = bucket
 	client.Path = path
 	client.Region = region
@@ -678,6 +684,11 @@ func applyLitestreamEnv() {
 	if v, ok := os.LookupEnv("LITESTREAM_SECRET_ACCESS_KEY"); ok {
 		if _, ok := os.LookupEnv("AWS_SECRET_ACCESS_KEY"); !ok {
 			os.Setenv("AWS_SECRET_ACCESS_KEY", v)
+		}
+	}
+	if v, ok := os.LookupEnv("LITESTREAM_SESSION_TOKEN"); ok {
+		if _, ok := os.LookupEnv("AWS_SESSION_TOKEN"); !ok {
+			os.Setenv("AWS_SESSION_TOKEN", v)
 		}
 	}
 }

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -44,6 +44,7 @@ type ReplicaClient struct {
 	// AWS authentication keys.
 	AccessKeyID     string
 	SecretAccessKey string
+	SessionToken    string
 
 	// S3 bucket information
 	Region         string
@@ -108,7 +109,7 @@ func (c *ReplicaClient) config() *aws.Config {
 	config := &aws.Config{}
 
 	if c.AccessKeyID != "" || c.SecretAccessKey != "" {
-		config.Credentials = credentials.NewStaticCredentials(c.AccessKeyID, c.SecretAccessKey, "")
+		config.Credentials = credentials.NewStaticCredentials(c.AccessKeyID, c.SecretAccessKey, c.SessionToken)
 	}
 	if c.Endpoint != "" {
 		config.Endpoint = aws.String(c.Endpoint)


### PR DESCRIPTION
 I use Litestream as my desktop software synchronization tool to synchronize sqlite to S3. 

For security reasons, clients usually use Security Token Service(STS) to upload directly to S3. STS must include the `access-key-id`, `secret-access-key`, and `session-token`, so I added the `session-token` to the yaml configuration file and environment variables. and source code.

Note that when using `session-token`, you must set `force-path-style: false`, otherwise you will encounter an error:

```
SecondLevelDomainForbidden: Please use virtual hosted style to access.
status code: 403
```

It appears to be a permissions error caused by **virtual hosted style**.

I have tested the `replicate` and `restore` commands using the Alibaba Cloud Object Storage S3 API, and it works well. I do not have access to AWS S3, please help test with AWS. Thank you.

Other similar requirements: [#407 ](https://github.com/benbjohnson/litestream/issues/407#issue-1325093461)