### PR TITLE
Add manual workflow for cloud integration tests

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -1,5 +1,9 @@
 name: Manual Integration Tests
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -99,6 +103,12 @@ jobs:
           LITESTREAM_S3_REGION: us-east-1
           LITESTREAM_S3_BUCKET: integration.litestream.io
 
+      - name: Create test results directory
+        if: always()
+        run: |
+          mkdir -p test-results
+          echo "Test completed at $(date)" > test-results/s3-test.log
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -140,6 +150,12 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /opt/gcp.json
           LITESTREAM_GS_BUCKET: integration.litestream.io
 
+      - name: Create test results directory
+        if: always()
+        run: |
+          mkdir -p test-results
+          echo "Test completed at $(date)" > test-results/gcs-test.log
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -175,6 +191,12 @@ jobs:
           LITESTREAM_ABS_ACCOUNT_NAME: ${{ secrets.LITESTREAM_ABS_ACCOUNT_NAME }}
           LITESTREAM_ABS_ACCOUNT_KEY: ${{ secrets.LITESTREAM_ABS_ACCOUNT_KEY }}
           LITESTREAM_ABS_BUCKET: integration
+
+      - name: Create test results directory
+        if: always()
+        run: |
+          mkdir -p test-results
+          echo "Test completed at $(date)" > test-results/abs-test.log
 
       - name: Upload test results
         if: always()
@@ -236,6 +258,7 @@ jobs:
 
       - name: Comment on PR (if applicable)
         if: github.event.inputs.pr_number != ''
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -262,9 +285,15 @@ jobs:
 
             body += `[View test results](${run_url})`;
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr_number,
-              body: body
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body: body
+              });
+              console.log(`Successfully commented on PR #${pr_number}`);
+            } catch (error) {
+              console.log(`Failed to comment on PR #${pr_number}: ${error.message}`);
+              // Don't fail the workflow if commenting fails
+            }

--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -1,0 +1,270 @@
+name: Manual Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to test (optional)'
+        required: false
+        type: string
+      branch:
+        description: 'Branch name to test (optional, ignored if PR number is provided)'
+        required: false
+        type: string
+        default: ''
+      test_s3:
+        description: 'Run S3 integration tests (AWS)'
+        required: false
+        default: true
+        type: boolean
+      test_gcs:
+        description: 'Run Google Cloud Storage integration tests'
+        required: false
+        default: false
+        type: boolean
+      test_abs:
+        description: 'Run Azure Blob Storage integration tests'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  setup:
+    name: Setup and Validation
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.get-ref.outputs.ref }}
+      ref_name: ${{ steps.get-ref.outputs.ref_name }}
+    steps:
+      - name: Determine checkout ref
+        id: get-ref
+        run: |
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            echo "ref=refs/pull/${{ github.event.inputs.pr_number }}/head" >> $GITHUB_OUTPUT
+            echo "ref_name=PR #${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "::notice::Testing PR #${{ github.event.inputs.pr_number }}"
+          elif [ -n "${{ github.event.inputs.branch }}" ]; then
+            echo "ref=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+            echo "ref_name=branch ${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+            echo "::notice::Testing branch ${{ github.event.inputs.branch }}"
+          else
+            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+            echo "ref_name=branch ${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "::notice::Testing current branch ${{ github.ref_name }}"
+          fi
+      
+      - name: Validate inputs
+        run: |
+          if [ "${{ github.event.inputs.test_s3 }}" != "true" ] && \
+             [ "${{ github.event.inputs.test_gcs }}" != "true" ] && \
+             [ "${{ github.event.inputs.test_abs }}" != "true" ]; then
+            echo "::error::At least one test type must be selected"
+            exit 1
+          fi
+          
+          echo "### Test Configuration" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Target:** ${{ steps.get-ref.outputs.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Integration Tests:**" >> $GITHUB_STEP_SUMMARY
+          echo "- S3 (AWS): ${{ github.event.inputs.test_s3 }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Google Cloud Storage: ${{ github.event.inputs.test_gcs }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Azure Blob Storage: ${{ github.event.inputs.test_abs }}" >> $GITHUB_STEP_SUMMARY
+
+  s3-integration:
+    name: S3 Integration Tests (AWS)
+    runs-on: ubuntu-latest
+    needs: setup
+    if: github.event.inputs.test_s3 == 'true'
+    concurrency:
+      group: integration-test-s3-manual
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - run: go env
+
+      - run: go install ./cmd/litestream
+
+      - run: go test -v ./replica_client_test.go -integration s3
+        env:
+          LITESTREAM_S3_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_S3_ACCESS_KEY_ID }}
+          LITESTREAM_S3_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_S3_SECRET_ACCESS_KEY }}
+          LITESTREAM_S3_REGION: us-east-1
+          LITESTREAM_S3_BUCKET: integration.litestream.io
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: s3-test-results
+          path: |
+            *.log
+            test-results/
+
+  gcs-integration:
+    name: Google Cloud Storage Integration Tests
+    runs-on: ubuntu-latest
+    needs: setup
+    if: github.event.inputs.test_gcs == 'true'
+    concurrency:
+      group: integration-test-gcp-manual
+      cancel-in-progress: false
+    steps:
+      - name: Extract GCP credentials
+        run: 'echo "$GOOGLE_APPLICATION_CREDENTIALS" > /opt/gcp.json'
+        shell: bash
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - run: go env
+
+      - run: go install ./cmd/litestream
+
+      - run: go test -v ./replica_client_test.go -integration gs
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /opt/gcp.json
+          LITESTREAM_GS_BUCKET: integration.litestream.io
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcs-test-results
+          path: |
+            *.log
+            test-results/
+
+  abs-integration:
+    name: Azure Blob Storage Integration Tests
+    runs-on: ubuntu-latest
+    needs: setup
+    if: github.event.inputs.test_abs == 'true'
+    concurrency:
+      group: integration-test-abs-manual
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - run: go env
+
+      - run: go install ./cmd/litestream
+
+      - run: go test -v ./replica_client_test.go -integration abs
+        env:
+          LITESTREAM_ABS_ACCOUNT_NAME: ${{ secrets.LITESTREAM_ABS_ACCOUNT_NAME }}
+          LITESTREAM_ABS_ACCOUNT_KEY: ${{ secrets.LITESTREAM_ABS_ACCOUNT_KEY }}
+          LITESTREAM_ABS_BUCKET: integration
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: abs-test-results
+          path: |
+            *.log
+            test-results/
+
+  summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [setup, s3-integration, gcs-integration, abs-integration]
+    if: always()
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+
+      - name: Generate summary
+        run: |
+          echo "## Integration Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Target: ${{ needs.setup.outputs.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          echo "### Integration Tests" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ needs.s3-integration.result }}" == "success" ]; then
+            echo "✅ **S3 (AWS):** Passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.s3-integration.result }}" == "failure" ]; then
+            echo "❌ **S3 (AWS):** Failed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.s3-integration.result }}" == "skipped" ]; then
+            echo "⏭️ **S3 (AWS):** Skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.gcs-integration.result }}" == "success" ]; then
+            echo "✅ **Google Cloud Storage:** Passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.gcs-integration.result }}" == "failure" ]; then
+            echo "❌ **Google Cloud Storage:** Failed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.gcs-integration.result }}" == "skipped" ]; then
+            echo "⏭️ **Google Cloud Storage:** Skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.abs-integration.result }}" == "success" ]; then
+            echo "✅ **Azure Blob Storage:** Passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.abs-integration.result }}" == "failure" ]; then
+            echo "❌ **Azure Blob Storage:** Failed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.abs-integration.result }}" == "skipped" ]; then
+            echo "⏭️ **Azure Blob Storage:** Skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "**Triggered by:** @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Run ID:** [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow:** ${{ github.workflow }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment on PR (if applicable)
+        if: github.event.inputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = ${{ github.event.inputs.pr_number }};
+            const run_url = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            
+            // Build status emoji based on results
+            let statusEmoji = '✅';
+            const failedJobs = [];
+            
+            if ('${{ needs.s3-integration.result }}' === 'failure') failedJobs.push('S3');
+            if ('${{ needs.gcs-integration.result }}' === 'failure') failedJobs.push('GCS');
+            if ('${{ needs.abs-integration.result }}' === 'failure') failedJobs.push('Azure');
+            
+            if (failedJobs.length > 0) {
+              statusEmoji = '❌';
+            }
+            
+            let body = `${statusEmoji} **Manual integration tests** have been run by @${{ github.actor }}\n\n`;
+            
+            if (failedJobs.length > 0) {
+              body += `Failed jobs: ${failedJobs.join(', ')}\n\n`;
+            }
+            
+            body += `[View test results](${run_url})`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              body: body
+            });

--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
             echo "ref_name=branch ${{ github.ref_name }}" >> $GITHUB_OUTPUT
             echo "::notice::Testing current branch ${{ github.ref_name }}"
           fi
-      
+
       - name: Validate inputs
         run: |
           if [ "${{ github.event.inputs.test_s3 }}" != "true" ] && \
@@ -61,7 +61,7 @@ jobs:
             echo "::error::At least one test type must be selected"
             exit 1
           fi
-          
+
           echo "### Test Configuration" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Target:** ${{ steps.get-ref.outputs.ref_name }}" >> $GITHUB_STEP_SUMMARY
@@ -201,9 +201,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Target: ${{ needs.setup.outputs.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           echo "### Integration Tests" >> $GITHUB_STEP_SUMMARY
-          
+
           if [ "${{ needs.s3-integration.result }}" == "success" ]; then
             echo "✅ **S3 (AWS):** Passed" >> $GITHUB_STEP_SUMMARY
           elif [ "${{ needs.s3-integration.result }}" == "failure" ]; then
@@ -211,7 +211,7 @@ jobs:
           elif [ "${{ needs.s3-integration.result }}" == "skipped" ]; then
             echo "⏭️ **S3 (AWS):** Skipped" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
           if [ "${{ needs.gcs-integration.result }}" == "success" ]; then
             echo "✅ **Google Cloud Storage:** Passed" >> $GITHUB_STEP_SUMMARY
           elif [ "${{ needs.gcs-integration.result }}" == "failure" ]; then
@@ -219,7 +219,7 @@ jobs:
           elif [ "${{ needs.gcs-integration.result }}" == "skipped" ]; then
             echo "⏭️ **Google Cloud Storage:** Skipped" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
           if [ "${{ needs.abs-integration.result }}" == "success" ]; then
             echo "✅ **Azure Blob Storage:** Passed" >> $GITHUB_STEP_SUMMARY
           elif [ "${{ needs.abs-integration.result }}" == "failure" ]; then
@@ -227,7 +227,7 @@ jobs:
           elif [ "${{ needs.abs-integration.result }}" == "skipped" ]; then
             echo "⏭️ **Azure Blob Storage:** Skipped" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "**Triggered by:** @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
@@ -241,27 +241,27 @@ jobs:
           script: |
             const pr_number = ${{ github.event.inputs.pr_number }};
             const run_url = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
-            
+
             // Build status emoji based on results
             let statusEmoji = '✅';
             const failedJobs = [];
-            
+
             if ('${{ needs.s3-integration.result }}' === 'failure') failedJobs.push('S3');
             if ('${{ needs.gcs-integration.result }}' === 'failure') failedJobs.push('GCS');
             if ('${{ needs.abs-integration.result }}' === 'failure') failedJobs.push('Azure');
-            
+
             if (failedJobs.length > 0) {
               statusEmoji = '❌';
             }
-            
+
             let body = `${statusEmoji} **Manual integration tests** have been run by @${{ github.actor }}\n\n`;
-            
+
             if (failedJobs.length > 0) {
               body += `Failed jobs: ${failedJobs.join(', ')}\n\n`;
             }
-            
+
             body += `[View test results](${run_url})`;
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- Adds a new manual workflow (workflow_dispatch) for running cloud integration tests on-demand
- Allows maintainers to test specific PRs or branches without merging to main
- Includes only the integration tests that are restricted to main branch in commit.yml

## Test Options
The workflow provides options to run:
- ✅ S3 integration tests (AWS) - defaults to enabled
- ⬜ Google Cloud Storage integration tests 
- ⬜ Azure Blob Storage integration tests

Tests that already run on every push/PR (S3 Mock, SFTP, unit tests, linting) are excluded since they're covered by the existing commit.yml workflow.

## Access Control
By default, only users with write access to the repository can trigger workflow_dispatch workflows. This includes:
- Repository owners
- Collaborators with write or admin permissions
- Organization members with appropriate permissions

No additional configuration is needed to restrict this to maintainers only.

## How to Use
1. Go to Actions tab
2. Select "Manual Integration Tests" workflow
3. Click "Run workflow"
4. Configure:
   - PR number OR branch name (optional)
   - Which cloud integration tests to run
5. Click "Run workflow"

## Test plan
Once merged:
- [ ] Test triggering the workflow for a specific PR
- [ ] Test triggering the workflow for a specific branch
- [ ] Verify S3 integration tests run successfully
- [ ] Verify access control (only maintainers can trigger)

🤖 Generated with [Claude Code](https://claude.ai/code)