### PR TITLE
Create parent directory on replica restore

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -7,11 +7,14 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"filippo.io/age"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // Default replica settings.
@@ -444,6 +447,15 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 
 	if len(rdrs) == 0 {
 		return fmt.Errorf("no matching backup files available")
+	}
+
+	// Create parent directory if it doesn't exist.
+	var dirInfo os.FileInfo
+	if db := r.DB(); db != nil {
+		dirInfo = db.dirInfo
+	}
+	if err := internal.MkdirAll(filepath.Dir(opt.OutputPath), dirInfo); err != nil {
+		return fmt.Errorf("create parent directory: %w", err)
 	}
 
 	// Output to temp file & atomically rename.

--- a/replica_test.go
+++ b/replica_test.go
@@ -217,14 +217,16 @@ func TestReplica_RestoreAndReplicateAfterDataLoss(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Restore again
+	// Restore to a path with non-existent parent directory to verify it gets created
+	restoredPath := dbDir + "/restored/db.sqlite"
+	restoreOpt.OutputPath = restoredPath
 	if err := db2.Replica.Restore(ctx, restoreOpt); err != nil {
 		t.Fatal(err)
 	}
-	t.Log("Step 4 complete: Second restore from backup")
+	t.Log("Step 4 complete: Second restore from backup to path with non-existent parent")
 
 	// Step 5: Verify the new data (value=2) exists in restored database
-	sqldb3 := testingutil.MustOpenSQLDB(t, dbPath)
+	sqldb3 := testingutil.MustOpenSQLDB(t, restoredPath)
 	defer sqldb3.Close()
 
 	var count int


### PR DESCRIPTION
## Description

Modifies litestream's restore command so that it creates the parent directory for the output file if the parent directory does not already exist.

## Motivation and Context

In litestream v0.3.x, the litestream restore command would create the necessary parent directory to receive the output database file if the directory did not exist. This behavior regressed in v0.5.0, so this change restores the v0.3.x functionality to ensure that an output directory exists when litestream attempts to restore from backup.

## How Has This Been Tested?

I updated `TestReplica_RestoreAndReplicateAfterDataLoss` to exercise this behavior, and I tested it one of my apps.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
