### PR TITLE
feat(s3): add X-Tigris-Consistent header for Tigris endpoints

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1307,6 +1307,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 
 	client.SignPayload = signSetting.value
 	client.RequireContentMD5 = requireSetting.value
+	client.IsTigris = isTigris
 
 	// Apply upload configuration if specified.
 	if c.PartSize != nil {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -1006,3 +1006,68 @@ func TestParseHost(t *testing.T) {
 		})
 	}
 }
+
+func TestReplicaClient_TigrisConsistentHeader(t *testing.T) {
+	data := mustLTX(t)
+
+	tests := []struct {
+		name       string
+		isTigris   bool
+		wantHeader string
+	}{
+		{name: "TigrisEnabled", isTigris: true, wantHeader: "true"},
+		{name: "TigrisDisabled", isTigris: false, wantHeader: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := make(chan http.Header, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+				_, _ = io.Copy(io.Discard, r.Body)
+
+				if r.Method == http.MethodPut {
+					select {
+					case headers <- r.Header.Clone():
+					default:
+					}
+					w.Header().Set("ETag", `"test-etag"`)
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client := NewReplicaClient()
+			client.Bucket = "test-bucket"
+			client.Path = "replica"
+			client.Region = "us-east-1"
+			client.Endpoint = server.URL
+			client.ForcePathStyle = true
+			client.AccessKeyID = "test-access-key"
+			client.SecretAccessKey = "test-secret-key"
+			client.IsTigris = tt.isTigris
+
+			ctx := context.Background()
+			if err := client.Init(ctx); err != nil {
+				t.Fatalf("Init() error: %v", err)
+			}
+
+			if _, err := client.WriteLTXFile(ctx, 0, 2, 2, bytes.NewReader(data)); err != nil {
+				t.Fatalf("WriteLTXFile() error: %v", err)
+			}
+
+			select {
+			case hdr := <-headers:
+				got := hdr.Get("X-Tigris-Consistent")
+				if got != tt.wantHeader {
+					t.Fatalf("X-Tigris-Consistent header = %q, want %q", got, tt.wantHeader)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for PUT request")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `IsTigris` field to `ReplicaClient` struct to track Tigris endpoint detection
- Set `X-Tigris-Consistent: true` header on all S3 requests when using Tigris endpoints
- Enable strong read-after-write consistency for Tigris object storage

## Background

Tigris is an S3-compatible object storage service that offers strong consistency when the `X-Tigris-Consistent: true` header is included in requests. Without this header, Tigris may return eventually consistent results, which could cause issues during replication and restore operations.

## Implementation

The implementation follows the existing pattern used for the User-Agent middleware:
1. Added `IsTigris bool` field to `ReplicaClient` struct
2. Set `IsTigris = true` in both `NewReplicaClientFromURL()` and `NewS3ReplicaClientFromConfig()` when Tigris endpoint is detected
3. Added middleware in `middlewareOption()` to set the `X-Tigris-Consistent: true` header on all requests when `IsTigris` is true

## Test plan

- [x] Added unit test `TestReplicaClient_TigrisConsistentHeader` that verifies:
  - Header is set to "true" when `IsTigris` is enabled
  - Header is not set when `IsTigris` is disabled
- [x] All existing tests pass
- [x] Pre-commit hooks pass (go-vet, staticcheck, goimports)

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)