### PR TITLE
fix(claude): move personal hooks to local settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,70 +1,6 @@
 {
-  "project_name": "Planning Center Sync",
-  "description": "Planning Center Sync project for Parable",
-
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|MultiEdit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint-files.sh",
-            "timeout": 30,
-            "run_in_background": false
-          }
-        ]
-      },
-      {
-        "matcher": "NotebookEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'Notebook edited - consider running tests'",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-
-    "PreToolUse": [
-      {
-        "matcher": "Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-edit-check.sh",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
-
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '📝 Processing request for Planning Center Sync project for Parable...'",
-            "timeout": 2
-          }
-        ]
-      }
-    ],
-
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-summary.sh",
-            "timeout": 10,
-            "run_in_background": true
-          }
-        ]
-      }
-    ]
-  },
+  "project_name": "Litestream",
+  "description": "Standalone disaster recovery tool for SQLite",
 
   "auto_formatting": {
     "enabled": true,
@@ -76,11 +12,11 @@
       "enabled": true,
       "tool": "jq"
     }
- },
+  },
 
   "file_permissions": {
     "read_only_patterns": [
       "*.pdf"
     ]
- }
+  }
 }


### PR DESCRIPTION
## Summary

- Remove hooks configuration from tracked `.claude/settings.json` since the hook scripts in `.claude/hooks/` are gitignored
- This fixes errors for contributors who have the settings file but not the hook files
- Also fixes incorrect project name/description that was copied from another project

Fixes the error Ben was seeing:
```
Stop hook error: Failed with non-blocking status code: /bin/sh:
/Users/benbjohnson/src/benbjohnson/litestream/.claude/hooks/session-summary.sh: No such file or directory
```

## Test plan

- [x] Verify settings.json no longer references hook files
- [ ] Confirm Ben no longer sees the hook error after pulling this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)