### PR TITLE
Update .gitignore to exclude development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .DS_Store
 /dist
 .vscode
+
+# Claude-related files
+.claude/
+CLAUDE.md
+
+# Binary
+litestream

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 CLAUDE.md
 
 # Binary
-litestream
+bin/


### PR DESCRIPTION
## Summary
This PR updates the `.gitignore` file to exclude development-related files that should not be tracked in the repository.

## Changes
- Added exclusion for Claude development environment files (`.claude/`, `CLAUDE.md`)
- Added exclusion for the compiled `litestream` binary

## Rationale
These additions help keep the repository clean during development:
- Claude-related files are specific to AI-assisted development environments
- The compiled binary should not be tracked as it's a build artifact

## Test plan
- [x] Verified that .gitignore properly excludes the specified files
- [x] Ensured no existing tracking patterns are affected