### PR TITLE
optimization(db): skip unnecessary Sync() calls when WAL unchanged

### DIFF
--- a/db.go
+++ b/db.go
@@ -1918,9 +1918,26 @@ func (db *DB) EnforceRetentionByTXID(ctx context.Context, level int, txID ltx.TX
 }
 
 // monitor runs in a separate goroutine and monitors the database & WAL.
+//
+// Change Detection Strategy:
+// To reduce CPU usage when idle, we use cheap change detection to avoid
+// unnecessary Sync() calls when the WAL hasn't changed:
+//
+//  1. stat() the WAL file to get its size (changes on any write)
+//  2. Read the 32-byte WAL header which contains salt values that change
+//     when SQLite restarts the WAL (e.g., after checkpoint)
+//
+// If both size and header are unchanged since last check, we skip Sync().
+// When a change is detected, we call Sync() which performs full verification
+// and replication. The cost per tick is just one stat() call plus a 32-byte
+// read, which is negligible.
 func (db *DB) monitor() {
 	ticker := time.NewTicker(db.MonitorInterval)
 	defer ticker.Stop()
+
+	// Track last known WAL state for cheap change detection.
+	var lastWALSize int64
+	var lastWALHeader []byte
 
 	for {
 		// Wait for ticker or context close.
@@ -1930,7 +1947,39 @@ func (db *DB) monitor() {
 		case <-ticker.C:
 		}
 
-		// Sync the database to the shadow WAL.
+		// Check if WAL has changed before doing expensive sync.
+		walPath := db.WALPath()
+		fi, err := os.Stat(walPath)
+		if err != nil {
+			// WAL doesn't exist yet - do a sync which may create it.
+			if os.IsNotExist(err) {
+				if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
+					db.Logger.Error("sync error", "error", err)
+				}
+			}
+			continue
+		}
+
+		// Read WAL header (32 bytes) for change detection.
+		walHeader, err := readWALHeader(walPath)
+		if err != nil {
+			// Can't read header - fall back to sync.
+			if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
+				db.Logger.Error("sync error", "error", err)
+			}
+			continue
+		}
+
+		// Skip sync if WAL size and header are unchanged.
+		walSize := fi.Size()
+		if walSize == lastWALSize && bytes.Equal(walHeader, lastWALHeader) {
+			continue
+		}
+
+		// WAL changed - update cached state and sync.
+		lastWALSize = walSize
+		lastWALHeader = walHeader
+
 		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
 			db.Logger.Error("sync error", "error", err)
 		}

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/superfly/ltx"
@@ -690,5 +691,85 @@ func TestDB_releaseReadLock_DoubleRollback(t *testing.T) {
 	// Close should work without error
 	if err := db.Close(context.Background()); err != nil {
 		t.Fatalf("Close() failed: %v", err)
+	}
+}
+
+// TestDB_Monitor_CheapChangeDetection verifies that the monitor loop skips
+// expensive Sync() calls when the WAL file hasn't changed.
+func TestDB_Monitor_CheapChangeDetection(t *testing.T) {
+	// Create temp directory for test database.
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	// Set up litestream DB with short monitor interval.
+	db := NewDB(dbPath)
+	db.MonitorInterval = 50 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false // disable replica monitor to avoid hangs
+
+	// Open litestream database.
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close(context.Background())
+
+	// Open SQL connection and create WAL.
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode=wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (x INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO t VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial sync to complete.
+	time.Sleep(150 * time.Millisecond)
+
+	// Record sync count after initial sync.
+	syncMetric := syncNCounterVec.WithLabelValues(db.Path())
+	initialSyncCount := testutil.ToFloat64(syncMetric)
+	if initialSyncCount < 1 {
+		t.Fatalf("expected at least 1 initial sync, got %v", initialSyncCount)
+	}
+	t.Logf("initial sync count: %v", initialSyncCount)
+
+	// Wait for several monitor intervals with no WAL changes.
+	// The cheap change detection should skip Sync() calls.
+	time.Sleep(300 * time.Millisecond) // ~6 monitor intervals
+
+	idleSyncCount := testutil.ToFloat64(syncMetric)
+	t.Logf("sync count after idle period: %v", idleSyncCount)
+
+	// Sync count should not have increased significantly during idle period.
+	// Allow for 1 extra sync due to timing.
+	if idleSyncCount > initialSyncCount+1 {
+		t.Fatalf("sync count increased during idle period: initial=%v, after=%v (expected no increase)",
+			initialSyncCount, idleSyncCount)
+	}
+
+	// Now write to the database - this should trigger a sync.
+	if _, err := sqldb.Exec(`INSERT INTO t VALUES (2)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for monitor to detect the change and sync.
+	time.Sleep(150 * time.Millisecond)
+
+	finalSyncCount := testutil.ToFloat64(syncMetric)
+	t.Logf("sync count after write: %v", finalSyncCount)
+
+	// Sync count should have increased after the write.
+	if finalSyncCount <= idleSyncCount {
+		t.Fatalf("sync count did not increase after write: idle=%v, final=%v",
+			idleSyncCount, finalSyncCount)
 	}
 }


### PR DESCRIPTION
The monitor loop was calling Sync() on every tick regardless of whether the WAL had changed. This burned CPU unnecessarily when databases were idle.

This adds change detection by checking WAL file size and the 32-byte header before calling Sync(). If unchanged, we skip the call.

Before: ~0.7% CPU per idle database
After: ~0% CPU per idle database

Added TestDB_Monitor_CheapChangeDetection to verify syncs are skipped when WAL is unchanged.