### PR TITLE
fix: improve error recovery for missing/corrupted LTX files

### DIFF
--- a/cmd/litestream/reset.go
+++ b/cmd/litestream/reset.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/benbjohnson/litestream"
+)
+
+// ResetCommand is a command for resetting local Litestream state for a database.
+type ResetCommand struct{}
+
+// Run executes the command.
+func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
+	fs := flag.NewFlagSet("litestream-reset", flag.ContinueOnError)
+	configPath, noExpandEnv := registerConfigFlag(fs)
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Validate arguments - need exactly one database path
+	if fs.NArg() == 0 {
+		return fmt.Errorf("database path required")
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	dbPath := fs.Arg(0)
+
+	// Make absolute if needed
+	if !filepath.IsAbs(dbPath) {
+		if dbPath, err = filepath.Abs(dbPath); err != nil {
+			return err
+		}
+	}
+
+	// Load configuration to find the database (if config exists)
+	var dbConfig *DBConfig
+	if *configPath != "" {
+		config, configErr := ReadConfigFile(*configPath, !*noExpandEnv)
+		if configErr != nil {
+			return fmt.Errorf("cannot read config: %w", configErr)
+		}
+
+		// Find database config
+		for _, dbc := range config.DBs {
+			expandedPath := dbc.Path
+			if !filepath.IsAbs(expandedPath) {
+				expandedPath, _ = filepath.Abs(expandedPath)
+			}
+			if expandedPath == dbPath {
+				dbConfig = dbc
+				break
+			}
+		}
+	}
+
+	// If no config found, check if database file exists
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return fmt.Errorf("database does not exist: %s", dbPath)
+	} else if err != nil {
+		return fmt.Errorf("cannot access database: %w", err)
+	}
+
+	// Create DB instance
+	var db *litestream.DB
+	if dbConfig != nil {
+		db, err = NewDBFromConfig(dbConfig)
+		if err != nil {
+			return fmt.Errorf("cannot create database from config: %w", err)
+		}
+	} else {
+		db = litestream.NewDB(dbPath)
+	}
+
+	// Check if meta path exists
+	metaPath := db.MetaPath()
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		fmt.Printf("No local state to reset for %s\n", dbPath)
+		fmt.Printf("Meta directory does not exist: %s\n", metaPath)
+		return nil
+	}
+
+	// Perform the reset
+	fmt.Printf("Resetting local Litestream state for: %s\n", dbPath)
+	fmt.Printf("Removing: %s\n", db.LTXDir())
+
+	if err := db.ResetLocalState(ctx); err != nil {
+		return fmt.Errorf("reset failed: %w", err)
+	}
+
+	fmt.Println("Reset complete. Next replication sync will create a fresh snapshot.")
+	return nil
+}
+
+// Usage prints the help screen to STDOUT.
+func (c *ResetCommand) Usage() {
+	fmt.Printf(`
+The reset command clears local Litestream state for a database.
+
+This is useful for recovering from corrupted or missing LTX files. The reset
+removes local LTX files from the metadata directory, forcing Litestream to
+create a fresh snapshot on the next sync. The database file itself is not
+modified.
+
+Usage:
+
+	litestream reset [arguments] <path>
+
+Arguments:
+
+	-config PATH
+	    Specifies the configuration file.
+	    Defaults to %s
+
+	-no-expand-env
+	    Disables environment variable expansion in configuration file.
+
+Examples:
+
+	# Reset local state for a specific database
+	litestream reset /path/to/database.db
+
+	# Reset using a specific configuration file
+	litestream reset -config /etc/litestream.yml /path/to/database.db
+
+`[1:],
+		DefaultConfigPath(),
+	)
+}

--- a/db.go
+++ b/db.go
@@ -233,6 +233,28 @@ func (db *DB) LTXDir() string {
 	return filepath.Join(db.metaPath, "ltx")
 }
 
+// ResetLocalState removes local LTX files, forcing a fresh snapshot on next sync.
+// This is useful for recovering from corrupted or missing LTX files.
+// The database file itself is not modified.
+func (db *DB) ResetLocalState(ctx context.Context) error {
+	db.Logger.Info("resetting local litestream state",
+		"meta_path", db.metaPath,
+		"ltx_dir", db.LTXDir())
+
+	// Remove all LTX files
+	if err := os.RemoveAll(db.LTXDir()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove ltx directory: %w", err)
+	}
+
+	// Clear cached LTX file info
+	db.maxLTXFileInfos.Lock()
+	db.maxLTXFileInfos.m = make(map[int]*ltx.FileInfo)
+	db.maxLTXFileInfos.Unlock()
+
+	db.Logger.Info("local state reset complete, next sync will create fresh snapshot")
+	return nil
+}
+
 // LTXLevelDir returns path of the given LTX compaction level.
 // Panics if level is negative.
 func (db *DB) LTXLevelDir(level int) string {
@@ -998,15 +1020,21 @@ func (db *DB) verify(ctx context.Context) (info syncInfo, err error) {
 	}
 
 	// Determine last WAL offset we save from.
-	ltxFile, err := os.Open(db.LTXPath(0, pos.TXID, pos.TXID))
+	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	ltxFile, err := os.Open(ltxPath)
 	if err != nil {
-		return info, fmt.Errorf("open ltx file: %w", err)
+		if os.IsNotExist(err) {
+			return info, NewLTXError("open", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), err)
+		}
+		return info, fmt.Errorf("open ltx file %s: %w", ltxPath, err)
 	}
 	defer func() { _ = ltxFile.Close() }()
 
 	dec := ltx.NewDecoder(ltxFile)
 	if err := dec.DecodeHeader(); err != nil {
-		return info, fmt.Errorf("decode ltx file: %w", err)
+		// Decode failure indicates corruption
+		ltxErr := NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+		return info, ltxErr
 	}
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
 	info.salt1 = dec.Header().WALSalt1

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -3,6 +3,7 @@ package litestream_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -191,7 +192,7 @@ func TestReplicaClient_OpenLTXFile(t *testing.T) {
 		t.Helper()
 		t.Parallel()
 
-		if _, err := c.OpenLTXFile(context.Background(), 0, ltx.TXID(1), ltx.TXID(1), 0, 0); !os.IsNotExist(err) {
+		if _, err := c.OpenLTXFile(context.Background(), 0, ltx.TXID(1), ltx.TXID(1), 0, 0); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("expected not exist, got %#v", err)
 		}
 	})
@@ -216,10 +217,10 @@ func TestReplicaClient_DeleteWALSegments(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := c.OpenLTXFile(context.Background(), 0, ltx.TXID(1), ltx.TXID(2), 0, 0); !os.IsNotExist(err) {
+		if _, err := c.OpenLTXFile(context.Background(), 0, ltx.TXID(1), ltx.TXID(2), 0, 0); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("expected not exist, got %#v", err)
 		}
-		if _, err := c.OpenLTXFile(context.Background(), 0, ltx.TXID(3), ltx.TXID(4), 0, 0); !os.IsNotExist(err) {
+		if _, err := c.OpenLTXFile(context.Background(), 0, ltx.TXID(3), ltx.TXID(4), 0, 0); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("expected not exist, got %#v", err)
 		}
 	})
@@ -388,7 +389,7 @@ func TestReplicaClient_S3_ErrorContext(t *testing.T) {
 		}
 
 		// Should return os.ErrNotExist for S3 NoSuchKey
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("expected os.ErrNotExist, got %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary

Improves user experience when LTX file errors occur during replication:

- Add `LTXError` type with recovery hints that provide clear, actionable error messages
- Add corruption detection - LTX decode failures now wrap as `ErrLTXCorrupted`  
- Add optional `auto-recover` config for replicas to automatically reset on LTX errors
- Add `litestream reset <db>` command to clear local LTX state without affecting the database

## Changes

### New Error Type (`litestream.go`)
```go
type LTXError struct {
    Op      string // "open", "read", "validate"
    Path    string // File path
    Level   int    // LTX level
    MinTXID uint64
    MaxTXID uint64
    Err     error  
    Hint    string // Recovery hint for users
}
```

### Auto-Recovery Option (`replica.go`)
New config option `auto-recover: true` that automatically resets local state when LTX errors occur. Disabled by default.

### Reset Command (`cmd/litestream/reset.go`)
```bash
litestream reset /path/to/database.db
```
Clears local LTX files, forcing a fresh snapshot on next sync.

## Test plan

- [x] New tests for `LTXError` type and hints
- [x] New test for `DB.ResetLocalState()`
- [x] All existing tests pass
- [x] Pre-commit hooks pass

Fixes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)