### PR TITLE
Don't sleep on context cancellation errors on shutdown

### DIFF
--- a/store.go
+++ b/store.go
@@ -162,21 +162,21 @@ LOOP:
 					slog.Debug("recently compacted, skipping", "level", lvl.Level, "path", db.Path())
 					continue
 				} else if err != nil {
-					// Don't log context cancellation errors during shutdown
+					// Don't log or sleep on context cancellation errors during shutdown
 					if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 						slog.Error("compaction failed", "level", lvl.Level, "error", err)
+						time.Sleep(1 * time.Second) // wait so we don't rack up S3 charges
 					}
-					time.Sleep(1 * time.Second) // wait so we don't rack up S3 charges
 				}
 
 				// Each time we snapshot, clean up everything before the oldest snapshot.
 				if lvl.Level == SnapshotLevel {
 					if err := s.EnforceSnapshotRetention(ctx, db); err != nil {
-						// Don't log context cancellation errors during shutdown
+						// Don't log or sleep on context cancellation errors during shutdown
 						if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 							slog.Error("retention enforcement failed", "error", err)
+							time.Sleep(1 * time.Second) // wait so we don't rack up S3 charges
 						}
-						time.Sleep(1 * time.Second) // wait so we don't rack up S3 charges
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Removes sleep from context cancellation errors during shutdown.

## Motivation and Context
Shutdown seems to take several seconds even when there's nothing to do.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ x ] Bug fix (non-breaking change which fixes an issue)

