### PR TITLE
feat(replicate): add -once, -force-snapshot, and -enforce-retention flags

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -127,7 +127,11 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		// Wait for signal to stop program.
 		select {
 		case err = <-c.execCh:
-			slog.Info("subprocess exited, litestream shutting down")
+			if c.cmd != nil {
+				slog.Info("subprocess exited, litestream shutting down")
+			} else {
+				slog.Info("replication complete, litestream shutting down")
+			}
 		case sig := <-signalCh:
 			slog.Info("signal received, litestream shutting down")
 

--- a/cmd/litestream/replicate_test.go
+++ b/cmd/litestream/replicate_test.go
@@ -8,6 +8,83 @@ import (
 	main "github.com/benbjohnson/litestream/cmd/litestream"
 )
 
+func TestReplicateCommand_ParseFlags_OnceFlags(t *testing.T) {
+	t.Run("OnceFlag", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-once", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("OnceWithForceSnapshot", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-once", "-force-snapshot", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("OnceWithEnforceRetention", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-once", "-enforce-retention", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("OnceWithAllFlags", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-once", "-force-snapshot", "-enforce-retention", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ForceSnapshotRequiresOnce", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-force-snapshot", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected error when -force-snapshot is used without -once")
+		}
+		expectedError := "cannot specify -force-snapshot flag without -once"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Errorf("expected error message to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("EnforceRetentionRequiresOnce", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-enforce-retention", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected error when -enforce-retention is used without -once")
+		}
+		expectedError := "cannot specify -enforce-retention flag without -once"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Errorf("expected error message to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("OnceAndExecMutuallyExclusive", func(t *testing.T) {
+		cmd := main.NewReplicateCommand()
+		args := []string{"-once", "-exec", "echo test", "test.db", "file:///tmp/replica"}
+		err := cmd.ParseFlags(context.Background(), args)
+		if err == nil {
+			t.Fatal("expected error when -once and -exec are both specified")
+		}
+		expectedError := "cannot specify -once flag with -exec"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Errorf("expected error message to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+}
+
 func TestReplicateCommand_ParseFlags_FlagPositioning(t *testing.T) {
 	t.Run("ExecFlagAfterPositionalArgs", func(t *testing.T) {
 		cmd := main.NewReplicateCommand()


### PR DESCRIPTION
## Summary

- Adds `-once` flag to replicate command for one-shot replication
- Adds `-force-snapshot` flag to force snapshot creation (requires `-once`)
- Adds `-enforce-retention` flag to enforce retention policies (requires `-once`)

This enables use cases like:
- Ensuring full replication before removing/migrating a database
- Cron-style execution of Litestream for periodic backups
- Taking encrypted snapshots on demand

When `-once` is used, all background monitors are disabled and the process exits cleanly after completing one sync cycle.

## Test plan

- [x] Unit tests for flag parsing and validation
- [x] Manual testing with file replica
- [x] Verified restore from replica created with `-once`
- [x] Tested `-force-snapshot` creates snapshot
- [x] Tested `-enforce-retention` enforces retention
- [x] All existing tests pass
- [x] Pre-commit hooks pass

## Example usage

```bash
# Basic one-shot replication
litestream replicate -once /path/to/db.db s3://bucket/backup

# With forced snapshot
litestream replicate -once -force-snapshot /path/to/db.db s3://bucket/backup

# With retention enforcement
litestream replicate -once -enforce-retention /path/to/db.db s3://bucket/backup

# All flags combined
litestream replicate -once -force-snapshot -enforce-retention /path/to/db.db s3://bucket/backup
```

Fixes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)