### PR TITLE
Add 30s level to default compaction levels

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -250,6 +250,7 @@ func DefaultConfig() Config {
 	defaultSnapshotRetention := 24 * time.Hour
 	return Config{
 		Levels: []*CompactionLevelConfig{
+			{Interval: 30 * time.Second},
 			{Interval: 5 * time.Minute},
 			{Interval: 1 * time.Hour},
 		},

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -560,15 +560,18 @@ dbs:
 		}
 
 		// When levels are not specified, defaults should be applied
-		if len(config.Levels) != 2 {
-			t.Fatalf("expected 2 default compaction levels, got %d", len(config.Levels))
+		if len(config.Levels) != 3 {
+			t.Fatalf("expected 3 default compaction levels, got %d", len(config.Levels))
 		}
 
-		// Check default intervals: 5m and 1h
-		if config.Levels[0].Interval != 5*time.Minute {
+		// Check default intervals: 30s, 5m and 1h
+		if config.Levels[0].Interval != 30*time.Second {
 			t.Errorf("expected default level[0] interval of 5m, got %v", config.Levels[0].Interval)
 		}
-		if config.Levels[1].Interval != 1*time.Hour {
+		if config.Levels[1].Interval != 5*time.Minute {
+			t.Errorf("expected default level[0] interval of 5m, got %v", config.Levels[0].Interval)
+		}
+		if config.Levels[2].Interval != 1*time.Hour {
 			t.Errorf("expected default level[1] interval of 1h, got %v", config.Levels[1].Interval)
 		}
 	})


### PR DESCRIPTION
## Description
This pull request adds a new level that compacts every 30s.

## Motivation and Context
Previously, we had 5m & 1h compaction intervals. However, that means that L1 could have 300 input files if syncs occur every second. That's fine for compaction but it's be good to reduce the number of files needed for restore.

This changes makes it so that L1 has up to 30 input files, L2 has up to 10 input files, and L3 has up to 24 input files.

## How Has This Been Tested?
Automated testing

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
