### PR TITLE
feat(cli): add status command for replication monitoring

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -159,6 +159,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 
 	case "restore":
 		return (&RestoreCommand{}).Run(ctx, args)
+	case "status":
+		return (&StatusCommand{}).Run(ctx, args)
 	case "version":
 		return (&VersionCommand{}).Run(ctx, args)
 	case "ltx":
@@ -191,6 +193,7 @@ The commands are:
 	ltx          list available LTX files for a database
 	replicate    runs a server to replicate databases
 	restore      recovers database backup from a replica
+	status       display replication status for databases
 	version      prints the binary version
 `[1:])
 }

--- a/cmd/litestream/status.go
+++ b/cmd/litestream/status.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/benbjohnson/litestream"
+)
+
+// StatusCommand is a command for displaying replication status.
+type StatusCommand struct{}
+
+// Run executes the command.
+func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
+	fs := flag.NewFlagSet("litestream-status", flag.ContinueOnError)
+	configPath, noExpandEnv := registerConfigFlag(fs)
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Load configuration.
+	if *configPath == "" {
+		*configPath = DefaultConfigPath()
+	}
+	config, err := ReadConfigFile(*configPath, !*noExpandEnv)
+	if err != nil {
+		return err
+	}
+
+	// If a specific database path is provided, filter to just that one.
+	var filterPath string
+	if fs.NArg() > 0 {
+		filterPath = fs.Arg(0)
+	}
+
+	// Print status for each database.
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "database\tstatus\tlocal txid\twal size")
+
+	for _, dbConfig := range config.DBs {
+		db, err := NewDBFromConfig(dbConfig)
+		if err != nil {
+			return err
+		}
+
+		// Filter if path specified.
+		if filterPath != "" && db.Path() != filterPath {
+			continue
+		}
+
+		status := c.getDBStatus(db)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			db.Path(),
+			status.Status,
+			status.LocalTXID,
+			status.WALSize,
+		)
+	}
+
+	return nil
+}
+
+// DBStatus holds the status information for a single database.
+type DBStatus struct {
+	Status    string
+	LocalTXID string
+	WALSize   string
+}
+
+// getDBStatus gathers status information for a database.
+func (c *StatusCommand) getDBStatus(db *litestream.DB) DBStatus {
+	status := DBStatus{
+		Status:    "unknown",
+		LocalTXID: "-",
+		WALSize:   "-",
+	}
+
+	// Check if database file exists.
+	dbPath := db.Path()
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		status.Status = "no database"
+		return status
+	}
+
+	// Get WAL file size.
+	walPath := db.WALPath()
+	if walInfo, err := os.Stat(walPath); err == nil {
+		status.WALSize = humanize.Bytes(uint64(walInfo.Size()))
+	} else if os.IsNotExist(err) {
+		status.WALSize = "0 B"
+	}
+
+	// Get local TXID from L0 directory.
+	_, maxTXID, err := db.MaxLTX()
+	if err == nil && maxTXID > 0 {
+		status.LocalTXID = maxTXID.String()
+		status.Status = "ok"
+	} else if err == nil {
+		status.Status = "not initialized"
+	} else {
+		status.Status = "error"
+	}
+
+	return status
+}
+
+// Usage prints the help screen to STDOUT.
+func (c *StatusCommand) Usage() {
+	fmt.Printf(`
+The status command displays the replication status of databases.
+
+Usage:
+
+	litestream status [arguments] [database path]
+
+Arguments:
+
+	-config PATH
+	    Specifies the configuration file.
+	    Defaults to %s
+
+	-no-expand-env
+	    Disables environment variable expansion in configuration file.
+
+If a database path is provided, only that database's status is shown.
+Otherwise, all configured databases are displayed.
+
+Output columns:
+  database      Path to the SQLite database
+  status        Current status (ok, not initialized, no database, error)
+  local txid    Latest local transaction ID
+  wal size      Current WAL file size
+
+Note: To see replica TXID and sync status, use the MCP tools or check logs
+while the replication daemon is running.
+
+`[1:],
+		DefaultConfigPath(),
+	)
+}

--- a/cmd/litestream/status_test.go
+++ b/cmd/litestream/status_test.go
@@ -1,0 +1,74 @@
+package main_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	main "github.com/benbjohnson/litestream/cmd/litestream"
+)
+
+func TestStatusCommand_Run(t *testing.T) {
+	t.Run("NoConfig", func(t *testing.T) {
+		cmd := &main.StatusCommand{}
+		err := cmd.Run(context.Background(), []string{"-config", "/nonexistent/config.yml"})
+		if err == nil {
+			t.Error("expected error for missing config")
+		}
+	})
+
+	t.Run("WithConfig", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+		configPath := filepath.Join(dir, "litestream.yml")
+
+		// Create a SQLite database.
+		if err := os.WriteFile(dbPath, []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create config file.
+		config := `dbs:
+  - path: ` + dbPath + `
+    replicas:
+      - url: file://` + filepath.Join(dir, "replica") + `
+`
+		if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &main.StatusCommand{}
+		err := cmd.Run(context.Background(), []string{"-config", configPath})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("FilterByPath", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+		configPath := filepath.Join(dir, "litestream.yml")
+
+		// Create a SQLite database.
+		if err := os.WriteFile(dbPath, []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create config file.
+		config := `dbs:
+  - path: ` + dbPath + `
+    replicas:
+      - url: file://` + filepath.Join(dir, "replica") + `
+`
+		if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &main.StatusCommand{}
+		err := cmd.Run(context.Background(), []string{"-config", configPath, dbPath})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a new `litestream status` command that displays replication status for configured databases without requiring the replication daemon to be running.

## Features

The command shows:
- Database path
- Status (ok, not initialized, no database, error)
- Local transaction ID (from L0 LTX files)
- WAL file size

## Usage

```bash
# Show all configured databases
$ litestream status
database              status           local txid          wal size
/path/to/app.db       ok               0000000000000855    4.1 KB
/path/to/data.db      not initialized  -                   0 B

# Show specific database
$ litestream status /path/to/app.db
database              status           local txid          wal size
/path/to/app.db       ok               0000000000000855    4.1 KB
```

## Limitations

This command provides offline inspection of replication state. To see real-time replica TXID, sync status, and replication lag, the daemon must be running (check logs or use MCP tools).

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Linters pass (go vet, staticcheck)
- [x] New tests added for StatusCommand

Fixes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)