### PR TITLE
Add busy-timeout-interval setting

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -283,12 +283,13 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 
 // DBConfig represents the configuration for a single database.
 type DBConfig struct {
-	Path               string         `yaml:"path"`
-	MetaPath           *string        `yaml:"meta-path"`
-	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
-	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
-	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
-	MaxCheckpointPageN *int           `yaml:"max-checkpoint-page-count"`
+	Path                string         `yaml:"path"`
+	MetaPath            *string        `yaml:"meta-path"`
+	MonitorInterval     *time.Duration `yaml:"monitor-interval"`
+	CheckpointInterval  *time.Duration `yaml:"checkpoint-interval"`
+	BusyTimeoutInterval *time.Duration `yaml:"busy-timeout-interval"`
+	MinCheckpointPageN  *int           `yaml:"min-checkpoint-page-count"`
+	MaxCheckpointPageN  *int           `yaml:"max-checkpoint-page-count"`
 
 	Replicas []*ReplicaConfig `yaml:"replicas"`
 }
@@ -312,6 +313,9 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	}
 	if dbc.CheckpointInterval != nil {
 		db.CheckpointInterval = *dbc.CheckpointInterval
+	}
+	if dbc.BusyTimeoutInterval != nil {
+		db.BusyTimeoutInterval = *dbc.BusyTimeoutInterval
 	}
 	if dbc.MinCheckpointPageN != nil {
 		db.MinCheckpointPageN = *dbc.MinCheckpointPageN

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -283,13 +283,13 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 
 // DBConfig represents the configuration for a single database.
 type DBConfig struct {
-	Path                string         `yaml:"path"`
-	MetaPath            *string        `yaml:"meta-path"`
-	MonitorInterval     *time.Duration `yaml:"monitor-interval"`
-	CheckpointInterval  *time.Duration `yaml:"checkpoint-interval"`
-	BusyTimeoutInterval *time.Duration `yaml:"busy-timeout-interval"`
-	MinCheckpointPageN  *int           `yaml:"min-checkpoint-page-count"`
-	MaxCheckpointPageN  *int           `yaml:"max-checkpoint-page-count"`
+	Path               string         `yaml:"path"`
+	MetaPath           *string        `yaml:"meta-path"`
+	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
+	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
+	BusyTimeout        *time.Duration `yaml:"busy-timeout"`
+	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
+	MaxCheckpointPageN *int           `yaml:"max-checkpoint-page-count"`
 
 	Replicas []*ReplicaConfig `yaml:"replicas"`
 }
@@ -314,8 +314,8 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	if dbc.CheckpointInterval != nil {
 		db.CheckpointInterval = *dbc.CheckpointInterval
 	}
-	if dbc.BusyTimeoutInterval != nil {
-		db.BusyTimeoutInterval = *dbc.BusyTimeoutInterval
+	if dbc.BusyTimeout != nil {
+		db.BusyTimeout = *dbc.BusyTimeout
 	}
 	if dbc.MinCheckpointPageN != nil {
 		db.MinCheckpointPageN = *dbc.MinCheckpointPageN

--- a/db.go
+++ b/db.go
@@ -26,19 +26,17 @@ import (
 
 // Default DB settings.
 const (
-	DefaultMonitorInterval    = 1 * time.Second
-	DefaultCheckpointInterval = 1 * time.Minute
-	DefaultMinCheckpointPageN = 1000
-	DefaultMaxCheckpointPageN = 10000
-	DefaultTruncatePageN      = 500000
+	DefaultMonitorInterval     = 1 * time.Second
+	DefaultCheckpointInterval  = 1 * time.Minute
+	DefaultBusyTimeoutInterval = 1 * time.Second
+	DefaultMinCheckpointPageN  = 1000
+	DefaultMaxCheckpointPageN  = 10000
+	DefaultTruncatePageN       = 500000
 )
 
 // MaxIndex is the maximum possible WAL index.
 // If this index is reached then a new generation will be started.
 const MaxIndex = 0x7FFFFFFF
-
-// BusyTimeout is the timeout to wait for EBUSY from SQLite.
-const BusyTimeout = 1 * time.Second
 
 // DB represents a managed instance of a SQLite database in the file system.
 type DB struct {
@@ -103,6 +101,9 @@ type DB struct {
 	// Frequency at which to perform db sync.
 	MonitorInterval time.Duration
 
+	// The timeout to wait for EBUSY from SQLite.
+	BusyTimeoutInterval time.Duration
+
 	// List of replicas for the database.
 	// Must be set before calling Open().
 	Replicas []*Replica
@@ -120,12 +121,13 @@ func NewDB(path string) *DB {
 		metaPath: filepath.Join(dir, "."+file+MetaDirSuffix),
 		notify:   make(chan struct{}),
 
-		MinCheckpointPageN: DefaultMinCheckpointPageN,
-		MaxCheckpointPageN: DefaultMaxCheckpointPageN,
-		TruncatePageN:      DefaultTruncatePageN,
-		CheckpointInterval: DefaultCheckpointInterval,
-		MonitorInterval:    DefaultMonitorInterval,
-		Logger:             slog.With("db", path),
+		MinCheckpointPageN:  DefaultMinCheckpointPageN,
+		MaxCheckpointPageN:  DefaultMaxCheckpointPageN,
+		TruncatePageN:       DefaultTruncatePageN,
+		CheckpointInterval:  DefaultCheckpointInterval,
+		MonitorInterval:     DefaultMonitorInterval,
+		BusyTimeoutInterval: DefaultBusyTimeoutInterval,
+		Logger:              slog.With("db", path),
 	}
 
 	db.dbSizeGauge = dbSizeGaugeVec.WithLabelValues(db.path)
@@ -411,7 +413,7 @@ func (db *DB) init() (err error) {
 	db.dirInfo = fi
 
 	dsn := db.path
-	dsn += fmt.Sprintf("?_busy_timeout=%d", BusyTimeout.Milliseconds())
+	dsn += fmt.Sprintf("?_busy_timeout=%d", db.BusyTimeoutInterval.Milliseconds())
 
 	// Connect to SQLite database. Use the driver registered with a hook to
 	// prevent WAL files from being removed.

--- a/db.go
+++ b/db.go
@@ -26,12 +26,12 @@ import (
 
 // Default DB settings.
 const (
-	DefaultMonitorInterval     = 1 * time.Second
-	DefaultCheckpointInterval  = 1 * time.Minute
-	DefaultBusyTimeoutInterval = 1 * time.Second
-	DefaultMinCheckpointPageN  = 1000
-	DefaultMaxCheckpointPageN  = 10000
-	DefaultTruncatePageN       = 500000
+	DefaultMonitorInterval    = 1 * time.Second
+	DefaultCheckpointInterval = 1 * time.Minute
+	DefaultBusyTimeout        = 1 * time.Second
+	DefaultMinCheckpointPageN = 1000
+	DefaultMaxCheckpointPageN = 10000
+	DefaultTruncatePageN      = 500000
 )
 
 // MaxIndex is the maximum possible WAL index.
@@ -102,7 +102,7 @@ type DB struct {
 	MonitorInterval time.Duration
 
 	// The timeout to wait for EBUSY from SQLite.
-	BusyTimeoutInterval time.Duration
+	BusyTimeout time.Duration
 
 	// List of replicas for the database.
 	// Must be set before calling Open().
@@ -121,13 +121,13 @@ func NewDB(path string) *DB {
 		metaPath: filepath.Join(dir, "."+file+MetaDirSuffix),
 		notify:   make(chan struct{}),
 
-		MinCheckpointPageN:  DefaultMinCheckpointPageN,
-		MaxCheckpointPageN:  DefaultMaxCheckpointPageN,
-		TruncatePageN:       DefaultTruncatePageN,
-		CheckpointInterval:  DefaultCheckpointInterval,
-		MonitorInterval:     DefaultMonitorInterval,
-		BusyTimeoutInterval: DefaultBusyTimeoutInterval,
-		Logger:              slog.With("db", path),
+		MinCheckpointPageN: DefaultMinCheckpointPageN,
+		MaxCheckpointPageN: DefaultMaxCheckpointPageN,
+		TruncatePageN:      DefaultTruncatePageN,
+		CheckpointInterval: DefaultCheckpointInterval,
+		MonitorInterval:    DefaultMonitorInterval,
+		BusyTimeout:        DefaultBusyTimeout,
+		Logger:             slog.With("db", path),
 	}
 
 	db.dbSizeGauge = dbSizeGaugeVec.WithLabelValues(db.path)
@@ -413,7 +413,7 @@ func (db *DB) init() (err error) {
 	db.dirInfo = fi
 
 	dsn := db.path
-	dsn += fmt.Sprintf("?_busy_timeout=%d", db.BusyTimeoutInterval.Milliseconds())
+	dsn += fmt.Sprintf("?_busy_timeout=%d", db.BusyTimeout.Milliseconds())
 
 	// Connect to SQLite database. Use the driver registered with a hook to
 	// prevent WAL files from being removed.


### PR DESCRIPTION
Adds a `busy-timeout` yaml setting that adjusts the `PRAGMA busy_timeout` in litestream to handle applications that hold the lock for longer than the default value of 1 second. 

(i.e. the converse of setting the https://litestream.io/tips/#busy-timeout in the application) 