### PR TITLE
Add default compaction levels

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -212,7 +212,16 @@ func (c *Config) propagateGlobalSettings() {
 
 // DefaultConfig returns a new instance of Config with defaults set.
 func DefaultConfig() Config {
-	return Config{}
+	return Config{
+		Levels: []*CompactionLevelConfig{
+			{Interval: 5 * time.Minute},
+			{Interval: 1 * time.Hour},
+		},
+		Snapshot: SnapshotConfig{
+			Interval:  24 * time.Hour,
+			Retention: 24 * time.Hour,
+		},
+	}
 }
 
 // CompactionLevels returns a full list of compaction levels include L0.
@@ -319,8 +328,7 @@ func ReadConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 
 // CompactionLevelConfig the configuration for a single level of compaction.
 type CompactionLevelConfig struct {
-	Interval  time.Duration `yaml:"interval"`
-	Retention time.Duration `yaml:"retention"`
+	Interval time.Duration `yaml:"interval"`
 }
 
 // DBConfig represents the configuration for a single database.


### PR DESCRIPTION
This pull request adds default compaction levels that are the equivalent of:

```yaml
levels:
  - interval: "5m"
  - interval: "1h"

snapshot:
  interval: "24h"
  retention: "24h"
```