### PR TITLE
chore: ignore local Ralph Wiggum loop planning files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CLAUDE.md
 
 # Binary
 bin/
+.claude/*.loop.local.md


### PR DESCRIPTION
## Summary
- Add `.claude/*.loop.local.md` to .gitignore for local autonomous loop state files

These files are used by the [Ralph Wiggum technique](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum) for Claude Code - an autonomous loop approach that enables long-running Claude sessions.

## Test plan
- [x] Verify the pattern correctly matches `.claude/*.loop.local.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)