### PR TITLE
fix(docs): remove outdated Slack and GitHub Discussions references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: ''
 ---
 
 <!--- Please provide as much detail as possible to help us reproduce and fix the issue -->
-<!--- For general questions, please use GitHub Discussions instead -->
 
 ## Bug Description
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Community Support
-    url: https://github.com/benbjohnson/litestream/discussions
-    about: Please ask and answer questions here
   - name: Documentation Issues
     url: https://github.com/benbjohnson/litestream.io/issues/new/choose
     about: Report documentation bugs or suggest improvements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,6 @@ We expect all contributors to:
 
 - **Documentation**: [litestream.io](https://litestream.io)
 - **Issues**: [GitHub Issues](https://github.com/benbjohnson/litestream/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/benbjohnson/litestream/discussions)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,13 @@ background process and safely replicates changes incrementally to another file
 or S3. Litestream only communicates with SQLite through the SQLite API so it
 will not corrupt your database.
 
-If you need support or have ideas for improving Litestream, please join the
-[Litestream Slack][slack] or visit the [GitHub Discussions](https://github.com/benbjohnson/litestream/discussions).
+If you need support or have ideas for improving Litestream, please visit
+[GitHub Issues](https://github.com/benbjohnson/litestream/issues).
 Please visit the [Litestream web site](https://litestream.io) for installation
 instructions and documentation.
 
 If you find this project interesting, please consider starring the project on
 GitHub.
-
-[slack]: https://join.slack.com/t/litestream/shared_invite/zt-n0j4s3ci-lx1JziR3bV6L2NMF723H3Q
 
 Contributing
 ------------

--- a/docs/REPLICA_CLIENT_GUIDE.md
+++ b/docs/REPLICA_CLIENT_GUIDE.md
@@ -760,4 +760,4 @@ Before submitting a new replica client:
 2. Check test files for expected behavior
 3. Run integration tests against your backend
 4. Use the mock client for rapid development
-5. Ask in GitHub discussions for design feedback
+5. Open a GitHub issue for design feedback


### PR DESCRIPTION
## Summary
- Replaced Slack and GitHub Discussions references with GitHub Issues in `README.md`
- Removed redundant Discussions link from `CONTRIBUTING.md` (Issues link already present)
- Removed Community Support contact link from `.github/ISSUE_TEMPLATE/config.yml`
- Removed "use Discussions" comment from `.github/ISSUE_TEMPLATE/bug_report.md`
- Updated `docs/REPLICA_CLIENT_GUIDE.md` to point to GitHub Issues

Fixes #1058

## Test plan
- [ ] Verify no remaining Slack/Discussions references: `rg -i "slack|discussions" --type md --type yaml`
- [ ] Verify `.github/ISSUE_TEMPLATE/config.yml` is valid YAML
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)