### PR TITLE
fix: `etc/litestream.yml` - Corrected indentation for `replica` entries

### DIFF
--- a/etc/litestream.yml
+++ b/etc/litestream.yml
@@ -3,14 +3,14 @@
 # secret-access-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx
 
 # dbs:
-#  - path: /path/to/primary/db            # Database to replicate from
-#    replicas:
-#      - path: /path/to/replica           # File-based replication
-#      - url:  s3://my.bucket.com/db      # S3-based replication
-#      - type: nats                       # NATS JetStream replication
-#        url: nats://nats.example.com:4222
-#        bucket: litestream-backups
-#        # Optional TLS configuration:
-#        # client-cert: /path/to/client.pem
-#        # client-key: /path/to/client.key
-#        # root-cas: [/path/to/ca.pem]
+#  - path: /path/to/primary/db          # Database to replicate from
+#    replica:
+#      path: /path/to/replica           # File-based replication
+#      url:  s3://my.bucket.com/db      # S3-based replication
+#      type: nats                       # NATS JetStream replication
+#      url: nats://nats.example.com:4222
+#      bucket: litestream-backups
+#      # Optional TLS configuration:
+#      # client-cert: /path/to/client.pem
+#      # client-key: /path/to/client.key
+#      # root-cas: [/path/to/ca.pem]


### PR DESCRIPTION
## Description
fixed indentation and formatting based on https://litestream.io/guides/s3/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
the document includes conflicting statements.

[s3 configuration page](https://litestream.io/guides/s3/#configuration-file-usage) says
```
dbs:
  - path: /path/to/local/db
    replica:
      url: s3://BUCKETNAME/PATHNAME
```

but `etc/litestream.yml` and [`Running in a Docker container` page](https://litestream.io/guides/docker/) say
```
# dbs:
#  - path: /path/to/primary/db            # Database to replicate from
#    replicas:
#      - path: /path/to/replica           # File-based replication
#      - url:  s3://my.bucket.com/db      # S3-based replication
```

These are conflicting about `replica` and `replicas` key, and its child structure.


## How Has This Been Tested?
<!--- Describe how you tested your changes -->
<!--- Include details of your testing environment if relevant -->

Latest version (v0.3.13) runs with former one, but latter failed. on macOS.


## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] My code follows the code style of this project (`go fmt`, `go vet`)
- [ ] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
