### PR TITLE
Update retention enforcement to use minTXID

### DIFF
--- a/db.go
+++ b/db.go
@@ -1381,7 +1381,7 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 
 	// If this is L1, clean up L0 files that are below the minTXID.
 	if dstLevel == 1 {
-		if err := db.EnforceRetentionByTXID(ctx, 0, maxTXID); err != nil {
+		if err := db.EnforceRetentionByTXID(ctx, 0, minTXID); err != nil {
 			// Don't log context cancellation errors during shutdown
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				db.Logger.Error("enforce L0 retention", "error", err)


### PR DESCRIPTION
## Description

Update retention enforcement to use `minTXID`, as described in the existing comment.

## Motivation and Context

Using `minTXID` matches the comment and contributes to fix the issue described in https://github.com/benbjohnson/litestream/issues/772#issuecomment-3380771816.

Using `maxTXID` causes issues with doing `litestream restore` concurrently `litestream replicate` (restoring to a "replica" while the "master" is continuously replicating): immediately after `CalcRestorePlan` creates a plan for "now", the L0 files needed can get deleted by a L0->L1 compaction.

This would also impact a read-replica VFS.

## How Has This Been Tested?

I tested this by creating a database with to which I continuously make changes, that is replicated with `litestream replicate fruits.db file:backup/fruits.db` and verifying that under L0->L1 compactions enough L0 files are kept to allow concurrent `litestream restore` operations to conclude at any recent TXID.

Only under a LN->L9 snapshot might necessary files be deleted, but that's avoided by increasing snapshot retention, which should at least be twice the snapshot interval for "concurrent restore" and "read-replica VFS" to work.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
