### PR TITLE
feat(ci): add stale issue workflow to auto-manage inactive issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,48 @@
+name: Stale Issue Manager
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues: Label after 90 days, close after 30 more days
+          days-before-stale: 90
+          days-before-close: 30
+          stale-issue-label: 'stale'
+
+          # Exempt these labels from stale marking
+          exempt-issue-labels: 'Soon,release-blocker'
+
+          # Message posted when issue becomes stale
+          stale-issue-message: >
+            This issue has been inactive for 90 days and will be automatically
+            closed in 30 days if there is no further activity. If this issue is
+            still relevant, please add a comment to keep it open. Thank you for
+            your contribution!
+
+          # Message posted when issue is closed
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. If you
+            believe this issue is still relevant, please reopen it or create a
+            new issue with updated information. Thank you!
+
+          # Disable pull request processing
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # Limit operations per run
+          operations-per-run: 100
+
+          # Remove stale label when there is activity
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Summary

Implements automatic stale issue management using GitHub's official `actions/stale` action to help maintain and triage older issues.

## Changes

- Added `.github/workflows/stale-issues.yml` workflow
- Issues inactive for 90 days receive a `stale` label and warning comment
- Issues with stale label that remain inactive for 30 more days (120 days total) are automatically closed
- Exempt labels: `Soon` and `release-blocker` are protected from stale marking
- Pull requests are excluded from this workflow
- Any user activity on an issue removes the stale label and resets the timer

## Configuration Details

- **Stale period**: 90 days of inactivity
- **Close period**: 30 additional days after stale label
- **Scope**: Issues only (not PRs)
- **Schedule**: Runs daily at midnight UTC
- **Manual trigger**: Available via workflow_dispatch for testing

## Safety Features

- First run will label old issues but give them a full 30-day grace period before closing
- Any comment removes the stale label and resets the timer
- Operations limited to 100 per run to avoid API limits
- Friendly, encouraging messages explaining the process

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)