### PR TITLE
fix(ci): update macOS runners and VFS verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: macos-13
+            runner: macos-15
           - arch: arm64
-            runner: macos-14
+            runner: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -172,8 +172,10 @@ jobs:
       - name: Verify artifact
         run: |
           file dist/litestream-vfs-darwin-${{ matrix.arch }}.dylib
-          # Verify the extension can be loaded by SQLite
-          sqlite3 ':memory:' ".load dist/litestream-vfs-darwin-${{ matrix.arch }}.dylib" ".exit" && echo "Extension loads successfully"
+          # Verify architecture matches target
+          lipo -info dist/litestream-vfs-darwin-${{ matrix.arch }}.dylib
+          # Verify the expected symbol exists (macOS sqlite3 doesn't support .load)
+          nm -gU dist/litestream-vfs-darwin-${{ matrix.arch }}.dylib | grep sqlite3_litestreamvfs_init && echo "Entry point symbol found"
 
       - name: Create archive
         run: |


### PR DESCRIPTION
## Summary

- Update macOS runners from macos-13/14 to macos-15 (macos-13 is retired)
- Replace sqlite3 `.load` verification with `lipo`/`nm` checks

## Problem

The v0.5.3-beta1 test release failed with two issues:

1. **macOS-13 runner retired**: GitHub has deprecated macos-13 runners
2. **VFS verification fails**: macOS system sqlite3 doesn't support `.load` command (compiled with `SQLITE_OMIT_LOAD_EXTENSION`)

## Solution

1. Update both macOS builds to use `macos-15` runner
2. Replace the sqlite3 load test with architecture and symbol verification:
   - `lipo -info` to verify correct architecture
   - `nm -gU | grep sqlite3_litestreamvfs_init` to verify entry point exists

This matches the approach used for Linux arm64 builds (which only verify ELF headers since they're cross-compiled).

## Test plan

- [x] Verified new verification commands work locally
- [ ] Merge PR and create v0.5.3-beta2 tag to test full release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)