### PR TITLE
fix(s3): add diagnostic logging for LTX file deletion

### DIFF
--- a/db.go
+++ b/db.go
@@ -1947,6 +1947,8 @@ func (db *DB) EnforceL0RetentionByTime(ctx context.Context) error {
 		}
 	}
 
+	db.Logger.Info("l0 retention enforced", "deleted_count", len(deleted), "max_l1_txid", maxL1TXID)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Adds visibility into S3/R2 DeleteObjects behavior to help diagnose issue #976
- Removes `Quiet` flag from DeleteObjects to get per-object deletion status
- Adds DELETE operation metrics to S3 replica client
- Adds logging when L0 retention enforcement runs

## Background

Analysis of the user's logs for #976 revealed:
- **Compaction IS working** - L1 files exist covering TXIDs 1-935
- **L0 retention DID run** - Files 1-532 were deleted locally
- **10x discrepancy**: 369 local files vs 3710 remote R2 files

This suggests local deletion works but remote R2 deletion may be silently failing. The `Quiet: true` flag on DeleteObjects suppresses per-object deletion status, making it impossible to know which files failed to delete.

## Changes

1. **`s3/replica_client.go`**: 
   - Remove `Quiet: aws.Bool(true)` from DeleteObjects call
   - Add DEBUG logging for batch delete requests and results
   - Add DELETE operation metrics (`litestream_operations_total{type="s3",op="DELETE"}`)

2. **`db.go`**:
   - Add INFO logging when L0 retention enforcement completes

## Test plan
- [x] Build passes
- [x] `go test ./s3/...` passes
- [ ] Deploy to environment with R2 and observe DELETE metrics/logs

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)
