### PR TITLE
fix(s3): disable aws-chunked encoding for all S3-compatible providers

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1307,7 +1307,6 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 
 	client.SignPayload = signSetting.value
 	client.RequireContentMD5 = requireSetting.value
-	client.IsTigris = isTigris
 
 	// Apply upload configuration if specified.
 	if c.PartSize != nil {

--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -285,7 +285,6 @@ func NewTigrisReplicaClient(tb testing.TB) *s3.ReplicaClient {
 	c.Endpoint = defaultTigrisEndpoint
 	c.ForcePathStyle = true
 	c.RequireContentMD5 = false
-	c.IsTigris = true
 	return c
 }
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -80,7 +80,6 @@ type ReplicaClient struct {
 	SkipVerify        bool
 	SignPayload       bool
 	RequireContentMD5 bool
-	IsTigris          bool
 
 	// Upload configuration
 	PartSize    int64 // Part size for multipart uploads (default: 5MB)
@@ -183,7 +182,6 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 	// Apply provider-specific defaults for S3-compatible providers.
 	if isTigris {
 		// Tigris: requires signed payloads, no MD5
-		client.IsTigris = true
 		if !signPayloadSet {
 			signPayload, signPayloadSet = true, true
 		}
@@ -575,7 +573,7 @@ func (c *ReplicaClient) middlewareOption() func(*middleware.Stack) error {
 			return err
 		}
 
-		if c.IsTigris {
+		if litestream.IsTigrisEndpoint(c.Endpoint) {
 			if err := stack.Build.Add(
 				middleware.BuildMiddlewareFunc(
 					"LitestreamTigrisConsistent",

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -1018,66 +1018,54 @@ func TestParseHost(t *testing.T) {
 }
 
 func TestReplicaClient_TigrisConsistentHeader(t *testing.T) {
+	// Test that non-Tigris endpoints do NOT send the X-Tigris-Consistent header.
+	// The Tigris case (header sent) requires an actual Tigris endpoint and is
+	// covered by Tigris integration tests.
 	data := mustLTX(t)
 
-	tests := []struct {
-		name       string
-		isTigris   bool
-		wantHeader string
-	}{
-		{name: "TigrisEnabled", isTigris: true, wantHeader: "true"},
-		{name: "TigrisDisabled", isTigris: false, wantHeader: ""},
+	headers := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		_, _ = io.Copy(io.Discard, r.Body)
+
+		if r.Method == http.MethodPut {
+			select {
+			case headers <- r.Header.Clone():
+			default:
+			}
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewReplicaClient()
+	client.Bucket = "test-bucket"
+	client.Path = "replica"
+	client.Region = "us-east-1"
+	client.Endpoint = server.URL // Non-Tigris endpoint
+	client.ForcePathStyle = true
+	client.AccessKeyID = "test-access-key"
+	client.SecretAccessKey = "test-secret-key"
+
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			headers := make(chan http.Header, 1)
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				defer r.Body.Close()
-				_, _ = io.Copy(io.Discard, r.Body)
+	if _, err := client.WriteLTXFile(ctx, 0, 2, 2, bytes.NewReader(data)); err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
 
-				if r.Method == http.MethodPut {
-					select {
-					case headers <- r.Header.Clone():
-					default:
-					}
-					w.Header().Set("ETag", `"test-etag"`)
-					w.WriteHeader(http.StatusOK)
-					return
-				}
-
-				w.WriteHeader(http.StatusOK)
-			}))
-			defer server.Close()
-
-			client := NewReplicaClient()
-			client.Bucket = "test-bucket"
-			client.Path = "replica"
-			client.Region = "us-east-1"
-			client.Endpoint = server.URL
-			client.ForcePathStyle = true
-			client.AccessKeyID = "test-access-key"
-			client.SecretAccessKey = "test-secret-key"
-			client.IsTigris = tt.isTigris
-
-			ctx := context.Background()
-			if err := client.Init(ctx); err != nil {
-				t.Fatalf("Init() error: %v", err)
-			}
-
-			if _, err := client.WriteLTXFile(ctx, 0, 2, 2, bytes.NewReader(data)); err != nil {
-				t.Fatalf("WriteLTXFile() error: %v", err)
-			}
-
-			select {
-			case hdr := <-headers:
-				got := hdr.Get("X-Tigris-Consistent")
-				if got != tt.wantHeader {
-					t.Fatalf("X-Tigris-Consistent header = %q, want %q", got, tt.wantHeader)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("timeout waiting for PUT request")
-			}
-		})
+	select {
+	case hdr := <-headers:
+		if got := hdr.Get("X-Tigris-Consistent"); got != "" {
+			t.Fatalf("X-Tigris-Consistent header = %q, want empty (non-Tigris endpoint)", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for PUT request")
 	}
 }


### PR DESCRIPTION
## Summary

- Extend the `RequestChecksumCalculation` fix to all S3-compatible providers with custom endpoints, not just Tigris
- Prevents `MalformedTrailerError` when uploading to Backblaze B2, Filebase, MinIO, DigitalOcean Spaces, Scaleway, and other providers that don't support aws-chunked content encoding with trailing checksums
- **Refactor**: Remove `IsTigris` struct field and use centralized `IsTigrisEndpoint()` function instead

## Root Cause

AWS SDK Go v2 v1.73.0+ introduced automatic checksum calculation using aws-chunked encoding with trailing checksums. Many S3-compatible providers don't support this encoding. The codebase had a fix for Tigris using `RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired`, but other providers like Backblaze B2 were not covered.

## Changes

1. **Fix**: Use `c.Endpoint != ""` instead of `c.IsTigris` for `RequestChecksumCalculation` setting
2. **Refactor**: Remove `IsTigris` field from `ReplicaClient` struct
3. **Refactor**: Use `litestream.IsTigrisEndpoint(c.Endpoint)` for `X-Tigris-Consistent` header

## Test plan

- [x] `go build -o bin/litestream ./cmd/litestream`
- [x] `go test -v ./s3/...`
- [x] `go test ./cmd/litestream/...`
- [x] `pre-commit run --all-files`

Fixes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)