### PR TITLE
fix(s3): disable aws-chunked encoding when using unsigned payloads

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -552,6 +552,13 @@ func (c *ReplicaClient) middlewareOption() func(*middleware.Stack) error {
 			if err := v4.AddContentSHA256HeaderMiddleware(stack); err != nil {
 				return err
 			}
+
+			// Disable AWS SDK v2's trailing checksum middleware which uses
+			// aws-chunked encoding that is incompatible with UNSIGNED-PAYLOAD.
+			// AWS S3 rejects requests with: "aws-chunked encoding is not supported
+			// when x-amz-content-sha256 UNSIGNED-PAYLOAD is supplied."
+			// See: https://github.com/aws/aws-sdk-go-v2/discussions/2960
+			stack.Finalize.Remove("addInputChecksumTrailer")
 		}
 
 		if !c.RequireContentMD5 {


### PR DESCRIPTION
## Summary

- Fixes #889: S3 uploads failing with "aws-chunked encoding is not supported when x-amz-content-sha256 UNSIGNED-PAYLOAD is supplied"
- AWS SDK v2 (v1.73.0+) introduced automatic checksum calculation that uses aws-chunked trailing checksums, which conflicts with unsigned payloads
- Removes only the `addInputChecksumTrailer` middleware when `SignPayload=false` to prevent aws-chunked encoding while preserving S3 Access Point support
- Adds test to verify aws-chunked encoding is not used with unsigned payloads

## Root Cause

The AWS SDK for Go v2 ([v1.73.0](https://github.com/aws/aws-sdk-go-v2/discussions/2960), released Jan 2025) introduced automatic CRC32 checksum calculation for S3 uploads. The `addInputChecksumTrailer` middleware uses `aws-chunked` content encoding to add trailing checksums, which AWS S3 rejects when combined with `UNSIGNED-PAYLOAD` signature.

The combination of:
- `x-amz-content-sha256: UNSIGNED-PAYLOAD` (from `SignPayload=false` default)
- `Content-Encoding: aws-chunked` (from SDK trailing checksum middleware)

...triggers the error: `aws-chunked encoding is not supported when x-amz-content-sha256 UNSIGNED-PAYLOAD is supplied`

## Solution

When `SignPayload=false`, remove only the trailing checksum middleware from the request stack:
- `addInputChecksumTrailer` (Finalize stack) - This is what adds aws-chunked encoding

We preserve:
- `SetupInputContext` - Required for S3 Access Point ARN resolution
- `ComputeInputPayloadChecksum` - Required for S3 Access Point functionality

This prevents aws-chunked encoding while still computing checksums as headers (not trailers).

## Test plan

- [x] Added `TestReplicaClient_UnsignedPayload_NoChunkedEncoding` to verify no aws-chunked encoding with unsigned payloads
- [x] All existing S3 tests pass
- [x] S3 Access Point integration test passes
- [x] All litestream tests pass
- [x] Pre-commit hooks pass (goimports, go-vet, staticcheck)
- [ ] Manual testing with AWS S3 (if available)
- [ ] Manual testing with Cloudflare R2 (if available)

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)