### PR TITLE
feat: add Codex CLI Skill for Litestream

### DIFF
--- a/.codex/skills/litestream/SKILL.md
+++ b/.codex/skills/litestream/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: litestream
+description: SQLite disaster recovery and streaming replication to cloud storage (S3, GCS, Azure, SFTP, NATS). Use this skill for configuring Litestream, deploying to cloud platforms, troubleshooting WAL replication issues, and implementing point-in-time recovery for SQLite databases.
+---
+
+# Litestream
+
+Litestream is a disaster recovery tool for SQLite that runs as a background process, continuously replicating database changes to cloud storage. It monitors the SQLite Write-Ahead Log (WAL), converts changes to immutable LTX files, and uploads them to your chosen storage backend.
+
+## Key Concepts
+
+- **WAL Monitoring**: Watches SQLite Write-Ahead Log for changes at configurable intervals
+- **LTX Files**: Immutable files containing database page changes, never modified after creation
+- **Generations**: Transaction ID (TXID) ranges enabling point-in-time recovery
+- **Compaction**: Merges LTX files at configurable intervals to reduce storage overhead
+
+## Quick Start
+
+### Installation
+
+```bash
+# macOS
+brew install litestream
+
+# Linux (Debian/Ubuntu)
+wget https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.deb
+sudo dpkg -i litestream-v0.3.13-linux-amd64.deb
+
+# Docker
+docker pull litestream/litestream
+```
+
+### Basic Replication
+
+```bash
+# Command line (single database)
+litestream replicate /path/to/db.sqlite s3://bucket/db
+
+# With config file
+litestream replicate -config /etc/litestream.yml
+```
+
+### Restore Database
+
+```bash
+# Restore latest backup
+litestream restore -o /path/to/restored.db s3://bucket/db
+
+# Point-in-time recovery
+litestream restore -timestamp 2024-01-15T10:30:00Z -o /tmp/db s3://bucket/db
+
+# Restore to specific transaction
+litestream restore -txid 1000 -o /tmp/db s3://bucket/db
+```
+
+### Check Status
+
+```bash
+# View all databases and their replication status
+litestream status
+
+# List available LTX files
+litestream ltx /path/to/db.sqlite
+```
+
+## Critical Rules
+
+These rules are essential for correct Litestream operation:
+
+1. **Lock Page at 1GB**: SQLite reserves the page at offset 0x40000000 (1GB). This page must always be skipped during replication and compaction. The page number varies by page size:
+   - 4KB pages: page 262145
+   - 8KB pages: page 131073
+   - 16KB pages: page 65537
+
+2. **LTX Files are Immutable**: Once created, LTX files are never modified. New changes create new files.
+
+3. **Single Replica per Database**: Each database can only replicate to one destination. Use multiple Litestream instances for multiple destinations.
+
+4. **WAL Mode Required**: SQLite must be in WAL mode (`PRAGMA journal_mode=WAL;`)
+
+5. **Use `litestream ltx`**: The `litestream wal` command is deprecated.
+
+## Storage Backends
+
+| Backend | URL Scheme | Example |
+|---------|-----------|---------|
+| AWS S3 | `s3://` | `s3://bucket/path` |
+| S3-Compatible (R2, Tigris, MinIO) | `s3://` | `s3://bucket/path?endpoint=host:port` |
+| Google Cloud Storage | `gs://` | `gs://bucket/path` |
+| Azure Blob Storage | `abs://` | `abs://container@account/path` |
+| SFTP | `sftp://` | `sftp://user@host:22/path` |
+| NATS JetStream | `nats://` | `nats://host:4222/bucket` |
+| WebDAV | `webdav://` | `webdav://host/path` |
+| Alibaba OSS | `oss://` | `oss://bucket/path` |
+| Local File | (path) | `/var/backups/db` |
+
+## Configuration File Example
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+      region: us-east-1
+      sync-interval: 1s
+```
+
+## When to Use This Skill
+
+Use Litestream skill when:
+- Configuring SQLite database replication to cloud storage
+- Setting up disaster recovery for SQLite applications
+- Troubleshooting replication issues (WAL growth, sync failures)
+- Implementing point-in-time recovery procedures
+- Deploying Litestream with Docker, Fly.io, Kubernetes, or systemd
+- Understanding WAL-based replication concepts
+
+## Skill Contents
+
+- `concepts/` - Architecture, replication mechanics, LTX format, SQLite WAL
+- `configuration/` - Storage backend configurations and examples
+- `commands/` - CLI command reference (replicate, restore, status, ltx)
+- `operations/` - Monitoring, troubleshooting, and recovery procedures
+- `deployment/` - Docker, Fly.io, Kubernetes, and systemd deployment guides
+- `scripts/` - Validation and diagnostic helper scripts
+
+## Common Issues
+
+### WAL Growing Too Large
+- Check sync interval (default 1s may be too slow for write-heavy workloads)
+- Verify storage backend connectivity
+- Check for checkpoint blocking (long-running transactions)
+
+### Replication Lag
+- Monitor with `litestream status`
+- Check network connectivity to storage backend
+- Review sync interval configuration
+
+### Restore Failures
+- Verify backup exists: `litestream ltx /path/to/db`
+- Check storage backend credentials
+- Ensure target directory is writable
+
+## Links
+
+- [Official Documentation](https://litestream.io)
+- [GitHub Repository](https://github.com/benbjohnson/litestream)
+- [Getting Started Guide](https://litestream.io/getting-started/)

--- a/.codex/skills/litestream/commands/databases.md
+++ b/.codex/skills/litestream/commands/databases.md
@@ -1,0 +1,134 @@
+# databases Command
+
+List all databases in the configuration file.
+
+## Synopsis
+
+```bash
+litestream databases [-config PATH]
+```
+
+## Description
+
+The `databases` command lists all databases defined in your Litestream configuration file along with their replica type.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-config PATH` | Configuration file path (default: `/etc/litestream.yml`) |
+| `-no-expand-env` | Disable environment variable expansion |
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `path` | Path to the SQLite database file |
+| `replica` | Storage backend type (s3, gs, abs, sftp, nats, file, etc.) |
+
+## Examples
+
+### Basic Usage
+
+```bash
+$ litestream databases
+
+path                    replica
+/data/app.db            s3
+/data/users.db          s3
+/data/logs.db           file
+```
+
+### With Custom Config
+
+```bash
+$ litestream databases -config /etc/litestream-prod.yml
+
+path                    replica
+/data/production.db     s3
+```
+
+## Use Cases
+
+### Verify Configuration
+
+Ensure all expected databases are configured:
+
+```bash
+$ litestream databases
+# Check output includes all your databases
+```
+
+### Script Integration
+
+Use in scripts to iterate over databases:
+
+```bash
+#!/bin/bash
+# Check status of all databases
+for db in $(litestream databases | tail -n +2 | cut -f1); do
+    echo "Checking: $db"
+    litestream status "$db"
+done
+```
+
+### Debugging
+
+Verify configuration is loading correctly:
+
+```bash
+# With environment expansion
+litestream databases
+
+# Without environment expansion
+litestream databases -no-expand-env
+```
+
+## Configuration Examples
+
+The output reflects your configuration:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/app
+
+  - path: /data/users.db
+    replica:
+      type: gs
+      bucket: my-bucket
+      path: users
+
+  - path: /data/logs.db
+    replica:
+      path: /mnt/backup/logs
+```
+
+Output:
+```
+path              replica
+/data/app.db      s3
+/data/users.db    gs
+/data/logs.db     file
+```
+
+## Common Issues
+
+### Empty output
+- Check config file exists at expected location
+- Verify config file syntax with `cat /etc/litestream.yml`
+
+### "too many arguments"
+- This command takes no positional arguments
+- Flags must come before any arguments
+
+### Wrong databases shown
+- Verify correct config file is being loaded
+- Check `-config` flag or default location
+
+## See Also
+
+- [Configuration Overview](../configuration/overview.md)
+- [status Command](status.md)
+- [replicate Command](replicate.md)

--- a/.codex/skills/litestream/commands/ltx.md
+++ b/.codex/skills/litestream/commands/ltx.md
@@ -1,0 +1,165 @@
+# ltx Command
+
+List LTX files available for a database.
+
+## Synopsis
+
+```bash
+# From configured database
+litestream ltx [-config PATH] DB_PATH
+
+# From replica URL
+litestream ltx REPLICA_URL
+```
+
+## Description
+
+The `ltx` command lists all LTX (Log Transaction) files available for a database. This is useful for:
+
+- Verifying backups exist
+- Finding available restore points
+- Debugging replication issues
+- Understanding the backup timeline
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-config PATH` | Configuration file path (default: `/etc/litestream.yml`) |
+| `-no-expand-env` | Disable environment variable expansion |
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `min_txid` | Starting transaction ID |
+| `max_txid` | Ending transaction ID |
+| `size` | File size in bytes |
+| `created` | Creation timestamp (RFC3339) |
+
+## Examples
+
+### List from Config
+
+```bash
+$ litestream ltx /data/app.db
+
+min_txid              max_txid              size     created
+0000000000000001      0000000000000100      4096     2024-01-15T10:00:00Z
+0000000000000101      0000000000000200      8192     2024-01-15T10:30:00Z
+0000000000000201      0000000000000300      4096     2024-01-15T11:00:00Z
+```
+
+### List from Replica URL
+
+```bash
+$ litestream ltx s3://mybucket/app-backup
+
+min_txid              max_txid              size     created
+0000000000000001      0000000000001000      102400   2024-01-15T00:00:00Z
+```
+
+### Check Specific Storage
+
+```bash
+# S3
+litestream ltx s3://bucket/path
+
+# GCS
+litestream ltx gs://bucket/path
+
+# Azure
+litestream ltx abs://container@account/path
+
+# SFTP
+litestream ltx sftp://user@host/path
+```
+
+## Understanding Output
+
+### Transaction ID Range
+
+Each LTX file covers a range of transactions:
+- `min_txid`: First transaction in file
+- `max_txid`: Last transaction in file
+
+Files should be contiguous for complete recovery.
+
+### Compaction Levels
+
+LTX files exist at different compaction levels:
+- **L0**: Raw files from WAL changes (many small files)
+- **L1+**: Compacted files (fewer, larger files)
+
+The `ltx` command shows L0 files. Compacted files may have wider TXID ranges.
+
+### File Sizes
+
+- Small files (~4KB): Few pages changed
+- Large files: Many pages changed or compacted
+- Consistent sizes: Regular write patterns
+
+## Use Cases
+
+### Verify Backup Exists
+
+```bash
+# Check that backups are being created
+litestream ltx s3://bucket/backup | head -5
+```
+
+### Find Restore Point
+
+```bash
+# Find transaction around a specific time
+litestream ltx /data/app.db | grep "2024-01-15T10"
+```
+
+### Diagnose Gaps
+
+```bash
+# Look for TXID gaps (missing transactions)
+litestream ltx /data/app.db
+# Check that max_txid of one file matches min_txid-1 of next
+```
+
+### Check Replication Lag
+
+```bash
+# Compare local vs remote TXIDs
+# Local TXID
+litestream status /data/app.db
+
+# Remote TXID (latest max_txid)
+litestream ltx s3://bucket/backup | tail -1
+```
+
+## Common Issues
+
+### "database not found in config"
+- Verify database path matches config exactly
+- Check config file is being loaded
+
+### "database has no replica"
+- Add replica configuration for the database
+- Check config file syntax
+
+### Empty output
+- No LTX files have been created yet
+- Start `litestream replicate` first
+- Make a write to the database to trigger replication
+
+### Connection errors
+- Verify storage credentials
+- Check network connectivity
+- Review endpoint configuration
+
+## Note: Deprecated Command
+
+The `litestream wal` command has been deprecated and replaced by `litestream ltx`. Use `ltx` for listing backup files.
+
+## See Also
+
+- [restore Command](restore.md)
+- [status Command](status.md)
+- [LTX Format](../concepts/ltx-format.md)

--- a/.codex/skills/litestream/commands/replicate.md
+++ b/.codex/skills/litestream/commands/replicate.md
@@ -1,0 +1,165 @@
+# replicate Command
+
+Continuously replicate SQLite databases to cloud storage.
+
+## Synopsis
+
+```bash
+# With config file
+litestream replicate [-config PATH]
+
+# With command line arguments
+litestream replicate [flags] DB_PATH REPLICA_URL [REPLICA_URL...]
+
+# Run application alongside replication
+litestream replicate -exec "myapp serve"
+```
+
+## Description
+
+The `replicate` command is the main Litestream daemon. It:
+
+1. Opens configured SQLite databases
+2. Monitors the WAL for changes
+3. Converts changes to LTX format
+4. Uploads to configured storage backends
+5. Manages checkpoints and compaction
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-config PATH` | Configuration file path (default: `/etc/litestream.yml`) |
+| `-no-expand-env` | Disable environment variable expansion |
+| `-exec COMMAND` | Run command as subprocess (shutdown when it exits) |
+| `-restore-if-db-not-exists` | Restore from replica if database doesn't exist |
+| `-once` | Replicate once and exit |
+| `-force-snapshot` | Force snapshot creation (requires `-once`) |
+| `-enforce-retention` | Enforce snapshot retention (requires `-once`) |
+
+## Examples
+
+### Using Config File
+
+```bash
+# Use default config location
+litestream replicate
+
+# Specify config file
+litestream replicate -config /path/to/litestream.yml
+```
+
+### Command Line Arguments
+
+```bash
+# Single replica
+litestream replicate /data/app.db s3://bucket/backup
+
+# Multiple replicas (deprecated: use config file)
+litestream replicate /data/app.db s3://bucket/backup sftp://user@host/backup
+```
+
+### Run Application Subprocess
+
+```bash
+# Via command line
+litestream replicate -exec "myapp serve --port 8080"
+
+# Via config file
+# exec: "myapp serve --port 8080"
+```
+
+Litestream will:
+1. Start replication
+2. Execute the command
+3. Shut down gracefully when command exits
+
+### Auto-Restore on Startup
+
+```bash
+litestream replicate -restore-if-db-not-exists
+```
+
+If the database doesn't exist, restore it from the replica before starting replication.
+
+### One-Shot Replication
+
+```bash
+# Replicate once and exit
+litestream replicate -once
+
+# Force snapshot during one-shot
+litestream replicate -once -force-snapshot
+
+# Enforce retention during one-shot
+litestream replicate -once -enforce-retention
+```
+
+Useful for:
+- Manual backup triggers
+- CI/CD pipelines
+- Periodic snapshots via cron
+
+## Behavior
+
+### Startup Sequence
+
+1. Load and validate configuration
+2. Open each configured database
+3. Optionally restore missing databases
+4. Start WAL monitoring
+5. Begin replication to backends
+6. Optionally execute subprocess
+7. Start metrics server (if configured)
+
+### Monitoring Intervals
+
+- **WAL Check**: Every `monitor-interval` (default: 10ms)
+- **Sync**: Every `sync-interval` (default: 1s)
+- **Checkpoint**: When page threshold reached or `checkpoint-interval` elapsed
+- **Compaction**: Per configured level intervals
+
+### Graceful Shutdown
+
+On SIGTERM or SIGINT:
+1. Stop accepting new connections
+2. Wait for in-flight syncs (up to `shutdown-sync-timeout`)
+3. Perform final sync
+4. Close databases
+5. Exit
+
+## Metrics
+
+When `addr` is configured, Prometheus metrics available at `/metrics`:
+
+```
+litestream_db_size_bytes{db="/path/to/db"}
+litestream_wal_size_bytes{db="/path/to/db"}
+litestream_sync_count_total{db="/path/to/db"}
+litestream_checkpoint_count_total{db="/path/to/db"}
+```
+
+## Common Issues
+
+### "database not found in config"
+- Verify database path matches exactly
+- Check path expansion (~ vs absolute)
+
+### "cannot specify -once with -exec"
+- These flags are mutually exclusive
+- Use one or the other
+
+### "flag must be positioned before arguments"
+- Put all flags before DB_PATH and REPLICA_URL
+- Example: `litestream replicate -once /data/app.db s3://bucket`
+
+### Database not syncing
+- Check sync-interval is appropriate
+- Verify storage backend credentials
+- Review logs for errors
+
+## See Also
+
+- [Configuration Overview](../configuration/overview.md)
+- [restore Command](restore.md)
+- [status Command](status.md)

--- a/.codex/skills/litestream/commands/restore.md
+++ b/.codex/skills/litestream/commands/restore.md
@@ -1,0 +1,188 @@
+# restore Command
+
+Restore a SQLite database from a backup.
+
+## Synopsis
+
+```bash
+# Restore from replica URL
+litestream restore -o OUTPUT_PATH REPLICA_URL
+
+# Restore from configured database
+litestream restore [-config PATH] [-o OUTPUT_PATH] DB_PATH
+```
+
+## Description
+
+The `restore` command recovers a SQLite database from LTX backup files. It can:
+
+- Restore to the latest available state
+- Restore to a specific point in time
+- Restore to a specific transaction ID
+- Skip restoration if database already exists
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-o PATH` | Output path for restored database (required with URL) |
+| `-config PATH` | Configuration file path |
+| `-no-expand-env` | Disable environment variable expansion |
+| `-timestamp TIME` | Restore to specific timestamp (RFC3339 format) |
+| `-txid TXID` | Restore to specific transaction ID |
+| `-parallelism N` | Number of parallel downloads (default: runtime.NumCPU) |
+| `-if-db-not-exists` | Skip if output file already exists |
+| `-if-replica-exists` | Skip if no backup files found |
+
+## Examples
+
+### Basic Restore
+
+```bash
+# From replica URL
+litestream restore -o /data/app.db s3://bucket/app-backup
+
+# From configured database
+litestream restore /data/app.db
+```
+
+### Point-in-Time Recovery
+
+Restore to a specific timestamp:
+
+```bash
+litestream restore -timestamp 2024-01-15T10:30:00Z -o /data/app.db s3://bucket/backup
+```
+
+Timestamp must be in RFC3339 format (ISO 8601 with timezone).
+
+### Restore to Transaction ID
+
+```bash
+litestream restore -txid 1000 -o /data/app.db s3://bucket/backup
+```
+
+### Conditional Restore
+
+```bash
+# Only restore if database doesn't exist
+litestream restore -if-db-not-exists -o /data/app.db s3://bucket/backup
+
+# Skip silently if no backups available
+litestream restore -if-replica-exists -o /data/app.db s3://bucket/backup
+```
+
+### Parallel Downloads
+
+Speed up large restores:
+
+```bash
+litestream restore -parallelism 8 -o /data/app.db s3://bucket/backup
+```
+
+## Restore Process
+
+1. **Connect** to storage backend
+2. **List** available LTX files
+3. **Find** target transaction (latest, timestamp, or TXID)
+4. **Download** required LTX files in parallel
+5. **Apply** pages in transaction order
+6. **Write** restored database to output path
+
+## Output Path Behavior
+
+### With Replica URL
+
+Output path (`-o`) is required:
+
+```bash
+litestream restore -o /data/app.db s3://bucket/backup
+```
+
+### With Config File
+
+If `-o` not specified, restores to the configured database path:
+
+```bash
+# Restores to /data/app.db (from config)
+litestream restore /data/app.db
+```
+
+Override with `-o`:
+
+```bash
+# Restore to different location
+litestream restore -o /tmp/test.db /data/app.db
+```
+
+## Finding Available Backups
+
+Before restoring, check available backups:
+
+```bash
+# List LTX files
+litestream ltx s3://bucket/backup
+
+# Output:
+# min_txid        max_txid        size    created
+# 0000000000000001 0000000000000100 4096    2024-01-15T10:00:00Z
+# 0000000000000101 0000000000000200 8192    2024-01-15T10:30:00Z
+```
+
+## Common Issues
+
+### "no matching backup files available"
+- Verify replica URL is correct
+- Check storage credentials
+- Use `litestream ltx` to see available backups
+- Add `-if-replica-exists` to skip silently
+
+### "output path required"
+- Add `-o PATH` when using replica URL directly
+
+### "database not found in config"
+- Verify database path matches config exactly
+- Check config file is loaded correctly
+
+### "invalid -timestamp"
+- Use RFC3339 format: `2024-01-15T10:30:00Z`
+- Include timezone (Z for UTC)
+
+### Slow restore
+- Increase `-parallelism` for large databases
+- Check network connectivity to storage backend
+
+## Automation
+
+### Startup Script
+
+```bash
+#!/bin/bash
+DB_PATH=/data/app.db
+REPLICA_URL=s3://bucket/backup
+
+# Restore if database doesn't exist
+if [ ! -f "$DB_PATH" ]; then
+    litestream restore -o "$DB_PATH" "$REPLICA_URL"
+fi
+
+# Start application
+exec myapp serve
+```
+
+### Docker Entrypoint
+
+```bash
+#!/bin/bash
+# Restore database if not present
+litestream restore -if-db-not-exists -o /data/app.db s3://bucket/backup
+
+# Start Litestream with application
+exec litestream replicate -exec "myapp serve"
+```
+
+## See Also
+
+- [replicate Command](replicate.md)
+- [ltx Command](ltx.md)
+- [Recovery Operations](../operations/recovery.md)

--- a/.codex/skills/litestream/commands/status.md
+++ b/.codex/skills/litestream/commands/status.md
@@ -1,0 +1,137 @@
+# status Command
+
+Display replication status for configured databases.
+
+## Synopsis
+
+```bash
+litestream status [-config PATH] [DATABASE_PATH]
+```
+
+## Description
+
+The `status` command shows the current replication state of databases in your configuration file. It displays:
+
+- Database path
+- Current status
+- Local transaction ID
+- WAL file size
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-config PATH` | Configuration file path (default: `/etc/litestream.yml`) |
+| `-no-expand-env` | Disable environment variable expansion |
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `database` | Path to the SQLite database file |
+| `status` | Current state: `ok`, `not initialized`, `no database`, `error` |
+| `local txid` | Latest local transaction ID |
+| `wal size` | Current WAL file size |
+
+## Status Values
+
+| Status | Description |
+|--------|-------------|
+| `ok` | Database is operational and has been replicated |
+| `not initialized` | Database exists but hasn't been replicated yet |
+| `no database` | Database file doesn't exist at configured path |
+| `error` | Unable to read database status |
+| `unknown` | Status could not be determined |
+
+## Examples
+
+### View All Databases
+
+```bash
+$ litestream status
+
+database           status            local txid            wal size
+/data/app.db       ok                0000000000001234      1.2 MB
+/data/users.db     ok                0000000000000567      256 KB
+/data/logs.db      not initialized   -                     0 B
+```
+
+### View Specific Database
+
+```bash
+$ litestream status /data/app.db
+
+database           status            local txid            wal size
+/data/app.db       ok                0000000000001234      1.2 MB
+```
+
+### With Custom Config
+
+```bash
+$ litestream status -config /etc/litestream-prod.yml
+```
+
+## Understanding the Output
+
+### Transaction ID (TXID)
+
+The local TXID shows the latest transaction that has been:
+1. Written to the WAL
+2. Converted to LTX format
+3. Stored locally
+
+This is the local state, not necessarily the replicated state.
+
+### WAL Size
+
+The WAL size indicates how much data is pending:
+- Small size: WAL is being checkpointed regularly
+- Large size: Checkpoint may be blocked or writes are very frequent
+- `0 B`: No pending changes or WAL doesn't exist
+
+## Limitations
+
+The `status` command shows **local state only**. It does not:
+- Connect to storage backends
+- Show replica TXID or sync status
+- Display replication lag
+
+For replica-side status, use:
+- `litestream ltx` to list remote LTX files
+- Check Prometheus metrics during `replicate`
+- Review Litestream logs
+
+## Common Issues
+
+### "no database"
+- Database file doesn't exist at configured path
+- Check path in config file
+- Run `litestream restore` if needed
+
+### "not initialized"
+- Database exists but Litestream hasn't created LTX files yet
+- Start `litestream replicate` to initialize
+- Make a write to trigger replication
+
+### "error"
+- Unable to read database metadata
+- Check file permissions
+- Verify database isn't corrupted
+
+## Monitoring
+
+For ongoing monitoring during replication:
+
+```bash
+# Watch status
+watch -n 5 litestream status
+
+# Or use Prometheus metrics
+curl http://localhost:9090/metrics | grep litestream
+```
+
+## See Also
+
+- [replicate Command](replicate.md)
+- [ltx Command](ltx.md)
+- [Monitoring](../operations/monitoring.md)

--- a/.codex/skills/litestream/concepts/architecture.md
+++ b/.codex/skills/litestream/concepts/architecture.md
@@ -1,0 +1,161 @@
+# Litestream Architecture
+
+## System Overview
+
+Litestream follows a layered architecture with clear separation of concerns:
+
+```
+Application Layer
+├── CLI Commands (replicate, restore, status, ltx)
+└── Configuration (YAML parsing, validation)
+        ↓
+Core Layer
+├── Store (multi-database coordination, compaction)
+├── DB (single database management, WAL monitoring)
+└── Replica (replication to single destination)
+        ↓
+Storage Abstraction
+└── ReplicaClient Interface
+        ↓
+Storage Implementations
+├── S3, GCS, Azure, OSS (cloud object storage)
+├── SFTP, WebDAV (file transfer protocols)
+├── NATS (message streaming)
+└── File (local filesystem)
+```
+
+## Core Components
+
+### Store
+
+The Store coordinates multiple databases and system-wide resources:
+
+- Manages list of monitored databases
+- Schedules compaction across all databases
+- Handles snapshot creation and retention
+- Configures compaction levels (L0, L1, L2...)
+
+### DB (Database Manager)
+
+The DB component manages a single SQLite database:
+
+- Opens and maintains SQLite connection
+- Monitors WAL for changes at `MonitorInterval`
+- Performs checkpoints when thresholds are reached
+- Converts WAL changes to LTX format
+- Coordinates with replicas for sync
+
+Key configuration:
+- `MonitorInterval`: How often to check for WAL changes (default: 10ms)
+- `CheckpointInterval`: Time-based checkpoint trigger
+- `MinCheckpointPageN`: Minimum pages before passive checkpoint
+- `TruncatePageN`: Emergency checkpoint threshold
+
+### Replica
+
+The Replica manages replication to a single destination:
+
+- Tracks replication position (TXID, PageNo, Checksum)
+- Uploads LTX files to storage backend
+- Handles sync intervals and retries
+
+Key configuration:
+- `SyncInterval`: How often to sync changes (default: 1s)
+- `ValidationInterval`: How often to validate replica integrity
+
+## Data Flow
+
+### Replication Flow
+
+1. **Application writes** to SQLite database
+2. SQLite writes changes to **WAL file**
+3. Litestream's **monitor goroutine** detects WAL changes
+4. Changes are converted to **LTX format**
+5. LTX files are uploaded via **ReplicaClient**
+6. Storage backend stores **immutable LTX files**
+7. Periodic **checkpoint** moves WAL changes to main database
+8. **Compaction** merges LTX files to reduce storage
+
+### Restoration Flow
+
+1. User requests restore with `litestream restore`
+2. Litestream queries storage for **available LTX files**
+3. Files are downloaded and **applied in order**
+4. Pages are written to **restored database**
+5. Lock page at 1GB is **always skipped**
+6. Final database is ready for use
+
+## LTX File Format
+
+LTX (Log Transaction) files are immutable containers for database changes:
+
+```
++------------------+
+|     Header       |  Magic, version, page size, TXID range
++------------------+
+|   Page Frames    |  Page number + page data (variable count)
++------------------+
+|   Page Index     |  Binary search index for page lookup
++------------------+
+|     Trailer      |  Checksums and metadata
++------------------+
+```
+
+### File Naming
+
+LTX files are named by their transaction range: `{MinTXID}-{MaxTXID}.ltx`
+
+Example: `0000000000000001-0000000000000100.ltx`
+
+### Compaction Levels
+
+- **L0**: Raw LTX files from WAL changes
+- **L1**: Hourly compaction (merges L0 files)
+- **L2**: Daily compaction (merges L1 files)
+- Higher levels for longer retention
+
+## Layer Responsibilities
+
+| Layer | Responsibility | Files |
+|-------|---------------|-------|
+| Store | Multi-DB coordination, compaction scheduling | `store.go` |
+| DB | WAL monitoring, checkpointing, LTX creation | `db.go` |
+| Replica | Sync mechanics, position tracking | `replica.go` |
+| ReplicaClient | Storage backend implementation | `*/replica_client.go` |
+
+**Important**: Database state logic (restoration, position) belongs in the DB layer, not the Replica layer.
+
+## Concurrency Model
+
+Litestream uses Go's concurrency primitives:
+
+- **sync.RWMutex** for protecting shared state
+- **Goroutines** for background monitoring and sync
+- **Channels** for shutdown coordination
+- **Context** for cancellation propagation
+
+Lock ordering to prevent deadlocks:
+1. Store.mu
+2. DB.mu
+3. DB.chkMu (checkpoint)
+4. Replica.mu
+
+## Metrics and Monitoring
+
+Prometheus metrics exposed on configured address:
+
+- `litestream_db_size_bytes` - Database file size
+- `litestream_wal_size_bytes` - WAL file size
+- `litestream_replica_lag_seconds` - Replication lag
+- `litestream_sync_count_total` - Total sync operations
+- `litestream_checkpoint_count_total` - Total checkpoints
+
+## Error Handling
+
+Litestream categorizes errors:
+
+1. **Recoverable**: Network timeouts, temporary unavailability (retried with backoff)
+2. **Fatal**: Database corruption, invalid configuration (stops operation)
+3. **Operational**: Checkpoint failures, sync delays (logged, continues)
+
+Exponential backoff: 1s initial, 1m max, doubles on each retry.

--- a/.codex/skills/litestream/concepts/generations.md
+++ b/.codex/skills/litestream/concepts/generations.md
@@ -1,0 +1,235 @@
+# Generations and Compaction
+
+Understanding TXID, generations, and compaction levels.
+
+## Transaction IDs (TXID)
+
+Every transaction in Litestream has a unique Transaction ID (TXID):
+
+- Monotonically increasing 64-bit integer
+- Starts at 1 for new databases
+- Increments with each transaction
+- Used for ordering and recovery
+
+### TXID Format
+
+Displayed as 16-character hex strings:
+```
+0000000000000001  (TXID 1)
+0000000000001234  (TXID 4660)
+FFFFFFFFFFFFFFFF  (max TXID)
+```
+
+## LTX File Naming
+
+LTX files are named by their transaction range:
+
+```
+{MinTXID}-{MaxTXID}.ltx
+```
+
+Examples:
+```
+0000000000000001-0000000000000100.ltx  # TXIDs 1-256
+0000000000000101-0000000000000200.ltx  # TXIDs 257-512
+```
+
+## Generations
+
+A generation represents a continuous sequence of transactions:
+
+- Starts with a base snapshot
+- Contains all changes since snapshot
+- New generation created when:
+  - Fresh database (no prior backup)
+  - Snapshot created
+  - Replication restarted from scratch
+
+### Generation Structure
+
+```
+generations/
+├── 0000000000000001/     # First generation
+│   ├── 0/                # Level 0 (raw)
+│   ├── 1/                # Level 1 (compacted)
+│   └── 2/                # Level 2 (more compacted)
+└── 0000000000000002/     # Second generation (after snapshot)
+    ├── 0/
+    ├── 1/
+    └── 2/
+```
+
+## Compaction Levels
+
+### Level Overview
+
+| Level | Contents | Typical Interval |
+|-------|----------|-----------------|
+| L0 | Raw LTX files from sync | - |
+| L1 | L0 files compacted | 30s |
+| L2 | L1 files compacted | 5m |
+| L3 | L2 files compacted | 1h |
+
+### Why Compact?
+
+1. **Reduce file count**: Many small files → fewer large files
+2. **Save storage**: Eliminate duplicate pages
+3. **Faster restore**: Fewer files to download
+
+### Compaction Process
+
+```
+L0: [1-10] [11-20] [21-30] [31-40] [41-50]
+         ↓ Compact
+L1: [1-50]
+         ↓ Compact (with more L1 files)
+L2: [1-500]
+```
+
+During compaction:
+1. Read files from lower level
+2. Merge pages (keep latest version of each page)
+3. Write single file at higher level
+4. Delete old files (after retention)
+
+### Page Deduplication
+
+If a page is modified multiple times:
+
+```
+L0 File 1: Page 5 (version A)
+L0 File 2: Page 5 (version B)
+L0 File 3: Page 5 (version C)
+
+After compaction:
+L1 File: Page 5 (version C only)
+```
+
+## Configuration
+
+### Compaction Levels
+
+```yaml
+levels:
+  - interval: 30s    # L1: Compact every 30 seconds
+  - interval: 5m     # L2: Compact every 5 minutes
+  - interval: 1h     # L3: Compact hourly
+```
+
+### L0 Retention
+
+```yaml
+l0-retention: 1h                    # Keep L0 files for 1 hour
+l0-retention-check-interval: 5m     # Check retention every 5 minutes
+```
+
+### Snapshots
+
+```yaml
+snapshot:
+  interval: 24h      # Create snapshot daily
+  retention: 24h     # Keep snapshots for 24 hours
+```
+
+## Recovery and Generations
+
+### Latest Recovery
+
+Uses most recent generation:
+1. Find latest snapshot (or start of generation)
+2. Apply all LTX files in order
+3. Result: Latest state
+
+### Point-in-Time Recovery
+
+Uses specific TXID or timestamp:
+1. Find generation containing target
+2. Find snapshot before target
+3. Apply LTX files up to target
+4. Result: State at that point
+
+### Example
+
+```bash
+# Find available TXIDs
+litestream ltx /data/app.db
+
+# Output:
+min_txid              max_txid              size     created
+0000000000000001      0000000000000100      4096     2024-01-15T10:00:00Z
+0000000000000101      0000000000000200      8192     2024-01-15T10:30:00Z
+
+# Restore to TXID 150
+litestream restore -txid 150 -o /tmp/db s3://bucket/backup
+```
+
+## Timestamp Preservation
+
+During compaction, the original timestamp is preserved:
+
+- **CreatedAt**: When the original data was written
+- Used for point-in-time recovery
+- Preserved even when files are merged
+
+## Storage Layout
+
+Full storage structure:
+
+```
+s3://bucket/backup/
+├── generations/
+│   ├── 0000000000000001/
+│   │   ├── 0/
+│   │   │   ├── 00000001-00000100.ltx
+│   │   │   └── 00000101-00000200.ltx
+│   │   ├── 1/
+│   │   │   └── 00000001-00001000.ltx
+│   │   └── 2/
+│   │       └── 00000001-00010000.ltx
+│   └── 0000000000000002/
+│       └── ...
+└── snapshots/
+    └── ...
+```
+
+## Best Practices
+
+### High-Frequency Writes
+
+```yaml
+levels:
+  - interval: 15s    # More frequent L1 compaction
+  - interval: 2m
+  - interval: 30m
+```
+
+### Long-Term Retention
+
+```yaml
+levels:
+  - interval: 1m
+  - interval: 15m
+  - interval: 6h     # Higher level for long retention
+  - interval: 24h
+
+snapshot:
+  interval: 168h     # Weekly snapshots
+  retention: 720h    # Keep for 30 days
+```
+
+### Minimize Storage Costs
+
+```yaml
+levels:
+  - interval: 30s
+  - interval: 5m
+  - interval: 1h
+
+l0-retention: 30m    # Delete L0 quickly after compaction
+```
+
+## See Also
+
+- [LTX Format](ltx-format.md)
+- [Replication](replication.md)
+- [Recovery](../operations/recovery.md)

--- a/.codex/skills/litestream/concepts/ltx-format.md
+++ b/.codex/skills/litestream/concepts/ltx-format.md
@@ -1,0 +1,231 @@
+# LTX File Format
+
+LTX (Log Transaction) is Litestream's immutable file format for storing database changes.
+
+## Overview
+
+LTX files contain:
+- Database page changes from transactions
+- Metadata for recovery (TXID range, timestamps)
+- Checksums for integrity verification
+
+Key properties:
+- **Immutable**: Never modified after creation
+- **Self-contained**: All data needed for that TXID range
+- **Efficient**: Binary format, page-level granularity
+
+## File Structure
+
+```
++------------------+
+|     Header       |  Fixed-size metadata
++------------------+
+|                  |
+|   Page Frames    |  Variable: page headers + data
+|                  |
++------------------+
+|   Page Index     |  Binary search index
++------------------+
+|     Trailer      |  Checksums and summary
++------------------+
+```
+
+## Header
+
+The header contains file metadata:
+
+| Field | Size | Description |
+|-------|------|-------------|
+| Magic | 4 bytes | "LTX\x00" |
+| Version | 4 bytes | Format version |
+| PageSize | 4 bytes | Database page size |
+| MinTXID | 8 bytes | Starting transaction ID |
+| MaxTXID | 8 bytes | Ending transaction ID |
+| Timestamp | 8 bytes | Creation timestamp |
+| Checksum | 8 bytes | Header checksum (CRC-64) |
+
+## Page Frames
+
+Each page frame contains:
+
+### Page Header
+
+| Field | Size | Description |
+|-------|------|-------------|
+| PageNo | 4 bytes | Page number in database |
+| Size | 4 bytes | Size of page data |
+| Checksum | 8 bytes | Page data checksum |
+
+### Page Data
+
+Raw page data follows the header:
+- Size equals database page size (typically 4KB)
+- Contains the exact bytes for that database page
+
+## Page Index
+
+Binary index for efficient page lookup:
+
+| Field | Size | Description |
+|-------|------|-------------|
+| PageNo | 4 bytes | Page number |
+| Offset | 8 bytes | Offset in file |
+| Size | 4 bytes | Size of page frame |
+
+The index enables:
+- O(log n) page lookup by number
+- Random access to specific pages
+- Efficient restoration
+
+## Trailer
+
+File summary and checksums:
+
+| Field | Size | Description |
+|-------|------|-------------|
+| PageIndexOffset | 8 bytes | Offset to page index |
+| PageIndexSize | 8 bytes | Size of page index |
+| PageCount | 4 bytes | Total pages in file |
+| Checksum | 8 bytes | Full file checksum |
+
+## Checksums
+
+LTX uses CRC-64 ECMA for integrity:
+- Header checksum: Verifies header integrity
+- Page checksums: Verifies individual pages
+- File checksum: Verifies entire file
+
+## File Naming
+
+Files are named by their TXID range:
+
+```
+{MinTXID}-{MaxTXID}.ltx
+```
+
+Examples:
+```
+0000000000000001-0000000000000100.ltx
+0000000000000101-0000000000000200.ltx
+```
+
+TXID is displayed as 16-character hexadecimal.
+
+## Lock Page Handling
+
+**Critical**: The SQLite lock page at 1GB must be skipped.
+
+| Page Size | Lock Page Number |
+|-----------|-----------------|
+| 4KB | 262145 |
+| 8KB | 131073 |
+| 16KB | 65537 |
+
+LTX files never contain the lock page:
+- Skipped during file creation
+- Skipped during restoration
+- Ensures database compatibility
+
+## Reading LTX Files
+
+### Header Reading
+
+1. Read first 52 bytes
+2. Verify magic is "LTX\x00"
+3. Validate header checksum
+4. Extract TXID range and page size
+
+### Page Reading
+
+1. Read trailer to get index offset
+2. Read page index
+3. Binary search for page number
+4. Seek to offset and read frame
+
+### Full File Reading
+
+1. Read and verify header
+2. Iterate page frames
+3. For each frame:
+   - Read page header
+   - Read page data
+   - Verify page checksum
+4. Verify file checksum in trailer
+
+## Creating LTX Files
+
+### From WAL Frames
+
+1. Create header with TXID range
+2. For each WAL frame:
+   - Skip if lock page
+   - Write page header
+   - Write page data
+3. Build page index
+4. Write index and trailer
+5. Calculate checksums
+
+### During Compaction
+
+1. Read source LTX files
+2. Merge pages (keep latest)
+3. Create new file with merged data
+4. Preserve earliest timestamp
+
+## Compaction Merging
+
+When pages appear in multiple files:
+
+```
+File 1: Page 5 (TXID 1-100)
+File 2: Page 5 (TXID 101-200)
+
+Merged: Page 5 (TXID 101-200 version only)
+```
+
+The latest version (highest TXID) is kept.
+
+## Size Characteristics
+
+### Small LTX Files
+- Few pages changed
+- Typical for low-activity databases
+- Size: ~4KB per page + overhead
+
+### Large LTX Files
+- Many pages changed
+- Result of compaction
+- Can be megabytes
+
+### Compacted Files
+- Eliminate duplicate pages
+- Larger TXID ranges
+- More efficient storage
+
+## Validation
+
+LTX files can be validated:
+
+```bash
+# List files (validates during read)
+litestream ltx /path/to/db
+
+# Restore validates during application
+litestream restore -o /tmp/test.db s3://bucket/backup
+```
+
+## Use in Recovery
+
+During restoration:
+1. List all LTX files
+2. Sort by TXID order
+3. Read pages from each file
+4. Apply to output database
+5. Skip lock page
+6. Verify checksums
+
+## See Also
+
+- [Replication](replication.md)
+- [Generations](generations.md)
+- [SQLite WAL](sqlite-wal.md)

--- a/.codex/skills/litestream/concepts/replication.md
+++ b/.codex/skills/litestream/concepts/replication.md
@@ -1,0 +1,192 @@
+# Replication Mechanics
+
+How Litestream replicates SQLite databases.
+
+## Replication Flow
+
+```
+1. Application writes to SQLite
+          ↓
+2. SQLite writes to WAL file
+          ↓
+3. Litestream monitors WAL (MonitorInterval)
+          ↓
+4. Changes converted to LTX format
+          ↓
+5. LTX files uploaded (SyncInterval)
+          ↓
+6. Storage backend stores files
+          ↓
+7. Periodic checkpoint & compaction
+```
+
+## WAL Monitoring
+
+Litestream monitors the WAL file for changes:
+
+```yaml
+monitor-interval: 10ms  # How often to check WAL (default)
+```
+
+The monitor:
+1. Checks WAL file size and modification time
+2. Compares with previous state
+3. Reads new frames when changes detected
+4. Notifies replicas of pending changes
+
+## Sync Process
+
+Syncing uploads changes to the storage backend:
+
+```yaml
+sync-interval: 1s  # How often to sync (default)
+```
+
+The sync process:
+1. Collects pending WAL frames
+2. Creates LTX file with page data
+3. Uploads to storage backend
+4. Updates replication position
+
+## Position Tracking
+
+Litestream tracks replication position using:
+
+- **TXID**: Transaction ID (monotonically increasing)
+- **PageNo**: Current page number within transaction
+- **Checksum**: Running checksum for validation
+
+Position is stored locally and used for:
+- Resuming replication after restart
+- Detecting gaps in replication
+- Point-in-time recovery
+
+## LTX File Creation
+
+WAL frames are converted to LTX format:
+
+1. Group frames by transaction
+2. Skip lock page (at 1GB mark)
+3. Write header with TXID range
+4. Write page frames with data
+5. Generate page index
+6. Write trailer with checksums
+
+## Checkpoint Coordination
+
+Litestream coordinates with SQLite checkpoints:
+
+### When Checkpoints Occur
+
+1. **Page threshold**: `min-checkpoint-page-count` reached
+2. **Time interval**: `checkpoint-interval` elapsed
+3. **Emergency**: `truncate-page-n` exceeded
+
+### Checkpoint Process
+
+1. Release read transaction temporarily
+2. Execute `PRAGMA wal_checkpoint(PASSIVE)`
+3. Restart read transaction
+4. Continue monitoring
+
+### Why PASSIVE Mode
+
+Litestream uses PASSIVE checkpoints:
+- Non-blocking (doesn't wait for readers)
+- Doesn't interrupt application writes
+- May not fully checkpoint if readers present
+
+## Compaction
+
+Compaction merges LTX files to reduce storage:
+
+### Compaction Levels
+
+| Level | Typical Interval | Purpose |
+|-------|-----------------|---------|
+| L0 | - | Raw files from sync |
+| L1 | 30s | Reduce file count |
+| L2 | 5m | Further consolidation |
+| L3 | 1h | Long-term storage |
+
+### Compaction Process
+
+1. List files at level N-1
+2. Read local files (preferred) or remote
+3. Merge pages, keeping latest version
+4. Write compacted file at level N
+5. Delete old files (after retention)
+
+### Immutability
+
+LTX files are **never modified** after creation:
+- New data creates new files
+- Compaction creates new merged files
+- Old files deleted only after retention
+
+## Eventual Consistency
+
+Storage backends may have eventual consistency:
+
+### During Compaction
+
+Litestream handles this by:
+1. Preferring local files when available
+2. Falling back to remote only when necessary
+3. Using retries with backoff
+
+### File Listing
+
+Some backends don't immediately show new files:
+- S3: Usually consistent, some edge cases
+- GCS: Usually consistent
+- SFTP: Immediate consistency
+
+## Recovery Position
+
+When restarting, Litestream:
+
+1. Reads local metadata for last position
+2. Validates against storage backend
+3. Resumes from validated position
+4. Creates new LTX files from WAL
+
+## Shadow WAL
+
+Litestream maintains a "shadow" of WAL state:
+
+- Prevents SQLite from checkpointing unsynced data
+- Ensures all changes are captured
+- Uses long-running read transaction
+
+## Sync Guarantees
+
+Litestream provides:
+
+- **Durability**: Data synced to storage survives local failure
+- **Ordering**: Transactions applied in order
+- **Completeness**: All committed transactions replicated
+
+It does **not** provide:
+- Real-time sync (subject to sync-interval)
+- Multi-master replication
+- Conflict resolution
+
+## Configuration Example
+
+```yaml
+dbs:
+  - path: /data/app.db
+    monitor-interval: 10ms       # WAL check frequency
+    checkpoint-interval: 1m      # Time-based checkpoint
+    min-checkpoint-page-count: 1000  # Page-based checkpoint
+    replica:
+      url: s3://bucket/backup
+      sync-interval: 1s          # Upload frequency
+```
+
+## See Also
+
+- [Architecture](architecture.md)
+- [SQLite WAL](sqlite-wal.md)
+- [LTX Format](ltx-format.md)

--- a/.codex/skills/litestream/concepts/sqlite-wal.md
+++ b/.codex/skills/litestream/concepts/sqlite-wal.md
@@ -1,0 +1,197 @@
+# SQLite WAL for Litestream
+
+Understanding SQLite's Write-Ahead Log (WAL) is essential for working with Litestream.
+
+## WAL Basics
+
+WAL is SQLite's method for atomic commits:
+
+1. Changes are **first written to WAL** (not main database)
+2. Main database file stays **unchanged until checkpoint**
+3. Readers see **consistent view** by merging WAL + main database
+
+```
+Write Transaction
+      ↓
+   WAL File  ←──── Litestream monitors this
+      ↓
+ Checkpoint
+      ↓
+ Main Database
+```
+
+## SQLite File Structure
+
+A SQLite database in WAL mode consists of:
+
+```
+database.db         # Main database file (pages)
+database.db-wal     # Write-ahead log (uncommitted changes)
+database.db-shm     # Shared memory (coordination between processes)
+```
+
+## WAL File Structure
+
+```
++------------------+
+| WAL Header       | 32 bytes - magic, page size, salt
++------------------+
+| Frame 1 Header   | 24 bytes - page number, checksums
+| Frame 1 Data     | Page size bytes (4KB typical)
++------------------+
+| Frame 2 Header   | 24 bytes
+| Frame 2 Data     | Page size bytes
++------------------+
+| ... more frames  |
++------------------+
+```
+
+### WAL Header (32 bytes)
+
+- Magic number: `0x377f0682` or `0x377f0683`
+- File format version
+- Database page size
+- Checkpoint sequence number
+- Salt values for checksums
+
+### Frame Header (24 bytes)
+
+- Page number in database
+- Database size in pages (at commit)
+- Salt values (must match header)
+- Cumulative checksums
+
+## The 1GB Lock Page
+
+**Critical**: SQLite reserves a page at exactly 1GB (0x40000000) for locking.
+
+### Lock Page Numbers by Page Size
+
+| Page Size | Lock Page Number |
+|-----------|-----------------|
+| 4KB | 262145 |
+| 8KB | 131073 |
+| 16KB | 65537 |
+| 32KB | 32769 |
+| 64KB | 16385 |
+
+### Why It Matters
+
+1. **Never contains user data** - SQLite skips this page
+2. **Must be skipped** - During replication and compaction
+3. **Only affects large databases** - Databases > 1GB
+4. **Page number varies** - Depends on page size
+
+### Calculating Lock Page
+
+```
+Lock Page Number = (1073741824 / page_size) + 1
+```
+
+Where 1073741824 = 0x40000000 = 1GB
+
+## Checkpoint Modes
+
+Checkpoints move WAL changes to the main database:
+
+### PASSIVE (Default)
+```sql
+PRAGMA wal_checkpoint(PASSIVE);
+```
+- Attempts checkpoint without blocking
+- Fails silently if readers present
+- Non-blocking
+
+### FULL
+```sql
+PRAGMA wal_checkpoint(FULL);
+```
+- Waits for readers to finish
+- Blocks new readers
+- Ensures complete checkpoint
+
+### RESTART
+```sql
+PRAGMA wal_checkpoint(RESTART);
+```
+- Like FULL, plus resets WAL
+- Next writer starts at WAL beginning
+- Litestream avoids this mode (can block writes)
+
+### TRUNCATE
+```sql
+PRAGMA wal_checkpoint(TRUNCATE);
+```
+- Like RESTART, plus truncates WAL file
+- Releases disk space
+- Used for emergency WAL control
+
+## Litestream's Checkpoint Strategy
+
+Litestream manages checkpoints based on:
+
+1. **Page count threshold** (`MinCheckpointPageN`)
+   - Triggers PASSIVE checkpoint when WAL reaches threshold
+
+2. **Time interval** (`CheckpointInterval`)
+   - Periodic PASSIVE checkpoint regardless of size
+
+3. **Emergency threshold** (`TruncatePageN`)
+   - Triggers TRUNCATE when WAL grows too large
+
+## Required SQLite Configuration
+
+For Litestream to work correctly:
+
+```sql
+-- Enable WAL mode (required)
+PRAGMA journal_mode = WAL;
+
+-- Set busy timeout (prevents lock errors)
+PRAGMA busy_timeout = 5000;
+
+-- Recommended sync mode with WAL
+PRAGMA synchronous = NORMAL;
+
+-- Disable auto-checkpoint (Litestream manages this)
+PRAGMA wal_autocheckpoint = 0;
+```
+
+## WAL Monitoring
+
+Litestream monitors WAL by:
+
+1. Checking WAL file size at `MonitorInterval` (default 10ms)
+2. Comparing with previous size
+3. Reading new frames when changes detected
+4. Converting frames to LTX format
+5. Notifying replicas of changes
+
+## Common WAL Issues
+
+### WAL Growing Indefinitely
+**Cause**: Checkpoint blocked by long-running readers
+**Solution**:
+- Close long-running transactions
+- Check for stuck read connections
+- Review `TruncatePageN` threshold
+
+### Checkpoint Not Running
+**Cause**: Application holding read transaction
+**Solution**:
+- Ensure transactions are committed/rolled back
+- Check for connection leaks
+
+### WAL File Missing
+**Cause**: Database not in WAL mode or just created
+**Solution**:
+- Run `PRAGMA journal_mode=WAL;`
+- Ensure at least one write has occurred
+
+## Key Takeaways
+
+1. **WAL is temporary** - Gets merged back to main database via checkpoint
+2. **Lock page is sacred** - Never write data at 1GB mark
+3. **Page size matters** - Affects lock page number and performance
+4. **Checkpoints are critical** - Balance WAL size vs. performance
+5. **Monitor WAL size** - Growing WAL indicates checkpoint issues

--- a/.codex/skills/litestream/configuration/abs.md
+++ b/.codex/skills/litestream/configuration/abs.md
@@ -1,0 +1,149 @@
+# Azure Blob Storage Configuration
+
+Replicate SQLite databases to Azure Blob Storage (ABS).
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: abs://container@storageaccount/path
+      account-name: ${AZURE_STORAGE_ACCOUNT}
+      account-key: ${AZURE_STORAGE_KEY}
+```
+
+## URL Format
+
+```
+abs://CONTAINER@STORAGEACCOUNT/PATH
+```
+
+Where:
+- `CONTAINER` - Azure blob container name
+- `STORAGEACCOUNT` - Azure storage account name
+- `PATH` - Path within the container
+
+## Authentication
+
+### Storage Account Key
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: abs://mycontainer@mystorageaccount/backups/app
+      account-name: mystorageaccount
+      account-key: ${AZURE_STORAGE_KEY}
+```
+
+### Environment Variables
+
+```bash
+export AZURE_STORAGE_ACCOUNT=mystorageaccount
+export AZURE_STORAGE_KEY=base64encodedkey==
+```
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: abs://mycontainer@mystorageaccount/backups/app
+      account-name: ${AZURE_STORAGE_ACCOUNT}
+      account-key: ${AZURE_STORAGE_KEY}
+```
+
+## Configuration Options
+
+| Option | Description |
+|--------|-------------|
+| `account-name` | Azure storage account name |
+| `account-key` | Storage account access key |
+
+## Examples
+
+### Basic Azure Backup
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: abs://backups@mycompanystorage/databases/app
+      account-name: mycompanystorage
+      account-key: ${AZURE_STORAGE_KEY}
+```
+
+### Multiple Databases
+
+```yaml
+account-name: mycompanystorage
+account-key: ${AZURE_STORAGE_KEY}
+
+dbs:
+  - path: /data/app1.db
+    replica:
+      url: abs://backups@mycompanystorage/app1
+
+  - path: /data/app2.db
+    replica:
+      url: abs://backups@mycompanystorage/app2
+```
+
+## Azure Setup
+
+### Create Storage Account
+
+```bash
+# Create resource group
+az group create --name myresourcegroup --location eastus
+
+# Create storage account
+az storage account create \
+  --name mystorageaccount \
+  --resource-group myresourcegroup \
+  --location eastus \
+  --sku Standard_LRS
+
+# Get storage account key
+az storage account keys list \
+  --account-name mystorageaccount \
+  --resource-group myresourcegroup \
+  --query '[0].value' -o tsv
+```
+
+### Create Container
+
+```bash
+az storage container create \
+  --name backups \
+  --account-name mystorageaccount \
+  --account-key $AZURE_STORAGE_KEY
+```
+
+## Access Tiers
+
+Azure Blob Storage offers different access tiers:
+- **Hot**: Frequently accessed data (default)
+- **Cool**: Infrequently accessed data
+- **Archive**: Rarely accessed data
+
+Litestream works best with Hot tier due to frequent small writes.
+
+## Troubleshooting
+
+### "Storage account not found"
+- Verify storage account name is correct
+- Check account exists in your Azure subscription
+
+### "Authorization failed"
+- Verify account key is correct and not expired
+- Check container exists
+- Ensure account key has write permissions
+
+### "Container not found"
+- Create the container before starting Litestream
+- Verify container name in URL matches
+
+### Slow performance
+- Use a storage account in the same region as your server
+- Consider Premium storage for high-frequency writes

--- a/.codex/skills/litestream/configuration/example-litestream.yml
+++ b/.codex/skills/litestream/configuration/example-litestream.yml
@@ -1,0 +1,178 @@
+# Litestream Configuration Example
+# Full reference: https://litestream.io/reference/config/
+
+# =============================================================================
+# GLOBAL SETTINGS
+# =============================================================================
+
+# Prometheus metrics endpoint (optional)
+# addr: ":9090"
+
+# Global AWS/S3 credentials (inherited by all S3 replicas)
+# access-key-id: ${AWS_ACCESS_KEY_ID}
+# secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+# region: us-east-1
+
+# Global sync interval for all replicas (default: 1s)
+# sync-interval: 1s
+
+# =============================================================================
+# COMPACTION LEVELS
+# =============================================================================
+
+# Multi-level compaction reduces storage overhead
+# Each level merges files from the previous level
+levels:
+  - interval: 30s     # L1: Compact L0 files every 30 seconds
+  - interval: 5m      # L2: Compact L1 files every 5 minutes
+  - interval: 1h      # L3: Compact L2 files hourly
+
+# Snapshot configuration
+snapshot:
+  interval: 24h       # Create daily snapshots
+  retention: 24h      # Keep snapshots for 24 hours
+
+# L0 file retention
+# l0-retention: 1h
+# l0-retention-check-interval: 5m
+
+# =============================================================================
+# LOGGING
+# =============================================================================
+
+logging:
+  level: info         # debug, info, warn, error
+  type: text          # text or json
+  # stderr: true      # Output to stderr instead of stdout
+
+# =============================================================================
+# HEARTBEAT (optional health monitoring)
+# =============================================================================
+
+# heartbeat-url: https://healthchecks.io/ping/your-uuid
+# heartbeat-interval: 5m
+
+# =============================================================================
+# SHUTDOWN SETTINGS
+# =============================================================================
+
+# shutdown-sync-timeout: 30s    # Max wait for final sync on shutdown
+# shutdown-sync-interval: 100ms # Retry interval during shutdown
+
+# =============================================================================
+# DATABASE CONFIGURATIONS
+# =============================================================================
+
+dbs:
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 1: Basic S3 Replication
+  # ---------------------------------------------------------------------------
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 2: S3 with Full Configuration
+  # ---------------------------------------------------------------------------
+  # - path: /data/production.db
+  #   monitor-interval: 10ms        # How often to check WAL (default: 10ms)
+  #   checkpoint-interval: 1m       # Time-based checkpoint interval
+  #   min-checkpoint-page-count: 1000  # Page threshold for checkpoint
+  #   busy-timeout: 5s              # SQLite busy timeout
+  #   replica:
+  #     url: s3://my-bucket/production
+  #     access-key-id: ${AWS_ACCESS_KEY_ID}
+  #     secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  #     region: us-west-2
+  #     sync-interval: 1s
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 3: S3-Compatible Storage (MinIO, R2, Tigris, etc.)
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   replica:
+  #     # Cloudflare R2
+  #     url: s3://bucket/path?endpoint=account-id.r2.cloudflarestorage.com
+  #
+  #     # Fly.io Tigris (auto-configures signing)
+  #     url: s3://bucket/path?endpoint=fly.storage.tigris.dev&region=auto
+  #
+  #     # MinIO (local)
+  #     url: s3://bucket/path?endpoint=localhost:9000&skipVerify=true
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 4: Google Cloud Storage
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   replica:
+  #     url: gs://my-bucket/backups/app
+  #     # Uses GOOGLE_APPLICATION_CREDENTIALS environment variable
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 5: Azure Blob Storage
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   replica:
+  #     url: abs://container@storageaccount/path
+  #     account-name: ${AZURE_STORAGE_ACCOUNT}
+  #     account-key: ${AZURE_STORAGE_KEY}
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 6: SFTP
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   replica:
+  #     url: sftp://user@backup-server.example.com:22/backups/app
+  #     key-path: /etc/litestream/sftp_key
+  #     # Recommended: Specify host key for security
+  #     # Get from: ssh-keyscan backup-server.example.com
+  #     host-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 7: NATS JetStream
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   replica:
+  #     type: nats
+  #     url: nats://nats.example.com:4222
+  #     bucket: litestream-backups
+  #     # Optional TLS:
+  #     # tls: true
+  #     # root-cas: [/path/to/ca.pem]
+  #     # client-cert: /path/to/client.pem
+  #     # client-key: /path/to/client.key
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 8: Local File Backup
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   replica:
+  #     path: /mnt/backup/app-replica
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 9: Directory Replication
+  # ---------------------------------------------------------------------------
+  # - dir: /data/databases          # Directory containing databases
+  #   pattern: "*.db"               # Match SQLite files
+  #   recursive: true               # Include subdirectories
+  #   watch: true                   # Monitor for new databases
+  #   replica:
+  #     url: s3://my-bucket/all-databases
+
+  # ---------------------------------------------------------------------------
+  # EXAMPLE 10: Auto-Restore on Startup
+  # ---------------------------------------------------------------------------
+  # - path: /data/app.db
+  #   restore-if-db-not-exists: true  # Restore from backup if DB missing
+  #   replica:
+  #     url: s3://my-bucket/app-backup
+
+# =============================================================================
+# EXEC: Run Application Alongside Replication
+# =============================================================================
+
+# Litestream can run your application as a subprocess
+# It will start replication first, then exec your command
+# When your application exits, Litestream shuts down gracefully
+
+# exec: "/usr/bin/myapp serve --port 8080"

--- a/.codex/skills/litestream/configuration/file.md
+++ b/.codex/skills/litestream/configuration/file.md
@@ -1,0 +1,201 @@
+# Local File Backend Configuration
+
+Replicate SQLite databases to local filesystem or mounted network storage.
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      path: /mnt/backups/app
+```
+
+## Configuration
+
+### Using Path
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      path: /var/backups/litestream/app
+```
+
+### Using URL
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: file:///var/backups/litestream/app
+```
+
+## Use Cases
+
+### Local Backup
+
+Simple local backup before cloud replication:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      path: /var/backups/app
+```
+
+### Network Attached Storage (NAS)
+
+Mount NAS and replicate:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      path: /mnt/nas/backups/app
+```
+
+### External Drive
+
+Replicate to mounted external drive:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      path: /mnt/external/backups/app
+```
+
+### Shared Network Drive (NFS/SMB)
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      path: /mnt/shared/backups/app
+```
+
+## Directory Structure
+
+Litestream creates this structure in the replica path:
+
+```
+/var/backups/app/
+├── generations/
+│   ├── 0000000000000001/     # Generation directory
+│   │   ├── 0/                # Level 0 (raw)
+│   │   │   ├── 00000001-00000010.ltx
+│   │   │   └── 00000011-00000020.ltx
+│   │   ├── 1/                # Level 1 (compacted)
+│   │   │   └── 00000001-00000100.ltx
+│   │   └── 2/                # Level 2 (more compacted)
+│   │       └── 00000001-00001000.ltx
+│   └── 0000000000000002/     # Next generation
+│       └── ...
+└── snapshots/                # Database snapshots
+    └── ...
+```
+
+## Permissions
+
+Ensure Litestream has write access:
+
+```bash
+# Create backup directory
+sudo mkdir -p /var/backups/litestream
+sudo chown litestream:litestream /var/backups/litestream
+
+# Or adjust permissions
+sudo chmod 755 /var/backups/litestream
+```
+
+## Examples
+
+### Development Setup
+
+Local backup for development:
+
+```yaml
+dbs:
+  - path: ~/projects/myapp/data.db
+    replica:
+      path: ~/backups/myapp
+```
+
+### Production with NFS
+
+```yaml
+dbs:
+  - path: /data/production.db
+    replica:
+      path: /mnt/nfs/litestream/production
+      sync-interval: 1s
+```
+
+### Multiple Databases to Same Location
+
+```yaml
+dbs:
+  - path: /data/app1.db
+    replica:
+      path: /var/backups/app1
+
+  - path: /data/app2.db
+    replica:
+      path: /var/backups/app2
+```
+
+## Performance Considerations
+
+### Local SSD
+- Best performance
+- Fastest sync times
+- Good for development
+
+### HDD/NAS
+- Slower than SSD
+- Consider increasing sync-interval
+- Good for secondary backups
+
+### Network Mounts (NFS/SMB)
+- Depends on network speed
+- May have higher latency
+- Ensure mount is reliable
+
+## Troubleshooting
+
+### "Permission denied"
+- Check directory ownership
+- Verify write permissions
+- Ensure parent directories exist
+
+### "No space left on device"
+- Free disk space
+- Configure retention to remove old files
+- Use compaction to reduce storage
+
+### "Mount point not available"
+- Verify network mount is connected
+- Check mount configuration
+- Add mount to fstab for auto-mount
+
+### Files not appearing
+- Check the full path including generations/
+- Verify sync-interval has elapsed
+- Look for .ltx files in subdirectories
+
+## Combining with Cloud Backup
+
+Use file backend as primary, cloud as secondary:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    # Primary: local for fast recovery
+    replica:
+      path: /var/backups/app
+
+# Note: Litestream supports only one replica per database.
+# For multiple destinations, run multiple Litestream instances
+# or use a tool like rclone to sync the file replica to cloud.
+```

--- a/.codex/skills/litestream/configuration/gcs.md
+++ b/.codex/skills/litestream/configuration/gcs.md
@@ -1,0 +1,178 @@
+# Google Cloud Storage Configuration
+
+Replicate SQLite databases to Google Cloud Storage (GCS).
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-bucket/backups/app
+```
+
+## URL Format
+
+```
+gs://BUCKET/PATH
+```
+
+## Authentication
+
+GCS uses Google Cloud Application Default Credentials (ADC).
+
+### Service Account Key (Recommended for Production)
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-bucket/app-backup
+```
+
+### GCE Instance Service Account
+
+On Google Compute Engine, uses the instance's service account automatically:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-bucket/app-backup
+```
+
+### User Credentials (Development)
+
+```bash
+gcloud auth application-default login
+```
+
+### Workload Identity (GKE)
+
+Configure Workload Identity in GKE, then use without credentials:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-bucket/app-backup
+```
+
+## Configuration
+
+GCS configuration is minimal - most settings come from ADC:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-bucket/backups/app
+      sync-interval: 1s
+```
+
+## IAM Permissions
+
+Required roles:
+- `roles/storage.objectViewer` - Read LTX files
+- `roles/storage.objectCreator` - Write LTX files
+- `roles/storage.objectAdmin` - Delete old files (for retention)
+
+Or custom IAM permissions:
+```
+storage.objects.get
+storage.objects.create
+storage.objects.delete
+storage.objects.list
+```
+
+## Bucket Configuration
+
+### Create Bucket
+
+```bash
+gsutil mb -l us-central1 gs://my-litestream-bucket
+```
+
+### Lifecycle Rules (Optional)
+
+Auto-delete old files:
+
+```bash
+cat > lifecycle.json << EOF
+{
+  "rule": [
+    {
+      "action": {"type": "Delete"},
+      "condition": {"age": 30}
+    }
+  ]
+}
+EOF
+
+gsutil lifecycle set lifecycle.json gs://my-bucket
+```
+
+### Versioning (Not Recommended)
+
+Litestream manages its own versioning through LTX files. GCS versioning is not needed and will increase costs.
+
+## Examples
+
+### Basic GCS Backup
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-company-backups/databases/app
+```
+
+### Multiple Databases to Same Bucket
+
+```yaml
+dbs:
+  - path: /data/app1.db
+    replica:
+      url: gs://my-bucket/app1
+
+  - path: /data/app2.db
+    replica:
+      url: gs://my-bucket/app2
+```
+
+### Cloud Run / Cloud Functions
+
+Use the service's identity:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: gs://my-bucket/app-backup
+```
+
+Ensure the service account has Storage Object Admin role.
+
+## Troubleshooting
+
+### "Permission denied"
+- Verify service account has required IAM roles
+- Check bucket-level permissions
+- Ensure GOOGLE_APPLICATION_CREDENTIALS is set correctly
+
+### "Bucket not found"
+- Verify bucket name is correct
+- Ensure bucket exists in the project
+
+### "Invalid credentials"
+- Re-run `gcloud auth application-default login`
+- Check service account key file is valid JSON
+- Verify key file path in GOOGLE_APPLICATION_CREDENTIALS
+
+### Slow uploads from outside GCP
+- Consider using a bucket in a region closer to your server
+- GCS is optimized for Google Cloud workloads

--- a/.codex/skills/litestream/configuration/nats.md
+++ b/.codex/skills/litestream/configuration/nats.md
@@ -1,0 +1,258 @@
+# NATS JetStream Configuration
+
+Replicate SQLite databases to NATS JetStream object storage.
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: litestream-backups
+```
+
+## URL Format
+
+```
+nats://HOST:PORT
+```
+
+The bucket is specified separately in configuration.
+
+## Configuration
+
+### Basic Setup
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://localhost:4222
+      bucket: app-backups
+```
+
+### With Authentication
+
+#### Username/Password
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      username: litestream
+      password: ${NATS_PASSWORD}
+```
+
+#### Token
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      token: ${NATS_TOKEN}
+```
+
+#### NKey
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      nkey: SUACS34K...
+```
+
+#### JWT + Seed (Decentralized Auth)
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      jwt: eyJ0eXAiOiJKV1QiLC...
+      seed: SUACS34K...
+```
+
+#### Credentials File
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      creds: /etc/litestream/nats.creds
+```
+
+## TLS Configuration
+
+### Basic TLS
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      tls: true
+```
+
+### TLS with Custom CA
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      tls: true
+      root-cas:
+        - /etc/litestream/ca.pem
+```
+
+### Mutual TLS (mTLS)
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats.example.com:4222
+      bucket: backups
+      tls: true
+      root-cas:
+        - /etc/litestream/ca.pem
+      client-cert: /etc/litestream/client.pem
+      client-key: /etc/litestream/client.key
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `url` | - | NATS server URL |
+| `bucket` | - | JetStream object store bucket |
+| `username` | - | Username for auth |
+| `password` | - | Password for auth |
+| `token` | - | Token for auth |
+| `nkey` | - | NKey seed for auth |
+| `jwt` | - | JWT for decentralized auth |
+| `seed` | - | Seed for JWT auth |
+| `creds` | - | Path to credentials file |
+| `tls` | false | Enable TLS |
+| `root-cas` | - | List of CA certificate paths |
+| `client-cert` | - | Client certificate path |
+| `client-key` | - | Client key path |
+| `max-reconnects` | 60 | Max reconnection attempts |
+| `reconnect-wait` | 2s | Wait between reconnects |
+| `timeout` | 10s | Connection timeout |
+
+## NATS Server Setup
+
+### Enable JetStream
+
+In `nats-server.conf`:
+
+```
+jetstream {
+    store_dir: /data/nats
+    max_mem: 1G
+    max_file: 10G
+}
+```
+
+### Create Object Store Bucket
+
+Using NATS CLI:
+
+```bash
+nats object add litestream-backups --storage file --replicas 3
+```
+
+### User Permissions
+
+For decentralized auth, the user needs:
+
+```
+publish: ["$JS.API.OBJECT.>"]
+subscribe: ["$JS.API.OBJECT.>", "_INBOX.>"]
+```
+
+## Examples
+
+### Local Development
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://localhost:4222
+      bucket: dev-backups
+```
+
+### Clustered NATS
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://nats1.example.com:4222,nats://nats2.example.com:4222,nats://nats3.example.com:4222
+      bucket: backups
+      username: litestream
+      password: ${NATS_PASSWORD}
+```
+
+### Synadia NGS (NATS Global Service)
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: nats
+      url: nats://connect.ngs.global
+      bucket: backups
+      creds: /etc/litestream/ngs.creds
+      tls: true
+```
+
+## Troubleshooting
+
+### "Connection refused"
+- Verify NATS server is running
+- Check firewall allows port 4222
+- Verify URL is correct
+
+### "Authorization violation"
+- Check username/password or credentials
+- Verify user has permissions for JetStream operations
+
+### "Bucket not found"
+- Create the object store bucket first
+- Verify bucket name is correct
+
+### "TLS handshake failed"
+- Verify CA certificate is correct
+- Check client cert/key match
+- Ensure server certificate is valid
+
+### Reconnection issues
+- Increase `max-reconnects` for unstable networks
+- Adjust `reconnect-wait` for your environment

--- a/.codex/skills/litestream/configuration/oss.md
+++ b/.codex/skills/litestream/configuration/oss.md
@@ -1,0 +1,155 @@
+# Alibaba Cloud OSS Configuration
+
+Replicate SQLite databases to Alibaba Cloud Object Storage Service (OSS).
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: oss://my-bucket/backups/app
+```
+
+## URL Format
+
+```
+oss://BUCKET/PATH
+```
+
+## Authentication
+
+### Environment Variables
+
+```bash
+export ALIBABA_CLOUD_ACCESS_KEY_ID=your-access-key
+export ALIBABA_CLOUD_ACCESS_KEY_SECRET=your-secret-key
+```
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: oss://my-bucket/backups/app
+```
+
+### Configuration File
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: oss://my-bucket/backups/app
+      access-key-id: ${ALIBABA_CLOUD_ACCESS_KEY_ID}
+      secret-access-key: ${ALIBABA_CLOUD_ACCESS_KEY_SECRET}
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `access-key-id` | - | Alibaba Cloud access key ID |
+| `secret-access-key` | - | Alibaba Cloud access key secret |
+| `endpoint` | - | Custom OSS endpoint |
+| `region` | - | OSS region |
+
+## Region Endpoints
+
+Common OSS endpoints:
+
+| Region | Endpoint |
+|--------|----------|
+| China (Hangzhou) | oss-cn-hangzhou.aliyuncs.com |
+| China (Shanghai) | oss-cn-shanghai.aliyuncs.com |
+| China (Beijing) | oss-cn-beijing.aliyuncs.com |
+| Singapore | oss-ap-southeast-1.aliyuncs.com |
+| US (Virginia) | oss-us-east-1.aliyuncs.com |
+| Germany (Frankfurt) | oss-eu-central-1.aliyuncs.com |
+
+## Examples
+
+### Basic OSS Backup
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: oss://my-backup-bucket/databases/app
+      access-key-id: ${ALIBABA_CLOUD_ACCESS_KEY_ID}
+      secret-access-key: ${ALIBABA_CLOUD_ACCESS_KEY_SECRET}
+```
+
+### With Custom Endpoint
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: oss://my-bucket/app
+      endpoint: oss-cn-shanghai.aliyuncs.com
+      access-key-id: ${ALIBABA_CLOUD_ACCESS_KEY_ID}
+      secret-access-key: ${ALIBABA_CLOUD_ACCESS_KEY_SECRET}
+```
+
+## Bucket Setup
+
+### Create Bucket via Console
+
+1. Go to Alibaba Cloud OSS Console
+2. Click "Create Bucket"
+3. Enter bucket name
+4. Select region
+5. Set storage class (Standard recommended)
+6. Set access control (Private recommended)
+
+### Create Bucket via CLI
+
+```bash
+aliyun oss mb oss://my-litestream-bucket --region cn-hangzhou
+```
+
+## Access Control
+
+### RAM Policy
+
+Create a RAM policy with minimum required permissions:
+
+```json
+{
+  "Version": "1",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "oss:GetObject",
+        "oss:PutObject",
+        "oss:DeleteObject",
+        "oss:ListObjects"
+      ],
+      "Resource": [
+        "acs:oss:*:*:my-bucket",
+        "acs:oss:*:*:my-bucket/*"
+      ]
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### "Access denied"
+- Verify access key ID and secret are correct
+- Check RAM user has required permissions
+- Ensure bucket ACL allows access
+
+### "Bucket not found"
+- Verify bucket name is correct
+- Check bucket exists in the expected region
+
+### "Invalid endpoint"
+- Ensure endpoint matches bucket's region
+- Use internal endpoint if within Alibaba Cloud VPC
+
+### Slow uploads
+- Use endpoint in same region as your server
+- Consider using internal endpoints within Alibaba Cloud

--- a/.codex/skills/litestream/configuration/overview.md
+++ b/.codex/skills/litestream/configuration/overview.md
@@ -1,0 +1,217 @@
+# Litestream Configuration Overview
+
+Litestream can be configured via command-line arguments (simple cases) or YAML configuration file (recommended for production).
+
+## Configuration File Location
+
+Default locations checked:
+1. `-config` flag path
+2. `/etc/litestream.yml`
+
+## Basic Structure
+
+```yaml
+# Global settings (optional)
+addr: ":9090"                    # Prometheus metrics address
+
+# Database configurations
+dbs:
+  - path: /data/app.db           # Database to replicate
+    replica:
+      url: s3://bucket/path      # Destination
+```
+
+## Database Configuration
+
+### Single Database
+
+```yaml
+dbs:
+  - path: /data/app.db
+    monitor-interval: 10ms        # WAL check frequency (default: 10ms)
+    checkpoint-interval: 1m       # Time-based checkpoint (default: 1m)
+    min-checkpoint-page-count: 1000  # Page threshold for checkpoint
+    busy-timeout: 5s              # SQLite busy timeout
+    replica:
+      url: s3://bucket/app-backup
+```
+
+### Directory of Databases
+
+```yaml
+dbs:
+  - dir: /data/databases         # Directory to scan
+    pattern: "*.db"              # File pattern to match
+    recursive: true              # Include subdirectories
+    watch: true                  # Monitor for new databases
+    replica:
+      url: s3://bucket/db-backups
+```
+
+## Replica Configuration
+
+### Using URL (Recommended)
+
+```yaml
+replica:
+  url: s3://bucket/path
+  sync-interval: 1s              # How often to sync (default: 1s)
+```
+
+### Using Type + Path
+
+```yaml
+replica:
+  type: s3
+  bucket: my-bucket
+  path: backups/app
+  region: us-east-1
+```
+
+## Global Defaults
+
+Set defaults for all replicas at the top level:
+
+```yaml
+# These apply to all replicas unless overridden
+access-key-id: ${AWS_ACCESS_KEY_ID}
+secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+region: us-east-1
+sync-interval: 1s
+
+dbs:
+  - path: /data/app1.db
+    replica:
+      url: s3://bucket/app1      # Uses global AWS credentials
+
+  - path: /data/app2.db
+    replica:
+      url: s3://bucket/app2      # Uses global AWS credentials
+```
+
+## Environment Variables
+
+Environment variables are expanded in configuration:
+
+```yaml
+dbs:
+  - path: ${DATABASE_PATH}
+    replica:
+      url: ${REPLICA_URL}
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+```
+
+Disable expansion with `-no-expand-env` flag.
+
+## Compaction Levels
+
+Configure multi-level compaction for storage efficiency:
+
+```yaml
+levels:
+  - interval: 30s     # L1: Compact every 30 seconds
+  - interval: 5m      # L2: Compact every 5 minutes
+  - interval: 1h      # L3: Compact hourly
+```
+
+Default levels: 30s, 5m, 1h
+
+## Snapshot Configuration
+
+```yaml
+snapshot:
+  interval: 24h       # Create snapshots daily
+  retention: 24h      # Keep snapshots for 24 hours
+```
+
+## L0 Retention
+
+```yaml
+l0-retention: 1h                    # Keep L0 files for 1 hour
+l0-retention-check-interval: 5m     # Check retention every 5 minutes
+```
+
+## Logging
+
+```yaml
+logging:
+  level: info         # debug, info, warn, error
+  type: text          # text or json
+  stderr: false       # Output to stderr instead of stdout
+```
+
+Or via environment: `LOG_LEVEL=debug`
+
+## Heartbeat
+
+Send periodic heartbeat to external URL:
+
+```yaml
+heartbeat-url: https://healthchecks.io/ping/xxx
+heartbeat-interval: 5m
+```
+
+## Shutdown Settings
+
+```yaml
+shutdown-sync-timeout: 30s      # Max time to wait for final sync
+shutdown-sync-interval: 100ms   # Retry interval during shutdown
+```
+
+## Subcommand Execution
+
+Run a subcommand alongside replication:
+
+```yaml
+exec: "myapp serve"
+```
+
+Litestream will:
+1. Start replication
+2. Execute the subcommand
+3. Shut down when subcommand exits
+
+## Metrics Server
+
+```yaml
+addr: ":9090"         # Prometheus metrics endpoint
+```
+
+Access metrics at `http://localhost:9090/metrics`
+
+## Database Settings Reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `path` | required | Database file path |
+| `dir` | - | Directory to scan for databases |
+| `pattern` | - | File pattern (required with `dir`) |
+| `recursive` | false | Scan subdirectories |
+| `watch` | false | Monitor directory for changes |
+| `meta-path` | - | Custom metadata directory |
+| `monitor-interval` | 10ms | WAL check frequency |
+| `checkpoint-interval` | 1m | Time-based checkpoint interval |
+| `busy-timeout` | 1s | SQLite busy timeout |
+| `min-checkpoint-page-count` | 1000 | Page threshold for passive checkpoint |
+| `truncate-page-n` | 10000 | Emergency truncate threshold |
+| `restore-if-db-not-exists` | false | Auto-restore on startup |
+
+## Replica Settings Reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `url` | - | Replica URL (recommended) |
+| `type` | - | Replica type (file, s3, gs, abs, sftp, nats, webdav, oss) |
+| `path` | - | Replica path |
+| `sync-interval` | 1s | Sync frequency |
+| `validation-interval` | - | Validation frequency |
+
+## Validation Errors
+
+Common configuration errors:
+
+- `cannot specify both 'path' and 'dir'` - Use one or the other
+- `'pattern' is required when using 'dir'` - Specify file pattern
+- `cannot specify url & path for replica` - Use URL or type+path
+- `age encryption is not currently supported` - Use v0.3.x for encryption

--- a/.codex/skills/litestream/configuration/s3.md
+++ b/.codex/skills/litestream/configuration/s3.md
@@ -1,0 +1,252 @@
+# S3 Configuration
+
+AWS S3 and S3-compatible storage backends.
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/backups/app
+```
+
+## URL Format
+
+```
+s3://BUCKET/PATH[?endpoint=HOST&region=REGION&...]
+```
+
+## AWS S3
+
+### Using Environment Variables (Recommended)
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+```
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+```
+
+### Using Config File
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+      region: us-east-1
+```
+
+### Using IAM Roles (EC2/ECS/Lambda)
+
+No credentials needed - uses instance profile:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+      region: us-east-1
+```
+
+### Using S3 Access Points (ARN)
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://arn:aws:s3:us-east-1:123456789012:accesspoint/my-access-point/backups
+```
+
+## S3-Compatible Providers
+
+### Cloudflare R2
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=ACCOUNT_ID.r2.cloudflarestorage.com
+      access-key-id: ${R2_ACCESS_KEY_ID}
+      secret-access-key: ${R2_SECRET_ACCESS_KEY}
+```
+
+### Fly.io Tigris
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=fly.storage.tigris.dev&region=auto
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+```
+
+Tigris auto-configures signing and Content-MD5 requirements.
+
+### DigitalOcean Spaces
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=nyc3.digitaloceanspaces.com&region=nyc3
+      access-key-id: ${DO_SPACES_KEY}
+      secret-access-key: ${DO_SPACES_SECRET}
+```
+
+### Backblaze B2
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=s3.us-west-000.backblazeb2.com&region=us-west-000
+      access-key-id: ${B2_KEY_ID}
+      secret-access-key: ${B2_APPLICATION_KEY}
+```
+
+### MinIO
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=localhost:9000&skipVerify=true
+      access-key-id: minioadmin
+      secret-access-key: minioadmin
+```
+
+### Scaleway Object Storage
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=s3.fr-par.scw.cloud&region=fr-par
+      access-key-id: ${SCW_ACCESS_KEY}
+      secret-access-key: ${SCW_SECRET_KEY}
+```
+
+### Filebase
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/path?endpoint=s3.filebase.com
+      access-key-id: ${FILEBASE_ACCESS_KEY}
+      secret-access-key: ${FILEBASE_SECRET_KEY}
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `access-key-id` | - | AWS access key |
+| `secret-access-key` | - | AWS secret key |
+| `region` | us-east-1 | AWS region |
+| `bucket` | - | S3 bucket name |
+| `endpoint` | - | Custom S3 endpoint |
+| `force-path-style` | auto | Use path-style URLs |
+| `sign-payload` | true | Sign request payloads |
+| `require-content-md5` | true | Require Content-MD5 header |
+| `skip-verify` | false | Skip TLS verification |
+| `part-size` | 5MB | Multipart upload part size |
+| `concurrency` | 5 | Upload concurrency |
+
+## Server-Side Encryption
+
+### SSE-S3 (AWS Managed Keys)
+
+Enabled by default on bucket - no configuration needed.
+
+### SSE-KMS (AWS KMS)
+
+```yaml
+replica:
+  url: s3://bucket/path
+  sse-kms-key-id: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-...
+```
+
+### SSE-C (Customer Provided Keys)
+
+```yaml
+replica:
+  url: s3://bucket/path
+  sse-customer-algorithm: AES256
+  sse-customer-key: ${SSE_CUSTOMER_KEY}
+  # OR from file:
+  sse-customer-key-path: /etc/litestream/sse-key
+```
+
+## URL Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `endpoint` | Custom S3 endpoint |
+| `region` | Override region |
+| `forcePathStyle` | true/false for path-style URLs |
+| `skipVerify` | true/false for TLS verification |
+| `signPayload` | true/false for payload signing |
+| `requireContentMD5` | true/false for Content-MD5 |
+
+Example:
+```
+s3://bucket/path?endpoint=minio:9000&skipVerify=true&forcePathStyle=true
+```
+
+## IAM Policy
+
+Minimum required permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-bucket",
+        "arn:aws:s3:::my-bucket/*"
+      ]
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### "Access Denied"
+- Verify IAM permissions include all required actions
+- Check bucket policy allows access
+- Ensure region is correct
+
+### "Bucket not found"
+- Verify bucket name is correct
+- Check region matches bucket location
+
+### "Connection refused" (custom endpoint)
+- Verify endpoint URL is correct
+- Check `skipVerify=true` for self-signed certs
+- Ensure `forcePathStyle=true` for most S3-compatible providers
+
+### Slow uploads
+- Increase `part-size` for large databases
+- Increase `concurrency` for faster uploads
+- Check network connectivity to endpoint

--- a/.codex/skills/litestream/configuration/sftp.md
+++ b/.codex/skills/litestream/configuration/sftp.md
@@ -1,0 +1,195 @@
+# SFTP Configuration
+
+Replicate SQLite databases to SFTP servers.
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: sftp://user@hostname:22/path/to/backup
+      key-path: /etc/litestream/sftp_key
+```
+
+## URL Format
+
+```
+sftp://USER@HOST:PORT/PATH
+```
+
+Where:
+- `USER` - SSH username
+- `HOST` - SFTP server hostname
+- `PORT` - SSH port (default: 22)
+- `PATH` - Absolute path on server
+
+## Authentication
+
+### SSH Key (Recommended)
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: sftp://backupuser@backup.example.com:22/backups/app
+      key-path: /etc/litestream/id_ed25519
+```
+
+Generate a key:
+```bash
+ssh-keygen -t ed25519 -f /etc/litestream/id_ed25519 -N ""
+# Copy public key to server
+ssh-copy-id -i /etc/litestream/id_ed25519.pub backupuser@backup.example.com
+```
+
+### Password Authentication
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: sftp://backupuser@backup.example.com/backups/app
+      password: ${SFTP_PASSWORD}
+```
+
+**Note**: Key-based authentication is strongly recommended for security.
+
+## Host Key Verification
+
+**Important**: Always specify the host key for production deployments.
+
+### Get Host Key
+
+```bash
+ssh-keyscan backup.example.com
+```
+
+Output example:
+```
+backup.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMvvyp...
+```
+
+### Configure Host Key
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: sftp://backupuser@backup.example.com/backups/app
+      key-path: /etc/litestream/id_ed25519
+      host-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMvvyp...
+```
+
+Without host-key verification, you're vulnerable to MITM attacks.
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `user` | - | SSH username |
+| `password` | - | SSH password |
+| `key-path` | - | Path to SSH private key |
+| `host-key` | - | Server's SSH host key |
+| `host` | - | SFTP hostname |
+| `concurrent-writes` | false | Enable concurrent uploads |
+
+## Examples
+
+### Basic SFTP Backup
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: sftp://backup@192.168.1.100:22/var/backups/litestream/app
+      key-path: ~/.ssh/backup_key
+      host-key: ssh-ed25519 AAAAC3...
+```
+
+### NAS/Network Storage
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: sftp://admin@nas.local/volume1/backups/app
+      key-path: /etc/litestream/nas_key
+      host-key: ssh-rsa AAAAB3Nza...
+```
+
+### Multiple Databases to Same Server
+
+```yaml
+dbs:
+  - path: /data/app1.db
+    replica:
+      url: sftp://backup@server.example.com/backups/app1
+      key-path: /etc/litestream/sftp_key
+      host-key: ssh-ed25519 AAAAC3...
+
+  - path: /data/app2.db
+    replica:
+      url: sftp://backup@server.example.com/backups/app2
+      key-path: /etc/litestream/sftp_key
+      host-key: ssh-ed25519 AAAAC3...
+```
+
+## Server Setup
+
+### Create Backup User
+
+```bash
+# Create user with restricted shell
+sudo useradd -m -s /bin/false backupuser
+
+# Create backup directory
+sudo mkdir -p /var/backups/litestream
+sudo chown backupuser:backupuser /var/backups/litestream
+
+# Add SSH key
+sudo mkdir -p /home/backupuser/.ssh
+sudo cp /path/to/public_key.pub /home/backupuser/.ssh/authorized_keys
+sudo chown -R backupuser:backupuser /home/backupuser/.ssh
+sudo chmod 700 /home/backupuser/.ssh
+sudo chmod 600 /home/backupuser/.ssh/authorized_keys
+```
+
+### Restrict to SFTP Only
+
+Add to `/etc/ssh/sshd_config`:
+
+```
+Match User backupuser
+    ForceCommand internal-sftp
+    ChrootDirectory /var/backups
+    AllowTcpForwarding no
+    X11Forwarding no
+```
+
+## Troubleshooting
+
+### "Connection refused"
+- Verify SSH service is running on server
+- Check port is correct (default 22)
+- Verify firewall allows SSH connections
+
+### "Permission denied"
+- Verify username is correct
+- Check SSH key permissions: `chmod 600 /path/to/key`
+- Ensure public key is in server's authorized_keys
+- Verify password is correct (if using password auth)
+
+### "Host key verification failed"
+- Get correct host key with `ssh-keyscan hostname`
+- Update `host-key` configuration
+- Or remove host-key to skip verification (not recommended)
+
+### "No such file or directory"
+- Ensure target directory exists on server
+- Verify user has write permissions to directory
+
+### Slow transfers
+- Enable `concurrent-writes: true` for parallel uploads
+- Check network latency to SFTP server
+- Consider using a server geographically closer

--- a/.codex/skills/litestream/configuration/webdav.md
+++ b/.codex/skills/litestream/configuration/webdav.md
@@ -1,0 +1,178 @@
+# WebDAV Configuration
+
+Replicate SQLite databases to WebDAV-compatible servers.
+
+## Quick Start
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://webdav.example.com/backups/app
+      webdav-username: ${WEBDAV_USER}
+      webdav-password: ${WEBDAV_PASS}
+```
+
+## Configuration
+
+WebDAV requires explicit type declaration:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://server.example.com/dav/backups
+      webdav-username: litestream
+      webdav-password: ${WEBDAV_PASSWORD}
+```
+
+## Configuration Options
+
+| Option | Description |
+|--------|-------------|
+| `webdav-url` | WebDAV server URL including path |
+| `webdav-username` | Authentication username |
+| `webdav-password` | Authentication password |
+
+## Examples
+
+### NextCloud
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://nextcloud.example.com/remote.php/dav/files/username/Backups/app
+      webdav-username: username
+      webdav-password: ${NEXTCLOUD_APP_PASSWORD}
+```
+
+**Note**: Use an app password, not your main NextCloud password.
+
+### ownCloud
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://owncloud.example.com/remote.php/webdav/Backups/app
+      webdav-username: username
+      webdav-password: ${OWNCLOUD_PASSWORD}
+```
+
+### Apache mod_dav
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://webdav.example.com/backups/app
+      webdav-username: davuser
+      webdav-password: ${WEBDAV_PASSWORD}
+```
+
+### Nginx with ngx_http_dav_module
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://dav.example.com/backups/app
+      webdav-username: backup
+      webdav-password: ${DAV_PASSWORD}
+```
+
+### Box.com
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replica:
+      type: webdav
+      webdav-url: https://dav.box.com/dav/Backups/app
+      webdav-username: your-email@example.com
+      webdav-password: ${BOX_PASSWORD}
+```
+
+## Server Setup
+
+### Apache mod_dav
+
+```apache
+<VirtualHost *:443>
+    ServerName webdav.example.com
+    DocumentRoot /var/www/webdav
+
+    <Directory /var/www/webdav>
+        Dav On
+        AuthType Basic
+        AuthName "WebDAV"
+        AuthUserFile /etc/apache2/.htpasswd
+        Require valid-user
+
+        Options +Indexes
+        DirectoryIndex disabled
+    </Directory>
+</VirtualHost>
+```
+
+Create user:
+```bash
+htpasswd -c /etc/apache2/.htpasswd davuser
+```
+
+### Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name dav.example.com;
+
+    root /var/www/webdav;
+
+    location / {
+        dav_methods PUT DELETE MKCOL COPY MOVE;
+        dav_ext_methods PROPFIND OPTIONS;
+
+        auth_basic "WebDAV";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+
+        client_max_body_size 100M;
+        create_full_put_path on;
+        dav_access user:rw group:rw all:r;
+    }
+}
+```
+
+## Troubleshooting
+
+### "401 Unauthorized"
+- Verify username and password are correct
+- Check authentication is enabled on server
+- For NextCloud/ownCloud, use app passwords
+
+### "404 Not Found"
+- Verify the URL path is correct
+- Ensure parent directories exist
+- Check URL includes full path to backup location
+
+### "403 Forbidden"
+- Verify user has write permissions
+- Check WebDAV is enabled for the location
+- Review server access control settings
+
+### "Connection refused"
+- Verify server is running
+- Check SSL certificate is valid
+- Ensure firewall allows HTTPS
+
+### Slow transfers
+- WebDAV has higher overhead than native protocols
+- Consider using S3 or SFTP for better performance
+- Check server's upload size limits

--- a/.codex/skills/litestream/deployment/docker.md
+++ b/.codex/skills/litestream/deployment/docker.md
@@ -1,0 +1,264 @@
+# Docker Deployment
+
+Run Litestream in Docker containers.
+
+## Official Image
+
+```bash
+docker pull litestream/litestream
+```
+
+## Basic Usage
+
+### Standalone Replication
+
+```bash
+docker run -d \
+  -v /path/to/data:/data \
+  -v /path/to/litestream.yml:/etc/litestream.yml \
+  -e AWS_ACCESS_KEY_ID=xxx \
+  -e AWS_SECRET_ACCESS_KEY=xxx \
+  litestream/litestream replicate
+```
+
+### One-Shot Restore
+
+```bash
+docker run --rm \
+  -v /path/to/data:/data \
+  -e AWS_ACCESS_KEY_ID=xxx \
+  -e AWS_SECRET_ACCESS_KEY=xxx \
+  litestream/litestream restore -o /data/app.db s3://bucket/backup
+```
+
+## Multi-Container with Docker Compose
+
+### Application + Litestream Sidecar
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+
+services:
+  app:
+    image: myapp:latest
+    volumes:
+      - db-data:/data
+    depends_on:
+      - litestream
+
+  litestream:
+    image: litestream/litestream
+    volumes:
+      - db-data:/data
+      - ./litestream.yml:/etc/litestream.yml
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    command: replicate
+
+volumes:
+  db-data:
+```
+
+### Litestream Configuration
+
+```yaml
+# litestream.yml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+```
+
+## Single Container Pattern
+
+Run both application and Litestream in one container:
+
+### Dockerfile
+
+```dockerfile
+FROM alpine:latest
+
+# Install Litestream
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz /tmp/
+RUN tar -xzf /tmp/litestream-*.tar.gz -C /usr/local/bin
+
+# Install your application
+COPY myapp /usr/local/bin/
+COPY litestream.yml /etc/litestream.yml
+
+# Create data directory
+RUN mkdir -p /data
+
+# Use Litestream as entrypoint to wrap your app
+ENTRYPOINT ["/usr/local/bin/litestream", "replicate", "-exec"]
+CMD ["myapp", "serve"]
+```
+
+### With Auto-Restore
+
+```dockerfile
+FROM alpine:latest
+
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz /tmp/
+RUN tar -xzf /tmp/litestream-*.tar.gz -C /usr/local/bin
+
+COPY myapp /usr/local/bin/
+COPY litestream.yml /etc/litestream.yml
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+RUN mkdir -p /data
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["myapp", "serve"]
+```
+
+```bash
+#!/bin/sh
+# entrypoint.sh
+
+# Restore database if it doesn't exist
+if [ ! -f /data/app.db ]; then
+    echo "Restoring database..."
+    litestream restore -if-replica-exists -o /data/app.db "${REPLICA_URL}"
+fi
+
+# Start Litestream with the application
+exec litestream replicate -exec "$@"
+```
+
+## Health Checks
+
+```yaml
+# docker-compose.yml
+services:
+  litestream:
+    image: litestream/litestream
+    volumes:
+      - db-data:/data
+      - ./litestream.yml:/etc/litestream.yml
+    healthcheck:
+      test: ["CMD", "litestream", "databases"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+```
+
+## Metrics Exposure
+
+```yaml
+# docker-compose.yml
+services:
+  litestream:
+    image: litestream/litestream
+    ports:
+      - "9090:9090"
+    volumes:
+      - db-data:/data
+      - ./litestream.yml:/etc/litestream.yml
+```
+
+```yaml
+# litestream.yml
+addr: ":9090"
+
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/backup
+```
+
+## Environment Variables
+
+Pass credentials via environment:
+
+```yaml
+# docker-compose.yml
+services:
+  litestream:
+    image: litestream/litestream
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_REGION=us-east-1
+```
+
+```yaml
+# litestream.yml (with env expansion)
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/backup
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+```
+
+## Volume Considerations
+
+### Persistent Volume
+
+```yaml
+volumes:
+  db-data:
+    driver: local
+```
+
+### tmpfs for Ephemeral
+
+```yaml
+services:
+  app:
+    tmpfs:
+      - /data
+```
+
+Use with auto-restore for ephemeral containers.
+
+## Multi-Stage Build
+
+```dockerfile
+# Build stage
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o myapp
+
+# Runtime stage
+FROM alpine:latest
+
+# Install Litestream
+COPY --from=litestream/litestream:latest /usr/local/bin/litestream /usr/local/bin/
+
+# Copy application
+COPY --from=builder /app/myapp /usr/local/bin/
+COPY litestream.yml /etc/litestream.yml
+
+ENTRYPOINT ["litestream", "replicate", "-exec"]
+CMD ["myapp"]
+```
+
+## Troubleshooting
+
+### Container exits immediately
+- Check Litestream logs: `docker logs <container>`
+- Verify configuration file exists
+- Check database path is correct
+
+### Permission denied
+- Ensure volumes have correct permissions
+- Use `user:` directive if needed
+- Check file ownership in container
+
+### Database not found
+- Verify volume mount paths
+- Check auto-restore is configured
+- Ensure replica has backups
+
+## See Also
+
+- [Fly.io Deployment](fly-io.md)
+- [Kubernetes Deployment](kubernetes.md)
+- [Configuration Overview](../configuration/overview.md)

--- a/.codex/skills/litestream/deployment/fly-io.md
+++ b/.codex/skills/litestream/deployment/fly-io.md
@@ -1,0 +1,295 @@
+# Fly.io Deployment
+
+Deploy SQLite applications with Litestream on Fly.io.
+
+## Overview
+
+Fly.io + Litestream is excellent for:
+- Single-node SQLite applications
+- Global edge deployment
+- Simple, cost-effective hosting
+
+## Tigris Storage (Recommended)
+
+Fly.io's Tigris is S3-compatible storage optimized for Fly:
+
+```bash
+# Create Tigris bucket
+fly storage create
+
+# Note the bucket name and credentials
+```
+
+### Configuration
+
+```yaml
+# litestream.yml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://your-bucket/app-backup?endpoint=fly.storage.tigris.dev&region=auto
+```
+
+Tigris automatically configures:
+- Signing settings
+- Content-MD5 handling
+- Regional optimization
+
+## Project Structure
+
+```
+myapp/
+├── Dockerfile
+├── fly.toml
+├── litestream.yml
+├── entrypoint.sh
+└── ... (application files)
+```
+
+## Dockerfile
+
+```dockerfile
+FROM alpine:latest
+
+# Install dependencies
+RUN apk add --no-cache ca-certificates
+
+# Install Litestream
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz /tmp/
+RUN tar -xzf /tmp/litestream-*.tar.gz -C /usr/local/bin && rm /tmp/litestream-*.tar.gz
+
+# Copy application
+COPY myapp /usr/local/bin/
+COPY litestream.yml /etc/litestream.yml
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+RUN mkdir -p /data
+
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+## Entrypoint Script
+
+```bash
+#!/bin/sh
+# entrypoint.sh
+set -e
+
+# Restore database if it doesn't exist
+if [ ! -f /data/app.db ]; then
+    echo "No database found. Attempting restore..."
+    litestream restore -if-replica-exists -o /data/app.db "${REPLICA_URL}"
+    if [ -f /data/app.db ]; then
+        echo "Database restored successfully."
+    else
+        echo "No backup found. Starting fresh."
+    fi
+fi
+
+# Start Litestream and application
+exec litestream replicate -exec "myapp serve"
+```
+
+## fly.toml
+
+```toml
+app = "myapp"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  REPLICA_URL = "s3://your-bucket/app-backup?endpoint=fly.storage.tigris.dev&region=auto"
+
+[mounts]
+  source = "data"
+  destination = "/data"
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+```
+
+## Setting Secrets
+
+```bash
+# For Tigris (credentials from fly storage create)
+fly secrets set AWS_ACCESS_KEY_ID=xxx
+fly secrets set AWS_SECRET_ACCESS_KEY=xxx
+
+# Or for external S3
+fly secrets set AWS_ACCESS_KEY_ID=AKIA...
+fly secrets set AWS_SECRET_ACCESS_KEY=xxx
+fly secrets set AWS_REGION=us-east-1
+```
+
+## Litestream Configuration
+
+```yaml
+# litestream.yml
+dbs:
+  - path: /data/app.db
+    replica:
+      url: ${REPLICA_URL}
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+      sync-interval: 1s
+```
+
+## Volume Setup
+
+Create persistent volume:
+
+```bash
+# Create volume in your region
+fly volumes create data --region iad --size 1
+
+# View volumes
+fly volumes list
+```
+
+## Deployment
+
+```bash
+# Deploy
+fly deploy
+
+# View logs
+fly logs
+
+# SSH into container
+fly ssh console
+```
+
+## Scaling Considerations
+
+### Single Instance (Recommended)
+
+SQLite works best with single writer:
+
+```bash
+# Set to exactly 1 instance
+fly scale count 1
+```
+
+### Regional Deployment
+
+Deploy to a single region for best SQLite performance:
+
+```toml
+primary_region = "iad"
+```
+
+### Read Replicas (Advanced)
+
+For read-heavy workloads, consider:
+- LiteFS for distributed reads
+- Multiple regions with read replicas
+
+## Health Checks
+
+```toml
+# fly.toml
+[[services]]
+  [services.http_checks]
+    interval = 10000
+    timeout = 2000
+    path = "/health"
+    method = "get"
+```
+
+## Monitoring
+
+### Fly Metrics
+
+```bash
+fly status
+fly logs
+```
+
+### Litestream Metrics
+
+Expose metrics endpoint:
+
+```yaml
+# litestream.yml
+addr: ":9091"
+```
+
+```toml
+# fly.toml (internal service for metrics)
+[[services]]
+  internal_port = 9091
+  protocol = "tcp"
+```
+
+## Troubleshooting
+
+### Database Not Persisting
+
+- Verify volume is mounted: `fly ssh console` then `ls -la /data`
+- Check volume exists: `fly volumes list`
+
+### Restore Failing
+
+- Check Tigris credentials: `fly secrets list`
+- Verify bucket exists and has data
+- Check logs: `fly logs`
+
+### Application Crashes on Start
+
+- Ensure entrypoint script has execute permission
+- Check Litestream configuration syntax
+- Verify database path matches volume mount
+
+### Slow Performance
+
+- Ensure single instance
+- Use volume in same region as app
+- Check Tigris latency (should be low within Fly)
+
+## Example: Go Application
+
+Complete example for a Go web app:
+
+```dockerfile
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY go.* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o myapp
+
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz /tmp/
+RUN tar -xzf /tmp/litestream-*.tar.gz -C /usr/local/bin
+
+COPY --from=builder /app/myapp /usr/local/bin/
+COPY litestream.yml /etc/litestream.yml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && mkdir -p /data
+
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+## See Also
+
+- [Docker Deployment](docker.md)
+- [S3 Configuration](../configuration/s3.md)
+- [Recovery Operations](../operations/recovery.md)

--- a/.codex/skills/litestream/deployment/kubernetes.md
+++ b/.codex/skills/litestream/deployment/kubernetes.md
@@ -1,0 +1,413 @@
+# Kubernetes Deployment
+
+Deploy Litestream with SQLite applications on Kubernetes.
+
+## Deployment Patterns
+
+### 1. Sidecar Container (Recommended)
+
+Litestream runs alongside your application:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 1  # SQLite requires single writer
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+        - name: litestream
+          image: litestream/litestream
+          args:
+            - replicate
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /etc/litestream.yml
+              subPath: litestream.yml
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: litestream-secrets
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litestream-secrets
+                  key: aws-secret-access-key
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: myapp-data
+        - name: config
+          configMap:
+            name: litestream-config
+```
+
+### 2. Init Container (Auto-Restore)
+
+Restore database before application starts:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 1
+  template:
+    spec:
+      initContainers:
+        - name: restore
+          image: litestream/litestream
+          args:
+            - restore
+            - -if-db-not-exists
+            - -if-replica-exists
+            - -o
+            - /data/app.db
+            - s3://bucket/backup
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: litestream-secrets
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litestream-secrets
+                  key: aws-secret-access-key
+
+      containers:
+        - name: app
+          image: myapp:latest
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+        - name: litestream
+          image: litestream/litestream
+          args:
+            - replicate
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /etc/litestream.yml
+              subPath: litestream.yml
+```
+
+## ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litestream-config
+data:
+  litestream.yml: |
+    dbs:
+      - path: /data/app.db
+        replica:
+          url: s3://my-bucket/app-backup
+          sync-interval: 1s
+```
+
+## Secrets
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: litestream-secrets
+type: Opaque
+stringData:
+  aws-access-key-id: "AKIA..."
+  aws-secret-access-key: "xxx"
+```
+
+Or create via kubectl:
+
+```bash
+kubectl create secret generic litestream-secrets \
+  --from-literal=aws-access-key-id=AKIA... \
+  --from-literal=aws-secret-access-key=xxx
+```
+
+## Persistent Volume Claim
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: myapp-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: fast-ssd  # Use appropriate storage class
+```
+
+## StatefulSet (Alternative)
+
+For stable network identity and storage:
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  serviceName: myapp
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+        - name: litestream
+          image: litestream/litestream
+          args:
+            - replicate
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /etc/litestream.yml
+              subPath: litestream.yml
+
+      volumes:
+        - name: config
+          configMap:
+            name: litestream-config
+
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+```
+
+## Service Account (GCS/Workload Identity)
+
+For GKE with Workload Identity:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: litestream-sa
+  annotations:
+    iam.gke.io/gcp-service-account: litestream@project-id.iam.gserviceaccount.com
+```
+
+```yaml
+spec:
+  serviceAccountName: litestream-sa
+  containers:
+    - name: litestream
+      image: litestream/litestream
+```
+
+## Health Probes
+
+```yaml
+containers:
+  - name: litestream
+    image: litestream/litestream
+    args:
+      - replicate
+    livenessProbe:
+      exec:
+        command:
+          - litestream
+          - databases
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readinessProbe:
+      exec:
+        command:
+          - litestream
+          - databases
+      initialDelaySeconds: 5
+      periodSeconds: 10
+```
+
+## Resource Limits
+
+```yaml
+containers:
+  - name: litestream
+    image: litestream/litestream
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+## Metrics with ServiceMonitor
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: litestream-metrics
+  labels:
+    app: myapp
+spec:
+  ports:
+    - port: 9090
+      name: metrics
+  selector:
+    app: myapp
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: litestream
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  endpoints:
+    - port: metrics
+```
+
+Update Litestream config:
+
+```yaml
+# litestream.yml
+addr: ":9090"
+
+dbs:
+  - path: /data/app.db
+    replica:
+      url: s3://bucket/backup
+```
+
+## Network Policies
+
+Allow egress to S3:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: litestream-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: myapp
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+```
+
+## Pod Disruption Budget
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: myapp-pdb
+spec:
+  minAvailable: 0  # Allow disruption (single replica)
+  selector:
+    matchLabels:
+      app: myapp
+```
+
+## Scaling Considerations
+
+### Single Replica
+
+SQLite requires single writer:
+
+```yaml
+spec:
+  replicas: 1
+```
+
+### Anti-Affinity (Multi-AZ PVC)
+
+If your PVC supports multi-AZ:
+
+```yaml
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: myapp
+                topologyKey: topology.kubernetes.io/zone
+```
+
+## Troubleshooting
+
+### Database not persisting
+- Verify PVC is bound: `kubectl get pvc`
+- Check pod events: `kubectl describe pod <pod>`
+
+### Restore failing
+- Check init container logs: `kubectl logs <pod> -c restore`
+- Verify secrets are correct: `kubectl get secret litestream-secrets -o yaml`
+
+### Litestream not starting
+- Check sidecar logs: `kubectl logs <pod> -c litestream`
+- Verify ConfigMap mounted: `kubectl exec <pod> -c litestream -- cat /etc/litestream.yml`
+
+## See Also
+
+- [Docker Deployment](docker.md)
+- [GCS Configuration](../configuration/gcs.md)
+- [S3 Configuration](../configuration/s3.md)

--- a/.codex/skills/litestream/deployment/systemd.md
+++ b/.codex/skills/litestream/deployment/systemd.md
@@ -1,0 +1,352 @@
+# Systemd Deployment
+
+Run Litestream as a systemd service on Linux.
+
+## Installation
+
+### Debian/Ubuntu
+
+```bash
+wget https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.deb
+sudo dpkg -i litestream-v0.3.13-linux-amd64.deb
+```
+
+### Other Linux
+
+```bash
+wget https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64.tar.gz
+tar -xzf litestream-v0.3.13-linux-amd64.tar.gz
+sudo mv litestream /usr/local/bin/
+```
+
+## Basic Service Unit
+
+### /etc/systemd/system/litestream.service
+
+```ini
+[Unit]
+Description=Litestream SQLite Replication
+After=network.target
+
+[Service]
+Type=simple
+User=litestream
+Group=litestream
+ExecStart=/usr/local/bin/litestream replicate
+Restart=on-failure
+RestartSec=5
+
+# Environment
+EnvironmentFile=/etc/litestream/env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Configuration
+
+### /etc/litestream.yml
+
+```yaml
+dbs:
+  - path: /var/lib/myapp/app.db
+    replica:
+      url: s3://my-bucket/app-backup
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+      region: us-east-1
+```
+
+### /etc/litestream/env
+
+```bash
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=xxx
+```
+
+Secure the environment file:
+
+```bash
+sudo chmod 600 /etc/litestream/env
+sudo chown litestream:litestream /etc/litestream/env
+```
+
+## User Setup
+
+Create dedicated user:
+
+```bash
+sudo useradd --system --no-create-home --shell /bin/false litestream
+```
+
+Grant access to database directory:
+
+```bash
+sudo chown -R litestream:litestream /var/lib/myapp
+# Or add to application group
+sudo usermod -a -G myapp litestream
+```
+
+## Service Management
+
+```bash
+# Enable on boot
+sudo systemctl enable litestream
+
+# Start service
+sudo systemctl start litestream
+
+# Check status
+sudo systemctl status litestream
+
+# View logs
+sudo journalctl -u litestream -f
+
+# Restart
+sudo systemctl restart litestream
+
+# Stop
+sudo systemctl stop litestream
+```
+
+## With Application
+
+### Application Service
+
+```ini
+# /etc/systemd/system/myapp.service
+[Unit]
+Description=My Application
+After=network.target litestream.service
+Requires=litestream.service
+
+[Service]
+Type=simple
+User=myapp
+ExecStart=/usr/local/bin/myapp serve
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Litestream Managing Application
+
+Alternative: Litestream runs and manages the app:
+
+```ini
+# /etc/systemd/system/litestream-app.service
+[Unit]
+Description=Litestream with Application
+After=network.target
+
+[Service]
+Type=simple
+User=myapp
+ExecStartPre=/usr/local/bin/litestream restore -if-db-not-exists -o /var/lib/myapp/app.db s3://bucket/backup
+ExecStart=/usr/local/bin/litestream replicate -exec "/usr/local/bin/myapp serve"
+Restart=always
+EnvironmentFile=/etc/litestream/env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Auto-Restore on Start
+
+```ini
+[Service]
+ExecStartPre=/usr/local/bin/litestream restore -if-db-not-exists -if-replica-exists -o /var/lib/myapp/app.db s3://bucket/backup
+ExecStart=/usr/local/bin/litestream replicate
+```
+
+## Hardening
+
+### Security Options
+
+```ini
+[Service]
+# Restrict capabilities
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+
+# Allow write only to data directory
+ReadWritePaths=/var/lib/myapp
+
+# Restrict network
+RestrictAddressFamilies=AF_INET AF_INET6
+
+# Restrict system calls
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+```
+
+### Full Hardened Unit
+
+```ini
+[Unit]
+Description=Litestream SQLite Replication
+After=network.target
+
+[Service]
+Type=simple
+User=litestream
+Group=litestream
+
+ExecStart=/usr/local/bin/litestream replicate
+
+Restart=on-failure
+RestartSec=5
+
+# Security
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ReadWritePaths=/var/lib/myapp
+EnvironmentFile=/etc/litestream/env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Logging
+
+### Journal Integration
+
+View logs:
+
+```bash
+# Follow logs
+sudo journalctl -u litestream -f
+
+# View recent logs
+sudo journalctl -u litestream --since "1 hour ago"
+
+# View errors only
+sudo journalctl -u litestream -p err
+```
+
+### Log Level
+
+In litestream.yml:
+
+```yaml
+logging:
+  level: info  # debug, info, warn, error
+```
+
+Or via environment:
+
+```bash
+# /etc/litestream/env
+LOG_LEVEL=debug
+```
+
+## Health Monitoring
+
+### Watchdog
+
+```ini
+[Service]
+WatchdogSec=60
+Restart=on-failure
+```
+
+### Heartbeat
+
+```yaml
+# litestream.yml
+heartbeat-url: https://healthchecks.io/ping/xxx
+heartbeat-interval: 5m
+```
+
+### Custom Health Check
+
+```bash
+#!/bin/bash
+# /usr/local/bin/litestream-health
+
+if ! systemctl is-active --quiet litestream; then
+    echo "CRITICAL: Litestream not running"
+    exit 2
+fi
+
+if ! litestream databases > /dev/null 2>&1; then
+    echo "WARNING: Cannot query databases"
+    exit 1
+fi
+
+echo "OK: Litestream running"
+exit 0
+```
+
+## Multiple Databases
+
+### Separate Services
+
+For different users/permissions:
+
+```bash
+# /etc/systemd/system/litestream-app1.service
+# /etc/systemd/system/litestream-app2.service
+```
+
+### Single Service Multiple DBs
+
+```yaml
+# /etc/litestream.yml
+dbs:
+  - path: /var/lib/app1/db.sqlite
+    replica:
+      url: s3://bucket/app1
+
+  - path: /var/lib/app2/db.sqlite
+    replica:
+      url: s3://bucket/app2
+```
+
+## Troubleshooting
+
+### Service won't start
+
+```bash
+# Check syntax
+sudo systemctl daemon-reload
+sudo systemctl start litestream
+
+# View detailed errors
+sudo journalctl -u litestream -n 50 --no-pager
+```
+
+### Permission denied
+
+```bash
+# Check file ownership
+ls -la /var/lib/myapp/
+
+# Check user groups
+id litestream
+
+# Fix permissions
+sudo chown -R litestream:litestream /var/lib/myapp
+```
+
+### Database locked
+
+- Ensure only one Litestream instance
+- Check for other processes using database
+
+```bash
+fuser /var/lib/myapp/app.db
+```
+
+## See Also
+
+- [Docker Deployment](docker.md)
+- [Configuration Overview](../configuration/overview.md)
+- [Monitoring](../operations/monitoring.md)

--- a/.codex/skills/litestream/operations/monitoring.md
+++ b/.codex/skills/litestream/operations/monitoring.md
@@ -1,0 +1,290 @@
+# Monitoring Litestream
+
+Monitor replication status, health, and performance.
+
+## Prometheus Metrics
+
+Enable metrics by setting the `addr` in configuration:
+
+```yaml
+addr: ":9090"
+```
+
+Access metrics at `http://localhost:9090/metrics`.
+
+### Available Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `litestream_db_size_bytes` | Gauge | Database file size |
+| `litestream_wal_size_bytes` | Gauge | WAL file size |
+| `litestream_total_wal_bytes` | Counter | Total bytes written to WAL |
+| `litestream_checkpoint_count_total` | Counter | Total checkpoints performed |
+| `litestream_sync_count_total` | Counter | Total syncs to replica |
+| `litestream_sync_error_count_total` | Counter | Total sync errors |
+
+### Labels
+
+Metrics include labels for filtering:
+
+- `db`: Database file path
+
+Example query:
+```promql
+litestream_wal_size_bytes{db="/data/app.db"}
+```
+
+## Prometheus Configuration
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'litestream'
+    static_configs:
+      - targets: ['localhost:9090']
+```
+
+## Grafana Dashboard
+
+### Basic Dashboard Panels
+
+**Database Size**
+```promql
+litestream_db_size_bytes
+```
+
+**WAL Size**
+```promql
+litestream_wal_size_bytes
+```
+
+**Sync Rate**
+```promql
+rate(litestream_sync_count_total[5m])
+```
+
+**Error Rate**
+```promql
+rate(litestream_sync_error_count_total[5m])
+```
+
+**Checkpoint Rate**
+```promql
+rate(litestream_checkpoint_count_total[5m])
+```
+
+## Alerting
+
+### Prometheus Alert Rules
+
+```yaml
+# alerts.yml
+groups:
+  - name: litestream
+    rules:
+      - alert: LitestreamSyncErrors
+        expr: rate(litestream_sync_error_count_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Litestream sync errors detected"
+          description: "Database {{ $labels.db }} has sync errors"
+
+      - alert: LitestreamWALTooLarge
+        expr: litestream_wal_size_bytes > 100000000  # 100MB
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "WAL file too large"
+          description: "WAL for {{ $labels.db }} is {{ $value | humanizeBytes }}"
+
+      - alert: LitestreamNoSyncs
+        expr: rate(litestream_sync_count_total[10m]) == 0
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No Litestream syncs"
+          description: "No syncs for {{ $labels.db }} in 15 minutes"
+```
+
+## Health Checks
+
+### Heartbeat URL
+
+Configure Litestream to ping a health check service:
+
+```yaml
+heartbeat-url: https://healthchecks.io/ping/your-uuid
+heartbeat-interval: 5m
+```
+
+Compatible services:
+- [Healthchecks.io](https://healthchecks.io)
+- [Cronitor](https://cronitor.io)
+- [Better Uptime](https://betteruptime.com)
+
+### Systemd Watchdog
+
+```ini
+# /etc/systemd/system/litestream.service
+[Service]
+WatchdogSec=30
+Restart=on-failure
+RestartSec=5
+```
+
+### Custom Health Check Script
+
+```bash
+#!/bin/bash
+# health-check.sh
+
+# Check if Litestream is running
+if ! pgrep -x litestream > /dev/null; then
+    echo "CRITICAL: Litestream not running"
+    exit 2
+fi
+
+# Check recent sync activity
+LAST_SYNC=$(stat -c %Y /data/.litestream/*/l0/*.ltx 2>/dev/null | sort -rn | head -1)
+NOW=$(date +%s)
+AGE=$((NOW - LAST_SYNC))
+
+if [ "$AGE" -gt 300 ]; then
+    echo "WARNING: No sync in $AGE seconds"
+    exit 1
+fi
+
+echo "OK: Last sync $AGE seconds ago"
+exit 0
+```
+
+## Log Monitoring
+
+### Logging Configuration
+
+```yaml
+logging:
+  level: info    # debug, info, warn, error
+  type: text     # text or json
+  stderr: false  # Output to stderr instead of stdout
+```
+
+### JSON Logging
+
+For log aggregation (ELK, Loki, etc.):
+
+```yaml
+logging:
+  type: json
+```
+
+### Log Levels
+
+| Level | Description |
+|-------|-------------|
+| `debug` | Verbose debugging information |
+| `info` | Normal operation messages |
+| `warn` | Warning conditions |
+| `error` | Error conditions |
+
+### Example Log Output
+
+```
+INFO  database opened path=/data/app.db
+INFO  replica started type=s3
+INFO  sync completed txid=1234 duration=45ms
+WARN  checkpoint delayed reason="readers present"
+ERROR sync failed error="connection timeout"
+```
+
+## Status Commands
+
+### Quick Status Check
+
+```bash
+# View all databases
+litestream status
+
+# Output:
+# database           status   local txid            wal size
+# /data/app.db       ok       0000000000001234      1.2 MB
+```
+
+### Verify Backups Exist
+
+```bash
+# List LTX files
+litestream ltx /data/app.db
+
+# Count backup files
+litestream ltx /data/app.db | wc -l
+```
+
+### Watch Status
+
+```bash
+# Continuous monitoring
+watch -n 5 litestream status
+```
+
+## Docker Monitoring
+
+### Docker Health Check
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD ["litestream", "databases"] || exit 1
+```
+
+### Docker Compose with Metrics
+
+```yaml
+services:
+  app:
+    image: myapp
+    volumes:
+      - ./data:/data
+
+  litestream:
+    image: litestream/litestream
+    volumes:
+      - ./data:/data
+      - ./litestream.yml:/etc/litestream.yml
+    ports:
+      - "9090:9090"
+    command: replicate
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9091:9090"
+```
+
+## Monitoring Checklist
+
+### Daily Checks
+- [ ] Verify Litestream is running
+- [ ] Check for sync errors in logs
+- [ ] Verify WAL size is reasonable
+
+### Weekly Checks
+- [ ] Review backup file counts
+- [ ] Test restore to verify backup integrity
+- [ ] Check storage usage trends
+
+### Monthly Checks
+- [ ] Full disaster recovery test
+- [ ] Review and update alerting thresholds
+- [ ] Audit access to backup storage
+
+## See Also
+
+- [Troubleshooting](troubleshooting.md)
+- [Recovery](recovery.md)
+- [status Command](../commands/status.md)

--- a/.codex/skills/litestream/operations/recovery.md
+++ b/.codex/skills/litestream/operations/recovery.md
@@ -1,0 +1,283 @@
+# Recovery Procedures
+
+Point-in-time recovery and disaster recovery procedures.
+
+## Recovery Types
+
+### Latest State Recovery
+
+Restore to the most recent backup:
+
+```bash
+litestream restore -o /data/app.db s3://bucket/backup
+```
+
+### Point-in-Time Recovery
+
+Restore to a specific timestamp:
+
+```bash
+litestream restore -timestamp 2024-01-15T10:30:00Z -o /data/app.db s3://bucket/backup
+```
+
+### Transaction-Based Recovery
+
+Restore to a specific transaction ID:
+
+```bash
+litestream restore -txid 1000 -o /data/app.db s3://bucket/backup
+```
+
+## Pre-Recovery Steps
+
+### 1. Stop the Application
+
+```bash
+# Stop application that uses the database
+systemctl stop myapp
+
+# Stop Litestream (if running)
+systemctl stop litestream
+```
+
+### 2. Backup Current State
+
+```bash
+# Even if corrupted, backup current state
+mv /data/app.db /data/app.db.corrupted
+mv /data/app.db-wal /data/app.db-wal.corrupted
+mv /data/app.db-shm /data/app.db-shm.corrupted
+```
+
+### 3. Verify Backup Availability
+
+```bash
+# List available backups
+litestream ltx s3://bucket/backup
+
+# Output shows TXID ranges and timestamps
+min_txid              max_txid              size     created
+0000000000000001      0000000000001000      102400   2024-01-15T00:00:00Z
+```
+
+## Recovery Procedures
+
+### Scenario 1: Complete Database Loss
+
+Database file was deleted or server failed.
+
+```bash
+# 1. Ensure directory exists
+mkdir -p /data
+
+# 2. Restore latest backup
+litestream restore -o /data/app.db s3://bucket/backup
+
+# 3. Verify integrity
+sqlite3 /data/app.db "PRAGMA integrity_check;"
+
+# 4. Restart services
+systemctl start litestream
+systemctl start myapp
+```
+
+### Scenario 2: Corruption Recovery
+
+Database became corrupted (e.g., disk error).
+
+```bash
+# 1. Stop services
+systemctl stop myapp litestream
+
+# 2. Move corrupted files
+mv /data/app.db /data/app.db.corrupted
+
+# 3. Restore from before corruption
+# Find timestamp before corruption occurred
+litestream ltx s3://bucket/backup | less
+
+# 4. Restore to that time
+litestream restore -timestamp 2024-01-14T23:00:00Z -o /data/app.db s3://bucket/backup
+
+# 5. Verify and restart
+sqlite3 /data/app.db "PRAGMA integrity_check;"
+systemctl start litestream
+systemctl start myapp
+```
+
+### Scenario 3: Accidental Data Deletion
+
+User accidentally deleted important data.
+
+```bash
+# 1. Identify when deletion occurred
+# (from application logs or user reports)
+
+# 2. Find backup from before deletion
+litestream ltx s3://bucket/backup | grep "2024-01-15T09"
+
+# 3. Restore to recovery database (don't overwrite production!)
+litestream restore -timestamp 2024-01-15T09:00:00Z -o /tmp/recovery.db s3://bucket/backup
+
+# 4. Extract needed data
+sqlite3 /tmp/recovery.db ".dump table_name" > recovery.sql
+
+# 5. Apply to production (carefully!)
+sqlite3 /data/app.db < recovery.sql
+```
+
+### Scenario 4: Server Migration
+
+Moving database to new server.
+
+```bash
+# On new server:
+
+# 1. Install Litestream
+brew install litestream  # or appropriate method
+
+# 2. Copy configuration
+scp oldserver:/etc/litestream.yml /etc/litestream.yml
+# Update paths if needed
+
+# 3. Restore database
+litestream restore -o /data/app.db s3://bucket/backup
+
+# 4. Start replication (will continue from current point)
+systemctl start litestream
+```
+
+### Scenario 5: Development Database Refresh
+
+Get production data for development.
+
+```bash
+# Create development copy from production backup
+litestream restore -o /tmp/dev.db s3://bucket/production-backup
+
+# Optionally sanitize data
+sqlite3 /tmp/dev.db << EOF
+UPDATE users SET email = 'test' || id || '@example.com';
+UPDATE users SET password_hash = 'invalidated';
+EOF
+```
+
+## Recovery Verification
+
+### Integrity Check
+
+```bash
+sqlite3 /data/app.db "PRAGMA integrity_check;"
+# Should output: ok
+```
+
+### Quick Check
+
+```bash
+sqlite3 /data/app.db "PRAGMA quick_check;"
+# Faster but less thorough
+```
+
+### Data Verification
+
+```bash
+# Check row counts match expectations
+sqlite3 /data/app.db "SELECT COUNT(*) FROM important_table;"
+
+# Check recent data exists
+sqlite3 /data/app.db "SELECT MAX(created_at) FROM transactions;"
+```
+
+## Automated Recovery
+
+### Docker Entrypoint
+
+```bash
+#!/bin/bash
+set -e
+
+# Auto-restore if database doesn't exist
+if [ ! -f /data/app.db ]; then
+    echo "Database not found, restoring from backup..."
+    litestream restore -if-replica-exists -o /data/app.db "$REPLICA_URL"
+fi
+
+# Start Litestream with application
+exec litestream replicate -exec "$@"
+```
+
+### Kubernetes Init Container
+
+```yaml
+initContainers:
+  - name: restore
+    image: litestream/litestream
+    command:
+      - litestream
+      - restore
+      - -if-db-not-exists
+      - -o
+      - /data/app.db
+      - s3://bucket/backup
+    volumeMounts:
+      - name: data
+        mountPath: /data
+```
+
+### Systemd Pre-Start
+
+```ini
+[Service]
+ExecStartPre=/usr/bin/litestream restore -if-db-not-exists -o /data/app.db s3://bucket/backup
+ExecStart=/usr/bin/litestream replicate
+```
+
+## Disaster Recovery Planning
+
+### RPO (Recovery Point Objective)
+
+How much data can you afford to lose?
+
+| Sync Interval | Typical RPO |
+|---------------|-------------|
+| 100ms | ~100ms |
+| 1s (default) | ~1s |
+| 10s | ~10s |
+| 1m | ~1m |
+
+### RTO (Recovery Time Objective)
+
+How fast must you recover?
+
+| Database Size | Restore Time (estimate) |
+|---------------|------------------------|
+| < 100MB | < 1 minute |
+| 100MB - 1GB | 1-5 minutes |
+| 1GB - 10GB | 5-30 minutes |
+| > 10GB | Depends on network |
+
+### Backup Strategy
+
+1. **Primary**: Continuous replication to cloud storage
+2. **Secondary**: Periodic snapshots for long-term retention
+3. **Tertiary**: Geographic replication (different region)
+
+### Testing Recovery
+
+Regularly test your recovery process:
+
+```bash
+# Monthly recovery test
+#!/bin/bash
+DATE=$(date +%Y%m%d)
+litestream restore -o /tmp/recovery-test-$DATE.db s3://bucket/backup
+sqlite3 /tmp/recovery-test-$DATE.db "PRAGMA integrity_check;"
+rm /tmp/recovery-test-$DATE.db
+echo "Recovery test passed: $DATE"
+```
+
+## See Also
+
+- [restore Command](../commands/restore.md)
+- [Troubleshooting](troubleshooting.md)
+- [Monitoring](monitoring.md)

--- a/.codex/skills/litestream/operations/troubleshooting.md
+++ b/.codex/skills/litestream/operations/troubleshooting.md
@@ -1,0 +1,302 @@
+# Troubleshooting Guide
+
+Common issues and their solutions.
+
+## Diagnostic Commands
+
+```bash
+# Check database status
+litestream status /path/to/db.sqlite
+
+# List LTX files (verify backups exist)
+litestream ltx /path/to/db.sqlite
+
+# Check database integrity
+sqlite3 /path/to/db.sqlite "PRAGMA integrity_check;"
+
+# Test restoration
+litestream restore -o /tmp/test.db s3://bucket/backup
+```
+
+## Common Issues
+
+### Issue: WAL Growing Too Large
+
+**Symptoms:**
+- WAL file grows to gigabytes
+- Disk space running low
+- Database performance degrading
+
+**Causes:**
+1. Long-running read transactions blocking checkpoint
+2. Checkpoint interval too long
+3. Application not closing connections
+
+**Solutions:**
+
+1. **Check for long-running transactions:**
+   ```sql
+   -- SQLite doesn't track this directly
+   -- Check application code for open transactions
+   ```
+
+2. **Adjust checkpoint settings:**
+   ```yaml
+   dbs:
+     - path: /data/app.db
+       min-checkpoint-page-count: 500   # Checkpoint more often
+       truncate-page-n: 5000            # Force truncate at threshold
+   ```
+
+3. **Monitor WAL size:**
+   ```bash
+   ls -la /data/app.db-wal
+   ```
+
+### Issue: Replication Not Starting
+
+**Symptoms:**
+- No LTX files created
+- `litestream status` shows "not initialized"
+
+**Causes:**
+1. Database not in WAL mode
+2. No writes have occurred
+3. Configuration error
+
+**Solutions:**
+
+1. **Enable WAL mode:**
+   ```sql
+   PRAGMA journal_mode = WAL;
+   ```
+
+2. **Make a test write:**
+   ```sql
+   -- Any write will trigger replication
+   CREATE TABLE IF NOT EXISTS _litestream_test (id INTEGER);
+   INSERT INTO _litestream_test VALUES (1);
+   DROP TABLE _litestream_test;
+   ```
+
+3. **Verify configuration:**
+   ```bash
+   litestream databases
+   # Should show your database
+   ```
+
+### Issue: "Access Denied" Errors
+
+**Symptoms:**
+- Sync errors in logs
+- "AccessDenied" or "Forbidden" messages
+
+**Causes:**
+1. Invalid credentials
+2. Insufficient permissions
+3. Bucket/container doesn't exist
+
+**Solutions:**
+
+1. **Verify credentials:**
+   ```bash
+   # For S3
+   aws s3 ls s3://your-bucket/
+
+   # For GCS
+   gsutil ls gs://your-bucket/
+   ```
+
+2. **Check IAM permissions:**
+   - S3: GetObject, PutObject, DeleteObject, ListBucket
+   - GCS: storage.objects.get, create, delete, list
+
+3. **Create bucket if missing:**
+   ```bash
+   aws s3 mb s3://your-bucket
+   ```
+
+### Issue: Restore Fails
+
+**Symptoms:**
+- "no matching backup files available"
+- Empty or corrupt restored database
+
+**Causes:**
+1. No backups exist
+2. Wrong replica URL
+3. Network connectivity issues
+
+**Solutions:**
+
+1. **Verify backups exist:**
+   ```bash
+   litestream ltx s3://bucket/backup
+   # Should show list of LTX files
+   ```
+
+2. **Check URL format:**
+   ```bash
+   # Correct
+   litestream restore -o /tmp/db s3://bucket/path
+
+   # Wrong (missing path)
+   litestream restore -o /tmp/db s3://bucket
+   ```
+
+3. **Test connectivity:**
+   ```bash
+   # For S3
+   aws s3 ls s3://bucket/path/
+   ```
+
+### Issue: Database Corruption After Restore
+
+**Symptoms:**
+- PRAGMA integrity_check fails
+- Application errors reading data
+
+**Causes:**
+1. Incomplete restore (interrupted)
+2. Lock page not properly skipped (unlikely in current versions)
+3. Source database was corrupted
+
+**Solutions:**
+
+1. **Verify source integrity:**
+   ```bash
+   # Restore to temp location
+   litestream restore -o /tmp/test.db s3://bucket/backup
+   sqlite3 /tmp/test.db "PRAGMA integrity_check;"
+   ```
+
+2. **Try point-in-time recovery:**
+   ```bash
+   # Restore to earlier state
+   litestream restore -timestamp 2024-01-14T00:00:00Z -o /tmp/test.db s3://bucket/backup
+   ```
+
+### Issue: High Replication Lag
+
+**Symptoms:**
+- Remote TXID far behind local
+- Long recovery point objective (RPO)
+
+**Causes:**
+1. Slow network connection
+2. Sync interval too long
+3. Storage backend throttling
+
+**Solutions:**
+
+1. **Reduce sync interval:**
+   ```yaml
+   dbs:
+     - path: /data/app.db
+       replica:
+         url: s3://bucket/backup
+         sync-interval: 100ms  # More frequent sync
+   ```
+
+2. **Check network:**
+   ```bash
+   # Time a test upload
+   time aws s3 cp /tmp/testfile s3://bucket/
+   ```
+
+3. **Monitor metrics:**
+   ```bash
+   curl localhost:9090/metrics | grep litestream
+   ```
+
+### Issue: Lock Page Errors (>1GB Databases)
+
+**Symptoms:**
+- Errors with databases larger than 1GB
+- Corruption around 1GB mark
+
+**Causes:**
+- SQLite reserves page at 0x40000000 for locking
+- This page must be skipped during replication
+
+**Note:** Current Litestream versions handle this automatically. If you see issues:
+
+1. **Ensure latest version:**
+   ```bash
+   litestream version
+   ```
+
+2. **Test with large database:**
+   ```bash
+   # Create test database > 1GB and verify replication
+   ```
+
+### Issue: Race Conditions / Data Races
+
+**Symptoms:**
+- Sporadic errors
+- Inconsistent behavior
+- Crashes under load
+
+**Solutions:**
+
+1. **Run tests with race detector:**
+   ```bash
+   go test -race -v ./...
+   ```
+
+2. **Ensure single writer:**
+   - Only one process should write to the database
+   - Multiple readers are okay
+
+### Issue: Slow Compaction
+
+**Symptoms:**
+- Many small LTX files accumulating
+- Storage costs increasing
+
+**Causes:**
+1. Compaction intervals too long
+2. Very high write volume
+3. Storage backend latency
+
+**Solutions:**
+
+1. **Adjust compaction levels:**
+   ```yaml
+   levels:
+     - interval: 15s    # Faster L1 compaction
+     - interval: 2m     # Faster L2 compaction
+     - interval: 30m    # Faster L3 compaction
+   ```
+
+2. **Monitor compaction:**
+   ```bash
+   # Count LTX files
+   litestream ltx /path/to/db | wc -l
+   ```
+
+## Getting Help
+
+1. **Check logs:**
+   ```bash
+   journalctl -u litestream -f
+   ```
+
+2. **Enable debug logging:**
+   ```yaml
+   logging:
+     level: debug
+   ```
+
+3. **Gather diagnostics:**
+   ```bash
+   litestream version
+   litestream databases
+   litestream status
+   ls -la /path/to/db*
+   ```
+
+4. **Report issues:**
+   - GitHub: https://github.com/benbjohnson/litestream/issues
+   - Include: version, config (redacted), error messages, steps to reproduce

--- a/.codex/skills/litestream/scripts/check-replication.sh
+++ b/.codex/skills/litestream/scripts/check-replication.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# check-replication.sh - Check Litestream replication status
+# Usage: ./check-replication.sh [database-path]
+
+set -e
+
+DB_PATH="${1:-}"
+CONFIG_PATH="${CONFIG_PATH:-/etc/litestream.yml}"
+
+echo "=== Litestream Replication Status Check ==="
+echo
+
+# Check if Litestream is running
+echo "1. Checking Litestream process..."
+if pgrep -x litestream > /dev/null; then
+    PID=$(pgrep -x litestream)
+    echo "   Litestream is RUNNING (PID: $PID)"
+else
+    echo "   Litestream is NOT RUNNING"
+    echo "   Start with: litestream replicate -config $CONFIG_PATH"
+fi
+
+# Check if Litestream command is available
+if ! command -v litestream &> /dev/null; then
+    echo
+    echo "ERROR: litestream command not found in PATH"
+    exit 1
+fi
+
+# Show status
+echo
+echo "2. Database status..."
+if [ -n "$DB_PATH" ]; then
+    litestream status -config "$CONFIG_PATH" "$DB_PATH" 2>/dev/null || echo "   Unable to get status"
+else
+    litestream status -config "$CONFIG_PATH" 2>/dev/null || echo "   Unable to get status"
+fi
+
+# List configured databases
+echo
+echo "3. Configured databases..."
+litestream databases -config "$CONFIG_PATH" 2>/dev/null || echo "   Unable to list databases"
+
+# Check WAL files
+echo
+echo "4. Checking WAL files..."
+if [ -n "$DB_PATH" ]; then
+    DBS="$DB_PATH"
+else
+    # Get database paths from config
+    DBS=$(litestream databases -config "$CONFIG_PATH" 2>/dev/null | tail -n +2 | cut -f1)
+fi
+
+for db in $DBS; do
+    if [ -f "$db" ]; then
+        echo "   Database: $db"
+
+        # Check WAL file
+        WAL_PATH="${db}-wal"
+        if [ -f "$WAL_PATH" ]; then
+            WAL_SIZE=$(ls -lh "$WAL_PATH" | awk '{print $5}')
+            echo "      WAL file: $WAL_SIZE"
+        else
+            echo "      WAL file: Not present"
+        fi
+
+        # Check database size
+        DB_SIZE=$(ls -lh "$db" | awk '{print $5}')
+        echo "      DB size: $DB_SIZE"
+
+        # Check metadata directory
+        META_DIR=$(dirname "$db")/.litestream
+        if [ -d "$META_DIR" ]; then
+            L0_COUNT=$(find "$META_DIR" -name "*.ltx" -path "*/0/*" 2>/dev/null | wc -l)
+            echo "      Local L0 files: $L0_COUNT"
+        else
+            echo "      Metadata dir: Not found"
+        fi
+    else
+        echo "   Database: $db (NOT FOUND)"
+    fi
+done
+
+# Check LTX files (if database specified)
+if [ -n "$DB_PATH" ] && [ -f "$DB_PATH" ]; then
+    echo
+    echo "5. Recent LTX files..."
+    litestream ltx -config "$CONFIG_PATH" "$DB_PATH" 2>/dev/null | head -11 || echo "   Unable to list LTX files"
+fi
+
+# Check system resources
+echo
+echo "6. System resources..."
+echo "   Disk space:"
+df -h $(dirname "${DB_PATH:-/var/lib}") 2>/dev/null | tail -1 | awk '{print "      Used: " $3 " / " $2 " (" $5 ")"}'
+
+if pgrep -x litestream > /dev/null; then
+    PID=$(pgrep -x litestream)
+    echo "   Litestream memory:"
+    ps -p "$PID" -o rss= 2>/dev/null | awk '{printf "      RSS: %.1f MB\n", $1/1024}'
+fi
+
+# Check metrics endpoint if configured
+echo
+echo "7. Metrics endpoint..."
+METRICS_ADDR=$(grep -E "^addr:" "$CONFIG_PATH" 2>/dev/null | head -1 | awk '{print $2}' | tr -d '"')
+if [ -n "$METRICS_ADDR" ]; then
+    # Handle :port format
+    if [[ "$METRICS_ADDR" == :* ]]; then
+        METRICS_URL="http://localhost${METRICS_ADDR}/metrics"
+    else
+        METRICS_URL="http://${METRICS_ADDR}/metrics"
+    fi
+
+    if curl -s --max-time 2 "$METRICS_URL" > /dev/null 2>&1; then
+        echo "   Metrics available at: $METRICS_URL"
+        echo "   Sample metrics:"
+        curl -s --max-time 2 "$METRICS_URL" 2>/dev/null | grep -E "^litestream_" | head -5 | sed 's/^/      /'
+    else
+        echo "   Metrics endpoint configured but not responding"
+    fi
+else
+    echo "   No metrics endpoint configured"
+fi
+
+# Summary
+echo
+echo "=== Summary ==="
+if pgrep -x litestream > /dev/null; then
+    echo "Status: Litestream is running"
+else
+    echo "Status: Litestream is NOT running"
+    echo "Action: Start with 'litestream replicate'"
+fi
+
+echo
+echo "=== Check Complete ==="

--- a/.codex/skills/litestream/scripts/diagnose-issues.sh
+++ b/.codex/skills/litestream/scripts/diagnose-issues.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# diagnose-issues.sh - Diagnose common Litestream issues
+# Usage: ./diagnose-issues.sh [database-path]
+
+set -e
+
+DB_PATH="${1:-}"
+CONFIG_PATH="${CONFIG_PATH:-/etc/litestream.yml}"
+
+echo "=== Litestream Diagnostics ==="
+echo
+
+ISSUES_FOUND=0
+
+# Helper function
+check_issue() {
+    local status="$1"
+    local message="$2"
+    if [ "$status" = "FAIL" ]; then
+        echo "   [FAIL] $message"
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    elif [ "$status" = "WARN" ]; then
+        echo "   [WARN] $message"
+    else
+        echo "   [OK]   $message"
+    fi
+}
+
+# 1. Check Litestream installation
+echo "1. Litestream Installation"
+if command -v litestream &> /dev/null; then
+    VERSION=$(litestream version 2>&1 || echo "unknown")
+    check_issue "OK" "Litestream installed: $VERSION"
+else
+    check_issue "FAIL" "Litestream not found in PATH"
+fi
+
+# 2. Check configuration
+echo
+echo "2. Configuration"
+if [ -f "$CONFIG_PATH" ]; then
+    check_issue "OK" "Config file exists: $CONFIG_PATH"
+
+    # Check syntax
+    if command -v yq &> /dev/null; then
+        if yq eval '.' "$CONFIG_PATH" > /dev/null 2>&1; then
+            check_issue "OK" "Config syntax valid"
+        else
+            check_issue "FAIL" "Config syntax invalid"
+        fi
+    fi
+
+    # Check for deprecated settings
+    if grep -q "wal:" "$CONFIG_PATH" 2>/dev/null; then
+        check_issue "WARN" "'wal:' is deprecated, use 'ltx:'"
+    fi
+
+    if grep -q "age:" "$CONFIG_PATH" 2>/dev/null; then
+        check_issue "FAIL" "Age encryption not supported in this version"
+    fi
+else
+    check_issue "FAIL" "Config file not found: $CONFIG_PATH"
+fi
+
+# 3. Check database
+echo
+echo "3. Database Status"
+
+if [ -n "$DB_PATH" ]; then
+    DBS="$DB_PATH"
+elif command -v litestream &> /dev/null && [ -f "$CONFIG_PATH" ]; then
+    DBS=$(litestream databases -config "$CONFIG_PATH" 2>/dev/null | tail -n +2 | cut -f1 || echo "")
+fi
+
+for db in $DBS; do
+    echo "   Checking: $db"
+
+    if [ ! -f "$db" ]; then
+        check_issue "WARN" "Database file not found"
+        continue
+    fi
+
+    # Check if in WAL mode
+    if command -v sqlite3 &> /dev/null; then
+        JOURNAL_MODE=$(sqlite3 "$db" "PRAGMA journal_mode;" 2>/dev/null || echo "error")
+        if [ "$JOURNAL_MODE" = "wal" ]; then
+            check_issue "OK" "Database is in WAL mode"
+        elif [ "$JOURNAL_MODE" = "error" ]; then
+            check_issue "WARN" "Could not read journal mode"
+        else
+            check_issue "FAIL" "Database not in WAL mode (current: $JOURNAL_MODE)"
+            echo "         Fix: Run 'sqlite3 $db \"PRAGMA journal_mode=WAL;\"'"
+        fi
+
+        # Check integrity
+        INTEGRITY=$(sqlite3 "$db" "PRAGMA quick_check;" 2>/dev/null || echo "error")
+        if [ "$INTEGRITY" = "ok" ]; then
+            check_issue "OK" "Database integrity check passed"
+        else
+            check_issue "FAIL" "Database integrity check failed: $INTEGRITY"
+        fi
+    fi
+
+    # Check WAL size
+    WAL_PATH="${db}-wal"
+    if [ -f "$WAL_PATH" ]; then
+        WAL_SIZE=$(stat -f%z "$WAL_PATH" 2>/dev/null || stat -c%s "$WAL_PATH" 2>/dev/null || echo "0")
+        WAL_SIZE_MB=$((WAL_SIZE / 1024 / 1024))
+        if [ "$WAL_SIZE_MB" -gt 100 ]; then
+            check_issue "WARN" "WAL file is large: ${WAL_SIZE_MB}MB (may need checkpoint)"
+        else
+            check_issue "OK" "WAL file size: ${WAL_SIZE_MB}MB"
+        fi
+    else
+        check_issue "OK" "No WAL file (database may be idle)"
+    fi
+
+    # Check file permissions
+    if [ -w "$db" ]; then
+        check_issue "OK" "Database is writable"
+    else
+        check_issue "FAIL" "Database is not writable"
+    fi
+
+    # Check for lock page issue (>1GB databases)
+    DB_SIZE=$(stat -f%z "$db" 2>/dev/null || stat -c%s "$db" 2>/dev/null || echo "0")
+    if [ "$DB_SIZE" -gt 1073741824 ]; then
+        check_issue "OK" "Database >1GB - lock page handling applies"
+    fi
+done
+
+# 4. Check process
+echo
+echo "4. Process Status"
+if pgrep -x litestream > /dev/null; then
+    PID=$(pgrep -x litestream)
+    check_issue "OK" "Litestream is running (PID: $PID)"
+
+    # Check resource usage
+    if command -v ps &> /dev/null; then
+        CPU=$(ps -p "$PID" -o %cpu= 2>/dev/null | tr -d ' ')
+        MEM=$(ps -p "$PID" -o %mem= 2>/dev/null | tr -d ' ')
+        RSS=$(ps -p "$PID" -o rss= 2>/dev/null | tr -d ' ')
+        RSS_MB=$((RSS / 1024))
+
+        if [ "${CPU%.*}" -gt 50 ]; then
+            check_issue "WARN" "High CPU usage: ${CPU}%"
+        else
+            check_issue "OK" "CPU usage: ${CPU}%"
+        fi
+
+        check_issue "OK" "Memory: ${RSS_MB}MB (${MEM}%)"
+    fi
+else
+    check_issue "FAIL" "Litestream is not running"
+fi
+
+# 5. Check connectivity
+echo
+echo "5. Storage Connectivity"
+# Try to list LTX files to verify connectivity
+if [ -n "$DBS" ] && command -v litestream &> /dev/null; then
+    for db in $DBS; do
+        if [ -f "$db" ]; then
+            if litestream ltx -config "$CONFIG_PATH" "$db" > /dev/null 2>&1; then
+                check_issue "OK" "Can connect to replica for $db"
+            else
+                check_issue "WARN" "Cannot verify replica connectivity for $db"
+            fi
+        fi
+    done
+fi
+
+# 6. Check disk space
+echo
+echo "6. Disk Space"
+if [ -n "$DBS" ]; then
+    for db in $DBS; do
+        if [ -f "$db" ]; then
+            DISK_USAGE=$(df "$(dirname "$db")" 2>/dev/null | tail -1 | awk '{print $5}' | tr -d '%')
+            if [ -n "$DISK_USAGE" ]; then
+                if [ "$DISK_USAGE" -gt 90 ]; then
+                    check_issue "FAIL" "Disk space critical: ${DISK_USAGE}% used"
+                elif [ "$DISK_USAGE" -gt 80 ]; then
+                    check_issue "WARN" "Disk space low: ${DISK_USAGE}% used"
+                else
+                    check_issue "OK" "Disk space: ${DISK_USAGE}% used"
+                fi
+            fi
+            break
+        fi
+    done
+fi
+
+# 7. Check recent logs
+echo
+echo "7. Recent Errors"
+if command -v journalctl &> /dev/null; then
+    ERRORS=$(journalctl -u litestream --since "1 hour ago" -p err 2>/dev/null | grep -v "^--" | tail -5)
+    if [ -n "$ERRORS" ]; then
+        check_issue "WARN" "Recent errors found in logs:"
+        echo "$ERRORS" | sed 's/^/         /'
+    else
+        check_issue "OK" "No recent errors in systemd logs"
+    fi
+else
+    check_issue "OK" "Systemd logs not available"
+fi
+
+# Summary
+echo
+echo "=== Diagnostics Summary ==="
+if [ "$ISSUES_FOUND" -gt 0 ]; then
+    echo "Found $ISSUES_FOUND issue(s) that may need attention"
+    echo
+    echo "Common fixes:"
+    echo "  - Enable WAL mode: sqlite3 db.sqlite 'PRAGMA journal_mode=WAL;'"
+    echo "  - Start Litestream: litestream replicate -config $CONFIG_PATH"
+    echo "  - Check credentials: verify AWS_ACCESS_KEY_ID, etc."
+    echo "  - View logs: journalctl -u litestream -f"
+else
+    echo "No issues found"
+fi
+
+echo
+echo "=== Diagnostics Complete ==="
+exit $ISSUES_FOUND

--- a/.codex/skills/litestream/scripts/validate-config.sh
+++ b/.codex/skills/litestream/scripts/validate-config.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# validate-config.sh - Validate Litestream configuration file
+# Usage: ./validate-config.sh [config-path]
+
+set -e
+
+CONFIG_PATH="${1:-/etc/litestream.yml}"
+
+echo "=== Litestream Configuration Validator ==="
+echo
+
+# Check if config file exists
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "ERROR: Configuration file not found: $CONFIG_PATH"
+    echo
+    echo "Usage: $0 [config-path]"
+    echo "Default: /etc/litestream.yml"
+    exit 1
+fi
+
+echo "Validating: $CONFIG_PATH"
+echo
+
+# Check YAML syntax
+echo "1. Checking YAML syntax..."
+if command -v yq &> /dev/null; then
+    if yq eval '.' "$CONFIG_PATH" > /dev/null 2>&1; then
+        echo "   YAML syntax: OK"
+    else
+        echo "   YAML syntax: INVALID"
+        yq eval '.' "$CONFIG_PATH" 2>&1 | head -5
+        exit 1
+    fi
+elif command -v python3 &> /dev/null; then
+    if python3 -c "import yaml; yaml.safe_load(open('$CONFIG_PATH'))" 2>/dev/null; then
+        echo "   YAML syntax: OK"
+    else
+        echo "   YAML syntax: INVALID"
+        python3 -c "import yaml; yaml.safe_load(open('$CONFIG_PATH'))" 2>&1 | head -5
+        exit 1
+    fi
+else
+    echo "   YAML syntax: SKIPPED (install yq or python3 for validation)"
+fi
+
+# Check for required sections
+echo
+echo "2. Checking configuration sections..."
+
+if grep -q "^dbs:" "$CONFIG_PATH" || grep -q "^dbs:" "$CONFIG_PATH"; then
+    echo "   Database config (dbs:): FOUND"
+else
+    echo "   Database config (dbs:): MISSING"
+    echo "   ERROR: At least one database must be configured"
+    exit 1
+fi
+
+# Check for deprecated settings
+echo
+echo "3. Checking for deprecated settings..."
+
+if grep -q "wal:" "$CONFIG_PATH"; then
+    echo "   WARNING: 'wal:' is deprecated, use 'ltx:' instead"
+fi
+
+if grep -q "replicas:" "$CONFIG_PATH"; then
+    echo "   WARNING: 'replicas:' array is deprecated, use single 'replica:' instead"
+fi
+
+if grep "name:" "$CONFIG_PATH" | grep -qv "account-name"; then
+    echo "   NOTE: Replica 'name:' field is deprecated"
+fi
+
+# Check for age encryption (not supported)
+if grep -q "age:" "$CONFIG_PATH"; then
+    echo "   ERROR: Age encryption is not currently supported"
+    echo "          Remove 'age:' section or use Litestream v0.3.x"
+    exit 1
+fi
+
+# Check for common issues
+echo
+echo "4. Checking for common configuration issues..."
+
+# Check for both path and dir
+if grep -A5 "^  - path:" "$CONFIG_PATH" | grep -q "dir:"; then
+    echo "   WARNING: Cannot specify both 'path' and 'dir' for a database"
+fi
+
+# Check for dir without pattern
+if grep -q "dir:" "$CONFIG_PATH"; then
+    if ! grep -A3 "dir:" "$CONFIG_PATH" | grep -q "pattern:"; then
+        echo "   WARNING: 'pattern:' is required when using 'dir:'"
+    fi
+fi
+
+# Check for environment variables
+echo
+echo "5. Checking for environment variables..."
+ENV_VARS=$(grep -oE '\$\{[^}]+\}|\$[A-Z_]+' "$CONFIG_PATH" 2>/dev/null || true)
+if [ -n "$ENV_VARS" ]; then
+    echo "   Environment variables found:"
+    echo "$ENV_VARS" | sort -u | while read -r var; do
+        var_name=$(echo "$var" | sed 's/\${\?\([^}]*\)}\?/\1/')
+        if [ -n "${!var_name:-}" ]; then
+            echo "      $var: SET"
+        else
+            echo "      $var: NOT SET (will need to be set at runtime)"
+        fi
+    done
+else
+    echo "   No environment variables found"
+fi
+
+# Check database paths
+echo
+echo "6. Checking database paths..."
+grep -E "^\s+path:" "$CONFIG_PATH" | while read -r line; do
+    path=$(echo "$line" | sed 's/.*path:\s*//' | tr -d '"' | tr -d "'")
+    # Skip if it looks like an env var
+    if echo "$path" | grep -q '\$'; then
+        echo "   $path: USES ENVIRONMENT VARIABLE"
+    elif [ -f "$path" ]; then
+        echo "   $path: EXISTS"
+    else
+        echo "   $path: NOT FOUND (will be created or restored)"
+    fi
+done
+
+# Check replica URLs
+echo
+echo "7. Checking replica URLs..."
+grep -E "^\s+url:" "$CONFIG_PATH" | while read -r line; do
+    url=$(echo "$line" | sed 's/.*url:\s*//' | tr -d '"' | tr -d "'")
+    scheme=$(echo "$url" | cut -d: -f1)
+    case "$scheme" in
+        s3)
+            echo "   $url: S3/S3-compatible"
+            ;;
+        gs)
+            echo "   $url: Google Cloud Storage"
+            ;;
+        abs)
+            echo "   $url: Azure Blob Storage"
+            ;;
+        sftp)
+            echo "   $url: SFTP"
+            ;;
+        nats)
+            echo "   $url: NATS JetStream"
+            ;;
+        file|/*)
+            echo "   $url: Local file"
+            ;;
+        *)
+            if echo "$url" | grep -q '\$'; then
+                echo "   $url: USES ENVIRONMENT VARIABLE"
+            else
+                echo "   $url: UNKNOWN SCHEME"
+            fi
+            ;;
+    esac
+done
+
+# Try to validate with Litestream itself
+echo
+echo "8. Attempting Litestream validation..."
+if command -v litestream &> /dev/null; then
+    if litestream databases -config "$CONFIG_PATH" > /dev/null 2>&1; then
+        echo "   Litestream validation: OK"
+        echo
+        echo "   Configured databases:"
+        litestream databases -config "$CONFIG_PATH" 2>/dev/null | head -20
+    else
+        echo "   Litestream validation: FAILED"
+        litestream databases -config "$CONFIG_PATH" 2>&1 | head -10
+    fi
+else
+    echo "   SKIPPED (litestream not in PATH)"
+fi
+
+echo
+echo "=== Validation Complete ==="

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# sync-skills.sh - Syncs content from source skill to Codex skill directory
+#
+# Codex ignores symlinked directories, so we must copy files to maintain
+# content parity between the Claude skill (skill/litestream/) and the
+# Codex skill (.codex/skills/litestream/).
+#
+# Run this script after updating the source skill content.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SOURCE="$REPO_ROOT/skill/litestream"
+DEST="$REPO_ROOT/.codex/skills/litestream"
+
+if [ ! -d "$SOURCE" ]; then
+    echo "Error: Source directory not found: $SOURCE"
+    exit 1
+fi
+
+if [ ! -d "$DEST" ]; then
+    echo "Error: Destination directory not found: $DEST"
+    echo "Create .codex/skills/litestream/SKILL.md first."
+    exit 1
+fi
+
+echo "Syncing skill content..."
+echo "  Source: $SOURCE"
+echo "  Dest:   $DEST"
+
+for dir in concepts configuration commands operations deployment scripts; do
+    if [ -d "$SOURCE/$dir" ]; then
+        rm -rf "$DEST/$dir"
+        cp -r "$SOURCE/$dir" "$DEST/$dir"
+        echo "  Copied: $dir/"
+    else
+        echo "  Skipped (not found): $dir/"
+    fi
+done
+
+echo ""
+echo "Sync complete. Files copied to $DEST"
+echo ""
+echo "Note: SKILL.md is NOT synced (Codex uses different frontmatter)."
+echo "Update .codex/skills/litestream/SKILL.md manually if needed."


### PR DESCRIPTION
## Summary

- Add OpenAI Codex CLI skill at `.codex/skills/litestream/`
- Create `scripts/sync-skills.sh` to maintain content parity with Claude skill
- Content identical to Claude skill (issue #966), adapted for Codex format

## Key Details

The Codex skill uses the same content as the Claude Agent Skill (#966) but with Codex-specific formatting:

| Aspect | Claude Skill | Codex Skill |
|--------|--------------|-------------|
| Location | `skill/litestream/` | `.codex/skills/litestream/` |
| SKILL.md | Has `version` field | No `version` field |
| Content sharing | Source of truth | Copied (Codex ignores symlinks) |

### Important: Symlinks Not Supported

[Codex documentation](https://developers.openai.com/codex/skills/create-skill/) states: "Codex ignores symlinked directories." Therefore, content is copied rather than symlinked.

The `scripts/sync-skills.sh` script copies content from `skill/litestream/` to `.codex/skills/litestream/` when updates are made.

## Usage

Codex users can:
- Enable with: `codex --enable skills`
- Invoke explicitly: `$litestream`
- Auto-activation: Codex activates the skill for Litestream-related tasks

## Dependencies

- Based on `feat/966-claude-agent-skill` branch
- Will need to rebase after #966 merges

## Test Plan

- [x] Verify SKILL.md name ≤100 chars (10 chars)
- [x] Verify SKILL.md description ≤500 chars (272 chars)
- [x] Verify directory structure matches Codex requirements
- [x] Verify sync script works correctly
- [ ] Test with Codex CLI (optional - skills are experimental)

Closes #968
