### PR TITLE
fix(db): handle WAL offset at header boundary in verify

### DIFF
--- a/db.go
+++ b/db.go
@@ -885,6 +885,21 @@ func (db *DB) verify(ctx context.Context) (info syncInfo, err error) {
 	salt2 := binary.BigEndian.Uint32(hdr0[20:])
 	saltMatch := salt1 == dec.Header().WALSalt1 && salt2 == dec.Header().WALSalt2
 
+	// Handle edge case where we're at WAL header (WALOffset=32, WALSize=0).
+	// This can happen when an LTX file represents a state at the beginning of the WAL
+	// with no frames written yet. We must check this before computing prevWALOffset
+	// to avoid underflow (32 - 4120 = -4088).
+	// See: https://github.com/benbjohnson/litestream/issues/900
+	if info.offset == WALHeaderSize {
+		slog.Debug("verify", "saltMatch", saltMatch, "atWALHeader", true)
+		if saltMatch {
+			info.snapshotting = false
+			return info, nil
+		}
+		info.reason = "wal header salt reset, snapshotting"
+		return info, nil
+	}
+
 	// If offset is at the beginning of the first page, we can't check for previous page.
 	prevWALOffset := info.offset - frameSize
 	slog.Debug("verify", "saltMatch", saltMatch, "prevWALOffset", prevWALOffset)


### PR DESCRIPTION
## Summary

Fixes #900 - `prev WAL offset is less than the header size: -4088`

When an LTX file has `WALOffset=32` (WALHeaderSize) and `WALSize=0`, the verify function calculated `prevWALOffset = 32 - 4120 = -4088`, which triggered the error.

### Root Cause

The code calculated `prevWALOffset = info.offset - frameSize` before checking if `info.offset` was already at the WAL header boundary. When `info.offset == WALHeaderSize`, there's no previous frame to reference.

### Fix

Add an early check for `info.offset == WALHeaderSize` before computing `prevWALOffset`, handling the edge case where an LTX file represents a state at the beginning of the WAL with no frames written.

## Test plan

- [x] Added regression test `TestDB_Verify_WALOffsetAtHeader` that reproduces the bug
- [x] All existing tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)