### PR TITLE
fix: move wal_autocheckpoint PRAGMA to DSN parameters

### DIFF
--- a/db.go
+++ b/db.go
@@ -398,7 +398,7 @@ func (db *DB) init(ctx context.Context) (err error) {
 	}
 	db.dirInfo = fi
 
-	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)",
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)&_pragma=wal_autocheckpoint(0)",
 		db.path, db.BusyTimeout.Milliseconds())
 
 	if db.db, err = sql.Open("sqlite", dsn); err != nil {
@@ -433,11 +433,6 @@ func (db *DB) init(ctx context.Context) (err error) {
 		return err
 	} else if mode != "wal" {
 		return fmt.Errorf("enable wal failed, mode=%q", mode)
-	}
-
-	// Disable autocheckpoint for litestream's connection.
-	if _, err := db.db.ExecContext(ctx, `PRAGMA wal_autocheckpoint = 0;`); err != nil {
-		return fmt.Errorf("disable autocheckpoint: %w", err)
 	}
 
 	// Create a table to force writes to the WAL when empty.


### PR DESCRIPTION
## Summary

Move the `wal_autocheckpoint = 0` PRAGMA from `ExecContext` to DSN parameters, consistent with how `busy_timeout` is already handled.

## Problem

Since `sql.DB` is a connection pool, using `ExecContext` for PRAGMAs only applies the setting to one random connection from the pool. This was identified by @ncruces in [PR #921 comments](https://github.com/benbjohnson/litestream/pull/921#issuecomment-3694736341).

## Solution

Move `wal_autocheckpoint` to the DSN parameters:

```go
// Before
dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)", ...)
// ... later ...
db.db.ExecContext(ctx, "PRAGMA wal_autocheckpoint = 0;")

// After  
dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(%d)&_pragma=wal_autocheckpoint(0)", ...)
```

This ensures the PRAGMA is applied to all connections from the pool.

Fixes #937

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)