### PR TITLE
fix: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,10 +33,12 @@ builds:
 
 archives:
   - id: main
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: >-
       {{ .ProjectName }}-
       {{- .Version }}-


### PR DESCRIPTION
## Description
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/benbjohnson/litestream/actions/runs/17651088561/job/50162056028#step:8:26): 
```
• DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
• DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```

## Motivation and Context
Just saw the [action failing](https://github.com/benbjohnson/litestream/actions/runs/17651088561/job/50162056028) and then the [deprecations](https://github.com/benbjohnson/litestream/actions/runs/17651088561/job/50162056028#step:8:26).

## How Has This Been Tested?
Run `goreleaser check`.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
