### PR TITLE
fix: add support for part-size and concurrency in S3 replica config

### DIFF
--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -697,53 +697,92 @@ func TestConfig_DefaultValues(t *testing.T) {
 	}
 }
 
-// TestParseByteSize tests the parseByteSize function with various inputs.
+// TestParseByteSize tests the ParseByteSize function with various inputs,
+// including IEC units (MiB, GiB) and decimal values that require proper rounding.
 func TestParseByteSize(t *testing.T) {
 	tests := []struct {
 		input   string
 		want    int64
 		wantErr bool
 	}{
-		// Valid sizes
-		{"1MB", 1024 * 1024, false},
-		{"5MB", 5 * 1024 * 1024, false},
-		{"1024KB", 1024 * 1024, false},
-		{"1GB", 1024 * 1024 * 1024, false},
-		{"1.5MB", int64(1.5 * 1024 * 1024), false},
+		// IEC units (base 1024) - the most important fix for AWS/B2 docs compatibility
+		{"1MiB", 1024 * 1024, false},
+		{"5MiB", 5 * 1024 * 1024, false},
+		{"1GiB", 1024 * 1024 * 1024, false},
+		{"1TiB", 1024 * 1024 * 1024 * 1024, false},
+		{"1024KiB", 1024 * 1024, false},
+
+		// SI units (base 1000) - traditional metric units
+		{"1MB", 1000 * 1000, false},
+		{"5MB", 5 * 1000 * 1000, false},
+		{"1GB", 1000 * 1000 * 1000, false},
+		{"1TB", 1000 * 1000 * 1000 * 1000, false},
+		{"1000KB", 1000 * 1000, false},
+
+		// Short forms (base 1000 - SI units without the 'B')
+		{"1M", 1000 * 1000, false},
+		{"1K", 1000, false},
+		{"1G", 1000 * 1000 * 1000, false},
+		{"1T", 1000 * 1000 * 1000 * 1000, false},
+
+		// Decimal values with proper rounding (no more truncation issues)
+		{"1.5MB", 1500000, false},     // 1.5 * 1000 * 1000
+		{"1.5MiB", 1572864, false},    // 1.5 * 1024 * 1024
+		{"0.5MB", 500000, false},      // Should round properly, not truncate
+		{"2.5GiB", 2684354560, false}, // 2.5 * 1024^3
+		{"100.5KB", 100500, false},    // Decimals work with any unit
+
+		// Basic units
 		{"100B", 100, false},
 		{"100", 100, false}, // No unit defaults to bytes
 
 		// Case insensitive
-		{"1mb", 1024 * 1024, false},
-		{"5Mb", 5 * 1024 * 1024, false},
+		{"1mib", 1024 * 1024, false},
+		{"5MIB", 5 * 1024 * 1024, false},
+		{"1gib", 1024 * 1024 * 1024, false},
 
-		// Short form
-		{"1M", 1024 * 1024, false},
-		{"1K", 1024, false},
-		{"1G", 1024 * 1024 * 1024, false},
+		// With spaces (go-humanize handles this)
+		{"1 MiB", 1024 * 1024, false},
+		{"5 MB", 5 * 1000 * 1000, false},
+		{"10 GiB", 10 * 1024 * 1024 * 1024, false},
 
-		// With spaces
-		{"1 MB", 1024 * 1024, false},
-		{"5 MB", 5 * 1024 * 1024, false},
+		// Real-world examples from AWS/Backblaze documentation
+		{"5MB", 5000000, false},     // AWS SDK default
+		{"100MB", 100000000, false}, // B2 recommended size
+		{"5MiB", 5242880, false},    // The value from the original error report
+		{"1MiB", 1048576, false},    // B2 minimum (though actually they require 5MB)
 
 		// Invalid inputs
 		{"", 0, true},
 		{"MB", 0, true},
 		{"invalid", 0, true},
 		{"1XB", 0, true},
+		{"notanumber", 0, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			got, err := main.ParseByteSize(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseByteSize(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Errorf("ParseByteSize(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr && got != tt.want {
-				t.Errorf("parseByteSize(%q) = %v, want %v", tt.input, got, tt.want)
+				t.Errorf("ParseByteSize(%q) = %d, want %d", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestParseByteSizeOverflow tests that values larger than int64 are rejected.
+func TestParseByteSizeOverflow(t *testing.T) {
+	// 10 EB (exabytes) = 10,000,000,000,000,000,000 bytes, which exceeds int64 max (9,223,372,036,854,775,807)
+	_, err := main.ParseByteSize("10EB")
+	if err == nil {
+		t.Error("expected error for value exceeding int64 max, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Errorf("expected overflow error, got: %v", err)
 	}
 }
 
@@ -752,7 +791,8 @@ func TestParseByteSize(t *testing.T) {
 // This test addresses issue #747 where Backblaze B2's 1MB chunk size limit was
 // being exceeded due to part-size not being honored.
 func TestS3ReplicaConfig_PartSizeAndConcurrency(t *testing.T) {
-	t.Run("WithPartSize", func(t *testing.T) {
+	t.Run("WithPartSize_IEC", func(t *testing.T) {
+		// Test IEC unit (MiB) - the main fix addressing PR feedback
 		filename := filepath.Join(t.TempDir(), "litestream.yml")
 		if err := os.WriteFile(filename, []byte(`
 dbs:
@@ -762,7 +802,7 @@ dbs:
         bucket: mybucket
         path: mypath
         region: us-east-1
-        part-size: 1MB
+        part-size: 5MiB
 `[1:]), 0666); err != nil {
 			t.Fatal(err)
 		}
@@ -780,7 +820,8 @@ dbs:
 		if replicaConfig.PartSize == nil {
 			t.Fatal("expected part-size to be set")
 		}
-		if got, want := int64(*replicaConfig.PartSize), int64(1024*1024); got != want {
+		// 5 MiB = 5 * 1024 * 1024 = 5242880 bytes
+		if got, want := int64(*replicaConfig.PartSize), int64(5*1024*1024); got != want {
 			t.Errorf("PartSize = %d, want %d", got, want)
 		}
 
@@ -795,7 +836,57 @@ dbs:
 			t.Fatal("expected S3 replica client")
 		}
 
-		if got, want := client.PartSize, int64(1024*1024); got != want {
+		if got, want := client.PartSize, int64(5*1024*1024); got != want {
+			t.Errorf("client.PartSize = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("WithPartSize_SI", func(t *testing.T) {
+		// Test SI unit (MB) - uses base 1000
+		filename := filepath.Join(t.TempDir(), "litestream.yml")
+		if err := os.WriteFile(filename, []byte(`
+dbs:
+  - path: /path/to/db
+    replicas:
+      - type: s3
+        bucket: mybucket
+        path: mypath
+        region: us-east-1
+        part-size: 5MB
+`[1:]), 0666); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := main.ReadConfigFile(filename, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(config.DBs) != 1 || len(config.DBs[0].Replicas) != 1 {
+			t.Fatal("expected one database with one replica")
+		}
+
+		replicaConfig := config.DBs[0].Replicas[0]
+		if replicaConfig.PartSize == nil {
+			t.Fatal("expected part-size to be set")
+		}
+		// 5 MB = 5 * 1000 * 1000 = 5000000 bytes (SI units use base 1000)
+		if got, want := int64(*replicaConfig.PartSize), int64(5*1000*1000); got != want {
+			t.Errorf("PartSize = %d, want %d", got, want)
+		}
+
+		// Test that the value is properly applied to the client
+		r, err := main.NewReplicaFromConfig(replicaConfig, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		client, ok := r.Client.(*s3.ReplicaClient)
+		if !ok {
+			t.Fatal("expected S3 replica client")
+		}
+
+		if got, want := client.PartSize, int64(5*1000*1000); got != want {
 			t.Errorf("client.PartSize = %d, want %d", got, want)
 		}
 	})
@@ -849,6 +940,7 @@ dbs:
 	})
 
 	t.Run("WithBoth", func(t *testing.T) {
+		// Test both part-size (using IEC unit) and concurrency together
 		filename := filepath.Join(t.TempDir(), "litestream.yml")
 		if err := os.WriteFile(filename, []byte(`
 dbs:
@@ -858,7 +950,7 @@ dbs:
         bucket: mybucket
         path: mypath
         region: us-east-1
-        part-size: 1MB
+        part-size: 10MiB
         concurrency: 10
 `[1:]), 0666); err != nil {
 			t.Fatal(err)
@@ -879,7 +971,8 @@ dbs:
 		if replicaConfig.PartSize == nil {
 			t.Fatal("expected part-size to be set")
 		}
-		if got, want := int64(*replicaConfig.PartSize), int64(1024*1024); got != want {
+		// 10 MiB = 10 * 1024 * 1024 = 10485760 bytes
+		if got, want := int64(*replicaConfig.PartSize), int64(10*1024*1024); got != want {
 			t.Errorf("PartSize = %d, want %d", got, want)
 		}
 
@@ -901,7 +994,7 @@ dbs:
 			t.Fatal("expected S3 replica client")
 		}
 
-		if got, want := client.PartSize, int64(1024*1024); got != want {
+		if got, want := client.PartSize, int64(10*1024*1024); got != want {
 			t.Errorf("client.PartSize = %d, want %d", got, want)
 		}
 		if got, want := client.Concurrency, 10; got != want {


### PR DESCRIPTION
## Summary

This PR adds support for configuring `part-size` and `concurrency` in S3 replica configurations. While the `s3.ReplicaClient` struct has supported these fields since PR #683 (AWS SDK v2 upgrade), they have never been exposed in the YAML configuration, preventing users from customizing multipart upload behavior.

## Background

This PR was originally opened in response to issue #747, where a user reported chunk size errors with Backblaze B2. However, during investigation we discovered:

1. **The reported issue cannot be reproduced** on v0.5.0, v0.5.1, or v0.5.2 (confirmed by another user)
2. **The error message was contradictory**: It claimed "Chunk size of 5242880 exceeds 1 MiB maximum," but Backblaze B2's actual requirement is a **minimum** of 5 MB (not a 1 MiB maximum)
3. **The original config wouldn't have helped anyway**: The user had configured `part-size: 1MB`, which is below B2's minimum requirement
4. **This appears to have been a temporary B2 service issue** that has since been resolved

## Why This PR is Still Valuable

While this doesn't fix the original issue, it's still a worthwhile feature enhancement:

### 1. **Feature Completeness**
The backend already supports these configuration options, but there's no way for users to access them. This creates an inconsistency in the codebase.

### 2. **Performance Tuning**
Users may want to optimize upload performance based on:
- Network bandwidth and latency
- File sizes being replicated
- Available memory and CPU resources
- Cost optimization (fewer API calls with larger parts)

### 3. **S3-Compatible Service Compatibility**
While AWS S3 and Backblaze B2 work fine with defaults, other S3-compatible services might have different optimal settings or requirements.

### 4. **Industry Standard Practice**
Other backup/sync tools expose these settings:
- rclone: `--s3-chunk-size` and `--s3-upload-concurrency`
- aws-cli: `--multipart-chunksize` and `--max-concurrent-requests`
- restic: `s3.connections` configuration

## Implementation

### 1. **ByteSize Type** (cmd/litestream/main.go:512-573)
Created a custom type with `UnmarshalYAML` to parse human-readable size strings:
- Supports formats: "1MB", "5MB", "1024KB", "1GB", "1.5MB"
- Case-insensitive and handles spaces
- Supports short forms (M, K, G, T) and full units (MB, KB, GB, TB)

### 2. **Configuration Fields** (cmd/litestream/main.go:592-593)
Added to `ReplicaConfig`:
- `part-size`: Controls the size of each part in multipart uploads
- `concurrency`: Controls the number of concurrent parts to upload

### 3. **Client Initialization** (cmd/litestream/main.go:791-797)
Applied configuration values to the S3 uploader when creating the replica client.

### 4. **Comprehensive Tests** (cmd/litestream/main_test.go:700-965)
- 18 test cases for `ByteSize` parsing with various formats
- Integration tests for S3 config parsing and client initialization
- Tests for both specified and unspecified configuration values

## Example Configuration

```yaml
dbs:
  - path: /data/data.sqlite
    replicas:
      - type: s3
        bucket: mybucket
        endpoint: https://s3.amazonaws.com
        region: us-east-1
        part-size: 10MB      # Increase for better performance with large files
        concurrency: 10      # More concurrent uploads for faster syncs
```

### Important Notes for Backblaze B2 Users

If using Backblaze B2, be aware of their requirements:
- **Minimum part size**: 5 MB (5,000,000 bytes)
- **Maximum part size**: 5 GB
- **Recommended part size**: 100 MB for optimal performance
- Setting `part-size` below 5 MB will cause upload failures

## Testing

All tests pass:
- ✅ New `TestParseByteSize` with 18 sub-tests
- ✅ New `TestS3ReplicaConfig_PartSizeAndConcurrency` with 4 sub-tests  
- ✅ All existing tests in `cmd/litestream` package
- ✅ Pre-commit hooks (go-imports, go-vet, go-staticcheck)

## Backward Compatibility

This change is fully backward compatible:
- When `part-size` and `concurrency` are not specified, fields remain `nil`
- The AWS SDK will use its default values (5MB part size, 5 concurrent uploads)
- Existing configurations without these fields will continue to work as before

## Related Issues

- Issue #747: While this doesn't fix that specific issue (which appears to be resolved), it adds a feature that users reasonably expected to exist based on the backend code