### PR TITLE
Rename 'wal' command to 'ltx'

### DIFF
--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -92,7 +92,7 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 // Usage prints the help screen to STDOUT.
 func (c *LTXCommand) Usage() {
 	fmt.Printf(`
-The wal command lists all ltx files available for a database.
+The ltx command lists all LTX files available for a database.
 
 Usage:
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -119,7 +119,11 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		return (&RestoreCommand{}).Run(ctx, args)
 	case "version":
 		return (&VersionCommand{}).Run(ctx, args)
+	case "ltx":
+		return (&LTXCommand{}).Run(ctx, args)
 	case "wal":
+		// Deprecated: Keep for backward compatibility
+		fmt.Fprintln(os.Stderr, "Warning: 'wal' command is deprecated, please use 'ltx' instead")
 		return (&LTXCommand{}).Run(ctx, args)
 	default:
 		if cmd == "" || cmd == "help" || strings.HasPrefix(cmd, "-") {
@@ -142,10 +146,10 @@ Usage:
 The commands are:
 
 	databases    list databases specified in config file
+	ltx          list available LTX files for a database
 	replicate    runs a server to replicate databases
 	restore      recovers database backup from a replica
 	version      prints the binary version
-	wal          list available WAL files for a database
 `[1:])
 }
 

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -41,6 +41,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcpServer.AddTool(GenerationsTool(configPath))
 	mcpServer.AddTool(RestoreTool(configPath))
 	mcpServer.AddTool(SnapshotsTool(configPath))
+	mcpServer.AddTool(LTXTool(configPath))
 
 	s.mux = http.NewServeMux()
 	s.mux.Handle("/", httplog.Logger(server.NewStreamableHTTPServer(mcpServer)))
@@ -324,9 +325,9 @@ func VersionTool() (mcp.Tool, server.ToolHandlerFunc) {
 	}
 }
 
-func WALTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
-	tool := mcp.NewTool("litestream_wal",
-		mcp.WithDescription("List all WAL files for a database or replica."),
+func LTXTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
+	tool := mcp.NewTool("litestream_ltx",
+		mcp.WithDescription("List all LTX files for a database or replica."),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Database path or replica URL.")),
 		mcp.WithString("config", mcp.Description("Path to the Litestream config file. Optional.")),
 		mcp.WithString("replica", mcp.Description("Replica name to filter by. Optional.")),
@@ -334,7 +335,7 @@ func WALTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := []string{"wal"}
+		args := []string{"ltx"}
 		config := configPath
 		if configVal, err := req.RequireString("config"); err == nil {
 			config = configVal


### PR DESCRIPTION
## Summary

This PR renames the `litestream wal` command to `litestream ltx` to better reflect that it now operates on LTX (Litestream Transaction) files rather than SQLite WAL files.

Fixes #671

## Changes

### 1. Command Registration (`cmd/litestream/main.go`)
- Added `ltx` as the primary command
- Kept `wal` as a deprecated alias that prints a warning message
- Updated the main help text to show `ltx` instead of `wal`

### 2. Help Text Updates (`cmd/litestream/ltx.go`)
- Changed "The wal command" to "The ltx command" in the usage description

### 3. MCP Integration Updates (`cmd/litestream/mcp.go`)
- Updated the MCP tool to use `ltx` command instead of `wal`
- Renamed `WALTool` function to `LTXTool`
- Updated tool name from `litestream_wal` to `litestream_ltx`
- Updated tool description to reference LTX files
- Added `LTXTool` registration in the MCP server

## Backward Compatibility

The `wal` command is maintained for backward compatibility. When users run `litestream wal`, they will see:
```
Warning: 'wal' command is deprecated, please use 'ltx' instead
```

The command will still execute normally after showing the warning.

## Testing

1. The new `ltx` command works as expected
2. The deprecated `wal` command shows a warning but still functions
3. Help text correctly references `ltx` throughout
4. MCP integration uses the new command name

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>