### PR TITLE
fix: busy timeout config

### DIFF
--- a/db.go
+++ b/db.go
@@ -376,8 +376,8 @@ func (db *DB) init(ctx context.Context) (err error) {
 	}
 	db.dirInfo = fi
 
-	dsn := db.path
-	dsn += fmt.Sprintf("?_busy_timeout=%d", db.BusyTimeout.Milliseconds())
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)",
+		db.path, db.BusyTimeout.Milliseconds())
 
 	if db.db, err = sql.Open("sqlite", dsn); err != nil {
 		return err


### PR DESCRIPTION
## Description

Fix how `PRAGMA busy_timeout` is being configured since switching from `mattn` to `modernc`.

## Motivation and Context

Busy timeout is still being configured like `mattn` not `modernc`.

Where `mattn` uses various [custom query parameters](https://github.com/mattn/go-sqlite3?tab=readme-ov-file#connection-string) (including `_busy_timeout`), `modernc` uses [`_pragma=name(value)` to configure all `PRAGMAS`](https://pkg.go.dev/modernc.org/sqlite#Driver.Open).

## How Has This Been Tested?

Ran `go test ./...`. Also attached a debugger and verified it reaches the correct place in the depths of `modernc`.

Could potentially add a `db.db.QueryRowContext(ctx, "PRAGMA busy_timeout;").Scan(&timeout)` to verify the change, if wanted.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
