### PR TITLE
Add LOG_LEVEL environment variable to set logging info

### DIFF
--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -35,6 +35,7 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		if r, err = NewReplicaFromConfig(&ReplicaConfig{URL: fs.Arg(0)}, nil); err != nil {
 			return err
 		}
+		initLog(os.Stdout, "INFO", "text")
 	} else {
 		if *configPath == "" {
 			*configPath = DefaultConfigPath()

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -88,6 +88,8 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 		return nil, fmt.Errorf("output path required")
 	}
 
+	initLog(os.Stdout, "INFO", "text")
+
 	// Exit successfully if the output file already exists.
 	if _, err := os.Stat(opt.OutputPath); !os.IsNotExist(err) && ifDBNotExists {
 		return nil, errSkipDBExists


### PR DESCRIPTION
## Description
This PR reads the `LOG_LEVEL` environment variable to set the appropriate level, if set. It overrides the config variable.

## Motivation and Context
This makes it easier to set debug logging without changing config. It also allows us to adjust logging level when no config is used.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
