### PR TITLE
Fix Azure Blob Storage DeleteLTXFiles using wrong TXID parameter

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -159,7 +159,7 @@ func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) e
 	}
 
 	for _, info := range a {
-		key := litestream.LTXFilePath(c.Path, info.Level, info.MaxTXID, info.MaxTXID)
+		key := litestream.LTXFilePath(c.Path, info.Level, info.MinTXID, info.MaxTXID)
 		blobURL := c.containerURL.NewBlobURL(key)
 		if _, err := blobURL.Delete(ctx, azblob.DeleteSnapshotsOptionNone, azblob.BlobAccessConditions{}); isNotExists(err) {
 			continue


### PR DESCRIPTION
## Summary
This PR fixes a bug in the Azure Blob Storage implementation where `DeleteLTXFiles` was using the wrong parameter when constructing file paths for deletion. This bug has been blocking successful main branch builds since July 19, 2025.

## Problem
The Azure Blob Storage integration tests have been failing due to a typo that was introduced in:
- **Commit:** 90cf9f2 
- **PR:** #645 ("Replace storage layer with LTX")
- **Date:** July 19, 2025

In `abs/replica_client.go` line 162:

```go
// Before (incorrect - introduced in 90cf9f2):
key := litestream.LTXFilePath(c.Path, info.Level, info.MaxTXID, info.MaxTXID)

// After (correct):
key := litestream.LTXFilePath(c.Path, info.Level, info.MinTXID, info.MaxTXID)
```

The function was using `info.MaxTXID` twice instead of using `info.MinTXID` and `info.MaxTXID`, causing the wrong filename to be generated for deletion operations.

## Impact
- Delete operations would fail silently (files with the incorrect name didn't exist)
- Integration tests `TestReplicaClient_DeleteWALSegments` and `TestReplicaClient_LTX` were failing
- This affects only Azure Blob Storage; other storage backends (S3, GCS) have the correct implementation
- **Main branch has been failing CI since July 19, 2025** (last successful main build was April 28, 2025)

## Why This Wasn't Caught Earlier
- The bug was introduced directly to main in the LTX refactor (PR #645)
- Azure integration tests only run on main branch (not on PRs) due to the `if: github.ref == 'refs/heads/main'` condition
- The tests have never passed with this bug - they've been failing continuously since July 19
- Recent PR merges (like #654) made the failure more visible but didn't cause it

## Testing
- [x] All tests pass locally
- [x] Code quality checks pass (go vet, goimports, pre-commit hooks)
- [x] Fix aligns with other storage backend implementations (S3, GCS, etc.)
- [ ] Azure integration tests should pass on main after this merge

## Notes
This fix should restore the main branch to green status for the first time since July 19, 2025.

🤖 Generated with [Claude Code](https://claude.ai/code)