### PR TITLE
Fix Azure LTX iterator memory bug causing test failures

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -209,12 +209,12 @@ type ltxFileIterator struct {
 	level  int
 	seek   ltx.TXID
 
-	ch     chan ltx.FileInfo
+	ch     chan *ltx.FileInfo
 	g      errgroup.Group
 	ctx    context.Context
 	cancel func()
 
-	info ltx.FileInfo
+	info *ltx.FileInfo
 	err  error
 }
 
@@ -223,7 +223,7 @@ func newLTXFileIterator(ctx context.Context, client *ReplicaClient, level int, s
 		client: client,
 		level:  level,
 		seek:   seek,
-		ch:     make(chan ltx.FileInfo),
+		ch:     make(chan *ltx.FileInfo),
 	}
 
 	itr.ctx, itr.cancel = context.WithCancel(ctx)
@@ -259,7 +259,7 @@ func (itr *ltxFileIterator) fetch() error {
 				continue
 			}
 
-			info := ltx.FileInfo{
+			info := &ltx.FileInfo{
 				Level:     itr.level,
 				MinTXID:   minTXID,
 				MaxTXID:   maxTXID,
@@ -311,7 +311,7 @@ func (itr *ltxFileIterator) Next() bool {
 func (itr *ltxFileIterator) Err() error { return itr.err }
 
 func (itr *ltxFileIterator) Item() *ltx.FileInfo {
-	return &itr.info
+	return itr.info
 }
 
 func isNotExists(err error) bool {


### PR DESCRIPTION
## Summary
- Fixed a critical bug in the Azure Blob Storage ltxFileIterator that was causing test failures
- The iterator was using value types instead of pointer types, causing memory aliasing issues
- All items returned by the iterator were referencing the same memory location

## Problem
The Azure Blob Storage integration tests were failing with an error showing that the iterator was returning TXID `0000000000000009` when it should have been returning `0000000000000001`. Investigation revealed that all items in the slice were pointing to the same memory location, which kept getting overwritten with each iteration.

## Solution
Changed the Azure iterator implementation to use pointers consistently:
- Changed channel type from `chan ltx.FileInfo` to `chan *ltx.FileInfo`
- Changed info field from `ltx.FileInfo` to `*ltx.FileInfo`
- Updated the fetch method to create and send pointer values
- Updated the `Item()` method to return `itr.info` directly (now a pointer)

This makes the Azure implementation consistent with the S3 and Google Cloud Storage implementations, which were already using pointers correctly.

## Testing
The existing `TestReplicaClient_LTX` test in `replica_client_test.go` serves as the regression test for this bug. This test:
- Creates 4 LTX files with different TXIDs
- Uses `ltx.SliceFileIterator` to collect all items from the iterator  
- Verifies that all 4 items are returned (not just one repeated)
- Verifies each item has the correct TXIDs and size

This test caught the bug because with the bug present, the slice would have 4 items but they'd all point to the same memory location (the last item processed), causing the first item to incorrectly show TXIDs 9-9 instead of 1-1.

## Test Plan
- [x] Verified the file backend tests still pass
- [x] Ran go vet and goimports
- [x] All pre-commit hooks pass
- [ ] Azure integration tests should now pass in CI (will be verified by the `TestReplicaClient_LTX` test)

🤖 Generated with [Claude Code](https://claude.ai/code)