### PR TITLE
feat: add v0.3.x backup types and path helpers (Phase 1)

### DIFF
--- a/v3.go
+++ b/v3.go
@@ -1,0 +1,139 @@
+package litestream
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// PosV3 represents a position in a v0.3.x backup.
+type PosV3 struct {
+	Generation string // 16-char hex string
+	Index      int    // WAL index
+	Offset     int64  // Offset within WAL segment
+}
+
+// IsZero returns true if the position is the zero value.
+func (p PosV3) IsZero() bool {
+	return p == (PosV3{})
+}
+
+// String returns a string representation of the position.
+func (p PosV3) String() string {
+	if p.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("%s/%08x:%016x", p.Generation, p.Index, p.Offset)
+}
+
+// SnapshotInfoV3 contains metadata about a v0.3.x snapshot.
+type SnapshotInfoV3 struct {
+	Generation string
+	Index      int
+	Size       int64
+	CreatedAt  time.Time
+}
+
+// Pos returns the position of this snapshot.
+func (info SnapshotInfoV3) Pos() PosV3 {
+	return PosV3{Generation: info.Generation, Index: info.Index, Offset: 0}
+}
+
+// WALSegmentInfoV3 contains metadata about a v0.3.x WAL segment.
+type WALSegmentInfoV3 struct {
+	Generation string
+	Index      int
+	Offset     int64
+	Size       int64
+	CreatedAt  time.Time
+}
+
+// Pos returns the position of this WAL segment.
+func (info WALSegmentInfoV3) Pos() PosV3 {
+	return PosV3{Generation: info.Generation, Index: info.Index, Offset: info.Offset}
+}
+
+// v0.3.x path constants.
+const (
+	GenerationsDirV3 = "generations"
+	SnapshotsDirV3   = "snapshots"
+	WALDirV3         = "wal"
+)
+
+// GenerationsPathV3 returns the path to the generations directory.
+func GenerationsPathV3(root string) string {
+	return path.Join(root, GenerationsDirV3)
+}
+
+// GenerationPathV3 returns the path to a specific generation.
+func GenerationPathV3(root, generation string) string {
+	return path.Join(root, GenerationsDirV3, generation)
+}
+
+// SnapshotsPathV3 returns the path to snapshots within a generation.
+func SnapshotsPathV3(root, generation string) string {
+	return path.Join(root, GenerationsDirV3, generation, SnapshotsDirV3)
+}
+
+// WALPathV3 returns the path to WAL segments within a generation.
+func WALPathV3(root, generation string) string {
+	return path.Join(root, GenerationsDirV3, generation, WALDirV3)
+}
+
+// SnapshotPathV3 returns the full path to a v0.3.x snapshot file.
+func SnapshotPathV3(root, generation string, index int) string {
+	return path.Join(SnapshotsPathV3(root, generation), FormatSnapshotFilenameV3(index))
+}
+
+// WALSegmentPathV3 returns the full path to a v0.3.x WAL segment file.
+func WALSegmentPathV3(root, generation string, index int, offset int64) string {
+	return path.Join(WALPathV3(root, generation), FormatWALSegmentFilenameV3(index, offset))
+}
+
+// FormatSnapshotFilenameV3 returns the filename for a v0.3.x snapshot.
+// Format: {index:08x}.snapshot.lz4
+func FormatSnapshotFilenameV3(index int) string {
+	return fmt.Sprintf("%08x.snapshot.lz4", index)
+}
+
+// FormatWALSegmentFilenameV3 returns the filename for a v0.3.x WAL segment.
+// Format: {index:08x}-{offset:016x}.wal.lz4
+func FormatWALSegmentFilenameV3(index int, offset int64) string {
+	return fmt.Sprintf("%08x-%016x.wal.lz4", index, offset)
+}
+
+var (
+	snapshotRegexV3   = regexp.MustCompile(`^([0-9a-f]{8})\.snapshot\.lz4$`)
+	walSegmentRegexV3 = regexp.MustCompile(`^([0-9a-f]{8})-([0-9a-f]{16})\.wal\.lz4$`)
+	generationRegexV3 = regexp.MustCompile(`^[0-9a-f]{16}$`)
+)
+
+// ParseSnapshotFilenameV3 parses a v0.3.x snapshot filename and returns the index.
+// Returns an error if the filename does not match the expected format.
+func ParseSnapshotFilenameV3(filename string) (index int, err error) {
+	m := snapshotRegexV3.FindStringSubmatch(filename)
+	if m == nil {
+		return 0, fmt.Errorf("invalid v0.3.x snapshot filename: %q", filename)
+	}
+	idx, _ := strconv.ParseInt(m[1], 16, 64)
+	return int(idx), nil
+}
+
+// ParseWALSegmentFilenameV3 parses a v0.3.x WAL segment filename.
+// Returns the WAL index and byte offset, or an error if the filename is invalid.
+func ParseWALSegmentFilenameV3(filename string) (index int, offset int64, err error) {
+	m := walSegmentRegexV3.FindStringSubmatch(filename)
+	if m == nil {
+		return 0, 0, fmt.Errorf("invalid v0.3.x WAL segment filename: %q", filename)
+	}
+	idx, _ := strconv.ParseInt(m[1], 16, 64)
+	off, _ := strconv.ParseInt(m[2], 16, 64)
+	return int(idx), off, nil
+}
+
+// IsGenerationIDV3 returns true if s is a valid v0.3.x generation ID (16 hex chars).
+func IsGenerationIDV3(s string) bool {
+	return generationRegexV3.MatchString(s)
+}

--- a/v3_test.go
+++ b/v3_test.go
@@ -1,0 +1,283 @@
+package litestream_test
+
+import (
+	"testing"
+
+	"github.com/benbjohnson/litestream"
+)
+
+func TestPosV3_IsZero(t *testing.T) {
+	if !(litestream.PosV3{}).IsZero() {
+		t.Error("zero value should return true")
+	}
+	if (litestream.PosV3{Generation: "abc"}).IsZero() {
+		t.Error("non-zero value should return false")
+	}
+}
+
+func TestPosV3_String(t *testing.T) {
+	tests := []struct {
+		pos  litestream.PosV3
+		want string
+	}{
+		{litestream.PosV3{}, ""},
+		{litestream.PosV3{Generation: "0123456789abcdef", Index: 1, Offset: 4096}, "0123456789abcdef/00000001:0000000000001000"},
+	}
+	for _, tt := range tests {
+		if got := tt.pos.String(); got != tt.want {
+			t.Errorf("PosV3%+v.String() = %q, want %q", tt.pos, got, tt.want)
+		}
+	}
+}
+
+func TestSnapshotInfoV3_Pos(t *testing.T) {
+	info := litestream.SnapshotInfoV3{Generation: "abc", Index: 5}
+	pos := info.Pos()
+	if pos.Generation != "abc" || pos.Index != 5 || pos.Offset != 0 {
+		t.Errorf("unexpected pos: %+v", pos)
+	}
+}
+
+func TestWALSegmentInfoV3_Pos(t *testing.T) {
+	info := litestream.WALSegmentInfoV3{Generation: "abc", Index: 5, Offset: 100}
+	pos := info.Pos()
+	if pos.Generation != "abc" || pos.Index != 5 || pos.Offset != 100 {
+		t.Errorf("unexpected pos: %+v", pos)
+	}
+}
+
+func TestFormatSnapshotFilenameV3(t *testing.T) {
+	tests := []struct {
+		index int
+		want  string
+	}{
+		{0, "00000000.snapshot.lz4"},
+		{1, "00000001.snapshot.lz4"},
+		{255, "000000ff.snapshot.lz4"},
+		{0x12345678, "12345678.snapshot.lz4"},
+	}
+	for _, tt := range tests {
+		if got := litestream.FormatSnapshotFilenameV3(tt.index); got != tt.want {
+			t.Errorf("FormatSnapshotFilenameV3(%d) = %q, want %q", tt.index, got, tt.want)
+		}
+	}
+}
+
+func TestParseSnapshotFilenameV3(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		tests := []struct {
+			filename string
+			want     int
+		}{
+			{"00000000.snapshot.lz4", 0},
+			{"00000001.snapshot.lz4", 1},
+			{"000000ff.snapshot.lz4", 255},
+			{"12345678.snapshot.lz4", 0x12345678},
+		}
+		for _, tt := range tests {
+			index, err := litestream.ParseSnapshotFilenameV3(tt.filename)
+			if err != nil {
+				t.Errorf("ParseSnapshotFilenameV3(%q) error: %v", tt.filename, err)
+				continue
+			}
+			if index != tt.want {
+				t.Errorf("ParseSnapshotFilenameV3(%q) = %d, want %d", tt.filename, index, tt.want)
+			}
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		invalids := []string{
+			"",
+			"invalid.txt",
+			"00000001.snapshot",      // missing .lz4
+			"0000001.snapshot.lz4",   // 7 chars, not 8
+			"000000001.snapshot.lz4", // 9 chars, not 8
+			"0000000g.snapshot.lz4",  // invalid hex
+			"00000001.SNAPSHOT.lz4",  // uppercase
+			"00000001.snapshot.lz4.bak",
+		}
+		for _, filename := range invalids {
+			_, err := litestream.ParseSnapshotFilenameV3(filename)
+			if err == nil {
+				t.Errorf("ParseSnapshotFilenameV3(%q) expected error", filename)
+			}
+		}
+	})
+}
+
+func TestFormatWALSegmentFilenameV3(t *testing.T) {
+	tests := []struct {
+		index  int
+		offset int64
+		want   string
+	}{
+		{0, 0, "00000000-0000000000000000.wal.lz4"},
+		{1, 4096, "00000001-0000000000001000.wal.lz4"},
+		{255, 0x123456789abcdef0, "000000ff-123456789abcdef0.wal.lz4"},
+	}
+	for _, tt := range tests {
+		if got := litestream.FormatWALSegmentFilenameV3(tt.index, tt.offset); got != tt.want {
+			t.Errorf("FormatWALSegmentFilenameV3(%d, %d) = %q, want %q", tt.index, tt.offset, got, tt.want)
+		}
+	}
+}
+
+func TestParseWALSegmentFilenameV3(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		tests := []struct {
+			filename   string
+			wantIndex  int
+			wantOffset int64
+		}{
+			{"00000000-0000000000000000.wal.lz4", 0, 0},
+			{"00000001-0000000000001000.wal.lz4", 1, 4096},
+			{"000000ff-123456789abcdef0.wal.lz4", 255, 0x123456789abcdef0},
+		}
+		for _, tt := range tests {
+			index, offset, err := litestream.ParseWALSegmentFilenameV3(tt.filename)
+			if err != nil {
+				t.Errorf("ParseWALSegmentFilenameV3(%q) error: %v", tt.filename, err)
+				continue
+			}
+			if index != tt.wantIndex || offset != tt.wantOffset {
+				t.Errorf("ParseWALSegmentFilenameV3(%q) = (%d, %d), want (%d, %d)",
+					tt.filename, index, offset, tt.wantIndex, tt.wantOffset)
+			}
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		invalids := []string{
+			"",
+			"invalid.wal",
+			"00000001.wal.lz4",                 // missing offset
+			"00000001-0000000000001000.wal",    // missing .lz4
+			"0000001-0000000000001000.wal.lz4", // 7 chars index
+			"00000001-000000000001000.wal.lz4", // 15 chars offset
+		}
+		for _, filename := range invalids {
+			_, _, err := litestream.ParseWALSegmentFilenameV3(filename)
+			if err == nil {
+				t.Errorf("ParseWALSegmentFilenameV3(%q) expected error", filename)
+			}
+		}
+	})
+}
+
+func TestIsGenerationIDV3(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"0123456789abcdef", true},
+		{"abcdef0123456789", true},
+		{"aaaaaaaaaaaaaaaa", true},
+		{"0000000000000000", true},
+		{"ffffffffffffffff", true},
+		{"0123456789ABCDEF", false},  // uppercase not valid
+		{"0123456789abcde", false},   // 15 chars, too short
+		{"0123456789abcdeff", false}, // 17 chars, too long
+		{"0123456789abcdeg", false},  // invalid hex char
+		{"", false},
+		{"generations", false},
+	}
+	for _, tt := range tests {
+		if got := litestream.IsGenerationIDV3(tt.s); got != tt.want {
+			t.Errorf("IsGenerationIDV3(%q) = %v, want %v", tt.s, got, tt.want)
+		}
+	}
+}
+
+func TestPathsV3(t *testing.T) {
+	root := "/data/replica"
+	gen := "0123456789abcdef"
+
+	t.Run("GenerationsPath", func(t *testing.T) {
+		got := litestream.GenerationsPathV3(root)
+		want := "/data/replica/generations"
+		if got != want {
+			t.Errorf("GenerationsPathV3(%q) = %q, want %q", root, got, want)
+		}
+	})
+
+	t.Run("GenerationPath", func(t *testing.T) {
+		got := litestream.GenerationPathV3(root, gen)
+		want := "/data/replica/generations/0123456789abcdef"
+		if got != want {
+			t.Errorf("GenerationPathV3(%q, %q) = %q, want %q", root, gen, got, want)
+		}
+	})
+
+	t.Run("SnapshotsPath", func(t *testing.T) {
+		got := litestream.SnapshotsPathV3(root, gen)
+		want := "/data/replica/generations/0123456789abcdef/snapshots"
+		if got != want {
+			t.Errorf("SnapshotsPathV3(%q, %q) = %q, want %q", root, gen, got, want)
+		}
+	})
+
+	t.Run("WALPath", func(t *testing.T) {
+		got := litestream.WALPathV3(root, gen)
+		want := "/data/replica/generations/0123456789abcdef/wal"
+		if got != want {
+			t.Errorf("WALPathV3(%q, %q) = %q, want %q", root, gen, got, want)
+		}
+	})
+
+	t.Run("SnapshotPath", func(t *testing.T) {
+		got := litestream.SnapshotPathV3(root, gen, 1)
+		want := "/data/replica/generations/0123456789abcdef/snapshots/00000001.snapshot.lz4"
+		if got != want {
+			t.Errorf("SnapshotPathV3(%q, %q, 1) = %q, want %q", root, gen, got, want)
+		}
+	})
+
+	t.Run("WALSegmentPath", func(t *testing.T) {
+		got := litestream.WALSegmentPathV3(root, gen, 1, 4096)
+		want := "/data/replica/generations/0123456789abcdef/wal/00000001-0000000000001000.wal.lz4"
+		if got != want {
+			t.Errorf("WALSegmentPathV3(%q, %q, 1, 4096) = %q, want %q", root, gen, got, want)
+		}
+	})
+}
+
+// TestFormatParseRoundtrip verifies that Format and Parse are inverses.
+func TestFormatParseRoundtrip(t *testing.T) {
+	t.Run("Snapshot", func(t *testing.T) {
+		for _, index := range []int{0, 1, 255, 0x12345678} {
+			filename := litestream.FormatSnapshotFilenameV3(index)
+			got, err := litestream.ParseSnapshotFilenameV3(filename)
+			if err != nil {
+				t.Errorf("roundtrip failed for index %d: %v", index, err)
+				continue
+			}
+			if got != index {
+				t.Errorf("roundtrip: FormatSnapshotFilenameV3(%d) -> %q -> ParseSnapshotFilenameV3 -> %d", index, filename, got)
+			}
+		}
+	})
+
+	t.Run("WALSegment", func(t *testing.T) {
+		cases := []struct {
+			index  int
+			offset int64
+		}{
+			{0, 0},
+			{1, 4096},
+			{255, 0x123456789abcdef0},
+		}
+		for _, tc := range cases {
+			filename := litestream.FormatWALSegmentFilenameV3(tc.index, tc.offset)
+			gotIndex, gotOffset, err := litestream.ParseWALSegmentFilenameV3(filename)
+			if err != nil {
+				t.Errorf("roundtrip failed for (%d, %d): %v", tc.index, tc.offset, err)
+				continue
+			}
+			if gotIndex != tc.index || gotOffset != tc.offset {
+				t.Errorf("roundtrip: FormatWALSegmentFilenameV3(%d, %d) -> %q -> (%d, %d)",
+					tc.index, tc.offset, filename, gotIndex, gotOffset)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add core types for v0.3.x backup format: `PosV3`, `SnapshotInfoV3`, `WALSegmentInfoV3`
- Add path helpers: `GenerationsPathV3`, `SnapshotsPathV3`, `WALPathV3`, etc.
- Add filename formatting/parsing: `FormatSnapshotFilenameV3`, `ParseSnapshotFilenameV3`, etc.
- Add generation ID validation: `IsGenerationIDV3`

This is Phase 1 of 5 for v0.3.x restore support (Issue #1034).

## Test plan

- [x] All V3 unit tests pass (`go test -v -run "V3" ./...`)
- [x] Roundtrip tests verify Format/Parse are inverses
- [x] Edge cases tested (invalid filenames, generation IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)