### PR TITLE
Provide the correct context for database lock acquisition

### DIFF
--- a/db.go
+++ b/db.go
@@ -389,7 +389,7 @@ func (db *DB) UpdatedAt() (time.Time, error) {
 
 // init initializes the connection to the database.
 // Skipped if already initialized or if the database file does not exist.
-func (db *DB) init() (err error) {
+func (db *DB) init(ctx context.Context) (err error) {
 	// Exit if already initialized.
 	if db.db != nil {
 		return nil
@@ -463,7 +463,7 @@ func (db *DB) init() (err error) {
 
 	// Start a long-running read transaction to prevent other transactions
 	// from checkpointing.
-	if err := db.acquireReadLock(); err != nil {
+	if err := db.acquireReadLock(ctx); err != nil {
 		return fmt.Errorf("acquire read lock: %w", err)
 	}
 
@@ -617,7 +617,7 @@ func (db *DB) cleanWAL() error {
 }
 
 // acquireReadLock begins a read transaction on the database to prevent checkpointing.
-func (db *DB) acquireReadLock() error {
+func (db *DB) acquireReadLock(ctx context.Context) error {
 	if db.rtx != nil {
 		return nil
 	}
@@ -629,7 +629,7 @@ func (db *DB) acquireReadLock() error {
 	}
 
 	// Execute read query to obtain read lock.
-	if _, err := tx.ExecContext(db.ctx, `SELECT COUNT(1) FROM _litestream_seq;`); err != nil {
+	if _, err := tx.ExecContext(ctx, `SELECT COUNT(1) FROM _litestream_seq;`); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -720,7 +720,7 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	defer db.mu.Unlock()
 
 	// Initialize database, if necessary. Exit if no DB exists.
-	if err := db.init(); err != nil {
+	if err := db.init(ctx); err != nil {
 		return err
 	} else if db.db == nil {
 		db.Logger.Debug("sync: no database found")
@@ -1332,7 +1332,7 @@ func (db *DB) checkpoint(ctx context.Context, generation, mode string) error {
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
-	if err := db.execCheckpoint(mode); err != nil {
+	if err := db.execCheckpoint(ctx, mode); err != nil {
 		return err
 	} else if _, err = db.db.Exec(`INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
 		return err
@@ -1384,7 +1384,7 @@ func (db *DB) checkpoint(ctx context.Context, generation, mode string) error {
 	return nil
 }
 
-func (db *DB) execCheckpoint(mode string) (err error) {
+func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// Ignore if there is no underlying database.
 	if db.db == nil {
 		return nil
@@ -1406,7 +1406,6 @@ func (db *DB) execCheckpoint(mode string) (err error) {
 	if err := db.releaseReadLock(); err != nil {
 		return fmt.Errorf("release read lock: %w", err)
 	}
-	defer func() { _ = db.acquireReadLock() }()
 
 	// A non-forced checkpoint is issued as "PASSIVE". This will only checkpoint
 	// if there are not pending transactions. A forced checkpoint ("RESTART")
@@ -1423,8 +1422,8 @@ func (db *DB) execCheckpoint(mode string) (err error) {
 	db.Logger.Debug("checkpoint", "mode", mode, "result", fmt.Sprintf("%d,%d,%d", row[0], row[1], row[2]))
 
 	// Reacquire the read lock immediately after the checkpoint.
-	if err := db.acquireReadLock(); err != nil {
-		return fmt.Errorf("release read lock: %w", err)
+	if err := db.acquireReadLock(ctx); err != nil {
+		return fmt.Errorf("acquire read lock: %w", err)
 	}
 
 	return nil
@@ -1513,7 +1512,7 @@ func (db *DB) CRC64(ctx context.Context) (uint64, Pos, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	if err := db.init(); err != nil {
+	if err := db.init(ctx); err != nil {
 		return 0, Pos{}, err
 	} else if db.db == nil {
 		return 0, Pos{}, os.ErrNotExist


### PR DESCRIPTION
The problem is that a `DB` context was being used to acquire a database lock when doing the last sync on database `Close`. At that point in time, the `DB` context has already been cancelled, hence this last sync could fail and produce an error `"error closing db"`.

I think this is a concurrency issue, but I could not replicate it locally. However, we have been using Litestream in production at work, and probably because our VMs are much less computationally capable (1 CPU, 512MB RAM), this bug was very apparent.

Below are our logs from production. We shipped this change on Aug 7 at 1PM, and no errors since.

![Logs from Litestream](https://github.com/user-attachments/assets/086cc5ab-792d-41de-b794-e0edd80b46b2)

