### PR TITLE
fix(s3): add ResponseChecksumValidation for S3-compatible providers

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -379,12 +379,14 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 
 	// S3-compatible providers (Tigris, Backblaze B2, MinIO, Filebase, etc.) don't
 	// support aws-chunked content encoding used by default checksum calculation
-	// in AWS SDK Go v2 v1.73.0+. Disable automatic checksum calculation for all
-	// custom endpoints.
+	// in AWS SDK Go v2 v1.73.0+. Disable automatic checksum calculation and
+	// response checksum validation for all custom endpoints.
 	// See: https://github.com/benbjohnson/litestream/issues/918
+	// See: https://github.com/benbjohnson/litestream/issues/947
 	if c.Endpoint != "" {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
 			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+			o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
 		})
 	}
 


### PR DESCRIPTION
## Summary

- Adds `ResponseChecksumValidation = WhenRequired` for custom S3 endpoints
- Complements the existing `RequestChecksumCalculation` fix from PR #919

## Background

Backblaze B2 and other S3-compatible providers can return "malformed trailing header" errors when the AWS SDK Go v2 attempts to validate response checksums. This is similar to the request checksum issue fixed in #919, but affects the response path.

Per [Backblaze B2 documentation](https://www.backblaze.com/docs/cloud-storage-use-the-aws-sdk-for-go-with-b2), both `RequestChecksumCalculation` and `ResponseChecksumValidation` should be set to `WhenRequired` for B2 compatibility.

## Test plan

- [x] All existing tests pass
- [x] pre-commit hooks pass
- [ ] CI passes
- [ ] @gwk to confirm fix resolves B2 issues (if available to test)

Fixes #947
Related to #918, #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)