### PR TITLE
fix(s3): disable aws-chunked encoding for Tigris endpoints

### DIFF
--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -277,6 +277,7 @@ func NewTigrisReplicaClient(tb testing.TB) *s3.ReplicaClient {
 	c.ForcePathStyle = true
 	c.SignPayload = true
 	c.RequireContentMD5 = false
+	c.IsTigris = true
 	return c
 }
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -318,6 +318,14 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		},
 	}
 
+	// Tigris doesn't support aws-chunked content encoding used by default
+	// checksum calculation in AWS SDK Go v2 v1.73.0+. Disable it for Tigris.
+	if c.IsTigris {
+		s3Opts = append(s3Opts, func(o *s3.Options) {
+			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		})
+	}
+
 	// Add custom endpoint if specified
 	c.configureEndpoint(&s3Opts)
 


### PR DESCRIPTION
## Summary

- Fixes `InvalidContentEncoding` error when uploading LTX files to Tigris
- AWS SDK Go v2 v1.73.0+ defaults to checksum calculation which uses `aws-chunked` content encoding
- Tigris doesn't support this encoding and rejects requests
- Disables default checksum calculation for Tigris by setting `RequestChecksumCalculation` to `WhenRequired`

## Test plan

- [x] Verify existing Tigris tests pass
- [x] Test replication to Tigris endpoint to confirm uploads succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)