### PR TITLE
fix(s3): default concurrency to 2 for Cloudflare R2

### DIFF
--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -313,6 +313,7 @@ func NewR2ReplicaClient(tb testing.TB) *s3.ReplicaClient {
 	c.Endpoint = *r2Endpoint
 	c.ForcePathStyle = true
 	c.SignPayload = true
+	c.Concurrency = 2 // R2 has a strict limit of 2-3 concurrent part uploads
 	return c
 }
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -394,6 +394,13 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// Create S3 client
 	c.s3 = s3.NewFromConfig(cfg, s3Opts...)
 
+	// Apply R2-specific defaults for library users who don't go through config parsing.
+	// R2 has a strict limit of 2-3 concurrent part uploads per multipart upload.
+	// See: https://github.com/benbjohnson/litestream/issues/948
+	if c.Concurrency == 0 && litestream.IsCloudflareR2Endpoint(c.Endpoint) {
+		c.Concurrency = 2
+	}
+
 	// Configure uploader with custom options if specified
 	uploaderOpts := []func(*manager.Uploader){}
 	if c.PartSize > 0 {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -391,6 +391,40 @@ func TestReplicaClient_UploaderConfiguration(t *testing.T) {
 			t.Errorf("expected default Concurrency to be 0, got %d", c.Concurrency)
 		}
 	})
+
+	t.Run("R2DefaultConcurrency", func(t *testing.T) {
+		c := NewReplicaClient()
+		c.Bucket = "test-bucket"
+		c.Endpoint = "https://account123.r2.cloudflarestorage.com"
+
+		// Verify initial concurrency is 0
+		if c.Concurrency != 0 {
+			t.Errorf("expected initial Concurrency to be 0, got %d", c.Concurrency)
+		}
+
+		// After Init(), R2 endpoints should get concurrency default of 2
+		// Note: Init() will fail without valid credentials, but the concurrency
+		// default is applied before AWS SDK initialization attempts
+		_ = c.Init(context.Background())
+
+		if c.Concurrency != 2 {
+			t.Errorf("expected R2 default Concurrency to be 2, got %d", c.Concurrency)
+		}
+	})
+
+	t.Run("R2ExplicitConcurrencyNotOverridden", func(t *testing.T) {
+		c := NewReplicaClient()
+		c.Bucket = "test-bucket"
+		c.Endpoint = "https://account123.r2.cloudflarestorage.com"
+		c.Concurrency = 5 // Explicit setting
+
+		// Init should not override explicit concurrency
+		_ = c.Init(context.Background())
+
+		if c.Concurrency != 5 {
+			t.Errorf("expected explicit Concurrency to be preserved, got %d", c.Concurrency)
+		}
+	})
 }
 
 // TestReplicaClient_ConfigureEndpoint tests the endpoint configuration helper


### PR DESCRIPTION
## Summary

- Add R2 endpoint detection to YAML config parsing (was missing)
- Auto-set `Concurrency=2` for R2 endpoints when not explicitly configured
- Apply the default in both config parsing and `Init()` for library users
- Update R2 integration test client with correct concurrency setting

## Root Cause

Cloudflare R2 has a **strict limit of 2-3 concurrent part uploads per multipart upload**. The AWS SDK defaults to 5 concurrent uploads (`DefaultUploadConcurrency = 5`), which causes 500 InternalError responses when uploading larger databases (>5MB) that trigger multipart uploads.

**Error pattern:**
- `CreateMultipartUpload` succeeds (returns upload_id)
- `UploadPart` fails with 500 errors after 10 retries

**Evidence:**
- Working user (@quolpr): ~2MB database → single PUT (no multipart)
- Failing user (@abhijit-hota): 225MB database → multipart with 5 concurrent parts → 500 errors

## Changes

| File | Change |
|------|--------|
| `cmd/litestream/main.go` | Add `isCloudflareR2` detection + concurrency default |
| `s3/replica_client.go` | Add R2 concurrency default in `Init()` for library users |
| `internal/testingutil/testingutil.go` | Update R2 test client |
| `cmd/litestream/main_test.go` | Add 3 R2 config tests |
| `s3/replica_client_test.go` | Add 2 R2 Init() tests |

## Workaround (for users on current release)

Until this is released, users can add `concurrency: 2` to their R2 config:

```yaml
replica:
  type: s3
  endpoint: https://ACCOUNT_ID.r2.cloudflarestorage.com
  concurrency: 2  # <-- Add this
  bucket: my-bucket
```

## Test plan

- [x] Added `TestNewS3ReplicaClientFromConfig/R2ConcurrencyDefault`
- [x] Added `TestNewS3ReplicaClientFromConfig/R2ConcurrencyConfigOverride`
- [x] Added `TestNewS3ReplicaClientFromConfig/R2URLEndpoint`
- [x] Added `TestReplicaClient_UploaderConfiguration/R2DefaultConcurrency`
- [x] Added `TestReplicaClient_UploaderConfiguration/R2ExplicitConcurrencyNotOverridden`
- [x] All existing tests pass
- [x] `pre-commit run --all-files` passes

Fixes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)