### PR TITLE
Improve error message when flags are positioned after positional arguments

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -79,6 +79,10 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 
 		dbConfig := &DBConfig{Path: fs.Arg(0)}
 		for _, u := range fs.Args()[1:] {
+			// Check if this looks like a flag that was placed after positional arguments
+			if len(u) > 0 && u[0] == '-' {
+				return fmt.Errorf("flag %q must be positioned before DB_PATH and REPLICA_URL arguments", u)
+			}
 			syncInterval := litestream.DefaultSyncInterval
 			dbConfig.Replicas = append(dbConfig.Replicas, &ReplicaConfig{
 				URL:          u,


### PR DESCRIPTION
## Summary
- Fixes issue #245 where `-exec` flag positioned after positional arguments produced a confusing error message
- Instead of "replica url scheme required: -exec", users now see: "flag \"-exec\" must be positioned before DB_PATH and REPLICA_URL arguments"

## Test plan
- [x] Built and tested the binary with flags in wrong position - shows clear error message
- [x] Tested with flags in correct position - works as expected  
- [x] All existing tests pass
- [x] Code passes go vet, go fmt, goimports, and staticcheck

🤖 Generated with [Claude Code](https://claude.ai/code)