### PR TITLE
docs: add GitHub issue template redirect for documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Community Support
     url: https://github.com/benbjohnson/litestream/discussions
     about: Please ask and answer questions here
+  - name: Documentation Issues
+    url: https://github.com/benbjohnson/litestream.io/issues/new/choose
+    about: Report documentation bugs or suggest improvements
   - name: Documentation
     url: https://litestream.io
     about: Check our documentation for setup and usage guides


### PR DESCRIPTION
## Summary
- Added a contact link in `.github/ISSUE_TEMPLATE/config.yml` to redirect users to the litestream.io repository for documentation-related issues
- This aligns with the new comprehensive documentation issue templates added in https://github.com/benbjohnson/litestream.io/pull/134

## Changes
- Updated `.github/ISSUE_TEMPLATE/config.yml` to include a "Documentation Issues" link that points to the litestream.io issue template chooser
- The link is positioned between "Community Support" and "Documentation" for logical flow

## Test Plan
- [x] Verify the updated config.yml is valid YAML
- [ ] Test the issue template chooser on GitHub to confirm the new link appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)