### PR TITLE
WIP: Add manual triggers for integration tests

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,6 +5,23 @@ on:
       - opened
       - synchronize
       - reopened
+  workflow_dispatch:
+    inputs:
+      run_s3_integration:
+        description: 'Run S3 Integration Tests'
+        required: false
+        default: false
+        type: boolean
+      run_gcp_integration:
+        description: 'Run GCP Integration Tests'
+        required: false
+        default: false
+        type: boolean
+      run_abs_integration:
+        description: 'Run Azure Blob Storage Integration Tests'
+        required: false
+        default: false
+        type: boolean
 
 env:
   GO_VERSION: "1.24"
@@ -109,7 +126,8 @@ jobs:
     name: Run S3 Integration Tests
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_s3_integration == 'true')
+    environment: integration-tests
     concurrency:
       group: integration-test-s3
     steps:
@@ -134,7 +152,8 @@ jobs:
     name: Run GCP Integration Tests
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_gcp_integration == 'true')
+    environment: integration-tests
     concurrency:
       group: integration-test-gcp
     steps:
@@ -163,7 +182,8 @@ jobs:
     name: Run Azure Blob Store Integration Tests
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_abs_integration == 'true')
+    environment: integration-tests
     concurrency:
       group: integration-test-abs
     steps:

--- a/.github/workflows/integration-tests-manual.yml
+++ b/.github/workflows/integration-tests-manual.yml
@@ -1,0 +1,126 @@
+name: Manual Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_s3:
+        description: 'Run S3 Integration Tests'
+        required: false
+        default: true
+        type: boolean
+      run_gcp:
+        description: 'Run GCP Integration Tests'
+        required: false
+        default: false
+        type: boolean
+      run_abs:
+        description: 'Run Azure Blob Storage Integration Tests'
+        required: false
+        default: false
+        type: boolean
+      pr_number:
+        description: 'Pull Request Number (optional)'
+        required: false
+        type: string
+
+env:
+  GO_VERSION: "1.24"
+
+jobs:
+  checkout-pr:
+    name: Checkout PR or Branch
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.get-ref.outputs.ref }}
+    steps:
+      - name: Get PR ref if provided
+        id: get-ref
+        run: |
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            echo "ref=refs/pull/${{ github.event.inputs.pr_number }}/head" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.get-ref.outputs.ref }}
+
+  s3-integration-test:
+    name: S3 Integration Tests
+    runs-on: ubuntu-latest
+    needs: checkout-pr
+    if: github.event.inputs.run_s3 == 'true'
+    environment: integration-tests
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.checkout-pr.outputs.ref }}
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - run: go install ./cmd/litestream
+
+      - name: Run S3 Integration Tests
+        run: go test -v ./replica_client_test.go -integration s3
+        env:
+          LITESTREAM_S3_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_S3_ACCESS_KEY_ID }}
+          LITESTREAM_S3_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_S3_SECRET_ACCESS_KEY }}
+          LITESTREAM_S3_REGION: us-east-1
+          LITESTREAM_S3_BUCKET: integration.litestream.io
+
+  gcp-integration-test:
+    name: GCP Integration Tests
+    runs-on: ubuntu-latest
+    needs: checkout-pr
+    if: github.event.inputs.run_gcp == 'true'
+    environment: integration-tests
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.checkout-pr.outputs.ref }}
+
+      - name: Extract GCP credentials
+        run: 'echo "$GOOGLE_APPLICATION_CREDENTIALS" > /opt/gcp.json'
+        shell: bash
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - run: go install ./cmd/litestream
+
+      - name: Run GCP Integration Tests
+        run: go test -v ./replica_client_test.go -integration gcs
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /opt/gcp.json
+          LITESTREAM_GCS_BUCKET: integration.litestream.io
+
+  abs-integration-test:
+    name: Azure Blob Storage Integration Tests
+    runs-on: ubuntu-latest
+    needs: checkout-pr
+    if: github.event.inputs.run_abs == 'true'
+    environment: integration-tests
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.checkout-pr.outputs.ref }}
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - run: go install ./cmd/litestream
+
+      - name: Run Azure Integration Tests
+        run: go test -v ./replica_client_test.go -integration abs
+        env:
+          LITESTREAM_ABS_ACCOUNT_NAME: ${{ secrets.LITESTREAM_ABS_ACCOUNT_NAME }}
+          LITESTREAM_ABS_ACCOUNT_KEY: ${{ secrets.LITESTREAM_ABS_ACCOUNT_KEY }}
+          LITESTREAM_ABS_BUCKET: integration

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -1,0 +1,92 @@
+# Integration Testing Guide
+
+## Manual Integration Test Execution
+
+Repository maintainers can manually trigger integration tests for pull requests before merging to main.
+
+### Two Methods Available
+
+#### Method 1: Via Modified commit.yml Workflow
+
+The main commit workflow now supports manual triggering with selective integration tests.
+
+1. Go to the [Actions tab](../../actions/workflows/commit.yml)
+2. Click "Run workflow"
+3. Select which integration tests to run:
+   - Run S3 Integration Tests
+   - Run GCP Integration Tests
+   - Run Azure Blob Storage Integration Tests
+4. Click "Run workflow" button
+
+#### Method 2: Via Dedicated Manual Integration Test Workflow
+
+A dedicated workflow for running integration tests on any PR or branch.
+
+1. Go to the [Actions tab](../../actions/workflows/integration-tests-manual.yml)
+2. Click "Run workflow"
+3. Fill in:
+   - **PR Number** (optional): Enter PR number to test that specific PR
+   - **Run S3**: Check to run S3 integration tests (default: true)
+   - **Run GCP**: Check to run GCP integration tests
+   - **Run ABS**: Check to run Azure Blob Storage integration tests
+4. Click "Run workflow" button
+
+### Environment Protection
+
+All integration test jobs use the `integration-tests` environment. To add approval requirements:
+
+1. Go to Settings → Environments
+2. Create/Configure `integration-tests` environment
+3. Add protection rules:
+   - Required reviewers (specify maintainers who can approve)
+   - Deployment branches (restrict to specific branches if needed)
+
+### Running Integration Tests Locally
+
+```bash
+# S3 Integration Tests
+export LITESTREAM_S3_ACCESS_KEY_ID="your-key"
+export LITESTREAM_S3_SECRET_ACCESS_KEY="your-secret"
+export LITESTREAM_S3_REGION="us-east-1"
+export LITESTREAM_S3_BUCKET="your-bucket"
+go test -v ./replica_client_test.go -integration s3
+
+# GCP Integration Tests
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+export LITESTREAM_GCS_BUCKET="your-bucket"
+go test -v ./replica_client_test.go -integration gcs
+
+# Azure Blob Storage Integration Tests
+export LITESTREAM_ABS_ACCOUNT_NAME="your-account"
+export LITESTREAM_ABS_ACCOUNT_KEY="your-key"
+export LITESTREAM_ABS_BUCKET="your-container"
+go test -v ./replica_client_test.go -integration abs
+```
+
+### Mock S3 Tests (No Credentials Required)
+
+```bash
+# Install moto
+pip install moto[s3,server]
+
+# Run mock S3 tests
+./etc/s3_mock.py go test -v ./replica_client_test.go -integration s3
+```
+
+## GitHub Secrets Configuration
+
+The following secrets must be configured in the repository settings:
+
+### S3
+
+- `LITESTREAM_S3_ACCESS_KEY_ID`
+- `LITESTREAM_S3_SECRET_ACCESS_KEY`
+
+### GCP
+
+- `GOOGLE_APPLICATION_CREDENTIALS` (JSON service account key)
+
+### Azure Blob Storage
+
+- `LITESTREAM_ABS_ACCOUNT_NAME`
+- `LITESTREAM_ABS_ACCOUNT_KEY`


### PR DESCRIPTION
## WIP: Manual Integration Test Triggers

This PR adds the ability to manually trigger integration tests for pull requests before merging to main.

### Changes
- ✨ Add `workflow_dispatch` event to `.github/workflows/commit.yml` with boolean inputs for each test type
- 📄 Create dedicated `.github/workflows/integration-tests-manual.yml` for cleaner manual test runs
- 🔒 Add environment protection support (`integration-tests`) for approval workflows
- 📚 Document setup and usage in `docs/INTEGRATION_TESTING.md`

### Features
- Manual triggering of S3, GCP, and Azure Blob Storage integration tests
- Optional PR number input to test specific pull requests
- Environment-based approval requirements for sensitive credentials
- Maintains existing automatic test behavior on main branch

### Next Steps
This is a work in progress. Need to:
1. Test the workflow configuration in a demo repository
2. Determine exact approval/protection requirements
3. Configure the `integration-tests` environment in repository settings
4. Finalize based on maintainer preferences

### Testing
Created a demo repository to validate this approach: `github-integration-testing-demo`

🤖 Generated with Claude Code (https://claude.ai/code)