### PR TITLE
add replication monitoring endpoint to unix sock

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -159,6 +159,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		slog.Info("litestream shut down")
 		return err
 
+	case "monitor":
+		return (&MonitorCommand{}).Run(ctx, args)
 	case "start":
 		return (&StartCommand{}).Run(ctx, args)
 	case "stop":
@@ -199,6 +201,7 @@ The commands are:
 
 	databases    list databases specified in config file
 	ltx          list available LTX files for a database
+	monitor      stream replication status in real-time
 	replicate    runs a server to replicate databases
 	reset        reset local state for a database
 	restore      recovers database backup from a replica

--- a/cmd/litestream/monitor.go
+++ b/cmd/litestream/monitor.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/benbjohnson/litestream"
+)
+
+// MonitorCommand represents the command to monitor replication status.
+type MonitorCommand struct{}
+
+// Run executes the monitor command.
+func (c *MonitorCommand) Run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("litestream-monitor", flag.ContinueOnError)
+	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
+	dbFilter := fs.String("db", "", "filter to specific database path")
+	rawOutput := fs.Bool("raw", false, "output raw NDJSON without formatting")
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Create HTTP client that connects via Unix socket
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", *socketPath)
+			},
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost/monitor", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to control socket: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("monitor failed: %s", resp.Status)
+	}
+
+	// Stream NDJSON events
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		if *rawOutput {
+			fmt.Println(line)
+			continue
+		}
+
+		var event litestream.StatusEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to parse event: %v\n", err)
+			continue
+		}
+
+		c.printEvent(&event, *dbFilter)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading stream: %w", err)
+	}
+
+	return nil
+}
+
+// printEvent formats and prints a status event.
+func (c *MonitorCommand) printEvent(event *litestream.StatusEvent, dbFilter string) {
+	switch event.Type {
+	case "full":
+		fmt.Printf("[%s] Connected - monitoring %d database(s)\n",
+			event.Timestamp.Format(time.RFC3339),
+			len(event.Databases))
+		for _, db := range event.Databases {
+			if dbFilter != "" && db.Path != dbFilter {
+				continue
+			}
+			c.printDatabaseStatus(&db)
+		}
+
+	case "sync":
+		if event.Database == nil {
+			return
+		}
+		if dbFilter != "" && event.Database.Path != dbFilter {
+			return
+		}
+		fmt.Printf("[%s] SYNC %s -> txid:%s\n",
+			event.Timestamp.Format(time.RFC3339),
+			event.Database.Path,
+			event.Database.ReplicaTXID)
+	}
+}
+
+// printDatabaseStatus prints the status of a single database.
+func (c *MonitorCommand) printDatabaseStatus(db *litestream.DatabaseStatus) {
+	status := db.Status
+	if !db.Enabled {
+		status = "disabled"
+	}
+
+	txidInfo := ""
+	if db.LocalTXID != "" {
+		txidInfo = fmt.Sprintf(" local:%s", db.LocalTXID)
+	}
+	if db.ReplicaTXID != "" {
+		txidInfo += fmt.Sprintf(" replica:%s", db.ReplicaTXID)
+	}
+	if db.SyncLag > 0 {
+		txidInfo += fmt.Sprintf(" lag:%d", db.SyncLag)
+	}
+
+	fmt.Printf("  %s [%s]%s\n", db.Path, status, txidInfo)
+}
+
+// Usage prints the help text for the monitor command.
+func (c *MonitorCommand) Usage() {
+	fmt.Println(`
+usage: litestream monitor [OPTIONS]
+
+Monitor replication status in real-time.
+
+Connects to the litestream control socket and streams replication events
+as they occur. Events are emitted when LTX files are uploaded to replicas.
+
+Options:
+  -socket PATH
+      Path to control socket (default: /var/run/litestream.sock).
+
+  -db PATH
+      Filter events to a specific database path.
+
+  -raw
+      Output raw NDJSON without formatting.
+
+Examples:
+  # Monitor all databases
+  litestream monitor
+
+  # Monitor specific database
+  litestream monitor -db /data/app.db
+
+  # Output raw NDJSON (for piping to other tools)
+  litestream monitor -raw | jq .
+`[1:])
+}

--- a/cmd/litestream/monitor_test.go
+++ b/cmd/litestream/monitor_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMonitorCommand_Run(t *testing.T) {
+	t.Run("ConnectionError", func(t *testing.T) {
+		cmd := &MonitorCommand{}
+		err := cmd.Run(context.Background(), []string{"-socket", "/nonexistent/socket.sock"})
+		if err == nil {
+			t.Error("expected error for nonexistent socket")
+		}
+	})
+
+	t.Run("FlagParsing", func(t *testing.T) {
+		// Just verify the command can parse flags without error
+		cmd := &MonitorCommand{}
+
+		// This will fail to connect, but flags should parse
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately so we don't wait for connection
+
+		err := cmd.Run(ctx, []string{"-socket", "/tmp/test.sock", "-db", "/path/to/db", "-raw"})
+		// Error expected due to cancelled context or connection failure
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+}
+
+func TestMonitorCommand_Usage(t *testing.T) {
+	cmd := &MonitorCommand{}
+	// Just verify Usage doesn't panic
+	cmd.Usage()
+}

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mattn/go-shellwords"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/abs"
@@ -286,6 +287,16 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 		c.Server.PathExpander = expand
 		if err := c.Server.Start(); err != nil {
 			slog.Warn("failed to start control server", "error", err)
+		}
+
+		// Wire up OnSync callbacks for status monitoring
+		for _, db := range c.Store.DBs() {
+			if db.Replica != nil {
+				db := db // capture for closure
+				db.Replica.OnSync = func(pos ltx.Pos) {
+					c.Server.StatusMonitor.NotifySync(db, pos)
+				}
+			}
 		}
 	}
 

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -289,11 +289,11 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 			slog.Warn("failed to start control server", "error", err)
 		}
 
-		// Wire up OnSync callbacks for status monitoring
+		// Wire up AfterSync callbacks for status monitoring
 		for _, db := range c.Store.DBs() {
 			if db.Replica != nil {
 				db := db // capture for closure
-				db.Replica.OnSync = func(pos ltx.Pos) {
+				db.Replica.AfterSync = func(pos ltx.Pos) {
 					c.Server.StatusMonitor.NotifySync(db, pos)
 				}
 			}

--- a/replica.go
+++ b/replica.go
@@ -53,6 +53,11 @@ type Replica struct {
 	// the position file and removing local LTX files, forcing a fresh sync.
 	// Disabled by default to prevent silent data loss scenarios.
 	AutoRecoverEnabled bool
+
+	// OnSync is called after LTX files are uploaded to the replica.
+	// Only fires when actual replication occurs (TXID advances).
+	// May be nil.
+	OnSync func(pos ltx.Pos)
 }
 
 func NewReplica(db *DB) *Replica {
@@ -164,6 +169,11 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 			return err
 		}
 		r.SetPos(ltx.Pos{TXID: txID})
+
+		// Notify listeners of actual replication
+		if r.OnSync != nil {
+			r.OnSync(r.Pos())
+		}
 	}
 
 	// Record successful sync for heartbeat monitoring.

--- a/replica.go
+++ b/replica.go
@@ -54,10 +54,10 @@ type Replica struct {
 	// Disabled by default to prevent silent data loss scenarios.
 	AutoRecoverEnabled bool
 
-	// OnSync is called after LTX files are uploaded to the replica.
+	// AfterSync is called after LTX files are uploaded to the replica.
 	// Only fires when actual replication occurs (TXID advances).
 	// May be nil.
-	OnSync func(pos ltx.Pos)
+	AfterSync func(pos ltx.Pos)
 }
 
 func NewReplica(db *DB) *Replica {
@@ -171,8 +171,8 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		r.SetPos(ltx.Pos{TXID: txID})
 
 		// Notify listeners of actual replication
-		if r.OnSync != nil {
-			r.OnSync(r.Pos())
+		if r.AfterSync != nil {
+			r.AfterSync(r.Pos())
 		}
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,269 @@
+package litestream_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal/testingutil"
+)
+
+// shortSocketPath returns a short socket path that won't exceed Unix socket limits.
+// Unix sockets have a max path length of ~104 chars on macOS.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ls")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
+func TestServer_HandleMonitor(t *testing.T) {
+	t.Run("StreamsInitialFullStatus", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore([]*litestream.DB{db}, levels)
+		store.CompactionMonitorEnabled = false
+
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close(t.Context())
+
+		// Create and sync data
+		if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create server with socket (use short path to avoid Unix socket length limits)
+		socketPath := shortSocketPath(t)
+		server := litestream.NewServer(store)
+		server.SocketPath = socketPath
+
+		if err := server.Start(); err != nil {
+			t.Fatalf("start server: %v", err)
+		}
+		defer server.Close()
+
+		// Connect via Unix socket
+		client := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", socketPath)
+				},
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost/monitor", nil)
+		if err != nil {
+			t.Fatalf("create request: %v", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+
+		contentType := resp.Header.Get("Content-Type")
+		if contentType != "application/x-ndjson" {
+			t.Errorf("expected Content-Type 'application/x-ndjson', got %q", contentType)
+		}
+
+		// Read initial full status event
+		scanner := bufio.NewScanner(resp.Body)
+		if !scanner.Scan() {
+			t.Fatal("expected to read first event")
+		}
+
+		var event litestream.StatusEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+
+		if event.Type != "full" {
+			t.Errorf("expected event type 'full', got %q", event.Type)
+		}
+		if len(event.Databases) != 1 {
+			t.Errorf("expected 1 database in full status, got %d", len(event.Databases))
+		}
+		if event.Databases[0].Path != db.Path() {
+			t.Errorf("expected path %q, got %q", db.Path(), event.Databases[0].Path)
+		}
+	})
+
+	t.Run("StreamsSyncEvents", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore([]*litestream.DB{db}, levels)
+		store.CompactionMonitorEnabled = false
+
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close(t.Context())
+
+		// Create server with socket (use short path to avoid Unix socket length limits)
+		socketPath := shortSocketPath(t)
+		server := litestream.NewServer(store)
+		server.SocketPath = socketPath
+
+		if err := server.Start(); err != nil {
+			t.Fatalf("start server: %v", err)
+		}
+		defer server.Close()
+
+		// Wire up OnSync callback
+		db.Replica.OnSync = func(pos ltx.Pos) {
+			server.StatusMonitor.NotifySync(db, pos)
+		}
+
+		// Connect via Unix socket
+		client := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", socketPath)
+				},
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost/monitor", nil)
+		if err != nil {
+			t.Fatalf("create request: %v", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+
+		// Skip initial full status
+		if !scanner.Scan() {
+			t.Fatal("expected to read first event")
+		}
+
+		// Now trigger a sync
+		if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read sync event
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("scanner error: %v", err)
+			}
+			t.Fatal("expected to read sync event")
+		}
+
+		var event litestream.StatusEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+
+		if event.Type != "sync" {
+			t.Errorf("expected event type 'sync', got %q", event.Type)
+		}
+		if event.Database == nil {
+			t.Fatal("expected non-nil database in sync event")
+		}
+		if event.Database.ReplicaTXID == "" {
+			t.Error("expected non-empty replica_txid in sync event")
+		}
+	})
+
+	t.Run("ClientDisconnect", func(t *testing.T) {
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore(nil, levels)
+
+		socketPath := shortSocketPath(t)
+		server := litestream.NewServer(store)
+		server.SocketPath = socketPath
+
+		if err := server.Start(); err != nil {
+			t.Fatalf("start server: %v", err)
+		}
+		defer server.Close()
+
+		// Connect and immediately disconnect
+		conn, err := net.Dial("unix", socketPath)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+
+		// Send HTTP request
+		_, err = conn.Write([]byte("GET /monitor HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		// Close connection
+		conn.Close()
+
+		// Server should handle this gracefully (test passes if no panic)
+	})
+}
+
+func TestServer_SocketPermissions(t *testing.T) {
+	levels := litestream.CompactionLevels{{Level: 0}}
+	store := litestream.NewStore(nil, levels)
+
+	socketPath := shortSocketPath(t)
+	server := litestream.NewServer(store)
+	server.SocketPath = socketPath
+	server.SocketPerms = 0600
+
+	if err := server.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer server.Close()
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("expected socket permissions 0600, got %o", perm)
+	}
+}

--- a/status.go
+++ b/status.go
@@ -1,0 +1,157 @@
+package litestream
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/superfly/ltx"
+)
+
+// StatusMonitor manages replication status monitoring and event streaming.
+type StatusMonitor struct {
+	store *Store
+
+	mu          sync.RWMutex
+	subscribers map[chan *StatusEvent]struct{}
+}
+
+// NewStatusMonitor creates a new status monitor.
+func NewStatusMonitor(store *Store) *StatusMonitor {
+	return &StatusMonitor{
+		store:       store,
+		subscribers: make(map[chan *StatusEvent]struct{}),
+	}
+}
+
+// Subscribe returns a channel for receiving status events.
+// The caller must call Unsubscribe when done to avoid resource leaks.
+func (m *StatusMonitor) Subscribe() chan *StatusEvent {
+	ch := make(chan *StatusEvent, 64)
+	m.mu.Lock()
+	m.subscribers[ch] = struct{}{}
+	m.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel and closes it.
+func (m *StatusMonitor) Unsubscribe(ch chan *StatusEvent) {
+	m.mu.Lock()
+	delete(m.subscribers, ch)
+	m.mu.Unlock()
+	close(ch)
+}
+
+// GetFullStatus returns a snapshot of all database statuses.
+func (m *StatusMonitor) GetFullStatus() []DatabaseStatus {
+	dbs := m.store.DBs()
+	statuses := make([]DatabaseStatus, 0, len(dbs))
+	for _, db := range dbs {
+		statuses = append(statuses, getDatabaseStatus(db))
+	}
+	return statuses
+}
+
+// NotifySync broadcasts a sync event to all subscribers.
+// Called by Replica.OnSync when LTX files are uploaded.
+func (m *StatusMonitor) NotifySync(db *DB, pos ltx.Pos) {
+	event := &StatusEvent{
+		Type:      "sync",
+		Timestamp: time.Now(),
+		Database: &DatabaseStatus{
+			Path:        db.Path(),
+			ReplicaTXID: pos.TXID.String(),
+			Status:      "ok",
+		},
+	}
+	m.broadcast(event)
+}
+
+// broadcast sends an event to all subscribers.
+// Events are dropped for slow subscribers to avoid blocking.
+func (m *StatusMonitor) broadcast(event *StatusEvent) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for ch := range m.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// Drop if subscriber is slow
+		}
+	}
+}
+
+// getDatabaseStatus gathers status information for a single database.
+func getDatabaseStatus(db *DB) DatabaseStatus {
+	status := DatabaseStatus{
+		Path:   db.Path(),
+		Status: "unknown",
+	}
+
+	status.Enabled = db.IsOpen()
+	if !status.Enabled {
+		status.Status = "disabled"
+		return status
+	}
+
+	// Get local TXID from L0 directory
+	_, maxTXID, err := db.MaxLTX()
+	if err == nil && maxTXID > 0 {
+		status.LocalTXID = maxTXID.String()
+		status.Status = "ok"
+	} else if err == nil {
+		status.Status = "initializing"
+	} else {
+		status.Status = "error"
+	}
+
+	// Get replica info
+	if db.Replica != nil {
+		replicaPos := db.Replica.Pos()
+		if !replicaPos.IsZero() {
+			status.ReplicaTXID = replicaPos.TXID.String()
+		}
+		status.ReplicaType = db.Replica.Client.Type()
+
+		// Calculate sync lag (local - replica)
+		if maxTXID > 0 && !replicaPos.IsZero() {
+			status.SyncLag = int64(maxTXID) - int64(replicaPos.TXID)
+		}
+	}
+
+	// Get last sync time
+	status.LastSyncAt = db.LastSuccessfulSyncAt()
+
+	// Get file sizes
+	if fi, err := os.Stat(db.Path()); err == nil {
+		status.DBSize = fi.Size()
+	}
+	if fi, err := os.Stat(db.WALPath()); err == nil {
+		status.WALSize = fi.Size()
+	}
+
+	return status
+}
+
+// StatusEvent represents a single NDJSON event sent to monitoring clients.
+type StatusEvent struct {
+	Type      string           `json:"type"` // "full" or "sync"
+	Timestamp time.Time        `json:"timestamp"`
+	Database  *DatabaseStatus  `json:"database,omitempty"`  // for "sync" events
+	Databases []DatabaseStatus `json:"databases,omitempty"` // for "full" events
+}
+
+// DatabaseStatus represents the replication status of a single database.
+type DatabaseStatus struct {
+	Path        string    `json:"path"`
+	Enabled     bool      `json:"enabled"`
+	LocalTXID   string    `json:"local_txid,omitempty"`
+	ReplicaTXID string    `json:"replica_txid,omitempty"`
+	LastSyncAt  time.Time `json:"last_sync_at,omitempty"`
+	Status      string    `json:"status"` // "ok", "syncing", "disabled", "error", "initializing"
+	SyncLag     int64     `json:"sync_lag,omitempty"`
+	ReplicaType string    `json:"replica_type,omitempty"`
+	DBSize      int64     `json:"db_size_bytes,omitempty"`
+	WALSize     int64     `json:"wal_size_bytes,omitempty"`
+}

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,268 @@
+package litestream_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal/testingutil"
+	"github.com/superfly/ltx"
+)
+
+func TestStatusMonitor_Subscribe(t *testing.T) {
+	t.Run("SubscribeAndUnsubscribe", func(t *testing.T) {
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore(nil, levels)
+		monitor := litestream.NewStatusMonitor(store)
+
+		ch := monitor.Subscribe()
+		if ch == nil {
+			t.Fatal("expected non-nil channel")
+		}
+
+		// Unsubscribe should close the channel
+		monitor.Unsubscribe(ch)
+
+		// Reading from closed channel should return ok=false
+		_, ok := <-ch
+		if ok {
+			t.Error("expected channel to be closed after Unsubscribe")
+		}
+	})
+
+	t.Run("MultipleSubscribers", func(t *testing.T) {
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore(nil, levels)
+		monitor := litestream.NewStatusMonitor(store)
+
+		ch1 := monitor.Subscribe()
+		ch2 := monitor.Subscribe()
+		ch3 := monitor.Subscribe()
+
+		if ch1 == ch2 || ch2 == ch3 || ch1 == ch3 {
+			t.Error("expected different channels for different subscribers")
+		}
+
+		monitor.Unsubscribe(ch1)
+		monitor.Unsubscribe(ch2)
+		monitor.Unsubscribe(ch3)
+	})
+}
+
+func TestStatusMonitor_NotifySync(t *testing.T) {
+	t.Run("BroadcastsToSubscribers", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore([]*litestream.DB{db}, levels)
+		store.CompactionMonitorEnabled = false
+
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close(t.Context())
+
+		monitor := litestream.NewStatusMonitor(store)
+
+		ch1 := monitor.Subscribe()
+		ch2 := monitor.Subscribe()
+		defer monitor.Unsubscribe(ch1)
+		defer monitor.Unsubscribe(ch2)
+
+		// Notify sync
+		pos := ltx.Pos{TXID: 42}
+		monitor.NotifySync(db, pos)
+
+		// Both subscribers should receive the event
+		select {
+		case event := <-ch1:
+			if event.Type != "sync" {
+				t.Errorf("expected type 'sync', got %q", event.Type)
+			}
+			if event.Database == nil {
+				t.Fatal("expected non-nil database in event")
+			}
+			if event.Database.ReplicaTXID != "000000000000002a" {
+				t.Errorf("expected replica_txid '000000000000002a', got %q", event.Database.ReplicaTXID)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for event on ch1")
+		}
+
+		select {
+		case event := <-ch2:
+			if event.Type != "sync" {
+				t.Errorf("expected type 'sync', got %q", event.Type)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for event on ch2")
+		}
+	})
+
+	t.Run("DropsEventsForSlowSubscribers", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore([]*litestream.DB{db}, levels)
+		store.CompactionMonitorEnabled = false
+
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close(t.Context())
+
+		monitor := litestream.NewStatusMonitor(store)
+
+		// Subscribe but don't read
+		ch := monitor.Subscribe()
+		defer monitor.Unsubscribe(ch)
+
+		// Send more events than the buffer size (64)
+		for i := 0; i < 100; i++ {
+			monitor.NotifySync(db, ltx.Pos{TXID: ltx.TXID(i)})
+		}
+
+		// Should not block - events should be dropped for slow subscriber
+		// This test passes if it doesn't hang
+	})
+}
+
+func TestStatusMonitor_GetFullStatus(t *testing.T) {
+	t.Run("EmptyStore", func(t *testing.T) {
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore(nil, levels)
+		monitor := litestream.NewStatusMonitor(store)
+
+		statuses := monitor.GetFullStatus()
+		if len(statuses) != 0 {
+			t.Errorf("expected empty statuses, got %d", len(statuses))
+		}
+	})
+
+	t.Run("WithDatabases", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore([]*litestream.DB{db}, levels)
+		store.CompactionMonitorEnabled = false
+
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close(t.Context())
+
+		monitor := litestream.NewStatusMonitor(store)
+
+		statuses := monitor.GetFullStatus()
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+
+		status := statuses[0]
+		if status.Path != db.Path() {
+			t.Errorf("expected path %q, got %q", db.Path(), status.Path)
+		}
+		if !status.Enabled {
+			t.Error("expected database to be enabled")
+		}
+	})
+
+	t.Run("WithSyncedDatabase", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		levels := litestream.CompactionLevels{{Level: 0}}
+		store := litestream.NewStore([]*litestream.DB{db}, levels)
+		store.CompactionMonitorEnabled = false
+
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close(t.Context())
+
+		// Create table and sync
+		if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		monitor := litestream.NewStatusMonitor(store)
+		statuses := monitor.GetFullStatus()
+
+		if len(statuses) != 1 {
+			t.Fatalf("expected 1 status, got %d", len(statuses))
+		}
+
+		status := statuses[0]
+		if status.Status != "ok" {
+			t.Errorf("expected status 'ok', got %q", status.Status)
+		}
+		if status.LocalTXID == "" {
+			t.Error("expected non-empty local_txid")
+		}
+		if status.ReplicaTXID == "" {
+			t.Error("expected non-empty replica_txid")
+		}
+		if status.ReplicaType != "file" {
+			t.Errorf("expected replica_type 'file', got %q", status.ReplicaType)
+		}
+	})
+}
+
+func TestStatusMonitor_ConcurrentAccess(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	levels := litestream.CompactionLevels{{Level: 0}}
+	store := litestream.NewStore([]*litestream.DB{db}, levels)
+	store.CompactionMonitorEnabled = false
+
+	if err := store.Open(t.Context()); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close(t.Context())
+
+	monitor := litestream.NewStatusMonitor(store)
+
+	var wg sync.WaitGroup
+
+	// Concurrent subscribers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch := monitor.Subscribe()
+			time.Sleep(10 * time.Millisecond)
+			monitor.Unsubscribe(ch)
+		}()
+	}
+
+	// Concurrent notifications
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(txid int) {
+			defer wg.Done()
+			monitor.NotifySync(db, ltx.Pos{TXID: ltx.TXID(txid)})
+		}(i)
+	}
+
+	// Concurrent status reads
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = monitor.GetFullStatus()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Add a monitoring endpoint to the unix socket server that streams replication status  when LTX files are uploaded. This enables real-time monitoring of replication progress.

Changes:
- Add OnSync callback to Replica that fires when LTX files are uploaded
- Add StatusMonitor for coordinating event streaming to subscribers
- Add GET /monitor endpoint to server with NDJSON streaming
- Add litestream monitor CLI command to consume the stream
- Add comprehensive tests for all new functionality

Usage:
  litestream monitor -socket /var/run/litestream.sock

