### PR TITLE
Fix minor Dockerfile warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 
 WORKDIR /src/litestream
 COPY . .


### PR DESCRIPTION
I was building and pushing my own Docker image for litestream because the last release was quite a while ago, and there are fixes on the main branch that I wanted to access. While doing it, I noticed `docker build` complains about the casing of the `AS` keyword.

```
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```