### PR TITLE
fix(deps): downgrade Go version from 1.25 to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /src/litestream
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/benbjohnson/litestream
 
-go 1.25
+go 1.24.1
 
-toolchain go1.25.4
+toolchain go1.24.11
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Summary

- Downgrades Go version requirement from 1.25 to 1.24
- Updates Dockerfile to use golang:1.24

## Motivation

The Go 1.25 requirement was incidentally introduced in commit e4e82ee alongside an unrelated typo fix. No Go 1.25-specific features are used in the codebase.

This downgrade makes Litestream more usable as a library by not requiring the latest Go version.

Resolves request in #801 (comment): https://github.com/benbjohnson/litestream/pull/801#issuecomment-3646165122

## Related

- Created issue to update docs: https://github.com/benbjohnson/litestream.io/issues/190

## Test plan

- [x] `go build ./cmd/litestream` succeeds
- [x] `go vet ./...` passes
- [x] `go test -short ./...` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)