### PR TITLE
Fix snapshot interval for command-line replication

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -59,6 +59,9 @@ func (c *ReplicateCommand) ParseFlags(ctx context.Context, args []string) (err e
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
 		}
 
+		// Initialize config with defaults when using command-line arguments
+		c.Config = DefaultConfig()
+
 		dbConfig := &DBConfig{Path: fs.Arg(0)}
 		for _, u := range fs.Args()[1:] {
 			syncInterval := litestream.DefaultSyncInterval


### PR DESCRIPTION
## Summary
Fixes issue #669 where command-line replication without a config file was causing continuous snapshots due to a 0s interval instead of the expected 24-hour default.

## Problem
When running `litestream replicate db.db s3://bucket/path` without a config file, the snapshot interval defaulted to 0s, causing:
- Continuous snapshot attempts
- Excessive resource usage
- Unnecessary storage consumption

## Solution
Initialize `Config` with `DefaultConfig()` when parsing command-line arguments to ensure proper default values are set, including the 24-hour snapshot interval.

## Changes
- Added `c.Config = DefaultConfig()` in `ParseFlags()` when command-line arguments are used
- This ensures the same defaults are applied whether using a config file or command-line arguments

## Test Results
Before fix:
```
starting compaction monitor level=9 interval=0s
```

After fix:
```
starting compaction monitor level=9 interval=24h0m0s
```

## Test plan
- [x] Verified command-line replication now uses 24h snapshot interval
- [x] Tested that config file mode still works correctly
- [x] Confirmed sync interval remains at 1s default
- [x] Build completes successfully

Fixes #669