### PR TITLE
feat(replicate): add --log-level CLI flag for runtime debugging

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -79,9 +79,11 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 		if c.Config, err = ReadConfigFile(*configPath, !*noExpandEnv); err != nil {
 			return err
 		}
-		// Override log level if CLI flag provided
+		// Override log level if CLI flag provided (takes precedence over env var)
 		if *logLevelFlag != "" {
 			c.Config.Logging.Level = *logLevelFlag
+			// Set env var so initLog sees CLI flag as highest priority
+			os.Setenv("LOG_LEVEL", *logLevelFlag)
 			logOutput := os.Stdout
 			if c.Config.Logging.Stderr {
 				logOutput = os.Stderr
@@ -104,6 +106,8 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 		logLevel := "INFO"
 		if *logLevelFlag != "" {
 			logLevel = *logLevelFlag
+			// Set env var so initLog sees CLI flag as highest priority
+			os.Setenv("LOG_LEVEL", *logLevelFlag)
 		}
 		c.Config.Logging.Level = logLevel
 		initLog(os.Stdout, logLevel, "text")


### PR DESCRIPTION
## Summary

- Add `--log-level` CLI flag to the `replicate` command
- Allows overriding config file `logging.level` at runtime for debugging
- Supports all log levels: trace, debug, info, warn, error

## Motivation

As described in #702, users currently need to edit configuration files and restart Litestream to change log levels. This is cumbersome in production environments where quick debugging is needed.

The new flag provides a simple way to temporarily increase verbosity:

```bash
litestream replicate -config /etc/litestream.yml --log-level debug
```

## Precedence

1. `--log-level` CLI flag (highest)
2. `LOG_LEVEL` environment variable
3. Config file `logging.level`
4. Default: INFO

The CLI flag takes precedence over the environment variable because it represents the most explicit form of user intent.

## Test plan

- [x] Unit tests for flag parsing with various log levels
- [x] Unit tests for default behavior (INFO)
- [x] Unit tests for flag positioning validation
- [x] Unit test verifying CLI flag overrides LOG_LEVEL env var
- [x] Verified `go build` succeeds
- [x] Verified help output shows new flag

Closes #702

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)