### PR TITLE
feat(s3): add automatic Tigris endpoint detection

### DIFF
--- a/etc/litestream.yml
+++ b/etc/litestream.yml
@@ -7,10 +7,8 @@
 #    replica:
 #      path: /path/to/replica             # File-based replication
 #      url:  s3://my.bucket.com/db        # S3-based replication
-#      # Example Fly.io Tigris setup (requires signed payloads & no Content-MD5 deletes)
+#      # Example Fly.io Tigris setup (signing/no-Content-MD5 are auto-enabled for this endpoint)
 #      # url: s3://my-tigris-bucket/db.sqlite?endpoint=fly.storage.tigris.dev&region=auto
-#      # sign-payload: true
-#      # require-content-md5: false
 #      type: nats                         # NATS JetStream replication
 #      url: nats://nats.example.com:4222
 #      bucket: litestream-backups


### PR DESCRIPTION
## Summary

This PR adds automatic detection and configuration for Tigris S3-compatible storage endpoints. When using Fly.io Tigris (`fly.storage.tigris.dev`), Litestream now automatically applies the required settings without manual configuration.

## Changes

- **Automatic endpoint detection**: Detects `fly.storage.tigris.dev` endpoints (with or without protocol prefix)
- **Auto-configuration**: Automatically sets required Tigris settings:
  - `SignPayload: true` (required by Tigris for authentication)
  - `RequireContentMD5: false` (Tigris doesn't support Content-MD5 headers on DELETE operations)
- **User override support**: Explicit configuration values take precedence over auto-detection
- **Simplified configuration**: Updated example config to reflect auto-configuration

## Implementation Details

Introduced a `boolSetting` type to track whether configuration values were explicitly set by the user. This allows the system to:
1. Apply defaults when values aren't explicitly set
2. Respect user overrides when they are explicitly configured
3. Auto-detect Tigris endpoints and apply appropriate defaults

## Test Coverage

Added test cases for:
- Auto-detection when using URL-based endpoint configuration
- Auto-detection when using config-based endpoint configuration  
- Manual override of auto-detected settings (ensures explicit config takes precedence)

## Test Plan

- [ ] Verify automatic Tigris configuration with URL-based setup
- [ ] Verify automatic Tigris configuration with config-based setup
- [ ] Verify manual overrides work correctly
- [ ] Run existing integration tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)