### PR TITLE
fix: correct LTXFiles seek filter to include spanning files

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -453,8 +453,10 @@ func (itr *ltxFileIterator) loadNextPage() bool {
 			Size:    *item.Properties.ContentLength,
 		}
 
-		// Skip if below seek TXID
-		if info.MinTXID < itr.seek {
+		// Skip if file ends before the seek TXID.
+		// Files that span across the seek point (minTXID < seek <= maxTXID)
+		// must be included because they contain TXIDs >= seek.
+		if info.MaxTXID < itr.seek {
 			continue
 		}
 

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -110,7 +110,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 		minTXID, maxTXID, err := ltx.ParseFilename(fi.Name())
 		if err != nil {
 			continue
-		} else if minTXID < seek {
+		} else if maxTXID < seek {
 			continue
 		}
 

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -306,8 +306,10 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 			continue
 		}
 
-		// Apply seek filter
-		if minTXID < seek {
+		// Skip if file ends before the seek TXID.
+		// Files that span across the seek point (minTXID < seek <= maxTXID)
+		// must be included because they contain TXIDs >= seek.
+		if maxTXID < seek {
 			continue
 		}
 

--- a/oss/replica_client.go
+++ b/oss/replica_client.go
@@ -574,8 +574,10 @@ func (itr *fileIterator) Next() bool {
 				MaxTXID: maxTXID,
 			}
 
-			// Skip if below seek TXID
-			if info.MinTXID < itr.seek {
+			// Skip if file ends before the seek TXID.
+			// Files that span across the seek point (minTXID < seek <= maxTXID)
+			// must be included because they contain TXIDs >= seek.
+			if info.MaxTXID < itr.seek {
 				continue
 			}
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -1255,8 +1255,10 @@ func (itr *fileIterator) Next() bool {
 				MaxTXID: maxTXID,
 			}
 
-			// Skip if below seek TXID
-			if info.MinTXID < itr.seek {
+			// Skip if file ends before the seek TXID.
+			// Files that span across the seek point (minTXID < seek <= maxTXID)
+			// must be included because they contain TXIDs >= seek.
+			if info.MaxTXID < itr.seek {
 				continue
 			}
 

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -243,7 +243,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 		minTXID, maxTXID, err := ltx.ParseFilename(path.Base(fi.Name()))
 		if err != nil {
 			continue
-		} else if minTXID < seek {
+		} else if maxTXID < seek {
 			continue
 		}
 

--- a/webdav/replica_client.go
+++ b/webdav/replica_client.go
@@ -153,7 +153,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 		minTXID, maxTXID, err := ltx.ParseFilename(path.Base(fi.Name()))
 		if err != nil {
 			continue
-		} else if minTXID < seek {
+		} else if maxTXID < seek {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Fixed a bug in `LTXFiles` iterator across all replica backends that caused compaction gaps
- The filter incorrectly used `minTXID < seek` instead of `maxTXID < seek`
- Files spanning across the seek point were being excluded, causing data loss during restore

## Problem

When a compacted file spans a large TXID range (e.g., `29b-2ac`), and a higher-level compaction seeks from a TXID within that range (e.g., `2aa`), the file was incorrectly filtered out because:

```
minTXID (29b) < seek (2aa)  →  file excluded (WRONG)
```

This caused TXIDs `2aa-2ac` to be missing from higher compaction levels, resulting in restore failures:

```
error="cannot calc restore plan: non-contiguous transaction files: prev=00000000000002a9 filename=00000000000002ad-00000000000002ae.ltx"
```

## Solution

Changed the filter condition from `minTXID < seek` to `maxTXID < seek`:

```
maxTXID (2ac) < seek (2aa)  →  false  →  file included (CORRECT)
```

## Files Changed

| Backend | File |
|---------|------|
| file | `file/replica_client.go` |
| s3 | `s3/replica_client.go` |
| abs | `abs/replica_client.go` |
| gs | `gs/replica_client.go` |
| oss | `oss/replica_client.go` |
| sftp | `sftp/replica_client.go` |
| webdav | `webdav/replica_client.go` |
| nats | `nats/replica_client.go` |

## Test plan

- [x] Added regression test `TestReplicaClient_LTX/SeekWithSpanningFile`
- [x] Verified test fails before fix, passes after
- [x] All existing `TestReplicaClient_*` tests pass
- [x] All `TestCompactor_*` tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)