### PR TITLE
feat(metrics): add metrics for local and replica LTX files

### DIFF
--- a/replica_test.go
+++ b/replica_test.go
@@ -1662,5 +1662,58 @@ func verifyRestoredDB(t *testing.T, path string) {
 	}
 	if result != "ok" {
 		t.Fatalf("integrity check returned: %s", result)
+// TestReplica_LTXStats verifies that LTXStats returns correct file counts and sizes from replica.
+func TestReplica_LTXStats(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	// Create table and insert data
+	if _, err := sqldb.Exec(`CREATE TABLE t (x TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO t (x) VALUES ('test data for replica ltx stats')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create replica with file client
+	c := file.NewReplicaClient(t.TempDir())
+	r := litestream.NewReplicaWithClient(db, c)
+
+	// Initially, replica should have no files
+	stats, err := r.LTXStats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats.ByLevel) != 0 {
+		t.Fatalf("expected 0 levels in replica initially, got %d", len(stats.ByLevel))
+	}
+
+	// Sync to replica
+	if err := r.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now replica should have files
+	stats, err = r.LTXStats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats.ByLevel) == 0 {
+		t.Fatal("expected at least 1 level with LTX files in replica after sync")
+	}
+
+	// Verify level 0 has files
+	level0Stats, ok := stats.ByLevel[0]
+	if !ok {
+		t.Fatal("expected level 0 stats to exist in replica")
+	}
+	if level0Stats.Files == 0 {
+		t.Fatal("expected at least 1 file in replica level 0")
+	}
+	if level0Stats.Bytes == 0 {
+		t.Fatal("expected non-zero bytes in replica level 0")
 	}
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add prometheus metrics to monitor LTX file sizes locally and in replicas:

| Metric                         | Labels                  | Description |
| -------------------------------|-------------------------|------------- |
| `litestream_local_ltx_files`   | db                      | Total LTX files in local metadata |
| `litestream_local_ltx_bytes`   | db                      | Total size of local LTX files |
| `litestream_replica_ltx_files` | db, replica_type, level | LTX files by compaction level |
| `litestream_replica_ltx_bytes` | db, replica_type, level | LTX bytes by compaction level |

Assisted by Claude Opus 4.5.

<details>
<summary>Example prometheus metrics</summary>

```txt
# HELP litestream_local_ltx_bytes Total size of LTX files in local metadata directory
# TYPE litestream_local_ltx_bytes gauge
litestream_local_ltx_bytes{db="/data/fruits.db"} 1991
# HELP litestream_local_ltx_files Total number of LTX files in local metadata directory
# TYPE litestream_local_ltx_files gauge
litestream_local_ltx_files{db="/data/fruits.db"} 4
# HELP litestream_replica_ltx_bytes Size of LTX files by compaction level (replica)
# TYPE litestream_replica_ltx_bytes gauge
litestream_replica_ltx_bytes{db="/data/fruits.db",level="0",replica_type="s3"} 1991
litestream_replica_ltx_bytes{db="/data/fruits.db",level="1",replica_type="s3"} 2290
litestream_replica_ltx_bytes{db="/data/fruits.db",level="2",replica_type="s3"} 1035
litestream_replica_ltx_bytes{db="/data/fruits.db",level="3",replica_type="s3"} 1035
litestream_replica_ltx_bytes{db="/data/fruits.db",level="9",replica_type="s3"} 1470
# HELP litestream_replica_ltx_files Number of LTX files by compaction level (replica)
# TYPE litestream_replica_ltx_files gauge
litestream_replica_ltx_files{db="/data/fruits.db",level="0",replica_type="s3"} 4
litestream_replica_ltx_files{db="/data/fruits.db",level="1",replica_type="s3"} 5
litestream_replica_ltx_files{db="/data/fruits.db",level="2",replica_type="s3"} 2
litestream_replica_ltx_files{db="/data/fruits.db",level="3",replica_type="s3"} 2
litestream_replica_ltx_files{db="/data/fruits.db",level="9",replica_type="s3"} 2
```

</details>

Example Grafana dashboard using these metrics
<img width="1486" height="700" alt="image" src="https://github.com/user-attachments/assets/b8fd9b6b-626a-4a2a-bb3c-b4b63215e4c0" />

☝️ This example involved making ~2MB of writes to a 13MB sqlite db. Litestream was configured with:
```yaml
    # Compaction levels
    levels:
      - interval: 5m
      - interval: 30m
      - interval: 1h

    # Global snapshot settings
    snapshot:
      interval: 30m
      retention: 1h
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to issue if applicable: -->
- Improve observability of LTX files stored locally and in replicas.
  - Locally: so we can size storage according to needs
  - Replica: so we can calculate storage costs
- This information helps understand and optimise settings for compaction levels and snapshots 
  
I implemented this to help debug #976

## How Has This Been Tested?
<!--- Describe how you tested your changes -->
<!--- Include details of your testing environment if relevant -->

I ran two instances in a test environment against two accounts with different compaction and snapshot settings. This was using R2 as a replica. Can confirm the metrics were generated and captured successfully and align with reality. 

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
