### PR TITLE
fix(vfs): resolve ARM64 segfault when loading extension

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: pre-commit/action@v3.0.0
 
   vfs-build-test:
-    name: VFS Build Test (macOS)
+    name: VFS Build & Load Test (macOS)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +43,26 @@ jobs:
       - name: Verify shared library created
         run: file dist/litestream-vfs.so
 
+      - name: Test extension loading (no segfault)
+        run: |
+          # Verify extension loads without segfault (will error on missing env var, that's OK)
+          output=$(sqlite3 ':memory:' ".load dist/litestream-vfs.so sqlite3_litestreamvfs_init" 2>&1) || true
+          echo "Output: $output"
+          # Check for segfault
+          if echo "$output" | grep -qi "segmentation fault\|signal.*segv\|bus error"; then
+            echo "ERROR: Extension loading caused a crash!"
+            exit 1
+          fi
+          # Expected: error about missing LITESTREAM_REPLICA_URL
+          if echo "$output" | grep -q "LITESTREAM_REPLICA_URL"; then
+            echo "SUCCESS: Extension loaded correctly (expected env var error)"
+          fi
+
+      - name: Run VFS load integration tests
+        run: go test -v -tags=vfs -run 'TestVFS_Load' ./cmd/litestream-vfs
+
   vfs-build-test-linux:
-    name: VFS Build Test (Linux)
+    name: VFS Build & Load Test (Linux)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,6 +76,66 @@ jobs:
 
       - name: Verify shared library created
         run: file dist/litestream-vfs-linux-amd64.so
+
+      - name: Test extension loading (no segfault)
+        run: |
+          # Verify extension loads without segfault (will error on missing env var, that's OK)
+          output=$(sqlite3 ':memory:' ".load dist/litestream-vfs-linux-amd64.so sqlite3_litestreamvfs_init" 2>&1) || true
+          echo "Output: $output"
+          # Check for segfault
+          if echo "$output" | grep -qi "segmentation fault\|signal.*segv\|bus error"; then
+            echo "ERROR: Extension loading caused a crash!"
+            exit 1
+          fi
+          # Expected: error about missing LITESTREAM_REPLICA_URL
+          if echo "$output" | grep -q "LITESTREAM_REPLICA_URL"; then
+            echo "SUCCESS: Extension loaded correctly (expected env var error)"
+          fi
+
+      - name: Run VFS load integration tests
+        run: go test -v -tags=vfs -run 'TestVFS_Load' ./cmd/litestream-vfs
+
+  vfs-build-test-linux-arm64:
+    name: VFS Build & Load Test (Linux ARM64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build VFS Linux ARM64 (native)
+        run: |
+          # On native ARM64 runner, build without cross-compilation
+          mkdir -p dist
+          go build -tags vfs,SQLITE3VFS_LOADABLE_EXT -o dist/litestream-vfs-linux-arm64.a -buildmode=c-archive ./cmd/litestream-vfs
+          cp dist/litestream-vfs-linux-arm64.h src/litestream-vfs.h
+          gcc -DSQLITE3VFS_LOADABLE_EXT -g -fPIC -shared -o dist/litestream-vfs-linux-arm64.so \
+            src/litestream-vfs.c dist/litestream-vfs-linux-arm64.a -lpthread -ldl -lm
+
+      - name: Verify shared library created
+        run: file dist/litestream-vfs-linux-arm64.so
+
+      - name: Test extension loading (no segfault)
+        run: |
+          # This test specifically catches the ARM64 segfault issue caused by
+          # uninitialized sqlite3_api pointers in loadable extensions.
+          output=$(sqlite3 ':memory:' ".load dist/litestream-vfs-linux-arm64.so sqlite3_litestreamvfs_init" 2>&1) || true
+          echo "Output: $output"
+          # Check for segfault - this was the original bug on ARM64
+          if echo "$output" | grep -qi "segmentation fault\|signal.*segv\|bus error"; then
+            echo "ERROR: Extension loading caused a crash on ARM64!"
+            echo "This indicates the sqlite3_api pointer fix may have regressed."
+            exit 1
+          fi
+          # Expected: error about missing LITESTREAM_REPLICA_URL
+          if echo "$output" | grep -q "LITESTREAM_REPLICA_URL"; then
+            echo "SUCCESS: Extension loaded correctly on ARM64 (expected env var error)"
+          fi
+
+      - name: Run VFS load integration tests
+        run: go test -v -tags=vfs -run 'TestVFS_Load' ./cmd/litestream-vfs
 
   build-windows:
     name: Build Windows

--- a/cmd/litestream-vfs/load_test.go
+++ b/cmd/litestream-vfs/load_test.go
@@ -1,0 +1,260 @@
+//go:build vfs
+// +build vfs
+
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestVFS_Load tests that the VFS extension can be loaded into sqlite3 without crashing.
+// This is a critical test that catches issues like the ARM64 segfault caused by
+// uninitialized sqlite3_api pointers.
+func TestVFS_Load(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("skipping: test only runs on darwin or linux")
+	}
+
+	// Check if sqlite3 CLI is available
+	sqlite3Path, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("skipping: sqlite3 CLI not found in PATH")
+	}
+
+	// Check if sqlite3 supports loading extensions
+	if !sqlite3SupportsExtensions(t, sqlite3Path) {
+		t.Skip("skipping: sqlite3 does not support loading extensions")
+	}
+
+	// Build the VFS extension
+	extPath := buildVFSExtensionForLoad(t)
+
+	// Try to load the extension - it should return an error about missing
+	// LITESTREAM_REPLICA_URL, but it should NOT segfault.
+	output, err := loadExtension(t, sqlite3Path, extPath)
+
+	// The extension should load and return an error about missing env var.
+	// A segfault would cause a different error (signal: segmentation fault).
+	if err != nil {
+		outputStr := string(output)
+
+		// Check for segfault - this is what we're trying to prevent
+		if strings.Contains(err.Error(), "signal:") ||
+			strings.Contains(outputStr, "Segmentation fault") ||
+			strings.Contains(outputStr, "SIGSEGV") {
+			t.Fatalf("extension loading caused a crash: %v\nOutput: %s", err, outputStr)
+		}
+
+		// Expected error: missing LITESTREAM_REPLICA_URL
+		if strings.Contains(outputStr, "LITESTREAM_REPLICA_URL") {
+			t.Logf("extension loaded successfully (expected env var error): %s", outputStr)
+			return
+		}
+
+		// Check for extension loading not supported
+		if strings.Contains(outputStr, "not authorized") ||
+			strings.Contains(outputStr, "unknown command") ||
+			strings.Contains(outputStr, "symbol not found") ||
+			strings.Contains(outputStr, "dlsym") {
+			t.Skipf("skipping: sqlite3 cannot load extensions: %s", outputStr)
+		}
+
+		// Some other error - might be acceptable
+		t.Logf("extension load returned error (not a crash): %v\nOutput: %s", err, outputStr)
+	} else {
+		t.Log("extension loaded successfully with no error")
+	}
+}
+
+// TestVFS_LoadWithReplicaURL tests loading with a valid replica URL.
+func TestVFS_LoadWithReplicaURL(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("skipping: test only runs on darwin or linux")
+	}
+
+	sqlite3Path, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("skipping: sqlite3 CLI not found in PATH")
+	}
+
+	if !sqlite3SupportsExtensions(t, sqlite3Path) {
+		t.Skip("skipping: sqlite3 does not support loading extensions")
+	}
+
+	extPath := buildVFSExtensionForLoad(t)
+
+	// Create a temporary directory for the replica
+	replicaDir := t.TempDir()
+
+	// Load extension with a file:// replica URL
+	env := []string{
+		"LITESTREAM_REPLICA_URL=file://" + replicaDir,
+	}
+
+	output, err := loadExtensionWithEnv(t, sqlite3Path, extPath, env)
+	outputStr := string(output)
+
+	// Check for segfault
+	if err != nil {
+		if strings.Contains(err.Error(), "signal:") ||
+			strings.Contains(outputStr, "Segmentation fault") {
+			t.Fatalf("extension loading caused a crash: %v\nOutput: %s", err, outputStr)
+		}
+	}
+
+	// Extension should load - verify by running a simple query
+	output, err = loadExtensionAndQuery(t, sqlite3Path, extPath, env, "SELECT 1;")
+	if err != nil {
+		outputStr = string(output)
+		if strings.Contains(outputStr, "not authorized") ||
+			strings.Contains(outputStr, "symbol not found") {
+			t.Skipf("skipping: sqlite3 cannot load extensions: %s", outputStr)
+		}
+		// Don't fail on other errors - the VFS might not find data
+		t.Logf("query returned error (not a crash): %v\nOutput: %s", err, outputStr)
+	} else {
+		if !strings.Contains(string(output), "1") {
+			t.Errorf("expected output to contain '1', got: %s", output)
+		}
+	}
+}
+
+// sqlite3SupportsExtensions checks if the sqlite3 binary can load extensions.
+func sqlite3SupportsExtensions(t *testing.T, sqlite3Path string) bool {
+	t.Helper()
+
+	// Try to run .load with a non-existent file - if extensions are disabled,
+	// we'll get "unknown command" or "not authorized" error
+	cmd := exec.Command(sqlite3Path, ":memory:", "-cmd", ".load /nonexistent/path")
+	output, _ := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	// These errors indicate extensions are disabled
+	if strings.Contains(outputStr, "unknown command") ||
+		strings.Contains(outputStr, "not authorized") {
+		return false
+	}
+
+	return true
+}
+
+// loadExtension attempts to load the VFS extension into sqlite3.
+func loadExtension(t *testing.T, sqlite3Path, extPath string) ([]byte, error) {
+	t.Helper()
+
+	cmd := exec.Command(sqlite3Path, ":memory:",
+		"-cmd", ".load "+extPath+" sqlite3_litestreamvfs_init",
+		"SELECT 'loaded';",
+	)
+
+	return cmd.CombinedOutput()
+}
+
+// loadExtensionWithEnv loads the extension with custom environment variables.
+func loadExtensionWithEnv(t *testing.T, sqlite3Path, extPath string, env []string) ([]byte, error) {
+	t.Helper()
+
+	cmd := exec.Command(sqlite3Path, ":memory:",
+		"-cmd", ".load "+extPath+" sqlite3_litestreamvfs_init",
+		"SELECT 'loaded';",
+	)
+	cmd.Env = append(os.Environ(), env...)
+
+	return cmd.CombinedOutput()
+}
+
+// loadExtensionAndQuery loads the extension and runs a query.
+func loadExtensionAndQuery(t *testing.T, sqlite3Path, extPath string, env []string, query string) ([]byte, error) {
+	t.Helper()
+
+	cmd := exec.Command(sqlite3Path, ":memory:",
+		"-cmd", ".load "+extPath+" sqlite3_litestreamvfs_init",
+		query,
+	)
+	cmd.Env = append(os.Environ(), env...)
+
+	return cmd.CombinedOutput()
+}
+
+// buildVFSExtensionForLoad builds the VFS extension and returns its path.
+func buildVFSExtensionForLoad(t *testing.T) string {
+	t.Helper()
+
+	projectRoot := findProjectRootForLoad(t)
+
+	// Determine the expected extension path based on OS and architecture
+	var extPath string
+	var makeTarget string
+
+	switch runtime.GOOS {
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			makeTarget = "vfs-darwin-arm64"
+			extPath = filepath.Join(projectRoot, "dist", "litestream-vfs-darwin-arm64.dylib")
+		} else {
+			makeTarget = "vfs-darwin-amd64"
+			extPath = filepath.Join(projectRoot, "dist", "litestream-vfs-darwin-amd64.dylib")
+		}
+	case "linux":
+		if runtime.GOARCH == "arm64" {
+			makeTarget = "vfs-linux-arm64"
+			extPath = filepath.Join(projectRoot, "dist", "litestream-vfs-linux-arm64.so")
+		} else {
+			makeTarget = "vfs-linux-amd64"
+			extPath = filepath.Join(projectRoot, "dist", "litestream-vfs-linux-amd64.so")
+		}
+	default:
+		t.Fatalf("unsupported OS: %s", runtime.GOOS)
+	}
+
+	// Check if extension already exists
+	if _, err := os.Stat(extPath); err == nil {
+		t.Logf("using existing VFS extension: %s", extPath)
+		return extPath
+	}
+
+	// Build the extension
+	t.Logf("building VFS extension with 'make %s'", makeTarget)
+
+	cmd := exec.Command("make", makeTarget)
+	cmd.Dir = projectRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to build VFS extension: %v", err)
+	}
+
+	// Verify it was created
+	if _, err := os.Stat(extPath); err != nil {
+		t.Fatalf("VFS extension not found after build: %s", extPath)
+	}
+
+	return extPath
+}
+
+// findProjectRootForLoad finds the project root directory.
+func findProjectRootForLoad(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root (go.mod)")
+		}
+		dir = parent
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -134,3 +134,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/psanford/sqlite3vfs => github.com/benbjohnson/sqlite3vfs v0.0.0-20260116214726-237d70b78790

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 h1:SciGFVNZ4mHdm7gpD1dgZYnCuVdX
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5/go.mod h1:iW40X4QBmUxdP+fZNOpfmkdMZqsovezbAeO+Ubiv2pk=
 github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
 github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/benbjohnson/sqlite3vfs v0.0.0-20260116214726-237d70b78790 h1:HElWgSxJSEmR49oi2ujS6m8scjoQr+4W0ZylV+I1ANA=
+github.com/benbjohnson/sqlite3vfs v0.0.0-20260116214726-237d70b78790/go.mod h1:iW4cSew5PAb1sMZiTEkVJAIBNrepaB6jTYjeP47WtI0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -242,8 +244,6 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/psanford/sqlite3vfs v0.0.0-20251127171934-4e34e03a991a h1:r4YWl0uVObCbBFvj1VsIlyHzgZwZOHvY1KdRaQjzzUc=
-github.com/psanford/sqlite3vfs v0.0.0-20251127171934-4e34e03a991a/go.mod h1:iW4cSew5PAb1sMZiTEkVJAIBNrepaB6jTYjeP47WtI0=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/src/litestream-vfs.c
+++ b/src/litestream-vfs.c
@@ -5,8 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/* sqlite3vfs already called SQLITE_EXTENSION_INIT1 */
-extern const sqlite3_api_routines *sqlite3_api;
+/* Define sqlite3_api here - sqlite3vfs uses extern to reference it */
+SQLITE_EXTENSION_INIT1
 
 /* Go function declarations */
 extern char* LitestreamVFSRegister(void);


### PR DESCRIPTION
## Summary

- Fixes segmentation fault when loading VFS extension on linux/arm64
- Root cause: duplicate `sqlite3_api` variables in separate C translation units, only one initialized
- Uses forked sqlite3vfs with `extern` declaration to share the pointer
- Adds CI jobs to test extension loading and prevent regression

## Problem

When loading `litestream.so` into sqlite3 CLI on linux/arm64:

```
sqlite> .load ./litestream.so
Segmentation fault
```

**Root cause:** Two separate `sqlite3_api` global variables were created:
1. `litestream-vfs.c` - was using `extern` (expecting sqlite3vfs to define it)
2. `sqlite3vfs.c` (in Go archive) - defined with `SQLITE_EXTENSION_INIT1`

Only one got initialized via `SQLITE_EXTENSION_INIT2(pApi)`, causing NULL pointer dereference.

## Solution

Flip the relationship:
- `litestream-vfs.c` now **defines** `sqlite3_api` via `SQLITE_EXTENSION_INIT1`
- Forked `sqlite3vfs` uses `extern` to **reference** it

## Changes

| File | Change |
|------|--------|
| `src/litestream-vfs.c` | Use `SQLITE_EXTENSION_INIT1` instead of `extern` |
| `go.mod` | Point to forked sqlite3vfs |
| `cmd/litestream-vfs/load_test.go` | New integration tests for extension loading |
| `.github/workflows/commit.yml` | Add load tests to macOS, Linux, and ARM64 CI jobs |

## Test plan

- [x] Extension loads without segfault on darwin-arm64
- [x] New `TestVFS_Load` tests pass locally
- [ ] CI passes on macOS
- [ ] CI passes on Linux amd64
- [ ] CI passes on Linux arm64 (new job)

🤖 Generated with [Claude Code](https://claude.ai/code)