### PR TITLE
fix(logging): add context to db initialization timeout warning

### DIFF
--- a/store.go
+++ b/store.go
@@ -371,7 +371,7 @@ func (s *Store) monitorCompactionLevel(ctx context.Context, lvl *CompactionLevel
 					"level", lvl.Level,
 					"dbs", notReadyDBs,
 					"timeout", DefaultDBInitTimeout,
-					"hint", "database may have corrupted local state or blocked transactions; try removing .sqlite-litestream directory and restarting")
+					"hint", "database may have corrupted local state or blocked transactions; try removing -litestream directory and restarting")
 			}
 			retryDeadline = time.Time{}
 		}


### PR DESCRIPTION
## Summary

Adds more context to the "timeout waiting for db initialization" warning message to help users diagnose issues.

**Before:**
```
level=WARN msg="timeout waiting for db initialization" level=1
```

**After:**
```
level=WARN msg="timeout waiting for db initialization" level=1 dbs=[/path/to/db1.sqlite /path/to/db2.sqlite] timeout=30s hint="database may have corrupted local state or blocked transactions; try removing .sqlite-litestream directory and restarting"
```

## Changes

- Track which specific database(s) are not ready (by path)
- Extract timeout to `DefaultDBInitTimeout` constant (30s) for reuse
- Include the timeout duration in the warning
- Add actionable hint about common causes and recovery steps

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Linters pass (go vet, staticcheck)

Fixes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)