### PR TITLE
feat(abs): add SAS token authentication for Azure Blob Storage

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -952,6 +952,7 @@ type ReplicaSettings struct {
 	// ABS settings
 	AccountName string `yaml:"account-name"`
 	AccountKey  string `yaml:"account-key"`
+	SASToken    string `yaml:"sas-token"`
 
 	// SFTP settings
 	Host             string `yaml:"host"`
@@ -1057,6 +1058,9 @@ func (rs *ReplicaSettings) SetDefaults(src *ReplicaSettings) {
 	}
 	if rs.AccountKey == "" {
 		rs.AccountKey = src.AccountKey
+	}
+	if rs.SASToken == "" {
+		rs.SASToken = src.SASToken
 	}
 
 	// SFTP settings
@@ -1494,6 +1498,7 @@ func newABSReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *
 	client := abs.NewReplicaClient()
 	client.AccountName = c.AccountName
 	client.AccountKey = c.AccountKey
+	client.SASToken = c.SASToken
 	client.Bucket = c.Bucket
 	client.Path = c.Path
 	client.Endpoint = c.Endpoint

--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -232,10 +232,24 @@ replicas:
     account-key: your-account-key
 ```
 
+**Using SAS Token** (for granular container-level access):
+
+```yaml
+replicas:
+  - url: abs://container-name/path
+    account-name: your-account-name
+    sas-token: "sv=2023-01-03&ss=b&srt=co&sp=rwdlacx..."
+```
+
+Or via environment variable: `LITESTREAM_AZURE_SAS_TOKEN`
+
 **Alternative Authentication**:
 
-- Connection string: `AZURE_STORAGE_CONNECTION_STRING`
-- Managed identity on Azure
+- SAS token: `sas-token` config or `LITESTREAM_AZURE_SAS_TOKEN` env var
+- Account key: `account-key` config or `LITESTREAM_AZURE_ACCOUNT_KEY` env var
+- Managed identity on Azure (via DefaultAzureCredential)
+
+**Authentication Priority**: SAS token > Account key > Default credential chain
 
 ## Alibaba Cloud OSS
 

--- a/internal/testingutil/testingutil.go
+++ b/internal/testingutil/testingutil.go
@@ -91,6 +91,7 @@ var (
 var (
 	absAccountName = flag.String("abs-account-name", os.Getenv("LITESTREAM_ABS_ACCOUNT_NAME"), "")
 	absAccountKey  = flag.String("abs-account-key", os.Getenv("LITESTREAM_ABS_ACCOUNT_KEY"), "")
+	absSASToken    = flag.String("abs-sas-token", os.Getenv("LITESTREAM_ABS_SAS_TOKEN"), "")
 	absBucket      = flag.String("abs-bucket", os.Getenv("LITESTREAM_ABS_BUCKET"), "")
 	absPath        = flag.String("abs-path", os.Getenv("LITESTREAM_ABS_PATH"), "")
 )
@@ -390,6 +391,7 @@ func NewABSReplicaClient(tb testing.TB) *abs.ReplicaClient {
 	c := abs.NewReplicaClient()
 	c.AccountName = *absAccountName
 	c.AccountKey = *absAccountKey
+	c.SASToken = *absSASToken
 	c.Bucket = *absBucket
 	c.Path = path.Join(*absPath, fmt.Sprintf("%016x", rand.Uint64()))
 	return c


### PR DESCRIPTION
## Summary
- Add SAS (Shared Access Signature) token support for Azure Blob Storage authentication
- SAS tokens provide granular, container-level access instead of full storage account access
- Authentication priority: SAS token > Account key > Default credential chain

## Changes
- `abs/replica_client.go`: Add SASToken field and implement SAS token authentication in Init()
- `cmd/litestream/main.go`: Add sas-token config option to ReplicaSettings
- `internal/testingutil/testingutil.go`: Add SAS token test flag for integration testing
- `docs/PROVIDER_COMPATIBILITY.md`: Document SAS token configuration

## Configuration
```yaml
replicas:
  - url: abs://container-name/path
    account-name: your-account-name
    sas-token: "sv=2023-01-03&ss=b&srt=co&sp=rwdlacx..."
```

Or via environment variable: `LITESTREAM_AZURE_SAS_TOKEN`

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [x] Linting passes (pre-commit hooks)
- [ ] Manual testing with real SAS token (requires Azure access)

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)