### PR TITLE
fix(test): correct snapshot directory path and expand CI test coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run quick integration tests
         run: |
           go test -v -tags=integration -timeout=30m ./tests/integration/... \
-            -run="TestFreshStart|TestDatabaseIntegrity|TestRapidCheckpoints|TestS3AccessPointLocalStack"
+            -run="TestFreshStart|TestDatabaseIntegrity|TestRapidCheckpoints|TestS3AccessPointLocalStack|TestRestore_|TestBinaryCompatibility|TestCompaction_Compatibility|TestVersionMigration|TestLockPage|TestDirectoryWatcher|TestDatabaseDeletion|TestWALGrowth|TestBusyTimeout|TestConcurrentOperations"
         env:
           CGO_ENABLED: 1
 

--- a/tests/integration/boundary_test.go
+++ b/tests/integration/boundary_test.go
@@ -157,9 +157,11 @@ func TestLockPageWithDifferentPageSizes(t *testing.T) {
 				t.Fatalf("Failed to start Litestream: %v", err)
 			}
 
-			time.Sleep(20 * time.Second)
-
-			fileCount, _ := db.GetReplicaFileCount()
+			t.Log("[3a] Waiting for replication to produce files...")
+			fileCount, err := db.WaitForReplicaFiles(1, 2*time.Minute)
+			if err != nil {
+				t.Logf("Warning: %v", err)
+			}
 			t.Logf("✓ LTX files: %d", fileCount)
 
 			db.StopLitestream()

--- a/tests/integration/compatibility_test.go
+++ b/tests/integration/compatibility_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -458,7 +459,7 @@ func TestVersionMigration_DirectoryLayout(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Test current v0.5.x layout (ltx/0/, ltx/1/, ltx/snapshot/)
+	// Test current v0.5.x layout (ltx/0/, ltx/1/, ..., ltx/9/ for snapshots)
 	t.Run("CurrentLayout", func(t *testing.T) {
 		replicaDir := t.TempDir()
 		client := file.NewReplicaClient(replicaDir)
@@ -477,7 +478,7 @@ func TestVersionMigration_DirectoryLayout(t *testing.T) {
 		}
 
 		// Verify structure
-		snapshotDir := filepath.Join(replicaDir, "ltx", "snapshot")
+		snapshotDir := filepath.Join(replicaDir, "ltx", strconv.Itoa(litestream.SnapshotLevel))
 		l0Dir := filepath.Join(replicaDir, "ltx", "0")
 
 		if _, err := os.Stat(snapshotDir); err != nil {

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -379,6 +379,22 @@ func (db *TestDB) GetReplicaFileCount() (int, error) {
 	return len(files), nil
 }
 
+func (db *TestDB) WaitForReplicaFiles(minFiles int, timeout time.Duration) (int, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		count, err := db.GetReplicaFileCount()
+		if err != nil {
+			return 0, err
+		}
+		if count >= minFiles {
+			return count, nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	count, _ := db.GetReplicaFileCount()
+	return count, fmt.Errorf("timeout waiting for %d replica files, got %d", minFiles, count)
+}
+
 func (db *TestDB) GetLitestreamLog() (string, error) {
 	logPath := filepath.Join(db.TempDir, "litestream.log")
 	content, err := os.ReadFile(logPath)


### PR DESCRIPTION
## Summary
- Fix `TestVersionMigration_DirectoryLayout` which was expecting a `"snapshot"` directory but the actual directory is named after `SnapshotLevel` (value `9`)
- Expand PR CI to include additional quick integration tests that were missing

## Changes
1. **Test fix** (`tests/integration/compatibility_test.go`):
   - Use `strconv.Itoa(litestream.SnapshotLevel)` instead of hardcoded `"snapshot"`
   - Updated comment to reflect actual layout (`ltx/9/` for snapshots)

2. **CI expansion** (`.github/workflows/integration-tests.yml`):
   - Added `TestRestore_*` tests (format consistency, LTX validation, point-in-time, multiple syncs, cross-platform paths)
   - Added `TestBinaryCompatibility`, `TestCompaction_Compatibility`, `TestVersionMigration`
   - Added `TestLockPage*`, `TestDirectoryWatcher*`
   - Added `TestDatabaseDeletion`, `TestWALGrowth`, `TestBusyTimeout`, `TestConcurrentOperations`

## Test plan
- [x] `TestVersionMigration_DirectoryLayout` passes locally
- [x] All compatibility tests pass locally
- [x] All DirectoryWatcher tests pass locally
- [ ] CI runs new test suite successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)