### PR TITLE
Remove multiple replica support

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
 )
 
@@ -43,15 +42,9 @@ func (c *DatabasesCommand) Run(ctx context.Context, args []string) (err error) {
 			return err
 		}
 
-		var replicaNames []string
-		for _, r := range db.Replicas {
-			replicaNames = append(replicaNames, r.Name())
-		}
-
 		fmt.Fprintf(w, "%s\t%s\n",
 			db.Path(),
-			strings.Join(replicaNames, ","),
-		)
+			db.Replica.Name())
 	}
 
 	return nil

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -285,7 +285,8 @@ type DBConfig struct {
 	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
 	MaxCheckpointPageN *int           `yaml:"max-checkpoint-page-count"`
 
-	Replicas []*ReplicaConfig `yaml:"replicas"`
+	Replica  *ReplicaConfig   `yaml:"replica"`
+	Replicas []*ReplicaConfig `yaml:"replicas"` // Deprecated
 }
 
 // NewDBFromConfig instantiates a DB based on a configuration.
@@ -318,14 +319,29 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 		db.MaxCheckpointPageN = *dbc.MaxCheckpointPageN
 	}
 
-	// Instantiate and attach replicas.
-	for _, rc := range dbc.Replicas {
-		r, err := NewReplicaFromConfig(rc, db)
-		if err != nil {
-			return nil, err
-		}
-		db.Replicas = append(db.Replicas, r)
+	// Instantiate and attach replica.
+	// v0.3.x and before supported multiple replicas but that was dropped to
+	// ensure there's a single remote data authority.
+	if dbc.Replica == nil && len(dbc.Replicas) == 0 {
+		return nil, fmt.Errorf("must specify replica for database")
+	} else if dbc.Replica != nil && len(dbc.Replicas) > 0 {
+		return nil, fmt.Errorf("cannot specify 'replica' and 'replicas' on a database")
+	} else if len(dbc.Replicas) > 1 {
+		return nil, fmt.Errorf("multiple replicas on a single database are no longer supported")
 	}
+
+	var rc *ReplicaConfig
+	if dbc.Replica != nil {
+		rc = dbc.Replica
+	} else {
+		rc = dbc.Replicas[0]
+	}
+
+	r, err := NewReplicaFromConfig(rc, db)
+	if err != nil {
+		return nil, err
+	}
+	db.Replica = r
 
 	return db, nil
 }
@@ -333,7 +349,7 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 // ReplicaConfig represents the configuration for a single replica in a database.
 type ReplicaConfig struct {
 	Type                   string         `yaml:"type"` // "file", "s3"
-	Name                   string         `yaml:"name"` // name of replica, optional.
+	Name                   string         `yaml:"name"` // Deprecated
 	Path                   string         `yaml:"path"`
 	URL                    string         `yaml:"url"`
 	Retention              *time.Duration `yaml:"retention"`

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -107,23 +107,22 @@ func (c *ReplicateCommand) Run() (err error) {
 
 	// Notify user that initialization is done.
 	for _, db := range c.DBs {
+		r := db.Replica
 		slog.Info("initialized db", "path", db.Path())
-		for _, r := range db.Replicas {
-			slog := slog.With("name", r.Name(), "type", r.Client.Type(), "sync-interval", r.SyncInterval)
-			switch client := r.Client.(type) {
-			case *file.ReplicaClient:
-				slog.Info("replicating to", "path", client.Path())
-			case *s3.ReplicaClient:
-				slog.Info("replicating to", "bucket", client.Bucket, "path", client.Path, "region", client.Region, "endpoint", client.Endpoint)
-			case *gcs.ReplicaClient:
-				slog.Info("replicating to", "bucket", client.Bucket, "path", client.Path)
-			case *abs.ReplicaClient:
-				slog.Info("replicating to", "bucket", client.Bucket, "path", client.Path, "endpoint", client.Endpoint)
-			case *sftp.ReplicaClient:
-				slog.Info("replicating to", "host", client.Host, "user", client.User, "path", client.Path)
-			default:
-				slog.Info("replicating to")
-			}
+		slog := slog.With("name", r.Name(), "type", r.Client.Type(), "sync-interval", r.SyncInterval)
+		switch client := r.Client.(type) {
+		case *file.ReplicaClient:
+			slog.Info("replicating to", "path", client.Path())
+		case *s3.ReplicaClient:
+			slog.Info("replicating to", "bucket", client.Bucket, "path", client.Path, "region", client.Region, "endpoint", client.Endpoint)
+		case *gcs.ReplicaClient:
+			slog.Info("replicating to", "bucket", client.Bucket, "path", client.Path)
+		case *abs.ReplicaClient:
+			slog.Info("replicating to", "bucket", client.Bucket, "path", client.Path, "endpoint", client.Endpoint)
+		case *sftp.ReplicaClient:
+			slog.Info("replicating to", "host", client.Host, "user", client.User, "path", client.Path)
+		default:
+			slog.Info("replicating to")
 		}
 	}
 

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -137,13 +137,7 @@ func (c *RestoreCommand) loadFromConfig(ctx context.Context, dbPath, configPath 
 		return nil, errSkipDBExists
 	}
 
-	// Determine the appropriate replica to restore from,
-	r, err := db.CalcRestoreTarget(ctx, *opt)
-	if err != nil {
-		return nil, err
-	}
-
-	return r, nil
+	return db.Replica, nil
 }
 
 // Usage prints the help screen to STDOUT.


### PR DESCRIPTION
Litestream v0.5.x needs to have a single remote data authority so we are removing support for multiple replicas on a single database.

## Configuration

The previous config syntax will still work:

```yaml
dbs:
  - path: /path/to/db.sqlite
    replicas:
      - url: s3://...
```

But there is also a new non-array option for specifying the single replica:

```yaml
dbs:
  - path: /path/to/db.sqlite
    replica:
      url: s3://...
```