### PR TITLE
feat(s3): improve observability for S3 operations and L0 retention

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -148,4 +148,20 @@ var (
 		Name: "litestream_replica_operation_bytes",
 		Help: "The number of bytes used by replica operations",
 	}, []string{"replica_type", "operation"})
+
+	OperationDurationHistogramVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "litestream_replica_operation_duration_seconds",
+		Help:    "Duration of replica operations by type and operation",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60},
+	}, []string{"replica_type", "operation"})
+
+	OperationErrorCounterVec = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "litestream_replica_operation_errors_total",
+		Help: "Number of replica operation errors by type, operation, and error code",
+	}, []string{"replica_type", "operation", "code"})
+
+	L0RetentionGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "litestream_l0_retention_files_total",
+		Help: "Number of L0 files by status during retention enforcement",
+	}, []string{"db", "status"})
 )

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -974,10 +974,14 @@ func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) e
 
 		c.logger.Debug("deleting ltx files batch", "count", n)
 
+		start := time.Now()
 		out, err := c.s3.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 			Bucket: aws.String(c.Bucket),
 			Delete: &types.Delete{Objects: objIDs[:n]},
 		})
+		duration := time.Since(start)
+		internal.OperationDurationHistogramVec.WithLabelValues(ReplicaClientType, "DELETE").Observe(duration.Seconds())
+
 		if err != nil {
 			return fmt.Errorf("s3: delete batch of %d objects: %w", n, err)
 		}
@@ -986,8 +990,29 @@ func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) e
 		if out != nil {
 			deleted = len(out.Deleted)
 		}
-		c.logger.Debug("delete batch completed", "requested", n, "deleted", deleted, "errors", len(out.Errors))
+		c.logger.Debug("delete batch completed",
+			"requested", n,
+			"deleted", deleted,
+			"errors", len(out.Errors),
+			"duration_ms", duration.Milliseconds())
 		internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "DELETE").Add(float64(deleted))
+
+		if len(out.Errors) > 0 {
+			for i, e := range out.Errors {
+				code := aws.ToString(e.Code)
+				internal.OperationErrorCounterVec.WithLabelValues(ReplicaClientType, "DELETE", code).Inc()
+
+				if i < 5 {
+					c.logger.Warn("delete object failed",
+						"key", aws.ToString(e.Key),
+						"code", code,
+						"message", aws.ToString(e.Message))
+				}
+			}
+			if len(out.Errors) > 5 {
+				c.logger.Warn("additional delete errors suppressed", "count", len(out.Errors)-5)
+			}
+		}
 
 		if err := deleteOutputError(out); err != nil {
 			return err


### PR DESCRIPTION
## Summary

Follow-up observability improvements for #976 (R2 silent deletion failures).

- **New Prometheus metrics** for detecting issues in aggregate:
  - `litestream_replica_operation_duration_seconds` - Histogram to detect slow/throttled operations
  - `litestream_replica_operation_errors_total` - Counter for errors by error code (S3 AccessDenied, etc.)
  - `litestream_l0_retention_files_total` - Gauge showing why L0 files aren't being deleted (eligible, not_compacted, too_recent)

- **Enhanced logging** for debugging specific incidents:
  - DeleteLTXFiles: Logs duration_ms per batch, individual error details (key, code, message)
  - EnforceL0RetentionByTime: Logs scan breakdown before deletion (total files, eligible, not_compacted_yet, too_recent)

These changes would have helped debug the original #976 issue faster - users could see DELETE ops slowing down via metrics and understand why files weren't deleted via logs.

## Test plan

- [x] Build passes
- [x] Unit tests pass for L0 retention and DeleteLTXFiles
- [x] Pre-commit checks pass
- [ ] Manual verification with Prometheus `/metrics` endpoint


🤖 Generated with [Claude Code](https://claude.com/claude-code)
