### PR TITLE
fix(ci): update Linux VFS runner from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
 
   vfs-build-linux:
     name: Build VFS (Linux ${{ matrix.arch }})
-    runs-on: ubuntu-20.04  # Use older Ubuntu for broader glibc compatibility (2.31)
+    runs-on: ubuntu-22.04  # glibc 2.35 (ubuntu-20.04 runners deprecated)
     needs: goreleaser
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Update Linux VFS build runner from `ubuntu-20.04` to `ubuntu-22.04`.

## Problem

The v0.5.3-beta2 release has Linux VFS jobs stuck in queue for 30+ minutes because **ubuntu-20.04 runners have been deprecated by GitHub** and are no longer available.

See: [GitHub Community Discussion](https://github.com/orgs/community/discussions/147604)

## Solution

Update to `ubuntu-22.04` which has glibc 2.35 (vs 2.31 on ubuntu-20.04).

## Tradeoff

Slightly reduced backwards compatibility with very old Linux distributions that only have glibc < 2.35. However, this is necessary since ubuntu-20.04 runners no longer exist.

## Test plan

- [ ] Merge and create v0.5.3-beta3 to verify Linux VFS builds complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)