### PR TITLE
fix: Install syft in release workflow for SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Install Syft for SBOM generation
+        uses: anchore/sbom-action/download-syft@v0
+        with:
+          syft-version: latest
+
       - name: Import GPG key
         if: ${{ env.GPG_PRIVATE_KEY != '' }}
         id: import_gpg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -166,5 +166,5 @@ release:
 #       - APPLE_DEVELOPER_TEAM_ID={{ .Env.APPLE_TEAM_ID }}
 #       - AC_PASSWORD={{ .Env.AC_PASSWORD }}
 
-sboms:
-  - artifacts: archive
+# sboms:
+#   - artifacts: archive

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -166,5 +166,5 @@ release:
 #       - APPLE_DEVELOPER_TEAM_ID={{ .Env.APPLE_TEAM_ID }}
 #       - AC_PASSWORD={{ .Env.AC_PASSWORD }}
 
-# sboms:
-#   - artifacts: archive
+sboms:
+  - artifacts: archive


### PR DESCRIPTION
## Summary
- Fixes the release workflow failure caused by missing `syft` executable
- Adds syft installation step to the GitHub Actions release workflow
- Re-enables SBOM generation in `.goreleaser.yml`

## Problem
The release workflow was failing with:
```
cataloging artifacts: syft failed: exec: "syft": executable file not found in $PATH
```

This was happening because GoReleaser v2 tries to generate SBOMs (Software Bill of Materials) using syft, but syft wasn't installed in the GitHub Actions environment.

## Solution
Added a step to install syft using the official `anchore/sbom-action/download-syft@v0` action before running GoReleaser. This ensures syft is available when GoReleaser tries to generate SBOMs for the release artifacts.

## Test Results
The v0.5.0-test.1 release initially failed due to this issue. After this fix is merged, releases should work properly with SBOM generation enabled.

🤖 Generated with [Claude Code](https://claude.ai/code)