### PR TITLE
feat: add directory replication support for multi-tenant databases

### DIFF
--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -1224,23 +1224,23 @@ func TestIsSQLiteDatabase(t *testing.T) {
 }
 
 func TestDBConfigValidation(t *testing.T) {
-	t.Run("both path and directory specified", func(t *testing.T) {
+	t.Run("both path and dir specified", func(t *testing.T) {
 		config := main.Config{
 			DBs: []*main.DBConfig{
 				{
-					Path:      "/path/to/db.sqlite",
-					Directory: "/path/to/dir",
+					Path: "/path/to/db.sqlite",
+					Dir:  "/path/to/dir",
 				},
 			},
 		}
 
 		err := config.Validate()
 		if err == nil {
-			t.Error("expected validation error when both path and directory are specified")
+			t.Error("expected validation error when both path and dir are specified")
 		}
 	})
 
-	t.Run("neither path nor directory specified", func(t *testing.T) {
+	t.Run("neither path nor dir specified", func(t *testing.T) {
 		config := main.Config{
 			DBs: []*main.DBConfig{
 				{},
@@ -1249,7 +1249,22 @@ func TestDBConfigValidation(t *testing.T) {
 
 		err := config.Validate()
 		if err == nil {
-			t.Error("expected validation error when neither path nor directory are specified")
+			t.Error("expected validation error when neither path nor dir are specified")
+		}
+	})
+
+	t.Run("dir without pattern", func(t *testing.T) {
+		config := main.Config{
+			DBs: []*main.DBConfig{
+				{
+					Dir: "/path/to/dir",
+				},
+			},
+		}
+
+		err := config.Validate()
+		if err == nil {
+			t.Error("expected validation error when dir is specified without pattern")
 		}
 	})
 
@@ -1271,7 +1286,7 @@ func TestDBConfigValidation(t *testing.T) {
 		config := main.DefaultConfig()
 		config.DBs = []*main.DBConfig{
 			{
-				Directory: "/path/to/dir",
+				Dir:       "/path/to/dir",
 				Pattern:   "*.db",
 				Recursive: true,
 			},
@@ -1295,8 +1310,8 @@ func TestNewDBsFromDirectoryConfig_UniquePaths(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "db3.db"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
-		Pattern:   "*.db",
+		Dir:     tmpDir,
+		Pattern: "*.db",
 		Replica: &main.ReplicaConfig{
 			Type:   "file",
 			Path:   "/backup/base",
@@ -1349,7 +1364,7 @@ func TestNewDBsFromDirectoryConfig_SubdirectoryPaths(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "team-b", "nested", "db3.db"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
+		Dir:       tmpDir,
 		Pattern:   "*.db",
 		Recursive: true,
 		Replica: &main.ReplicaConfig{
@@ -1398,7 +1413,7 @@ func TestNewDBsFromDirectoryConfig_DuplicateFilenames(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "team-b", "db.sqlite"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
+		Dir:       tmpDir,
 		Pattern:   "*.sqlite",
 		Recursive: true,
 		Replica: &main.ReplicaConfig{
@@ -1450,7 +1465,7 @@ func TestNewDBsFromDirectoryConfig_S3URL(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "team-b", "nested", "db.sqlite"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
+		Dir:       tmpDir,
 		Pattern:   "*.sqlite",
 		Recursive: true,
 		Replica: &main.ReplicaConfig{
@@ -1495,7 +1510,7 @@ func TestNewDBsFromDirectoryConfig_ReplicasArrayURL(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "subs", "db2.sqlite"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
+		Dir:       tmpDir,
 		Pattern:   "*.sqlite",
 		Recursive: true,
 		Replicas: []*main.ReplicaConfig{
@@ -1550,8 +1565,8 @@ func TestNewDBsFromDirectoryConfig_SpecialCharacters(t *testing.T) {
 	}
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
-		Pattern:   "*.db",
+		Dir:     tmpDir,
+		Pattern: "*.db",
 		Replica: &main.ReplicaConfig{
 			Type: "file",
 			Path: "/backup",
@@ -1586,8 +1601,8 @@ func TestNewDBsFromDirectoryConfig_EmptyBasePath(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "test.db"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
-		Pattern:   "*.db",
+		Dir:     tmpDir,
+		Pattern: "*.db",
 		Replica: &main.ReplicaConfig{
 			Type: "file",
 			Path: "", // Empty base path
@@ -1620,8 +1635,8 @@ func TestNewDBsFromDirectoryConfig_ReplicasArray(t *testing.T) {
 	createSQLiteDB(t, filepath.Join(tmpDir, "db2.db"))
 
 	config := &main.DBConfig{
-		Directory: tmpDir,
-		Pattern:   "*.db",
+		Dir:     tmpDir,
+		Pattern: "*.db",
 		Replicas: []*main.ReplicaConfig{
 			{
 				Type: "file",

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -126,13 +126,13 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 	var dbs []*litestream.DB
 	for _, dbConfig := range c.Config.DBs {
 		// Handle directory configuration
-		if dbConfig.Directory != "" {
+		if dbConfig.Dir != "" {
 			dirDbs, err := NewDBsFromDirectoryConfig(dbConfig)
 			if err != nil {
 				return err
 			}
 			dbs = append(dbs, dirDbs...)
-			slog.Info("found databases in directory", "directory", dbConfig.Directory, "count", len(dirDbs))
+			slog.Info("found databases in directory", "dir", dbConfig.Dir, "count", len(dirDbs))
 		} else {
 			// Handle single database configuration
 			db, err := NewDBFromConfig(dbConfig)


### PR DESCRIPTION
## Summary

Adds directory replication support for multi-tenant applications where each tenant has their own SQLite database file.

Closes #42

## Configuration

```yaml
dbs:
  - directory: /var/lib/tenants
    pattern: "*.db"
    recursive: true
    replica:
      type: s3
      bucket: backups
      path: tenants
```

## Replica Path Behavior

Each database gets a unique replica path by appending its relative path from the directory root:

**Example**:
```
directory: /var/lib/databases
replica path: backups/prod

Results:
  /var/lib/databases/tenant1.db        → backups/prod/tenant1.db/ltx/...
  /var/lib/databases/team-a/db2.db     → backups/prod/team-a/db2.db/ltx/...
```

This ensures isolated storage per database with no collision risk.

## Features

- Scan directories for SQLite databases with configurable patterns (`*.db`, `*.sqlite`, etc.)
- Recursive directory scanning
- SQLite header validation (prevents replicating non-SQLite files)
- Mix directory and single-database configs
- Preserves directory structure in replica paths
- Works with all storage backends (S3, GCS, ABS, SFTP, WebDAV, File, NATS)

## Testing

- Comprehensive test coverage for path uniqueness
- Tests for subdirectory handling, duplicate filenames, special characters
- All existing tests passing