### PR TITLE
fix(s3): default to https:// for cloud endpoints (UX improvement)

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1254,11 +1254,8 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 
 		// Override with query parameters if provided
 		if qEndpoint := query.Get("endpoint"); qEndpoint != "" {
-			// Ensure endpoint has a scheme
-			if !strings.HasPrefix(qEndpoint, "http://") && !strings.HasPrefix(qEndpoint, "https://") {
-				// Default to http for non-TLS endpoints (common for local/dev)
-				qEndpoint = "http://" + qEndpoint
-			}
+			// Ensure endpoint has a scheme (defaults to https:// for cloud, http:// for local)
+			qEndpoint, _ = litestream.EnsureEndpointScheme(qEndpoint)
 			uendpoint = qEndpoint
 			// Default to path style for custom endpoints unless explicitly set to false
 			if query.Get("forcePathStyle") != "false" {

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -2465,8 +2465,8 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		if client.Bucket != "my-tigris-bucket" {
 			t.Errorf("expected bucket 'my-tigris-bucket', got %q", client.Bucket)
 		}
-		if client.Endpoint != "http://fly.storage.tigris.dev" {
-			t.Errorf("expected Tigris endpoint, got %q", client.Endpoint)
+		if client.Endpoint != "https://fly.storage.tigris.dev" {
+			t.Errorf("expected Tigris endpoint with https scheme, got %q", client.Endpoint)
 		}
 		if client.Region != "auto" {
 			t.Errorf("expected region 'auto' for Tigris, got %q", client.Region)

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -144,10 +144,8 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 
 	// Override with query parameters if provided
 	if qEndpoint := query.Get("endpoint"); qEndpoint != "" {
-		// Ensure endpoint has a scheme
-		if !strings.HasPrefix(qEndpoint, "http://") && !strings.HasPrefix(qEndpoint, "https://") {
-			qEndpoint = "http://" + qEndpoint
-		}
+		// Ensure endpoint has a scheme (defaults to https:// for cloud, http:// for local)
+		qEndpoint, _ = litestream.EnsureEndpointScheme(qEndpoint)
 		endpoint = qEndpoint
 		// Default to path style for custom endpoints unless explicitly set to false
 		if query.Get("forcePathStyle") != "false" {


### PR DESCRIPTION
## Summary

UX improvement: Default to `https://` for cloud endpoints when users omit the scheme.

**Note:** This is NOT the fix for R2/B2 upload failures (issues #948, #947). Those were caused by AWS SDK checksum headers and fixed in PR #956 (Uploader checksum) and PR #950 (Response checksum). This PR is a complementary UX improvement that prevents a common misconfiguration.

## What This Does

- Add `IsLocalEndpoint()` to detect localhost and private network endpoints
- Add `EnsureEndpointScheme()` to add appropriate scheme based on endpoint type
- Cloud endpoints (R2, B2, Tigris, DigitalOcean, etc.) now default to `https://`
- Local development endpoints (localhost, 192.168.x, 10.x, etc.) still default to `http://`

## Why This Helps

When users specify an endpoint without a scheme:
```yaml
endpoint: account_id.r2.cloudflarestorage.com  # Missing https://
```

Previously this defaulted to `http://` which fails silently with cloud providers requiring HTTPS. Now it intelligently defaults to `https://` for cloud endpoints.

## Test plan

- [x] Added `TestIsLocalEndpoint` with comprehensive test cases
- [x] Added `TestEnsureEndpointScheme` verifying the behavior
- [x] Updated `TestTigrisURLEndpoint` to expect https://
- [x] All existing tests pass
- [x] `pre-commit run --all-files` passes

## Related Issues

Related to #912, #948 (as UX improvement, not the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
