### PR TITLE
feat: add v0.3.x file open with LZ4 decompression (Phase 3)

### DIFF
--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -349,3 +349,25 @@ func (c *ReplicaClient) WALSegmentsV3(ctx context.Context, generation string) ([
 	})
 	return segments, nil
 }
+
+// OpenSnapshotV3 opens a v0.3.x snapshot file for reading.
+// The returned reader provides LZ4-decompressed data.
+func (c *ReplicaClient) OpenSnapshotV3(ctx context.Context, generation string, index int) (io.ReadCloser, error) {
+	path := filepath.Join(c.path, litestream.GenerationsDirV3, generation, litestream.SnapshotsDirV3, litestream.FormatSnapshotFilenameV3(index))
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return internal.NewLZ4Reader(f), nil
+}
+
+// OpenWALSegmentV3 opens a v0.3.x WAL segment file for reading.
+// The returned reader provides LZ4-decompressed data.
+func (c *ReplicaClient) OpenWALSegmentV3(ctx context.Context, generation string, index int, offset int64) (io.ReadCloser, error) {
+	path := filepath.Join(c.path, litestream.GenerationsDirV3, generation, litestream.WALDirV3, litestream.FormatWALSegmentFilenameV3(index, offset))
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return internal.NewLZ4Reader(f), nil
+}

--- a/v3.go
+++ b/v3.go
@@ -3,6 +3,7 @@ package litestream
 import (
 	"context"
 	"fmt"
+	"io"
 	"path"
 	"regexp"
 	"strconv"
@@ -154,4 +155,12 @@ type ReplicaClientV3 interface {
 	// WALSegmentsV3 returns WAL segments for a generation, sorted by index then offset.
 	// Returns an empty slice if no WAL segments exist.
 	WALSegmentsV3(ctx context.Context, generation string) ([]WALSegmentInfoV3, error)
+
+	// OpenSnapshotV3 opens a v0.3.x snapshot for reading.
+	// The returned reader provides LZ4-decompressed data.
+	OpenSnapshotV3(ctx context.Context, generation string, index int) (io.ReadCloser, error)
+
+	// OpenWALSegmentV3 opens a v0.3.x WAL segment for reading.
+	// The returned reader provides LZ4-decompressed data.
+	OpenWALSegmentV3(ctx context.Context, generation string, index int, offset int64) (io.ReadCloser, error)
 }


### PR DESCRIPTION
## Summary
- Extend `ReplicaClientV3` interface with `OpenSnapshotV3()` and `OpenWALSegmentV3()` methods
- Add `NewLZ4Reader()` helper for LZ4 decompression with proper resource cleanup
- Implement both methods for `file.ReplicaClient`

This is Phase 3 of the v0.3.x backup restore support (following Phases 1-2 in #1045 and #1048).

## Test plan
- [x] Not-found errors return `os.ErrNotExist`
- [x] LZ4 decompression works correctly
- [x] All V3 tests pass (`go test -v -run "V3" ./...`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)