### PR TITLE
fix: add Content-MD5 header for S3 DeleteObjects to support OCI compatibility

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -489,8 +489,8 @@ func marshalDeleteObjects(deleteInput *types.Delete) ([]byte, error) {
 		return nil, nil
 	}
 
-	buf := bytes.NewBuffer(nil)
-	encoder := smithyxml.NewEncoder(buf)
+	var buf bytes.Buffer
+	encoder := smithyxml.NewEncoder(&buf)
 	root := smithyxml.StartElement{
 		Name: smithyxml.Name{
 			Local: "Delete",


### PR DESCRIPTION
## Summary

Fixes #802

Add smithy middleware to compute and inject `Content-MD5` header for S3 `DeleteObjects` operations, enabling compatibility with OCI Object Storage and other S3-compatible services that require this header for batch delete operations.

### Background / Root Cause

This issue is a regression introduced when migrating from AWS SDK v1 to v2:

- **v0.3.x and v0.4.x**: Used AWS SDK v1, which automatically added `Content-MD5` headers to all `DeleteObjects` requests. OCI Object Storage and other S3-compatible services worked correctly because the checksum was always present.

- **v0.5.x (PR #683, commit 347dabb)**: Migrated S3 replica to `aws-sdk-go-v2`. The v2 SDK's generated `DeleteObjects` middleware **no longer adds `Content-MD5` by default** unless the newer checksum pipeline (`RequestChecksumCalculation`) is explicitly enabled. We weren't opting into it.

- **Why it went unnoticed**: Native AWS S3 doesn't require `Content-MD5` for `DeleteObjects`, so the regression wasn't caught in testing. However, S3-compatible services like OCI Object Storage still enforce this requirement and return 400 errors without the header.

**In short**: OCI support never went away intentionally—we just lost the automatic checksum once the SDK changed how deletes are serialized.

### Problem

OCI Object Storage's S3-compatible API requires a `Content-MD5` header for `DeleteObjects` operations, returning a 400 error without it:

```
operation error S3: DeleteObjects, https response error StatusCode: 400, 
api error InvalidRequest: Missing required header for this request: Content-MD5
```

The AWS SDK v2 no longer includes `Content-MD5` by default, preferring newer checksum mechanisms. This breaks compatibility with S3-compatible services like OCI that still require the legacy header.

### Solution

This PR implements a three-phase middleware approach:

1. **Serialize Phase** - Precomputes the DeleteObjects XML payload using AWS SDK's smithy XML encoder to ensure byte-for-byte match with the actual request body, then caches the MD5 checksum in middleware stack context

2. **Build Phase** - Ensures "litestream" appears in the User-Agent header (prepends if needed, avoids duplicates)

3. **Finalize Phase** - Injects the `Content-MD5` header only if not already set by the SDK (non-invasive, future-proof)

### Implementation Details

- **XML Serialization**: Uses smithy's official `smithyxml.NewEncoder` and `smithytime.FormatHTTPDate` to mirror AWS SDK's serializer exactly
- **Deterministic Checksums**: Handles all ObjectIdentifier fields (ETag, Key, LastModifiedTime, Size, VersionId) with proper XML namespace
- **Non-Breaking**: Only affects DeleteObjects operations; other S3 operations unchanged
- **SDK Compatible**: Respects SDK-provided checksums; won't override if already present

### Code Quality

- ✅ Comprehensive test coverage with mocked HTTP transport
- ✅ Validates Content-MD5 matches actual request body MD5
- ✅ Tests User-Agent injection
- ✅ Tests middleware respects pre-existing Content-MD5 headers
- ✅ Documentation comments explain middleware flow and SDK compatibility
- ✅ All existing tests pass
- ✅ Pre-commit hooks pass (go-imports, go-vet, staticcheck)

### Testing

```bash
go test -v ./s3/... -run "TestReplicaClientDeleteLTXFiles"
=== RUN   TestReplicaClientDeleteLTXFiles_ContentMD5
--- PASS: TestReplicaClientDeleteLTXFiles_ContentMD5 (0.00s)
=== RUN   TestReplicaClientDeleteLTXFiles_PreexistingContentMD5
--- PASS: TestReplicaClientDeleteLTXFiles_PreexistingContentMD5 (0.00s)
PASS
```

### Impact

- Restores OCI Object Storage compatibility (broken in v0.5.0+)
- Fixes batch deletion failures during retention enforcement
- Maintains compatibility with AWS S3 and other S3-compatible services
- No breaking changes to existing functionality

---

**Note**: This PR is marked as draft for initial review. Ready for final review once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
