### PR TITLE
Re-add -if-replica-exists flag

### DIFF
--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -26,7 +26,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	fs.Var((*txidVar)(&opt.TXID), "txid", "transaction ID")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
-	// ifReplicaExists := fs.Bool("if-replica-exists", false, "")
+	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -68,18 +68,16 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 	}
 
-	/*
-		// TODO(ltx): Fix -if-replica-exists flag
-
-		// Return an error if no matching targets found.
-		// If optional flag set, return success. Useful for automated recovery.
+	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) {
 		if *ifReplicaExists {
 			slog.Info("no matching backups found")
 			return nil
 		}
-	*/
-
-	return r.Restore(ctx, opt)
+		return fmt.Errorf("no matching backup files available")
+	} else if err != nil {
+		return err
+	}
+	return nil
 }
 
 // loadFromURL creates a replica & updates the restore options from a replica URL.

--- a/replica.go
+++ b/replica.go
@@ -415,8 +415,6 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	infos, err := CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
 	if err != nil {
 		return fmt.Errorf("cannot calc restore plan: %w", err)
-	} else if len(infos) == 0 {
-		return fmt.Errorf("no matching backup files available")
 	}
 
 	r.Logger().Debug("restore plan", "n", len(infos), "txid", infos[len(infos)-1].MaxTXID, "timestamp", infos[len(infos)-1].CreatedAt)


### PR DESCRIPTION
## Description
This pull request re-adds the `-if-replica-exists` flag to `litestream restore`.

## Motivation and Context
This was accidentally removed as part of the LTX upgrade. The `restore` command now checks if `Restore()` returns `ErrTxNotAvailable` and will log the issue without returning a non-zero error code.

Fixes https://github.com/benbjohnson/litestream/issues/774

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
