### PR TITLE
Switch to S3 HEAD to find bucket location

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -136,12 +136,12 @@ func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (st
 
 	// Fetch bucket location, if possible. Must be bucket owner.
 	// This call can return a nil location which means it's in us-east-1.
-	if out, err := s3.New(sess).GetBucketLocation(&s3.GetBucketLocationInput{
+	if out, err := s3.New(sess).HeadBucketWithContext(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}); err != nil {
 		return "", err
-	} else if out.LocationConstraint != nil {
-		return *out.LocationConstraint, nil
+	} else if out.BucketRegion != nil {
+		return *out.BucketRegion, nil
 	}
 	return DefaultRegion, nil
 }


### PR DESCRIPTION
S3's GetBucketLocation is deprecated so switching to a HEAD request to find the bucket location.

Fixes #574.