### PR TITLE
Reject age encryption configuration until support is restored

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -573,7 +573,7 @@ func NewReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *litestream.Re
 	// write plaintext data to remote storage instead of encrypted data.
 	// See: https://github.com/benbjohnson/litestream/issues/790
 	if len(c.Age.Identities) > 0 || len(c.Age.Recipients) > 0 {
-		return nil, fmt.Errorf("age encryption is not currently supported; configuration would be silently ignored resulting in plaintext data being written to remote storage (see issue #790)")
+		return nil, fmt.Errorf("age encryption is not currently supported, if you need encryption please revert back to Litestream v0.3.x")
 	}
 
 	// Build replica.

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -234,8 +234,8 @@ func TestNewReplicaFromConfig_AgeEncryption(t *testing.T) {
 		if !strings.Contains(err.Error(), "age encryption is not currently supported") {
 			t.Errorf("expected age encryption error, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "issue #790") {
-			t.Errorf("expected error to reference issue #790, got: %v", err)
+		if !strings.Contains(err.Error(), "revert back to Litestream v0.3.x") {
+			t.Errorf("expected error to reference v0.3.x, got: %v", err)
 		}
 	})
 
@@ -252,6 +252,9 @@ func TestNewReplicaFromConfig_AgeEncryption(t *testing.T) {
 		if !strings.Contains(err.Error(), "age encryption is not currently supported") {
 			t.Errorf("expected age encryption error, got: %v", err)
 		}
+		if !strings.Contains(err.Error(), "revert back to Litestream v0.3.x") {
+			t.Errorf("expected error to reference v0.3.x, got: %v", err)
+		}
 	})
 
 	t.Run("RejectBoth", func(t *testing.T) {
@@ -267,6 +270,9 @@ func TestNewReplicaFromConfig_AgeEncryption(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "age encryption is not currently supported") {
 			t.Errorf("expected age encryption error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "revert back to Litestream v0.3.x") {
+			t.Errorf("expected error to reference v0.3.x, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

This PR adds explicit validation to reject age encryption configuration, preventing users from believing their data is encrypted when it's actually being written as plaintext to remote storage.

## Problem

As reported in https://github.com/benbjohnson/litestream/pull/715#issuecomment-3395496318, age encryption configuration is currently accepted but no actual encryption occurs. This is a critical security issue.

**Root Cause:**
Age encryption functionality was removed during the LTX storage layer refactor in PR #645 (commit 90cf9f2, June 2025). While configuration parsing remains, the encryption/decryption wrappers were not reimplemented.

**Current State:**
- ✅ Configuration parsing accepts age identities and recipients  
- ❌ No encryption applied during `WriteLTXFile`
- ❌ No decryption applied during `OpenLTXFile`
- ❌ Plaintext data written to all remote storage backends

## Solution

Add explicit validation in `NewReplicaFromConfig` to error out if age configuration is present. This prevents silent data exposure until proper encryption support can be restored in the LTX layer.

## Changes

- **cmd/litestream/main.go:570-577**: Add validation check that rejects age encryption configuration with clear error message
- **cmd/litestream/main_test.go:220-283**: Add comprehensive test suite covering:
  - Rejection of age identities
  - Rejection of age recipients  
  - Rejection when both are configured
  - Success when neither is configured

## Testing

```bash
$ go test -v ./cmd/litestream -run TestNewReplicaFromConfig_AgeEncryption
=== RUN   TestNewReplicaFromConfig_AgeEncryption
=== RUN   TestNewReplicaFromConfig_AgeEncryption/RejectIdentities
=== RUN   TestNewReplicaFromConfig_AgeEncryption/RejectRecipients
=== RUN   TestNewReplicaFromConfig_AgeEncryption/RejectBoth
=== RUN   TestNewReplicaFromConfig_AgeEncryption/AllowEmpty
--- PASS: TestNewReplicaFromConfig_AgeEncryption (0.00s)
```

All existing tests continue to pass.

## User Impact

Users with age encryption configured will now receive a clear error message:
```
age encryption is not currently supported; configuration would be silently 
ignored resulting in plaintext data being written to remote storage (see issue #790)
```

This is a **breaking change** for users who have age encryption configured, but it's necessary to prevent silent security failures.

## Future Work

Proper encryption support needs to be reimplemented in the LTX layer as originally intended. This PR provides interim protection until that work is completed.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)