### PR TITLE
fix(cmd): ensure structured logging for all commands

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -75,6 +75,8 @@ func (e *ConfigValidationError) Unwrap() error {
 }
 
 func main() {
+	initLog(os.Stdout, "INFO", "text")
+
 	m := NewMain()
 	if err := m.Run(context.Background(), os.Args[1:]); errors.Is(err, flag.ErrHelp) || errors.Is(err, errStop) {
 		os.Exit(1)

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -37,6 +37,8 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		return fmt.Errorf("too many arguments")
 	}
 
+	initLog(os.Stdout, "INFO", "text")
+
 	// Parse timestamp, if specified.
 	if *timestampStr != "" {
 		if opt.Timestamp, err = time.Parse(time.RFC3339, *timestampStr); err != nil {
@@ -85,8 +87,6 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 	if opt.OutputPath == "" {
 		return nil, fmt.Errorf("output path required")
 	}
-
-	initLog(os.Stdout, "INFO", "text")
 
 	// Exit successfully if the output file already exists.
 	if _, err := os.Stat(opt.OutputPath); !os.IsNotExist(err) && ifDBNotExists {


### PR DESCRIPTION
## Summary

- Initialize logging at the start of `main()` before any command runs
- Ensures all `slog` calls use the configured handler instead of the default handler
- Commands that load config files will reconfigure logging via `ReadConfigFile()` with user's preferred settings

## Background

A logging audit revealed that `slog` was being called before `initLog()` in several places:
- `main.go:82` - error handling in `main()` before any command runs
- `restore.go:54, 64, 73` - info messages in RestoreCommand.Run()

With this fix, logging is initialized with default settings (`INFO` level, `text` format) at program startup. Commands that use config files will reconfigure logging to match user's settings when `ReadConfigFile()` is called.

## Test plan

- [x] Build passes: `go build ./cmd/litestream/...`
- [x] Tests pass: `go test -race ./cmd/litestream/...`
- [x] Pre-commit hooks pass

Fixes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)