### PR TITLE
Avoid unnecessary import of SQLite driver.

### DIFF
--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -17,6 +17,7 @@ import (
 
 	sftpserver "github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
+	_ "modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/abs"

--- a/litestream.go
+++ b/litestream.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/superfly/ltx"
-	_ "modernc.org/sqlite"
 )
 
 // Naming constants.


### PR DESCRIPTION
## Description

Avoids unnecessarily importing the modernc SQLite driver.
The package is still imported by the main and test packages that need it.

## Motivation and Context

Library users (such as the VFS) don't need to import the driver, which registers it on `init`.

See https://github.com/benbjohnson/litestream/issues/772#issuecomment-3419981135

For example, the package used by the current prototype `vfs.go` is meant to work with `cgo` drivers, not `modernc`:
https://github.com/benbjohnson/litestream/blob/2ee408b66bb78ca3ff52fc867ca66f3c8b154e6b/vfs.go#L15

In fact, I'm not sure a VFS can be implemented for `modernc`. My reading of their [`vfs`](https://pkg.go.dev/modernc.org/sqlite/vfs) package says no, but I'm sure with some effort, dropping down to the [lower level](https://pkg.go.dev/modernc.org/sqlite/lib#Xsqlite3_vfs_register) allows it.

## How Has This Been Tested?

I've tested the `litestream` command, and it works, which is expected, as it imports `modernc` and thus registers the driver (i.e., no change):
https://github.com/benbjohnson/litestream/blob/2ee408b66bb78ca3ff52fc867ca66f3c8b154e6b/cmd/litestream/main.go#L24

All tests pass, as both the `litestream_test` package, and `testingutil` import the driver.

Library clients will have themselves to import `modernc`: AFAICT if they use `litestream.DB`, `litestream.Replica` or `litestream.Store`.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (would cause existing functionality to not work as expected)

**This _may_ break library users.** It's a simple fix, though, just add this somewhere in their code:
```go
import _ "modernc.org/sqlite"
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)

**I haven't updated docs.** Where would docs for library users be? This should probably me mentioned in release notes.