### PR TITLE
fix(ci): use jq for NATS CLI version extraction in GitHub Actions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -219,8 +219,14 @@ jobs:
 
       - name: Create NATS Object Store Bucket
         run: |
-          # Install NATS CLI - get latest version
-          NATS_VERSION=$(curl -s https://api.github.com/repos/nats-io/natscli/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+          # Install NATS CLI - get latest version using jq for JSON parsing
+          NATS_VERSION=$(curl -fsSL https://api.github.com/repos/nats-io/natscli/releases/latest \
+            | jq -r '.tag_name' \
+            | sed 's/^v//')
+          if [ -z "$NATS_VERSION" ] || [ "$NATS_VERSION" = "null" ]; then
+            echo "Failed to determine latest NATS CLI version"
+            exit 1
+          fi
           wget "https://github.com/nats-io/natscli/releases/download/v${NATS_VERSION}/nats-${NATS_VERSION}-linux-amd64.zip" -O nats.zip
           unzip nats.zip
           sudo mv "nats-${NATS_VERSION}-linux-amd64/nats" /usr/local/bin/


### PR DESCRIPTION
## Summary

Fixes the NATS integration test failure caused by fragile version extraction in the GitHub Actions workflow.

## Changes

- Replace `grep | sed` pattern with `jq` for parsing GitHub API JSON response
- Add `-fsSL` flags to `curl` for better error handling
- Add explicit error checking for empty/null version strings
- Provide clear error message on failure

## Why

The original version extraction command was returning empty strings, likely due to:
- GitHub API rate limiting
- Transient network issues
- Regex pattern edge cases

This resulted in malformed download URLs like:
```
https://github.com/nats-io/natscli/releases/download/v/nats--linux-amd64.zip
```

## Testing

- `jq` is pre-installed on GitHub Actions runners
- Error handling will fail fast with clear messaging
- More robust against API rate limits and network issues

Fixes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)