### PR TITLE
test(replica_url): add comprehensive tests for URL parsing

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -68,17 +68,15 @@ func NewReplicaClient() *ReplicaClient {
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
 // URL format: abs://[account-name@]container/path
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	client := NewReplicaClient()
 
-	// Parse account name from userinfo if present (abs://account@container/path)
-	if idx := strings.Index(host, "@"); idx != -1 {
-		client.AccountName = host[:idx]
-		client.Bucket = host[idx+1:]
-	} else {
-		client.Bucket = host
+	// Extract account name from userinfo if present (abs://account@container/path)
+	if userinfo != nil {
+		client.AccountName = userinfo.Username()
 	}
 
+	client.Bucket = host
 	client.Path = urlPath
 
 	if client.Bucket == "" {

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1125,7 +1125,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 	}
 
 	if c.URL != "" {
-		_, host, upath, query, err := litestream.ParseReplicaURLWithQuery(c.URL)
+		_, host, upath, query, _, err := litestream.ParseReplicaURLWithQuery(c.URL)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -1498,7 +1498,7 @@ func TestFindSQLiteDatabases(t *testing.T) {
 func TestParseReplicaURLWithQuery(t *testing.T) {
 	t.Run("S3WithEndpoint", func(t *testing.T) {
 		url := "s3://mybucket/path/to/db?endpoint=localhost:9000&region=us-east-1&forcePathStyle=true"
-		scheme, host, path, query, err := litestream.ParseReplicaURLWithQuery(url)
+		scheme, host, path, query, _, err := litestream.ParseReplicaURLWithQuery(url)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1524,7 +1524,7 @@ func TestParseReplicaURLWithQuery(t *testing.T) {
 
 	t.Run("S3WithoutQuery", func(t *testing.T) {
 		url := "s3://mybucket/path/to/db"
-		scheme, host, path, query, err := litestream.ParseReplicaURLWithQuery(url)
+		scheme, host, path, query, _, err := litestream.ParseReplicaURLWithQuery(url)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1544,7 +1544,7 @@ func TestParseReplicaURLWithQuery(t *testing.T) {
 
 	t.Run("FileURL", func(t *testing.T) {
 		url := "file:///path/to/db"
-		scheme, host, path, query, err := litestream.ParseReplicaURLWithQuery(url)
+		scheme, host, path, query, _, err := litestream.ParseReplicaURLWithQuery(url)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1582,7 +1582,7 @@ func TestParseReplicaURLWithQuery(t *testing.T) {
 
 	t.Run("S3TigrisExample", func(t *testing.T) {
 		url := "s3://mybucket/db?endpoint=fly.storage.tigris.dev&region=auto"
-		scheme, host, path, query, err := litestream.ParseReplicaURLWithQuery(url)
+		scheme, host, path, query, _, err := litestream.ParseReplicaURLWithQuery(url)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1605,7 +1605,7 @@ func TestParseReplicaURLWithQuery(t *testing.T) {
 
 	t.Run("S3WithSkipVerify", func(t *testing.T) {
 		url := "s3://mybucket/db?endpoint=self-signed.local&skipVerify=true"
-		_, _, _, query, err := litestream.ParseReplicaURLWithQuery(url)
+		_, _, _, query, _, err := litestream.ParseReplicaURLWithQuery(url)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -44,7 +44,7 @@ func NewReplicaClient(path string) *ReplicaClient {
 
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	// For file URLs, the path is the full path
 	if urlPath == "" {
 		return nil, fmt.Errorf("file replica path required")

--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -54,7 +54,7 @@ func NewReplicaClient() *ReplicaClient {
 
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	if host == "" {
 		return nil, fmt.Errorf("bucket required for gs replica URL")
 	}

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -91,13 +91,19 @@ func NewReplicaClient() *ReplicaClient {
 
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
-// URL format: nats://host[:port]/bucket
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+// URL format: nats://[user:pass@]host[:port]/bucket
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	client := NewReplicaClient()
 
 	// Reconstruct URL without bucket path
 	if host != "" {
 		client.URL = fmt.Sprintf("nats://%s", host)
+	}
+
+	// Extract credentials from userinfo if present
+	if userinfo != nil {
+		client.Username = userinfo.Username()
+		client.Password, _ = userinfo.Password()
 	}
 
 	// Extract bucket name from path

--- a/oss/replica_client.go
+++ b/oss/replica_client.go
@@ -74,7 +74,7 @@ func NewReplicaClient() *ReplicaClient {
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
 // URL format: oss://bucket[.oss-region.aliyuncs.com]/path
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	client := NewReplicaClient()
 
 	bucket, region, _ := ParseHost(host)

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -96,7 +96,7 @@ func NewReplicaClient() *ReplicaClient {
 
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	client := NewReplicaClient()
 
 	var (

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -70,20 +69,13 @@ func NewReplicaClient() *ReplicaClient {
 // NewReplicaClientFromURL creates a new ReplicaClient from URL components.
 // This is used by the replica client factory registration.
 // URL format: sftp://[user[:password]@]host[:port]/path
-func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values) (litestream.ReplicaClient, error) {
+func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, userinfo *url.Userinfo) (litestream.ReplicaClient, error) {
 	client := NewReplicaClient()
 
-	// Parse userinfo from host if present
-	if idx := strings.Index(host, "@"); idx != -1 {
-		userinfo := host[:idx]
-		host = host[idx+1:]
-
-		if colonIdx := strings.Index(userinfo, ":"); colonIdx != -1 {
-			client.User = userinfo[:colonIdx]
-			client.Password = userinfo[colonIdx+1:]
-		} else {
-			client.User = userinfo
-		}
+	// Extract credentials from userinfo
+	if userinfo != nil {
+		client.User = userinfo.Username()
+		client.Password, _ = userinfo.Password()
 	}
 
 	client.Host = host


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for PR #884's replica URL parsing refactor, and **fixes a credential handling regression**.

### Fix: Preserve URL Credentials in Factory Pattern

The original PR #884 introduced a regression where URL credentials (user:pass@host) were being stripped by Go's `url.Parse()` before reaching the factory functions. This broke authenticated URLs like:

- `sftp://user:pass@host/path`
- `webdav://user:pass@host/path`
- `abs://account@container/path`
- `nats://user:pass@host/bucket`

**This PR fixes the issue by:**

1. Adding `userinfo *url.Userinfo` parameter to `ReplicaClientFactory` type
2. Updating `ParseReplicaURLWithQuery` to return userinfo
3. Updating all backend factories to extract credentials from userinfo

### Test Coverage Added

- **Backend factory tests**: ABS, GS, NATS, OSS, SFTP, WebDAV, WebDAVS
- **Credential tests**: SFTP with user/password, WebDAV/WebDAVS with credentials, NATS with credentials, ABS with account
- **Error case tests**: Missing bucket/host/user validation for all backends
- **Helper function tests**: `IsTigrisEndpoint`, `RegionFromS3ARN`, `CleanReplicaURLPath`
- **Edge cases**: S3 ARN URLs, empty file paths, nil query values

### Files Changed

| File | Change |
|------|--------|
| `replica_url.go` | Added userinfo to factory signature and return value |
| `abs/replica_client.go` | Extract AccountName from userinfo |
| `sftp/replica_client.go` | Extract User and Password from userinfo |
| `webdav/replica_client.go` | Extract Username and Password from userinfo |
| `nats/replica_client.go` | Extract Username and Password from userinfo |
| `s3/replica_client.go` | Updated signature (no credentials used) |
| `gs/replica_client.go` | Updated signature (no credentials used) |
| `oss/replica_client.go` | Updated signature (no credentials used) |
| `file/replica_client.go` | Updated signature (no credentials used) |
| `replica_url_test.go` | Comprehensive tests including credential validation |

## Test Plan

- [x] All credential tests pass (SFTP, WebDAV, NATS, ABS)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./cmd/litestream`)
- [x] Pre-commit hooks pass (goimports, go-vet, staticcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Plumbs URL userinfo through parsing and factory APIs to preserve credentials, updates backends to extract them, and adds extensive tests across schemes and helpers.
> 
> - **Core URL/API**:
>   - Add `userinfo *url.Userinfo` to `ReplicaClientFactory` and thread through `NewReplicaClientFromURL` and `ParseReplicaURLWithQuery` (now returns `userinfo`).
>   - Update `ParseReplicaURL` to use new signature.
> - **Backends**:
>   - `sftp`, `webdav`, `nats`, `abs`: extract credentials/account from `userinfo`; validate required parts; update factory signatures.
>   - `s3`, `gs`, `oss`, `file`: update factory signatures; `s3` respects query params (endpoint/region/flags) unchanged.
> - **CLI/Config**:
>   - Adjust calls to `ParseReplicaURLWithQuery` for extra return value in `cmd/litestream`.
> - **Tests**:
>   - Add comprehensive factory tests for `s3`, `gs`, `abs`, `sftp`, `webdav(s)`, `nats`, `oss`, `file` including credential and error cases.
>   - Add helper tests for `IsTigrisEndpoint`, `RegionFromS3ARN`, `CleanReplicaURLPath`, and improved `BoolQueryValue` cases.
>   - Update existing tests to new `ParseReplicaURLWithQuery` signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d38cf9d30498ffceb4375cb122414f4262b64c13. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->