### PR TITLE
fix(wal): filter stale pages when database shrinks

### DIFF
--- a/wal_reader.go
+++ b/wal_reader.go
@@ -215,6 +215,14 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 		}
 	}
 
+	// Remove pages that exceed the final commit size. This can occur when the
+	// database shrinks (e.g., via VACUUM) between transactions in the WAL.
+	for pgno := range m {
+		if pgno > commit {
+			delete(m, pgno)
+		}
+	}
+
 	// If full transactions available, return the original offset.
 	if len(m) == 0 {
 		return m, 0, 0, nil


### PR DESCRIPTION
## Summary

- Fixes page number out-of-bounds error when database shrinks via VACUUM, DELETE with auto-vacuum, or truncation
- Adds filtering in `PageMap()` to remove stale page references that exceed the final commit size
- Adds test `TestDB_SyncAfterVacuum` to verify the fix

## Root Cause

In `wal_reader.go:PageMap()`, page references were accumulated across all committed transactions in the WAL. When a database shrunk (e.g., via VACUUM), pages from earlier transactions that exceeded the new commit size remained in the page map, causing the LTX encoder to fail with:

```
error="sync: write ltx from wal: encode ltx frame (pgno=21471): page number 21471 out-of-bounds for commit size 21470"
```

## Fix

Added filtering after reading all WAL frames to remove pages that exceed the final commit size:

```go
// Remove pages that exceed the final commit size. This can occur when the
// database shrinks (e.g., via VACUUM) between transactions in the WAL.
for pgno := range m {
    if pgno > commit {
        delete(m, pgno)
    }
}
```

## Test plan

- [x] Reproduced issue on main branch with 22,053-page database shrunk via VACUUM
- [x] Verified fix resolves the error
- [x] Added `TestDB_SyncAfterVacuum` test
- [x] All existing tests pass
- [x] Pre-commit hooks pass

Fixes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)