### PR TITLE
fix(examples): use DSN params for PRAGMAs in library examples

### DIFF
--- a/_examples/library/basic/main.go
+++ b/_examples/library/basic/main.go
@@ -98,20 +98,9 @@ func run(ctx context.Context) error {
 	}
 }
 
-func openAppDB(ctx context.Context, path string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode = wal;`); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout = 5000;`); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	return db, nil
+func openAppDB(_ context.Context, path string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(wal)", path)
+	return sql.Open("sqlite", dsn)
 }
 
 func initSchema(ctx context.Context, db *sql.DB) error {

--- a/_examples/library/s3/main.go
+++ b/_examples/library/s3/main.go
@@ -168,20 +168,9 @@ func restoreIfNotExists(ctx context.Context, client *s3.ReplicaClient, dbPath st
 	return nil
 }
 
-func openAppDB(ctx context.Context, path string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode = wal;`); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout = 5000;`); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	return db, nil
+func openAppDB(_ context.Context, path string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(wal)", path)
+	return sql.Open("sqlite", dsn)
 }
 
 func initSchema(ctx context.Context, db *sql.DB) error {


### PR DESCRIPTION
## Summary

Address feedback from @ncruces on PR #921 regarding incorrect patterns and missing documentation in the library usage examples.

## Changes

- **PRAGMA pattern fix**: Use DSN parameters (`_pragma=busy_timeout(5000)&_pragma=journal_mode(wal)`) instead of `ExecContext` for PRAGMAs. An `sql.DB` is a connection pool, and `ExecContext` only applies the PRAGMA to one random connection, not all connections.

- **POSIX documentation fix**: Changed "Note (macOS):" to "Note (POSIX platforms):" since POSIX locks affect all POSIX platforms (Linux, macOS, BSD), not just macOS.

- **New "Important Constraints" section** documenting:
  - Required driver (`modernc.org/sqlite`)
  - Lifecycle management (cannot close Litestream while app connections are open)
  - PRAGMA configuration best practices

## Related

- Original feedback: https://github.com/benbjohnson/litestream/pull/921#issuecomment-3694736341
- Follow-up issue for db.go fix: #937

## Test plan

- [x] Both examples compile (`go build`)
- [x] Pre-commit hooks pass
- [x] Markdown linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)