### PR TITLE
fix(deps): remove unused age encryption dependency

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"filippo.io/age"
 	"github.com/dustin/go-humanize"
 	"github.com/superfly/ltx"
 	"gopkg.in/yaml.v2"
@@ -1012,22 +1011,6 @@ func NewReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *litestream.Re
 	r := litestream.NewReplica(db)
 	if v := c.SyncInterval; v != nil {
 		r.SyncInterval = *v
-	}
-	for _, str := range c.Age.Identities {
-		identities, err := age.ParseIdentities(strings.NewReader(str))
-		if err != nil {
-			return nil, err
-		}
-
-		r.AgeIdentities = append(r.AgeIdentities, identities...)
-	}
-	for _, str := range c.Age.Recipients {
-		recipients, err := age.ParseRecipients(strings.NewReader(str))
-		if err != nil {
-			return nil, err
-		}
-
-		r.AgeRecipients = append(r.AgeRecipients, recipients...)
 	}
 
 	// Build and set client on replica.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -162,10 +162,6 @@ type Replica struct {
     SyncInterval time.Duration
     MonitorEnabled bool
 
-    // Encryption
-    AgeIdentities []age.Identity
-    AgeRecipients []age.Recipient
-
     // Lifecycle
     cancel func()
     wg     sync.WaitGroup
@@ -711,41 +707,6 @@ func (r *Replica) syncWithRetry(ctx context.Context) error {
    - Compaction runs independently per level
 
 ## Security Considerations
-
-### Encryption (Age)
-
-```go
-// Encryption during write
-func (r *Replica) encryptData(data []byte) ([]byte, error) {
-    if len(r.AgeRecipients) == 0 {
-        return data, nil // No encryption
-    }
-
-    var buf bytes.Buffer
-    w, err := age.Encrypt(&buf, r.AgeRecipients...)
-    if err != nil {
-        return nil, err
-    }
-
-    _, err = w.Write(data)
-    w.Close()
-    return buf.Bytes(), err
-}
-
-// Decryption during read
-func (r *Replica) decryptData(data []byte) ([]byte, error) {
-    if len(r.AgeIdentities) == 0 {
-        return data, nil // No decryption needed
-    }
-
-    rd, err := age.Decrypt(bytes.NewReader(data), r.AgeIdentities...)
-    if err != nil {
-        return nil, err
-    }
-
-    return io.ReadAll(rd)
-}
-```
 
 ### Access Control
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.25.4
 
 require (
 	cloud.google.com/go/storage v1.36.0
-	filippo.io/age v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
@@ -52,7 +51,10 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-require github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.3.0
+require (
+	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.3.0
+	github.com/markusmobius/go-dateparser v1.2.4
+)
 
 require (
 	cloud.google.com/go v0.111.0 // indirect
@@ -95,7 +97,6 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magefile/mage v1.14.0 // indirect
-	github.com/markusmobius/go-dateparser v1.2.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ cloud.google.com/go/pubsub v1.33.0 h1:6SPCPvWav64tj0sVX/+npCBKhUi/UjJehy9op/V3p2
 cloud.google.com/go/pubsub v1.33.0/go.mod h1:f+w71I33OMyxf9VpMVcZbnG5KSUkCOUHYpFd5U1GdRc=
 cloud.google.com/go/storage v1.36.0 h1:P0mOkAcaJxhCTvAkMhxMfrTKiNcub4YmmPBtlhAyTr8=
 cloud.google.com/go/storage v1.36.0/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
-filippo.io/age v1.1.1 h1:pIpO7l151hCnQ4BdyBujnGP2YlUo0uj6sAVNHGBvXHg=
-filippo.io/age v1.1.1/go.mod h1:l03SrzDUrBkdBx8+IILdnn2KZysqQdbEBUQ4p3sqEQE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2 h1:Hr5FTipp7SL07o2FvoVOX9HRiRH3CR3Mj8pxqCcdD5A=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2/go.mod h1:QyVsSSN64v5TGltphKLQ2sQxe4OBQg0J1eKRcVBnfgE=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0 h1:MhRfI58HblXzCtWEZCO0feHs8LweePB3s90r7WaR1KU=
@@ -272,6 +270,8 @@ github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4ql
 github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/wasilibs/go-re2 v1.3.0 h1:LFhBNzoStM3wMie6rN2slD1cuYH2CGiHpvNL3UtcsMw=
 github.com/wasilibs/go-re2 v1.3.0/go.mod h1:AafrCXVvGRJJOImMajgJ2M7rVmWyisVK7sFshbxnVrg=
+github.com/wasilibs/nottinygc v0.4.0 h1:h1TJMihMC4neN6Zq+WKpLxgd9xCFMw7O9ETLwY2exJQ=
+github.com/wasilibs/nottinygc v0.4.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/replica.go
+++ b/replica.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"filippo.io/age"
 	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -46,10 +45,6 @@ type Replica struct {
 	// If true, replica monitors database for changes automatically.
 	// Set to false if replica is being used synchronously (such as in tests).
 	MonitorEnabled bool
-
-	// Encryption identities and recipients
-	AgeIdentities []age.Identity
-	AgeRecipients []age.Recipient
 }
 
 func NewReplica(db *DB) *Replica {


### PR DESCRIPTION
## Summary

Removes the `filippo.io/age` dependency parsing code which was disabled in #790 but never fully removed from the codebase. Keeps the age config struct and validation so users still receive a clear error message if they try to use age encryption.

## Context

- Age encryption was disabled during the LTX storage layer refactor (#790)
- Config validation rejected any age encryption settings before the parsing code could execute
- The age parsing loops and Replica struct fields were unreachable dead code

## Changes

- Remove `filippo.io/age` dependency from `go.mod`
- Remove `AgeIdentities`/`AgeRecipients` fields from `Replica` struct
- Remove age parsing loops from `NewReplicaFromConfig` (the code that called `age.ParseIdentities` and `age.ParseRecipients`)
- Remove age encryption code examples from `docs/ARCHITECTURE.md`

**Kept intact:**
- `Age` config struct in `ReplicaSettings` (for YAML parsing)
- Age encryption validation check with error message
- Age defaults propagation in `SetDefaults`
- Tests for age encryption rejection

## Test plan

- [x] `go build ./cmd/litestream` - build succeeds
- [x] `go test ./...` - all tests pass
- [x] `go vet ./...` - no issues
- [x] `staticcheck ./...` - no issues
- [x] Verified `filippo.io/age` no longer in `go.mod` or `go.sum`
- [x] Verified age config validation still returns error for users

## Follow-up

After this PR is merged, PR #860 (security/deps update) should be rebased - the age update will no longer be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)