### PR TITLE
feat: add v0.3.x snapshot/WAL listing for file backend (Phase 2)

### DIFF
--- a/file/replica_client_test.go
+++ b/file/replica_client_test.go
@@ -179,6 +179,390 @@ func createLTXHeader(minTXID, maxTXID ltx.TXID) []byte {
 	return createLTXData(minTXID, maxTXID, nil)
 }
 
+func TestReplicaClient_GenerationsV3(t *testing.T) {
+	t.Run("NoGenerationsDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		c := file.NewReplicaClient(tmpDir)
+
+		generations, err := c.GenerationsV3(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(generations) != 0 {
+			t.Fatalf("expected no generations, got %v", generations)
+		}
+	})
+
+	t.Run("EmptyGenerationsDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(tmpDir, "generations"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		generations, err := c.GenerationsV3(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(generations) != 0 {
+			t.Fatalf("expected no generations, got %v", generations)
+		}
+	})
+
+	t.Run("MultipleGenerationsSorted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		genDir := filepath.Join(tmpDir, "generations")
+		// Create in non-sorted order
+		for _, gen := range []string{"ffffffffffffffff", "0000000000000001", "aaaaaaaaaaaaaaaa"} {
+			if err := os.MkdirAll(filepath.Join(genDir, gen), 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		generations, err := c.GenerationsV3(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"0000000000000001", "aaaaaaaaaaaaaaaa", "ffffffffffffffff"}
+		if len(generations) != len(want) {
+			t.Fatalf("got %d generations, want %d", len(generations), len(want))
+		}
+		for i, g := range generations {
+			if g != want[i] {
+				t.Errorf("generations[%d] = %q, want %q", i, g, want[i])
+			}
+		}
+	})
+
+	t.Run("SkipsInvalidIDs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		genDir := filepath.Join(tmpDir, "generations")
+		// Create mix of valid and invalid
+		for _, name := range []string{
+			"0000000000000001", // valid
+			"invalid",          // invalid - not hex
+			"0123456789abcde",  // invalid - 15 chars
+			"0123456789ABCDEF", // invalid - uppercase
+			"aaaaaaaaaaaaaaaa", // valid
+		} {
+			if err := os.MkdirAll(filepath.Join(genDir, name), 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		generations, err := c.GenerationsV3(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"0000000000000001", "aaaaaaaaaaaaaaaa"}
+		if len(generations) != len(want) {
+			t.Fatalf("got %d generations, want %d: %v", len(generations), len(want), generations)
+		}
+		for i, g := range generations {
+			if g != want[i] {
+				t.Errorf("generations[%d] = %q, want %q", i, g, want[i])
+			}
+		}
+	})
+
+	t.Run("SkipsFiles", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		genDir := filepath.Join(tmpDir, "generations")
+		if err := os.MkdirAll(genDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create a file with valid generation name (should be skipped)
+		if err := os.WriteFile(filepath.Join(genDir, "0000000000000001"), []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// Create a valid directory
+		if err := os.MkdirAll(filepath.Join(genDir, "aaaaaaaaaaaaaaaa"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		generations, err := c.GenerationsV3(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(generations) != 1 || generations[0] != "aaaaaaaaaaaaaaaa" {
+			t.Fatalf("expected only valid directory, got %v", generations)
+		}
+	})
+}
+
+func TestReplicaClient_SnapshotsV3(t *testing.T) {
+	gen := "0123456789abcdef"
+
+	t.Run("NoSnapshotsDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		c := file.NewReplicaClient(tmpDir)
+
+		snapshots, err := c.SnapshotsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshots) != 0 {
+			t.Fatalf("expected no snapshots, got %v", snapshots)
+		}
+	})
+
+	t.Run("EmptySnapshotsDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(tmpDir, "generations", gen, "snapshots"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		snapshots, err := c.SnapshotsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshots) != 0 {
+			t.Fatalf("expected no snapshots, got %v", snapshots)
+		}
+	})
+
+	t.Run("SingleSnapshot", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		snapshotsDir := filepath.Join(tmpDir, "generations", gen, "snapshots")
+		if err := os.MkdirAll(snapshotsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create snapshot file
+		path := filepath.Join(snapshotsDir, "00000001.snapshot.lz4")
+		if err := os.WriteFile(path, []byte("test data"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		snapshots, err := c.SnapshotsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshots) != 1 {
+			t.Fatalf("expected 1 snapshot, got %d", len(snapshots))
+		}
+		if snapshots[0].Generation != gen {
+			t.Errorf("Generation = %q, want %q", snapshots[0].Generation, gen)
+		}
+		if snapshots[0].Index != 1 {
+			t.Errorf("Index = %d, want 1", snapshots[0].Index)
+		}
+		if snapshots[0].Size != 9 { // len("test data")
+			t.Errorf("Size = %d, want 9", snapshots[0].Size)
+		}
+	})
+
+	t.Run("MultipleSnapshotsSorted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		snapshotsDir := filepath.Join(tmpDir, "generations", gen, "snapshots")
+		if err := os.MkdirAll(snapshotsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create snapshots in non-sorted order
+		for _, idx := range []int{0xff, 0x01, 0x10} {
+			filename := fmt.Sprintf("%08x.snapshot.lz4", idx)
+			if err := os.WriteFile(filepath.Join(snapshotsDir, filename), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		snapshots, err := c.SnapshotsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshots) != 3 {
+			t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+		}
+		wantIndices := []int{0x01, 0x10, 0xff}
+		for i, s := range snapshots {
+			if s.Index != wantIndices[i] {
+				t.Errorf("snapshots[%d].Index = %d, want %d", i, s.Index, wantIndices[i])
+			}
+		}
+	})
+
+	t.Run("SkipsInvalidFilenames", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		snapshotsDir := filepath.Join(tmpDir, "generations", gen, "snapshots")
+		if err := os.MkdirAll(snapshotsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create mix of valid and invalid
+		files := map[string]bool{
+			"00000001.snapshot.lz4": true,  // valid
+			"invalid.snapshot.lz4":  false, // invalid
+			"00000002.snapshot":     false, // missing .lz4
+			"00000003.wal.lz4":      false, // wrong type
+			"00000004.snapshot.lz4": true,  // valid
+		}
+		for name := range files {
+			if err := os.WriteFile(filepath.Join(snapshotsDir, name), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		snapshots, err := c.SnapshotsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshots) != 2 {
+			t.Fatalf("expected 2 valid snapshots, got %d", len(snapshots))
+		}
+	})
+}
+
+func TestReplicaClient_WALSegmentsV3(t *testing.T) {
+	gen := "0123456789abcdef"
+
+	t.Run("NoWALDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		c := file.NewReplicaClient(tmpDir)
+
+		segments, err := c.WALSegmentsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(segments) != 0 {
+			t.Fatalf("expected no segments, got %v", segments)
+		}
+	})
+
+	t.Run("EmptyWALDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(tmpDir, "generations", gen, "wal"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		segments, err := c.WALSegmentsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(segments) != 0 {
+			t.Fatalf("expected no segments, got %v", segments)
+		}
+	})
+
+	t.Run("SingleSegment", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		walDir := filepath.Join(tmpDir, "generations", gen, "wal")
+		if err := os.MkdirAll(walDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create WAL segment file
+		path := filepath.Join(walDir, "00000001-0000000000001000.wal.lz4")
+		if err := os.WriteFile(path, []byte("wal data"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		segments, err := c.WALSegmentsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(segments) != 1 {
+			t.Fatalf("expected 1 segment, got %d", len(segments))
+		}
+		if segments[0].Generation != gen {
+			t.Errorf("Generation = %q, want %q", segments[0].Generation, gen)
+		}
+		if segments[0].Index != 1 {
+			t.Errorf("Index = %d, want 1", segments[0].Index)
+		}
+		if segments[0].Offset != 0x1000 {
+			t.Errorf("Offset = %d, want %d", segments[0].Offset, 0x1000)
+		}
+		if segments[0].Size != 8 { // len("wal data")
+			t.Errorf("Size = %d, want 8", segments[0].Size)
+		}
+	})
+
+	t.Run("MultipleSortedByIndexThenOffset", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		walDir := filepath.Join(tmpDir, "generations", gen, "wal")
+		if err := os.MkdirAll(walDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create WAL segments in non-sorted order
+		segments := []struct {
+			index  int
+			offset int64
+		}{
+			{2, 0x2000},
+			{1, 0x1000},
+			{1, 0x0000},
+			{2, 0x0000},
+		}
+		for _, s := range segments {
+			filename := fmt.Sprintf("%08x-%016x.wal.lz4", s.index, s.offset)
+			if err := os.WriteFile(filepath.Join(walDir, filename), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		result, err := c.WALSegmentsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result) != 4 {
+			t.Fatalf("expected 4 segments, got %d", len(result))
+		}
+		// Verify sorted order: index 1 offset 0, index 1 offset 0x1000, index 2 offset 0, index 2 offset 0x2000
+		expected := []struct {
+			index  int
+			offset int64
+		}{
+			{1, 0x0000},
+			{1, 0x1000},
+			{2, 0x0000},
+			{2, 0x2000},
+		}
+		for i, s := range result {
+			if s.Index != expected[i].index || s.Offset != expected[i].offset {
+				t.Errorf("segments[%d] = (%d, %d), want (%d, %d)",
+					i, s.Index, s.Offset, expected[i].index, expected[i].offset)
+			}
+		}
+	})
+
+	t.Run("SkipsInvalidFilenames", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		walDir := filepath.Join(tmpDir, "generations", gen, "wal")
+		if err := os.MkdirAll(walDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create mix of valid and invalid
+		files := []string{
+			"00000001-0000000000000000.wal.lz4", // valid
+			"invalid.wal.lz4",                   // invalid
+			"00000002.wal.lz4",                  // missing offset
+			"00000003-0000000000001000.wal",     // missing .lz4
+			"00000004-0000000000002000.wal.lz4", // valid
+		}
+		for _, name := range files {
+			if err := os.WriteFile(filepath.Join(walDir, name), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		c := file.NewReplicaClient(tmpDir)
+
+		result, err := c.WALSegmentsV3(context.Background(), gen)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 valid segments, got %d", len(result))
+		}
+	})
+}
+
 /*
 func TestReplica_Sync(t *testing.T) {
 	// Ensure replica can successfully sync after DB has sync'd.

--- a/v3.go
+++ b/v3.go
@@ -1,6 +1,7 @@
 package litestream
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"regexp"
@@ -136,4 +137,21 @@ func ParseWALSegmentFilenameV3(filename string) (index int, offset int64, err er
 // IsGenerationIDV3 returns true if s is a valid v0.3.x generation ID (16 hex chars).
 func IsGenerationIDV3(s string) bool {
 	return generationRegexV3.MatchString(s)
+}
+
+// ReplicaClientV3 reads v0.3.x backup data.
+// ReplicaClient implementations that support v0.3.x restore should implement this interface.
+type ReplicaClientV3 interface {
+	// GenerationsV3 returns a list of generation IDs in the replica.
+	// Returns an empty slice if no v0.3.x backups exist.
+	// Generation IDs are sorted in ascending order.
+	GenerationsV3(ctx context.Context) ([]string, error)
+
+	// SnapshotsV3 returns snapshots for a generation, sorted by index.
+	// Returns an empty slice if no snapshots exist.
+	SnapshotsV3(ctx context.Context, generation string) ([]SnapshotInfoV3, error)
+
+	// WALSegmentsV3 returns WAL segments for a generation, sorted by index then offset.
+	// Returns an empty slice if no WAL segments exist.
+	WALSegmentsV3(ctx context.Context, generation string) ([]WALSegmentInfoV3, error)
 }


### PR DESCRIPTION
## Summary
- Add `ReplicaClientV3` interface with methods to list v0.3.x generations, snapshots, and WAL segments
- Implement the interface for `file.ReplicaClient`
- Add comprehensive tests covering empty dirs, sorting, and invalid filename handling

This is Phase 2 of the v0.3.x backup restore support (following Phase 1 in #1045).

## Test plan
- [x] All V3 tests pass (`go test -v -run "V3" ./...`)
- [x] Full test suite passes (`go test ./file/... ./...` excluding pre-existing integration failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)