### PR TITLE
fix(s3): auto-detect S3-compatible providers and default to signed payloads

### DIFF
--- a/replica_url.go
+++ b/replica_url.go
@@ -201,6 +201,81 @@ func IsTigrisEndpoint(endpoint string) bool {
 	return endpoint == "fly.storage.tigris.dev"
 }
 
+// IsDigitalOceanEndpoint returns true if the endpoint is Digital Ocean Spaces.
+func IsDigitalOceanEndpoint(endpoint string) bool {
+	host := extractEndpointHost(endpoint)
+	if host == "" {
+		return false
+	}
+	return strings.HasSuffix(host, ".digitaloceanspaces.com")
+}
+
+// IsBackblazeEndpoint returns true if the endpoint is Backblaze B2.
+func IsBackblazeEndpoint(endpoint string) bool {
+	host := extractEndpointHost(endpoint)
+	if host == "" {
+		return false
+	}
+	return strings.HasSuffix(host, ".backblazeb2.com")
+}
+
+// IsFilebaseEndpoint returns true if the endpoint is Filebase.
+func IsFilebaseEndpoint(endpoint string) bool {
+	host := extractEndpointHost(endpoint)
+	if host == "" {
+		return false
+	}
+	return host == "s3.filebase.com"
+}
+
+// IsScalewayEndpoint returns true if the endpoint is Scaleway Object Storage.
+func IsScalewayEndpoint(endpoint string) bool {
+	host := extractEndpointHost(endpoint)
+	if host == "" {
+		return false
+	}
+	return strings.HasSuffix(host, ".scw.cloud")
+}
+
+// IsMinIOEndpoint returns true if the endpoint appears to be MinIO or similar
+// (a custom endpoint with a port number that is not a known cloud provider).
+func IsMinIOEndpoint(endpoint string) bool {
+	host := extractEndpointHost(endpoint)
+	if host == "" {
+		return false
+	}
+	// MinIO typically uses host:port format without .com domain
+	// Check for port number in the host
+	if !strings.Contains(host, ":") {
+		return false
+	}
+	// Exclude known cloud providers
+	if strings.Contains(host, ".amazonaws.com") ||
+		strings.Contains(host, ".digitaloceanspaces.com") ||
+		strings.Contains(host, ".backblazeb2.com") ||
+		strings.Contains(host, ".filebase.com") ||
+		strings.Contains(host, ".scw.cloud") ||
+		strings.Contains(host, "tigris.dev") {
+		return false
+	}
+	return true
+}
+
+// extractEndpointHost extracts the host from an endpoint URL or returns the
+// endpoint as-is if it's not a full URL.
+func extractEndpointHost(endpoint string) string {
+	endpoint = strings.TrimSpace(strings.ToLower(endpoint))
+	if endpoint == "" {
+		return ""
+	}
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		if u, err := url.Parse(endpoint); err == nil && u.Host != "" {
+			return u.Host
+		}
+	}
+	return endpoint
+}
+
 // IsURL returns true if s appears to be a URL (has a scheme).
 var isURLRegex = regexp.MustCompile(`^\w+:\/\/`)
 


### PR DESCRIPTION
## Summary

- Fixes #894: S3-compatible providers (Digital Ocean Spaces, Backblaze B2, MinIO, Filebase, Scaleway) returning SignatureDoesNotMatch errors after v0.5.3 upgrade
- Auto-detects known S3-compatible provider endpoints and defaults to signed payloads (`sign-payload: true`)
- Explicit `sign-payload` configuration still overrides auto-detection
- Adds comprehensive tests for endpoint detection and SignPayload defaults

## Root Cause

v0.5.3 introduced `SignPayload=false` as the default, which adds `x-amz-content-sha256: UNSIGNED-PAYLOAD` header to requests. Many S3-compatible providers don't properly support this header format and require signed payloads with actual SHA256 hashes.

## Solution

Auto-detect S3-compatible providers by their endpoint URLs and default to signed payloads:

| Provider | Endpoint Pattern | Default SignPayload |
|----------|------------------|---------------------|
| Digital Ocean Spaces | `*.digitaloceanspaces.com` | `true` |
| Backblaze B2 | `s3.*.backblazeb2.com` | `true` |
| Filebase | `s3.filebase.com` | `true` |
| Scaleway | `s3.*.scw.cloud` | `true` |
| MinIO | `host:port` (custom endpoints) | `true` |
| Tigris | `fly.storage.tigris.dev` | `true` (existing) |
| AWS S3 | `*.amazonaws.com` | `false` (default) |

## Test plan

- [x] Unit tests for endpoint detection functions (`TestIsDigitalOceanEndpoint`, `TestIsBackblazeEndpoint`, etc.)
- [x] Unit tests verifying SignPayload defaults for each provider
- [x] Test that explicit `sign-payload=false` overrides provider defaults
- [x] All existing tests pass
- [x] Pre-commit hooks pass (goimports, go-vet, staticcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)