### PR TITLE
fix(iterator): surface blob listing errors for better diagnostics

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -394,7 +394,7 @@ func newLTXFileIterator(ctx context.Context, client *ReplicaClient, level int, s
 func (itr *ltxFileIterator) Close() (err error) {
 	itr.closed = true
 	itr.cancel()
-	return nil
+	return itr.err
 }
 
 func (itr *ltxFileIterator) Next() bool {

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -503,7 +503,7 @@ func (itr *ltxFileIterator) Err() error {
 	return itr.err
 }
 
-// Close closes the iterator.
+// Close closes the iterator and returns any error that occurred during iteration.
 func (itr *ltxFileIterator) Close() error {
-	return nil
+	return itr.err
 }

--- a/oss/replica_client.go
+++ b/oss/replica_client.go
@@ -501,11 +501,11 @@ func (itr *fileIterator) initPaginator() {
 	})
 }
 
-// Close stops iteration.
+// Close stops iteration and returns any error that occurred during iteration.
 func (itr *fileIterator) Close() (err error) {
 	itr.closed = true
 	itr.cancel()
-	return nil
+	return itr.err
 }
 
 // Next returns the next file. Returns false when no more files are available.

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -1166,11 +1166,11 @@ func (itr *fileIterator) fetchMetadataBatch(keys []string) error {
 	return nil
 }
 
-// Close stops iteration.
+// Close stops iteration and returns any error that occurred during iteration.
 func (itr *fileIterator) Close() (err error) {
 	itr.closed = true
 	itr.cancel()
-	return nil
+	return itr.err
 }
 
 // Next returns the next file. Returns false when no more files are available.


### PR DESCRIPTION
## Summary

Modified iterator `Close()` methods to return `itr.err` instead of `nil`. This ensures errors from blob listing (auth failures, permission errors) are properly surfaced through the standard `Close()` call pattern.

Previously, errors from Azure/S3/GCS blob iteration were silently ignored because `Close()` returned `nil` even when `Err()` had an error. This caused misleading error messages like "no matching backup files available" when the actual issue was authentication failure.

## Important Note

**This is not a complete fix for #1016** - it improves diagnostic information by surfacing the underlying errors. The root cause (Azure CLI authentication not working across machines) still needs investigation. However, with this change, users will now see the actual error:

```
error="cannot calc restore plan: abs: cannot list blobs: ... AuthorizationFailure"
```

Instead of the unhelpful:
```
error="no matching backup files available"
```

## Changes

| Backend | Change |
|---------|--------|
| `abs/replica_client.go` | `Close()` returns `itr.err` |
| `s3/replica_client.go` | `Close()` returns `itr.err` |
| `oss/replica_client.go` | `Close()` returns `itr.err` |
| `nats/replica_client.go` | `Close()` returns `itr.err` |

Note: GCS (`gs/replica_client.go`) already had the correct behavior.

## Test plan

- [x] Verified with Azurite (Azure Blob Storage emulator)
- [x] Backup with correct credentials works
- [x] Restore with correct credentials works  
- [x] Restore with wrong credentials now shows `AuthorizationFailure` instead of "no matching backup files"
- [x] `go test ./...` passes
- [x] `pre-commit run --all-files` passes

Related to #1016

🤖 Generated with [Claude Code](https://claude.ai/code)
