### PR TITLE
fix(s3): add default https scheme to endpoints without protocol

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -210,9 +210,16 @@ func (c *ReplicaClient) configureEndpoint(opts *[]func(*s3.Options)) {
 	if c.Endpoint != "" {
 		*opts = append(*opts, func(o *s3.Options) {
 			o.UsePathStyle = c.ForcePathStyle
-			o.BaseEndpoint = aws.String(c.Endpoint)
+
+			endpoint := c.Endpoint
+			// Add scheme if not present
+			if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+				endpoint = "https://" + endpoint
+			}
+
+			o.BaseEndpoint = aws.String(endpoint)
 			// For MinIO and other S3-compatible services
-			if strings.HasPrefix(c.Endpoint, "http://") {
+			if strings.HasPrefix(endpoint, "http://") {
 				o.EndpointOptions.DisableHTTPS = true
 			}
 		})

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -152,6 +152,12 @@ func TestReplicaClient_ConfigureEndpoint(t *testing.T) {
 			expectHTTPS:    true,
 		},
 		{
+			name:           "EndpointWithoutScheme",
+			endpoint:       "s3.us-west-002.backblazeb2.com",
+			forcePathStyle: false,
+			expectHTTPS:    true,
+		},
+		{
 			name:           "EmptyEndpoint",
 			endpoint:       "",
 			forcePathStyle: false,


### PR DESCRIPTION
## Summary

Fixes the issue where Backblaze and other S3-compatible endpoints fail with "Custom endpoint was not a valid URI" when the endpoint is provided without a protocol scheme.

## Problem

The AWS SDK v2 requires endpoints to be valid URIs with a scheme (http:// or https://), but users were providing endpoints like `s3.us-west-002.backblazeb2.com` without a protocol prefix. This caused endpoint validation errors in the SDK.

## Solution

Updated the `configureEndpoint` function to automatically prepend `https://` to endpoints that don't have a scheme. The fix:
- Checks if endpoint has a scheme before setting it
- Adds `https://` as the default if no scheme is present
- Continues to respect explicit `http://` prefixes for services like MinIO

## Changes

- `s3/replica_client.go`: Added scheme detection and default https prepending
- `s3/replica_client_test.go`: Added test case for endpoints without scheme (Backblaze scenario)

## Test Plan

- All existing S3 tests pass
- New test case validates endpoint without scheme gets https:// prepended
- Tested with Backblaze endpoint format from the issue

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)