### PR TITLE
Multi-level compaction

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -35,7 +35,7 @@ func (c *DatabasesCommand) Run(ctx context.Context, args []string) (err error) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
 	defer w.Flush()
 
-	fmt.Fprintln(w, "path\treplicas")
+	fmt.Fprintln(w, "path\treplica")
 	for _, dbConfig := range config.DBs {
 		db, err := NewDBFromConfig(dbConfig)
 		if err != nil {
@@ -44,7 +44,7 @@ func (c *DatabasesCommand) Run(ctx context.Context, args []string) (err error) {
 
 		fmt.Fprintf(w, "%s\t%s\n",
 			db.Path(),
-			db.Replica.Name())
+			db.Replica.Client.Type())
 	}
 
 	return nil

--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -70,7 +70,7 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 	defer w.Flush()
 
 	fmt.Fprintln(w, "min_txid\tmax_txid\tsize\tcreated")
-	itr, err := r.Client.LTXFiles(ctx, 0)
+	itr, err := r.Client.LTXFiles(ctx, 0, 0)
 	if err != nil {
 		return err
 	}

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -28,8 +28,8 @@ type ReplicateCommand struct {
 
 	Config Config
 
-	// List of managed databases specified in the config.
-	DBs []*litestream.DB
+	// Manages the set of databases & compaction levels.
+	Store *litestream.Store
 }
 
 func NewReplicateCommand() *ReplicateCommand {
@@ -92,24 +92,23 @@ func (c *ReplicateCommand) Run() (err error) {
 		slog.Error("no databases specified in configuration")
 	}
 
+	var dbs []*litestream.DB
 	for _, dbConfig := range c.Config.DBs {
 		db, err := NewDBFromConfig(dbConfig)
 		if err != nil {
 			return err
 		}
-
-		// Open database & attach to program.
-		if err := db.Open(); err != nil {
-			return err
-		}
-		c.DBs = append(c.DBs, db)
+		dbs = append(dbs, db)
 	}
 
+	levels := c.Config.CompactionLevels()
+	c.Store = litestream.NewStore(dbs, levels)
+
 	// Notify user that initialization is done.
-	for _, db := range c.DBs {
+	for _, db := range c.Store.DBs() {
 		r := db.Replica
 		slog.Info("initialized db", "path", db.Path())
-		slog := slog.With("name", r.Name(), "type", r.Client.Type(), "sync-interval", r.SyncInterval)
+		slog := slog.With("type", r.Client.Type(), "sync-interval", r.SyncInterval)
 		switch client := r.Client.(type) {
 		case *file.ReplicaClient:
 			slog.Info("replicating to", "path", client.Path())
@@ -166,13 +165,8 @@ func (c *ReplicateCommand) Run() (err error) {
 
 // Close closes all open databases.
 func (c *ReplicateCommand) Close() (err error) {
-	for _, db := range c.DBs {
-		if e := db.Close(context.Background()); e != nil {
-			db.Logger.Error("error closing db", "error", e)
-			if err == nil {
-				err = e
-			}
-		}
+	if e := c.Store.Close(); e != nil {
+		slog.Error("failed to close database", "error", e)
 	}
 	return err
 }

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -107,7 +107,7 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 }
 
 // loadFromConfig returns a replica & updates the restore options from a DB reference.
-func (c *RestoreCommand) loadFromConfig(ctx context.Context, dbPath, configPath string, expandEnv, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
+func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath string, expandEnv, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	// Load configuration.
 	config, err := ReadConfigFile(configPath, expandEnv)
 	if err != nil {

--- a/compaction_level.go
+++ b/compaction_level.go
@@ -1,0 +1,106 @@
+package litestream
+
+import (
+	"fmt"
+	"time"
+)
+
+// SnapshotLevel represents the level which full snapshots are held.
+const SnapshotLevel = 9
+
+// CompactionLevel represents a single part of a multi-level compaction.
+// Each level merges LTX files from the previous level into larger time granularities.
+type CompactionLevel struct {
+	// The numeric level. Must match the index in the list of levels.
+	Level int
+
+	// The frequency that the level is compacted from the previous level.
+	Interval time.Duration
+
+	// The duration that files in this level are stored.
+	Retention time.Duration
+}
+
+// PrevCompactionAt returns the time when the last compaction occurred.
+// Returns the current time if it is exactly a multiple of the level interval.
+func (lvl *CompactionLevel) PrevCompactionAt(now time.Time) time.Time {
+	return now.Truncate(lvl.Interval).UTC()
+}
+
+// NextCompactionAt returns the time until the next compaction occurs.
+// Returns the current time if it is exactly a multiple of the level interval.
+func (lvl *CompactionLevel) NextCompactionAt(now time.Time) time.Time {
+	return lvl.PrevCompactionAt(now).Add(lvl.Interval)
+}
+
+// CompactionLevels represents a sorted slice of non-snapshot compaction levels.
+type CompactionLevels []*CompactionLevel
+
+// Level returns the compaction level at the given index.
+// Returns an error if the index is a snapshot level or is out of bounds.
+func (a CompactionLevels) Level(level int) (*CompactionLevel, error) {
+	if level == SnapshotLevel {
+		return nil, fmt.Errorf("invalid argument, snapshot level")
+	}
+	if level < 0 || level > a.MaxLevel() {
+		return nil, fmt.Errorf("level out of bounds: %d", level)
+	}
+	return a[level], nil
+}
+
+// MaxLevel return the highest non-snapshot compaction level.
+func (a CompactionLevels) MaxLevel() int {
+	return len(a) - 1
+}
+
+// Validate returns an error if the levels are invalid.
+func (a CompactionLevels) Validate() error {
+	if len(a) == 0 {
+		return fmt.Errorf("at least one compaction level is required")
+	}
+
+	for i, lvl := range a {
+		if i != lvl.Level {
+			return fmt.Errorf("compaction level number out of order: %d, expected %d", lvl.Level, i)
+		} else if lvl.Level > SnapshotLevel-1 {
+			return fmt.Errorf("compaction level cannot exceed %d", SnapshotLevel-1)
+		}
+
+		if lvl.Level == 0 && lvl.Interval != 0 {
+			return fmt.Errorf("cannot set interval on compaction level zero")
+		}
+
+		if lvl.Level != 0 && lvl.Interval <= 0 {
+			return fmt.Errorf("interval required for level %d", lvl.Level)
+		}
+	}
+	return nil
+}
+
+// IsValidLevel returns true if level is a valid compaction level number.
+func (a CompactionLevels) IsValidLevel(level int) bool {
+	if level == SnapshotLevel {
+		return true
+	}
+	return level >= 0 && level < len(a)
+}
+
+// PrevLevel returns the previous compaction level.
+// Returns -1 if there is no previous level.
+func (a CompactionLevels) PrevLevel(level int) int {
+	if level == SnapshotLevel {
+		return a.MaxLevel()
+	}
+	return level - 1
+}
+
+// NextLevel returns the next compaction level.
+// Returns -1 if there is no next level.
+func (a CompactionLevels) NextLevel(level int) int {
+	if level == SnapshotLevel {
+		return -1
+	} else if level == a.MaxLevel() {
+		return SnapshotLevel
+	}
+	return level + 1
+}

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -89,12 +89,18 @@ func (c *ReplicaClient) DeleteAll(ctx context.Context) error {
 }
 
 // LTXFiles returns an iterator over all available LTX files for a level.
-func (c *ReplicaClient) LTXFiles(ctx context.Context, level int) (ltx.FileIterator, error) {
+func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID) (ltx.FileIterator, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}
+
 	dir := litestream.LTXLevelDir(c.Path, level)
-	return newLTXFileIterator(c.bkt.Objects(ctx, &storage.Query{Prefix: dir + "/"}), level), nil
+	prefix := dir + "/"
+	if seek != 0 {
+		prefix += seek.String()
+	}
+
+	return newLTXFileIterator(c.bkt.Objects(ctx, &storage.Query{Prefix: prefix}), level), nil
 }
 
 // WriteLTXFile writes an LTX file from rd to a remote path.

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -12,7 +12,7 @@ var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
 
 type ReplicaClient struct {
 	DeleteAllFunc      func(ctx context.Context) error
-	LTXFilesFunc       func(ctx context.Context, level int) (ltx.FileIterator, error)
+	LTXFilesFunc       func(ctx context.Context, level int, seek ltx.TXID) (ltx.FileIterator, error)
 	OpenLTXFileFunc    func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (io.ReadCloser, error)
 	WriteLTXFileFunc   func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error)
 	DeleteLTXFilesFunc func(ctx context.Context, a []*ltx.FileInfo) error
@@ -24,8 +24,8 @@ func (c *ReplicaClient) DeleteAll(ctx context.Context) error {
 	return c.DeleteAllFunc(ctx)
 }
 
-func (c *ReplicaClient) LTXFiles(ctx context.Context, level int) (ltx.FileIterator, error) {
-	return c.LTXFilesFunc(ctx, level)
+func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID) (ltx.FileIterator, error) {
+	return c.LTXFilesFunc(ctx, level, seek)
 }
 
 func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (io.ReadCloser, error) {

--- a/replica_client.go
+++ b/replica_client.go
@@ -13,7 +13,8 @@ type ReplicaClient interface {
 	Type() string
 
 	// LTXFiles returns an iterator of all LTX files on the replica for a given level.
-	LTXFiles(ctx context.Context, level int) (ltx.FileIterator, error)
+	// If seek is specified, the iterator start from the given TXID or the next available if not found.
+	LTXFiles(ctx context.Context, level int, seek ltx.TXID) (ltx.FileIterator, error)
 
 	// OpenLTXFile returns a reader that contains an LTX file at a given TXID.
 	// Returns an os.ErrNotFound error if the LTX file does not exist.

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -80,7 +80,7 @@ func TestReplicaClient_LTX(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		itr, err := c.LTXFiles(context.Background(), 0)
+		itr, err := c.LTXFiles(context.Background(), 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -115,7 +115,7 @@ func TestReplicaClient_LTX(t *testing.T) {
 	RunWithReplicaClient(t, "NoWALs", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Parallel()
 
-		itr, err := c.LTXFiles(context.Background(), 0)
+		itr, err := c.LTXFiles(context.Background(), 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/replica_test.go
+++ b/replica_test.go
@@ -6,24 +6,8 @@ import (
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
-	"github.com/benbjohnson/litestream/mock"
 	"github.com/superfly/ltx"
 )
-
-func TestReplica_Name(t *testing.T) {
-	t.Run("WithName", func(t *testing.T) {
-		if got, want := litestream.NewReplica(nil, "NAME").Name(), "NAME"; got != want {
-			t.Fatalf("Name()=%v, want %v", got, want)
-		}
-	})
-	t.Run("WithoutName", func(t *testing.T) {
-		r := litestream.NewReplica(nil, "")
-		r.Client = &mock.ReplicaClient{}
-		if got, want := r.Name(), "mock"; got != want {
-			t.Fatalf("Name()=%v, want %v", got, want)
-		}
-	})
-}
 
 func TestReplica_Sync(t *testing.T) {
 	db, sqldb := MustOpenDBs(t)
@@ -45,7 +29,7 @@ func TestReplica_Sync(t *testing.T) {
 	t.Logf("position after sync: %s", dpos.String())
 
 	c := file.NewReplicaClient(t.TempDir())
-	r := litestream.NewReplica(db, "")
+	r := litestream.NewReplica(db)
 	c.Replica, r.Client = r, c
 
 	if err := r.Sync(context.Background()); err != nil {

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -155,7 +155,7 @@ func (c *ReplicaClient) DeleteAll(ctx context.Context) (err error) {
 }
 
 // LTXFiles returns an iterator over all available LTX files for a level.
-func (c *ReplicaClient) LTXFiles(ctx context.Context, level int) (_ ltx.FileIterator, err error) {
+func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID) (_ ltx.FileIterator, err error) {
 	defer func() { c.resetOnConnError(err) }()
 
 	sftpClient, err := c.Init(ctx)
@@ -176,6 +176,8 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int) (_ ltx.FileIter
 	for _, fi := range fis {
 		minTXID, maxTXID, err := ltx.ParseFilename(path.Base(fi.Name()))
 		if err != nil {
+			continue
+		} else if minTXID < seek {
 			continue
 		}
 

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,94 @@
+package litestream_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/litestream"
+)
+
+func TestStore_CompactDB(t *testing.T) {
+	t.Run("L1", func(t *testing.T) {
+		db0, sqldb0 := MustOpenDBs(t)
+		defer MustCloseDBs(t, db0, sqldb0)
+
+		db1, sqldb1 := MustOpenDBs(t)
+		defer MustCloseDBs(t, db1, sqldb1)
+
+		levels := litestream.CompactionLevels{
+			{Level: 0},
+			{Level: 1, Interval: 1 * time.Second},
+			{Level: 2, Interval: 500 * time.Millisecond},
+		}
+		s := litestream.NewStore([]*litestream.DB{db0, db1}, levels)
+		s.CompactionMonitorEnabled = false
+		if err := s.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		if _, err := sqldb0.Exec(`CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb0.Exec(`INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := s.CompactDB(t.Context(), db0, levels[1]); err != nil {
+			t.Fatal(err)
+		}
+
+		// Re-compacting immediately should return an error that it's too soon.
+		if _, err := s.CompactDB(t.Context(), db0, levels[1]); err != litestream.ErrCompactionTooEarly {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		// Re-compacting after the interval should show that there is nothing to compact.
+		time.Sleep(levels[1].Interval)
+		if _, err := s.CompactDB(t.Context(), db0, levels[1]); err != litestream.ErrNoCompaction {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+
+	t.Run("Snapshot", func(t *testing.T) {
+		db0, sqldb0 := MustOpenDBs(t)
+		defer MustCloseDBs(t, db0, sqldb0)
+
+		levels := litestream.CompactionLevels{
+			{Level: 0},
+			{Level: 1, Interval: 100 * time.Millisecond},
+			{Level: 2, Interval: 500 * time.Millisecond},
+		}
+		s := litestream.NewStore([]*litestream.DB{db0}, levels)
+		s.CompactionMonitorEnabled = false
+		if err := s.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		if _, err := sqldb0.Exec(`CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb0.Exec(`INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Re-compacting immediately should return an error that there's nothing to compact.
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != litestream.ErrCompactionTooEarly {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+}


### PR DESCRIPTION
This pull request adds a new `Store` type that manages the compactions & snapshots for individual `DB` objects. This has been moved from the `DB` object itself as we want to support a large number of databases for a single Litestream process and we need to be able to limit the number of replica client interactions at a given time.

The multi-level restore will be implemented in a separate PR.