### PR TITLE
vfs: Add Dockerfile.vfs for building VFS-enabled images

### DIFF
--- a/Dockerfile.vfs
+++ b/Dockerfile.vfs
@@ -1,0 +1,62 @@
+FROM golang:1.24 AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y git ca-certificates gcc libc6-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src/litestream
+COPY . .
+
+ARG LITESTREAM_VERSION=latest
+
+# Build main litestream binary with VFS support
+RUN --mount=type=cache,target=/root/.cache/go-build \
+	--mount=type=cache,target=/go/pkg \
+	CGO_ENABLED=1 go build \
+    -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}'" \
+    -tags "vfs,SQLITE3VFS_LOADABLE_EXT" \
+    -o /usr/local/bin/litestream ./cmd/litestream
+
+# Build VFS loadable extension following official Makefile
+# Use -ftls-model=local-dynamic to fix Alpine TLS issues
+RUN --mount=type=cache,target=/root/.cache/go-build \
+	--mount=type=cache,target=/go/pkg \
+	mkdir -p dist && \
+    CGO_ENABLED=1 go build \
+    -tags "vfs,SQLITE3VFS_LOADABLE_EXT" \
+    -buildmode=c-archive \
+    -o dist/litestream-vfs.a ./cmd/litestream-vfs && \
+    mv dist/litestream-vfs.h src/litestream-vfs.h && \
+    gcc -DSQLITE3VFS_LOADABLE_EXT -g -fPIC -shared \
+    -o dist/litestream-vfs.so \
+    src/litestream-vfs.c \
+    dist/litestream-vfs.a \
+    -lpthread -ldl -lm
+
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y ca-certificates sqlite3 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create lib directory and copy binaries and VFS extension
+RUN mkdir -p /usr/local/lib
+COPY --from=builder /usr/local/bin/litestream /usr/local/bin/litestream
+COPY --from=builder /src/litestream/dist/litestream-vfs.so /usr/local/lib/litestream-vfs.so
+
+# Set environment variables
+ENV LITESTREAM_LOG_LEVEL=info
+
+# Create wrapper for SQLite with VFS
+RUN cat > /usr/local/bin/litestream-vfs-sqlite << 'EOF' && chmod +x /usr/local/bin/litestream-vfs-sqlite
+#!/bin/sh
+if [ -z "$LITESTREAM_REPLICA_URL" ]; then
+    echo "Error: LITESTREAM_REPLICA_URL environment variable required"
+    echo "Example: export LITESTREAM_REPLICA_URL='s3://bucket/path'"
+    exit 1
+fi
+sqlite3 -cmd ".load /usr/local/lib/litestream-vfs.so sqlite3_litestreamvfs_init" "$@"
+EOF
+
+ENTRYPOINT ["/usr/local/bin/litestream"]
+CMD ["--help"]

--- a/cmd/litestream-vfs/main.go
+++ b/cmd/litestream-vfs/main.go
@@ -42,14 +42,21 @@ func LitestreamVFSRegister() {
 	var err error
 
 	replicaURL := os.Getenv("LITESTREAM_REPLICA_URL")
+	if replicaURL == "" {
+		log.Printf("litestream-vfs: LITESTREAM_REPLICA_URL environment variable required")
+		return
+	}
+
 	client, err = litestream.NewReplicaClientFromURL(replicaURL)
 	if err != nil {
-		log.Fatalf("failed to create replica client from URL: %s", err)
+		log.Printf("litestream-vfs: failed to create replica client from URL: %s", err)
+		return
 	}
 
 	// Initialize the client.
 	if err := client.Init(context.Background()); err != nil {
-		log.Fatalf("failed to initialize litestream replica client: %s", err)
+		log.Printf("litestream-vfs: failed to initialize replica client: %s", err)
+		return
 	}
 
 	var level slog.Level
@@ -64,7 +71,8 @@ func LitestreamVFSRegister() {
 	vfs := litestream.NewVFS(client, logger)
 
 	if err := sqlite3vfs.RegisterVFS("litestream", vfs); err != nil {
-		log.Fatalf("failed to register litestream vfs: %s", err)
+		log.Printf("litestream-vfs: failed to register VFS: %s", err)
+		return
 	}
 }
 


### PR DESCRIPTION
## Description

- replace `log.Fatalf` with `log.Printf` + `return` in VFS extension to prevent SQLite crashes and unfindable error messages
- use `debian:bookworm-slim` as the base image due to issues compiling the shared library

> Alpine uses musl libc which has TLS (Thread Local Storage) compatibility issues with Go-built shared libraries. When loading the VFS extension, we got TLS relocation errors like "initial-exec TLS resolves to dynamic definition". Debian/Ubuntu with glibc loads the Go-built `.so` file without these issues, making it the practical choice for the VFS Docker image.

I've built this image with:

```
docker buildx build -f Dockerfile.vfs . --tag imjasonh/litestream:vfs --push --platform=linux/amd64,linux/arm64
```

and an image is available at https://hub.docker.com/layers/imjasonh/litestream/vfs

## Motivation and Context

This adds a Dockerfile to build an image (e.g., `litestream/litestream:vfs`) which includes the VFS extension and a sqlite wrapper that pre-loads it

## How Has This Been Tested?

> Tested with Docker build that creates both litestream binary and VFS loadable extension. Validated by:
> 
> 1. **VFS registration**: Extension loads successfully and registers "litestream" VFS 
> 2. **End-to-end flow**: Created test database → replicated with litestream → read data through VFS using `file:path?vfs=litestream`
> 3. **Error handling**: Confirmed graceful failures with helpful error messages instead of process crashes
> 4. **Cross-platform**: Debian-based runtime works reliably (Alpine has musl/TLS issues with Go shared libs)
> 
> Test command: Created SQLite database, replicated to file backend, then successfully queried via VFS extension.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [n/a] I have updated the documentation accordingly (if needed)