### PR TITLE
fix(release): rename VFS extension to litestream.so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,12 +125,6 @@ jobs:
           sha256sum litestream-vfs-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz \
             > litestream-vfs-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz.sha256
 
-      - name: Generate checksum
-        run: |
-          cd dist
-          sha256sum litestream-vfs-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz \
-            > litestream-vfs-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.tar.gz.sha256
-
       - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -187,12 +181,6 @@ jobs:
           cp litestream-vfs-darwin-${{ matrix.arch }}.dylib litestream.dylib
           tar -czvf litestream-vfs-${{ steps.version.outputs.version }}-darwin-${{ matrix.arch }}.tar.gz \
             litestream.dylib
-
-      - name: Generate checksum
-        run: |
-          cd dist
-          shasum -a 256 litestream-vfs-${{ steps.version.outputs.version }}-darwin-${{ matrix.arch }}.tar.gz \
-            > litestream-vfs-${{ steps.version.outputs.version }}-darwin-${{ matrix.arch }}.tar.gz.sha256
 
       - name: Generate checksum
         run: |


### PR DESCRIPTION
## Summary

Renames the VFS SQLite extension file inside tarballs from `litestream-vfs.so` to `litestream.so` (and `.dylib` on macOS) to match the VFS registration name "litestream".

This builds on PR #864 which first standardizes the filename to `litestream-vfs.so`.

## Changes

- Linux: `litestream-vfs.so` → `litestream.so`
- macOS: `litestream-vfs.dylib` → `litestream.dylib`

## Test plan

- [ ] Verify tarball contents after release workflow runs
- [ ] Verify extension loads correctly with `.load litestream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)