### PR TITLE
feat(ci): add Cloudflare R2 integration tests

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -373,6 +373,31 @@ jobs:
           LITESTREAM_ABS_ACCOUNT_KEY:      ${{ secrets.LITESTREAM_ABS_ACCOUNT_KEY }}
           LITESTREAM_ABS_BUCKET:           integration
 
+  r2-integration-test:
+    name: Run Cloudflare R2 Integration Tests
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: integration-test-r2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - run: go env
+
+      - run: go install ./cmd/litestream
+
+      - run: go test -v ./replica_client_test.go -integration -replica-clients=r2
+        env:
+          LITESTREAM_R2_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_R2_ACCESS_KEY_ID }}
+          LITESTREAM_R2_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_R2_SECRET_ACCESS_KEY }}
+          LITESTREAM_R2_ENDPOINT: ${{ secrets.LITESTREAM_R2_ENDPOINT }}
+          LITESTREAM_R2_BUCKET: ${{ secrets.LITESTREAM_R2_BUCKET }}
+
   sftp-integration-test:
     name: Run SFTP Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: false
         type: boolean
+      test_r2:
+        description: 'Run Cloudflare R2 integration tests'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   setup:
@@ -67,7 +72,8 @@ jobs:
           if [ "${{ github.event.inputs.test_s3 }}" != "true" ] && \
              [ "${{ github.event.inputs.test_gcs }}" != "true" ] && \
              [ "${{ github.event.inputs.test_abs }}" != "true" ] && \
-             [ "${{ github.event.inputs.test_tigris }}" != "true" ]; then
+             [ "${{ github.event.inputs.test_tigris }}" != "true" ] && \
+             [ "${{ github.event.inputs.test_r2 }}" != "true" ]; then
             echo "::error::At least one test type must be selected"
             exit 1
           fi
@@ -81,6 +87,7 @@ jobs:
           echo "- Google Cloud Storage: ${{ github.event.inputs.test_gcs }}" >> $GITHUB_STEP_SUMMARY
           echo "- Azure Blob Storage: ${{ github.event.inputs.test_abs }}" >> $GITHUB_STEP_SUMMARY
           echo "- Fly.io Tigris: ${{ github.event.inputs.test_tigris }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Cloudflare R2: ${{ github.event.inputs.test_r2 }}" >> $GITHUB_STEP_SUMMARY
 
   s3-integration:
     name: S3 Integration Tests (AWS)
@@ -162,6 +169,49 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tigris-test-results
+          path: |
+            *.log
+            test-results/
+
+  r2-integration:
+    name: Cloudflare R2 Integration Tests
+    runs-on: ubuntu-latest
+    needs: setup
+    if: github.event.inputs.test_r2 == 'true'
+    concurrency:
+      group: integration-test-r2-manual
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - run: go env
+
+      - run: go install ./cmd/litestream
+
+      - run: go test -v ./replica_client_test.go -integration -replica-clients=r2
+        env:
+          LITESTREAM_R2_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_R2_ACCESS_KEY_ID }}
+          LITESTREAM_R2_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_R2_SECRET_ACCESS_KEY }}
+          LITESTREAM_R2_ENDPOINT: ${{ secrets.LITESTREAM_R2_ENDPOINT }}
+          LITESTREAM_R2_BUCKET: ${{ secrets.LITESTREAM_R2_BUCKET }}
+
+      - name: Create test results directory
+        if: always()
+        run: |
+          mkdir -p test-results
+          echo "Test completed at $(date)" > test-results/r2-test.log
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: r2-test-results
           path: |
             *.log
             test-results/
@@ -258,7 +308,7 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [setup, s3-integration, gcs-integration, abs-integration, tigris-integration]
+    needs: [setup, s3-integration, gcs-integration, abs-integration, tigris-integration, r2-integration]
     if: always()
     steps:
       - name: Download all artifacts
@@ -306,6 +356,14 @@ jobs:
             echo "⏭️ **Fly.io Tigris:** Skipped" >> $GITHUB_STEP_SUMMARY
           fi
 
+          if [ "${{ needs.r2-integration.result }}" == "success" ]; then
+            echo "✅ **Cloudflare R2:** Passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.r2-integration.result }}" == "failure" ]; then
+            echo "❌ **Cloudflare R2:** Failed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.r2-integration.result }}" == "skipped" ]; then
+            echo "⏭️ **Cloudflare R2:** Skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "**Triggered by:** @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
@@ -329,6 +387,7 @@ jobs:
             if ('${{ needs.gcs-integration.result }}' === 'failure') failedJobs.push('GCS');
             if ('${{ needs.abs-integration.result }}' === 'failure') failedJobs.push('Azure');
             if ('${{ needs.tigris-integration.result }}' === 'failure') failedJobs.push('Tigris');
+            if ('${{ needs.r2-integration.result }}' === 'failure') failedJobs.push('R2');
 
             if (failedJobs.length > 0) {
               statusEmoji = '❌';

--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -65,6 +65,14 @@ var (
 	tigrisSecretAccessKey = flag.String("tigris-secret-access-key", os.Getenv("LITESTREAM_TIGRIS_SECRET_ACCESS_KEY"), "")
 )
 
+// Cloudflare R2 settings (S3-compatible)
+var (
+	r2AccessKeyID     = flag.String("r2-access-key-id", os.Getenv("LITESTREAM_R2_ACCESS_KEY_ID"), "")
+	r2SecretAccessKey = flag.String("r2-secret-access-key", os.Getenv("LITESTREAM_R2_SECRET_ACCESS_KEY"), "")
+	r2Endpoint        = flag.String("r2-endpoint", os.Getenv("LITESTREAM_R2_ENDPOINT"), "")
+	r2Bucket          = flag.String("r2-bucket", os.Getenv("LITESTREAM_R2_BUCKET"), "")
+)
+
 // Google cloud storage settings
 var (
 	gsBucket = flag.String("gs-bucket", os.Getenv("LITESTREAM_GS_BUCKET"), "")
@@ -230,6 +238,8 @@ func NewReplicaClient(tb testing.TB, typ string) litestream.ReplicaClient {
 		return NewOSSReplicaClient(tb)
 	case "tigris":
 		return NewTigrisReplicaClient(tb)
+	case "r2":
+		return NewR2ReplicaClient(tb)
 	default:
 		tb.Fatalf("invalid replica client type: %q", typ)
 		return nil
@@ -278,6 +288,33 @@ func NewTigrisReplicaClient(tb testing.TB) *s3.ReplicaClient {
 	c.SignPayload = true
 	c.RequireContentMD5 = false
 	c.IsTigris = true
+	return c
+}
+
+// NewR2ReplicaClient returns an S3 client configured for Cloudflare R2.
+// Skips the test if R2 credentials are not configured.
+func NewR2ReplicaClient(tb testing.TB) *s3.ReplicaClient {
+	tb.Helper()
+
+	if *r2AccessKeyID == "" || *r2SecretAccessKey == "" {
+		tb.Skip("r2 credentials not configured (set LITESTREAM_R2_ACCESS_KEY_ID/SECRET_ACCESS_KEY)")
+	}
+	if *r2Endpoint == "" {
+		tb.Skip("r2 endpoint not configured (set LITESTREAM_R2_ENDPOINT)")
+	}
+	if *r2Bucket == "" {
+		tb.Skip("r2 bucket not configured (set LITESTREAM_R2_BUCKET)")
+	}
+
+	c := s3.NewReplicaClient()
+	c.AccessKeyID = *r2AccessKeyID
+	c.SecretAccessKey = *r2SecretAccessKey
+	c.Region = "auto"
+	c.Bucket = *r2Bucket
+	c.Path = path.Join("integration-tests", fmt.Sprintf("%016x", rand.Uint64()))
+	c.Endpoint = *r2Endpoint
+	c.ForcePathStyle = true
+	c.SignPayload = true
 	return c
 }
 


### PR DESCRIPTION
## Summary

- Add Cloudflare R2 to the integration test suite following the existing Tigris pattern
- Add R2 client factory in testingutil.go with graceful skip when credentials are not configured
- Add R2 job to manual-integration-tests.yml workflow for manual triggering
- Add R2 job to commit.yml for automatic testing on merge to main

## Test plan

- [ ] CI passes (R2 tests will skip gracefully until secrets are configured)
- [ ] Verify YAML syntax is valid
- [ ] After secrets are configured (#916), manually trigger R2 integration test to verify

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)