### PR TITLE
feat: add agent skill for cross-platform LLM agent support

### DIFF
--- a/skills/litestream/SKILL.md
+++ b/skills/litestream/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: litestream
+description: >-
+  Expert knowledge for contributing to Litestream, a standalone disaster recovery
+  tool for SQLite. Provides architectural understanding, code patterns, critical
+  rules, and debugging procedures for WAL monitoring, LTX replication format,
+  storage backend implementation, multi-level compaction, and SQLite page
+  management. Use when working with Litestream source code, writing storage
+  backends, debugging replication issues, implementing compaction logic, or
+  handling SQLite WAL operations.
+license: Apache-2.0
+metadata:
+  author: benbjohnson
+  version: "1.0"
+  repository: https://github.com/benbjohnson/litestream
+---
+
+# Litestream Agent Skill
+
+Litestream is a standalone disaster recovery tool for SQLite. It runs as a
+background process, monitors the SQLite WAL (Write-Ahead Log), converts changes
+to immutable LTX files, and replicates them to cloud storage. It uses
+`modernc.org/sqlite` (pure Go, no CGO required).
+
+## Quick Start
+
+```bash
+# Build
+go build -o bin/litestream ./cmd/litestream
+
+# Test (always use race detector)
+go test -race -v ./...
+
+# Code quality
+pre-commit run --all-files
+```
+
+## Critical Rules
+
+These invariants must never be violated:
+
+### 1. Lock Page at 1GB
+
+SQLite reserves a page at byte offset 0x40000000 (1 GB). Always skip it during
+replication and compaction. The page number varies by page size:
+
+| Page Size | Lock Page Number |
+|-----------|------------------|
+| 4 KB      | 262145           |
+| 8 KB      | 131073           |
+| 16 KB     | 65537            |
+| 32 KB     | 32769            |
+
+```go
+lockPgno := ltx.LockPgno(pageSize)
+if pgno == lockPgno {
+    continue
+}
+```
+
+### 2. LTX Files Are Immutable
+
+Once an LTX file is written, it must never be modified. New changes create new
+files. This guarantees point-in-time recovery integrity.
+
+### 3. Single Replica per Database
+
+Each database replicates to exactly one destination. The Replica component
+manages replication mechanics; database state belongs in the DB layer.
+
+### 4. Read Local Before Remote During Compaction
+
+Cloud storage is eventually consistent. Always read from local disk first:
+
+```go
+f, err := os.Open(db.LTXPath(info.Level, info.MinTXID, info.MaxTXID))
+if err == nil {
+    return f, nil // Use local copy
+}
+return replica.Client.OpenLTXFile(...) // Fall back to remote
+```
+
+### 5. Preserve Timestamps During Compaction
+
+Set the compacted file's `CreatedAt` to the earliest source file timestamp to
+maintain temporal granularity for point-in-time restoration.
+
+```go
+info.CreatedAt = oldestSourceFile.CreatedAt
+```
+
+### 6. Use Lock() Not RLock() for Writes
+
+```go
+// CORRECT
+r.mu.Lock()
+defer r.mu.Unlock()
+r.pos = pos
+
+// WRONG - race condition
+r.mu.RLock()
+defer r.mu.RUnlock()
+r.pos = pos
+```
+
+### 7. Atomic File Operations
+
+Always write to a temp file then rename. Never write directly to the final path.
+
+```go
+tmpFile, err := os.CreateTemp(dir, ".tmp-*")
+// ... write data, sync ...
+os.Rename(tmpFile.Name(), finalPath)
+```
+
+## Architecture
+
+### System Layers
+
+| Layer   | File(s)                  | Responsibility                            |
+|---------|--------------------------|-------------------------------------------|
+| App     | `cmd/litestream/`        | CLI commands, YAML/env config             |
+| Store   | `store.go`               | Multi-DB coordination, compaction         |
+| DB      | `db.go`                  | Single DB management, WAL monitoring      |
+| Replica | `replica.go`             | Replication to one destination            |
+| Storage | `*/replica_client.go`    | Backend implementations (S3, GCS, etc.)   |
+
+Database state logic belongs in the DB layer, not the Replica layer.
+
+### ReplicaClient Interface
+
+All storage backends implement this interface from `replica_client.go`:
+
+```go
+type ReplicaClient interface {
+    Type() string
+    Init(ctx context.Context) error
+    LTXFiles(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error)
+    OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error)
+    WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error)
+    DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) error
+    DeleteAll(ctx context.Context) error
+}
+```
+
+Key contract details:
+- `OpenLTXFile` must return `os.ErrNotExist` when file is missing
+- `WriteLTXFile` must set `CreatedAt` from backend metadata or upload time
+- `LTXFiles` with `useMetadata=true` fetches accurate timestamps (for PIT restore)
+- `LTXFiles` with `useMetadata=false` uses fast timestamps (normal operations)
+
+### Lock Ordering
+
+Always acquire locks in this order to prevent deadlocks:
+
+1. `Store.mu`
+2. `DB.mu`
+3. `DB.chkMu`
+4. `Replica.mu`
+
+### Core Components
+
+**DB** (`db.go`): Manages SQLite connection, WAL monitoring, checkpointing, and
+long-running read transaction for consistency. Key fields: `path`, `db`, `rtx`
+(read transaction), `pageSize`, `notify` channel.
+
+**Replica** (`replica.go`): Tracks replication position (`ltx.Pos` with TXID,
+PageNo, Checksum). One replica per database.
+
+**Store** (`store.go`): Coordinates multiple databases and schedules compaction
+across levels.
+
+## LTX File Format
+
+LTX (Log Transaction) files are immutable, checksummed archives of database
+changes. Structure:
+
+```
++------------------+
+|     Header       |  100 bytes (magic "LTX1", page size, TXID range, timestamp)
++------------------+
+|   Page Frames    |  4-byte pgno + pageSize bytes data, per page
++------------------+
+|   Page Index     |  Binary search index for page lookup
++------------------+
+|     Trailer      |  16 bytes (post-apply checksum, file checksum)
++------------------+
+```
+
+### Naming Convention
+
+```
+Format:  MMMMMMMMMMMMMMMM-NNNNNNNNNNNNNNNN.ltx
+Example: 0000000000000001-0000000000000064.ltx  (TXID 1-100)
+```
+
+### Compaction Levels
+
+```
+Level 0: /ltx/0000/  Raw LTX files (no compaction)
+Level 1: /ltx/0001/  Compacted periodically
+Level 2: /ltx/0002/  Compacted less frequently
+```
+
+Default compaction levels: L0 (raw), L1 (30s), L2 (5min), L3 (1h), plus daily
+snapshots. Compaction merges files by deduplicating pages (latest version wins)
+and always skips the lock page.
+
+## Code Patterns
+
+### DO
+
+- Return errors immediately; let callers decide handling
+- Use `fmt.Errorf("context: %w", err)` for error wrapping
+- Handle database state in the DB layer, not Replica
+- Use `db.verify()` to trigger snapshots (don't reimplement)
+- Test with race detector: `go test -race`
+- Use lazy iterators for `LTXFiles` (paginate, don't load all at once)
+
+### DON'T
+
+- Write data at the 1 GB lock page boundary
+- Modify LTX files after creation
+- Put database state logic in the Replica layer
+- Use `RLock()` when writing shared state
+- Write directly to final file paths (use temp + rename)
+- Ignore context cancellation in long operations
+- Return generic errors instead of `os.ErrNotExist` for missing files
+
+## Specialized Knowledge Areas
+
+Load reference files on demand based on the task:
+
+| Task                              | Reference File                          |
+|-----------------------------------|-----------------------------------------|
+| Understanding system design       | `references/ARCHITECTURE.md`            |
+| Writing or reviewing code         | `references/PATTERNS.md`                |
+| Working with LTX files            | `references/LTX_FORMAT.md`              |
+| WAL monitoring or page operations | `references/SQLITE_INTERNALS.md`        |
+| Implementing storage backends     | `references/REPLICA_CLIENT_GUIDE.md`    |
+| Writing or debugging tests        | `references/TESTING_GUIDE.md`           |
+
+## Common Debugging Procedures
+
+### Replication Not Working
+
+1. Verify WAL mode: `PRAGMA journal_mode` must return `wal`
+2. Check monitor interval and that the monitor goroutine is running
+3. Confirm `db.notify` channel is being signaled on WAL changes
+4. Check replica position: `replica.Pos()` should advance with writes
+5. Look for `os.ErrNotExist` from `OpenLTXFile` (file not replicated yet)
+
+### Large Database Issues (>1 GB)
+
+1. Verify lock page is being skipped: check `ltx.LockPgno(pageSize)`
+2. Test with multiple page sizes (4K, 8K, 16K, 32K)
+3. Run with databases both smaller and larger than 1 GB
+4. Ensure page iteration loops include the `continue` guard for lock page
+
+### Compaction Problems
+
+1. Confirm local L0 files exist before compaction reads them
+2. Check that `CreatedAt` timestamps are preserved (earliest source)
+3. Verify compaction level intervals in `Store.levels`
+4. Look for eventual consistency issues if reading from remote storage
+
+### Storage Backend Issues
+
+1. Return `os.ErrNotExist` for missing files (not generic errors)
+2. Support partial reads via `offset`/`size` in `OpenLTXFile`
+3. Handle context cancellation in all methods
+4. Test concurrent operations with `-race` flag
+5. For eventually consistent backends, add retry logic with backoff
+
+## Contribution Guidelines
+
+### What's Accepted
+
+- Bug fixes and patches (welcome)
+- Documentation improvements
+- Small code improvements and performance optimizations
+- Security vulnerability reports (report privately)
+
+### Discuss First
+
+- Feature requests: open an issue before implementing
+- Large changes: discuss approach in an issue first
+
+### Pre-Submit Checklist
+
+- [ ] Read relevant docs from the reference table above
+- [ ] Follow patterns in `references/PATTERNS.md`
+- [ ] Run `go test -race -v ./...`
+- [ ] Run `pre-commit run --all-files`
+- [ ] For page iteration: test with >1 GB databases
+- [ ] Show investigation evidence in PR (see CONTRIBUTING.md)
+
+## Testing
+
+```bash
+# Full test suite with race detection
+go test -race -v ./...
+
+# Specific areas
+go test -race -v -run TestReplica_Sync ./...
+go test -race -v -run TestDB_Sync ./...
+go test -race -v -run TestStore_CompactDB ./...
+
+# Coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+```
+
+Key testing areas:
+- Lock page handling with >1 GB databases and multiple page sizes
+- Race conditions in position updates, WAL monitoring, and checkpointing
+- Eventual consistency in storage backend operations
+- Atomic file operations and cleanup on error paths
+
+## Environment Validation
+
+Run `scripts/validate-setup.sh` to verify your development environment is
+correctly configured for Litestream development.

--- a/skills/litestream/references/ARCHITECTURE.md
+++ b/skills/litestream/references/ARCHITECTURE.md
@@ -1,0 +1,164 @@
+# Litestream Architecture Reference
+
+Condensed architectural reference for agents working on Litestream.
+
+## System Layers
+
+```
+Application Layer    cmd/litestream/       CLI commands, YAML/env config
+Core Layer           store.go              Multi-DB coordination, compaction scheduling
+                     db.go                 Single DB management, WAL monitoring, checkpoints
+                     replica.go            Replication to single destination, position tracking
+Storage Abstraction  replica_client.go     ReplicaClient interface
+Storage Backends     s3/, gs/, abs/,       Backend-specific implementations
+                     oss/, file/, sftp/,
+                     nats/, webdav/
+```
+
+Database state logic belongs in the DB layer. The Replica layer handles
+replication mechanics only.
+
+## Core Components
+
+### DB (db.go)
+
+The heart of Litestream. Manages a single SQLite database.
+
+Key fields:
+- `path` / `metaPath`: Database and metadata paths
+- `db *sql.DB`: SQLite connection (via modernc.org/sqlite, pure Go)
+- `f *os.File`: Long-running file descriptor
+- `rtx *sql.Tx`: Long-running read transaction (prevents checkpoint past read point)
+- `pageSize int`: Database page size (critical for lock page calculation)
+- `mu sync.RWMutex`: Protects struct fields
+- `chkMu sync.RWMutex`: Checkpoint coordination lock
+- `notify chan struct{}`: WAL change notifications
+
+Key methods:
+- `Open()` / `Close()`: Lifecycle management
+- `monitor()`: Background WAL monitoring loop
+- `checkWAL()`: Detect WAL changes by comparing size/checksum
+- `Checkpoint(mode)`: Run SQLite checkpoint (PASSIVE, FULL, TRUNCATE)
+- `autoCheckpoint()`: Threshold-based checkpoint decisions
+- `Sync()`: Synchronize pending changes to replicas
+- `Compact()`: Merge LTX files at a given level
+
+Configuration:
+- `MinCheckpointPageN`: Minimum pages for passive checkpoint
+- `TruncatePageN`: Emergency truncate checkpoint threshold
+- `CheckpointInterval`: Time-based passive checkpoint interval
+- `MonitorInterval`: WAL monitoring frequency
+- Note: RESTART checkpoint mode permanently removed (issue #724)
+
+### Replica (replica.go)
+
+Manages replication to a single destination.
+
+Key fields:
+- `db *DB`: Parent database
+- `Client ReplicaClient`: Storage backend
+- `pos ltx.Pos`: Current replication position (TXID + PageNo + Checksum)
+- `mu sync.RWMutex`: Protects position
+
+Position tracking: `SetPos()` MUST use `Lock()` not `RLock()`.
+
+### Store (store.go)
+
+Coordinates multiple databases and manages compaction.
+
+Key fields:
+- `dbs []*DB`: Managed databases
+- `levels CompactionLevels`: Compaction level configuration
+
+Default compaction levels: L0 (raw), L1 (30s), L2 (5min), L3 (1h),
+plus daily snapshots.
+
+## WAL Monitoring
+
+The monitor loop in `db.go` runs on a ticker:
+
+1. `checkWAL()` compares current WAL size/checksum to previous state
+2. If changed, notify replicas via `notifyReplicas()`
+3. Check if checkpoint needed via `shouldCheckpoint()`
+4. Run `autoCheckpoint()` if thresholds are met
+
+Checkpoint strategy:
+- WAL pages > `TruncatePageN` → TRUNCATE checkpoint (emergency)
+- WAL pages > `MinCheckpointPageN` → PASSIVE checkpoint
+- `CheckpointInterval` elapsed → PASSIVE checkpoint
+
+## Compaction Algorithm
+
+High-level flow (in `store.go`):
+
+1. Determine if level is due for compaction (`shouldCompact`)
+2. Enumerate level L-1 files via `ReplicaClient.LTXFiles`
+3. Prefer local copies (`os.Open(db.LTXPath(...))`) over remote reads
+4. Stream through `ltx.NewCompactor` (page deduplication, lock page skipping)
+5. Write merged file via `ReplicaClient.WriteLTXFile` for level L
+6. Set `CreatedAt` to earliest source file timestamp
+7. Update cached max file info; delete old L0 files when promoting to L1
+
+## State Management
+
+### Database States
+
+Closed → Opening → Open → Monitoring ↔ Syncing/Checkpointing → Closing → Closed
+
+### Replica States
+
+Idle → Starting → Monitoring ↔ Syncing/Uploading → Stopping → Idle
+
+Error states retry with exponential backoff (1s initial, 1min max).
+
+## Initialization Flow
+
+1. `Store.Open()` iterates databases
+2. For each DB: open SQLite connection → read page size → create metadata dir →
+   start long-running read transaction → initialize replicas → start monitor
+3. For each Replica: create with client → load previous position from metadata →
+   validate against database → start sync goroutine
+4. Store starts compaction monitors
+
+## Error Handling
+
+### Error Categories
+
+- **Recoverable**: Network timeouts, temporary storage unavailability, lock contention
+- **Fatal**: Database corruption, invalid configuration, disk full
+- **Operational**: Checkpoint failures, compaction conflicts, sync delays
+
+### Error Propagation
+
+```
+ReplicaClient.WriteLTXFile() error
+    → Replica.Sync() error
+        → DB.Sync() error
+            → Store.monitorDB() // logs error, continues
+```
+
+## Lock Ordering
+
+Always acquire in this order to prevent deadlocks:
+
+1. `Store.mu`
+2. `DB.mu`
+3. `DB.chkMu`
+4. `Replica.mu`
+
+## Goroutine Management
+
+- Use `sync.WaitGroup` for lifecycle tracking
+- Signal shutdown via `context.Cancel()`
+- Wait with timeout in `Close()` methods
+- Every goroutine must have a `defer wg.Done()`
+
+## Performance Characteristics
+
+| Operation    | Time       | Space          |
+|-------------|------------|----------------|
+| WAL Monitor | O(1)       | O(1) + metrics |
+| Page Write  | O(1)       | Original DB + WAL |
+| Compaction  | O(n pages) | Temporary during merge |
+| Restoration | O(n·log m) | n=pages, m=files |
+| File List   | O(k files) | Per-level |

--- a/skills/litestream/references/LTX_FORMAT.md
+++ b/skills/litestream/references/LTX_FORMAT.md
@@ -1,0 +1,191 @@
+# LTX Format Reference
+
+Condensed reference for agents working with Litestream's LTX file format.
+
+## Overview
+
+LTX (Log Transaction) is Litestream's custom format for storing database changes.
+LTX files are:
+- **Immutable**: Once written, never modified
+- **Self-contained**: Each file is independent
+- **Indexed**: Contains page index for efficient seeks
+- **Checksummed**: CRC-64 ECMA integrity verification
+
+## File Structure
+
+```
++---------------------+
+|      Header         |  100 bytes
++---------------------+
+|    Page Frames      |  Variable (4-byte pgno + pageSize data per page)
++---------------------+
+|    Page Index       |  Binary search index
++---------------------+
+|      Trailer        |  16 bytes
++---------------------+
+
+FileSize = HeaderSize + (PageCount * (4 + PageSize)) + PageIndexSize + TrailerSize
+```
+
+## Header (100 bytes)
+
+```
+Offset  Size  Field
+0       4     Magic ("LTX1")
+4       4     Flags (bit 1 = NoChecksum)
+8       4     PageSize
+12      4     Commit (page count after applying)
+16      8     MinTXID
+24      8     MaxTXID
+32      8     Timestamp (ms since Unix epoch)
+40      8     PreApplyChecksum
+48      8     WALOffset (0 for snapshots)
+56      8     WALSize (0 for snapshots)
+64      4     WALSalt1
+68      4     WALSalt2
+72      8     NodeID
+80     20     Reserved (zeros)
+```
+
+The version is implied by the magic string. `"LTX1"` → `ltx.Version == 2`.
+
+## Page Frames
+
+Each frame contains one database page:
+
+```
+Offset  Size      Field
+0       4         Page Number (1-based)
+4       PageSize  Page Data
+```
+
+Constraints:
+- Pages written in sequential order during creation
+- Lock page at 1 GB boundary is never included
+- In compacted files, only the latest version of each page
+
+## Page Index
+
+Binary search index for efficient random access to pages. Use
+`ltx.DecodePageIndex()` to parse into a map of page number to
+`ltx.PageIndexElem`:
+
+```go
+type PageIndexElem struct {
+    Level   int
+    MinTXID TXID
+    MaxTXID TXID
+    Offset  int64  // Byte offset of encoded payload
+    Size    int64  // Bytes occupied by encoded payload
+}
+```
+
+## Trailer (16 bytes)
+
+```
+Offset  Size  Field
+0       8     PostApplyChecksum (database checksum after applying file)
+8       8     FileChecksum (CRC-64 of entire file)
+```
+
+The trailer is always at the end of the file. Read it by seeking
+`-TrailerSize` from `io.SeekEnd`.
+
+## File Naming Convention
+
+```
+Format:  MMMMMMMMMMMMMMMM-NNNNNNNNNNNNNNNN.ltx
+         MinTXID (16 hex)  MaxTXID (16 hex)
+
+Example: 0000000000000001-0000000000000064.ltx  (TXID 1-100)
+         0000000000000065-00000000000000c8.ltx  (TXID 101-200)
+```
+
+Parse with `ltx.ParseFilename()`, format with `ltx.FormatFilename()`.
+
+## Compaction Levels
+
+LTX files are organized in levels for efficient storage:
+
+```
+Level 0: /ltx/0000/  Raw LTX files (no compaction)
+Level 1: /ltx/0001/  Compacted (default: every 30s)
+Level 2: /ltx/0002/  Compacted (default: every 5min)
+Level 3: /ltx/0003/  Compacted (default: every 1h)
+Snapshots:           Full database state (daily)
+```
+
+### Compaction Process
+
+1. Enumerate level L-1 files
+2. Build page map (newer pages overwrite older)
+3. Write merged file skipping lock page
+4. Preserve earliest `CreatedAt` from source files
+5. Delete old L0 files when promoting to L1
+
+```go
+// Page deduplication: latest version wins
+for _, file := range files {
+    for _, page := range file.Pages {
+        pageMap[page.Number] = page
+    }
+}
+```
+
+## Checksums
+
+LTX uses CRC-64 ECMA checksums (`hash/crc64` with `crc64.ECMA` table):
+
+- **PreApplyChecksum**: Database state before applying this file
+- **PostApplyChecksum**: Database state after applying this file
+- **FileChecksum**: Integrity of the entire LTX file
+
+## Reading LTX Files
+
+```go
+dec := ltx.NewDecoder(reader)
+header, err := dec.Header()
+for {
+    var hdr ltx.PageHeader
+    data := make([]byte, header.PageSize)
+    if err := dec.DecodePage(&hdr, data); err == io.EOF {
+        break
+    }
+    // Process hdr.Pgno and data
+}
+trailer := dec.Trailer()
+```
+
+## Writing LTX Files
+
+```go
+enc := ltx.NewEncoder(writer)
+enc.EncodeHeader(header)
+for _, page := range pages {
+    if page.Number == ltx.LockPgno(pageSize) {
+        continue // Skip lock page
+    }
+    enc.EncodePage(pageHeader, pageData)
+}
+enc.EncodePageIndex(index)
+enc.EncodeTrailer()
+enc.Close()
+```
+
+## CLI Inspection
+
+```bash
+litestream ltx /path/to/db.sqlite
+litestream ltx s3://bucket/db
+```
+
+For low-level inspection, use the Go API with `ltx.NewDecoder`.
+
+## WAL to LTX Conversion
+
+SQLite WAL frames are converted to LTX format during replication:
+1. Read WAL frames from the WAL file
+2. Skip the lock page
+3. Add checksums and build page index
+4. Write as immutable LTX file
+5. Upload to storage backend

--- a/skills/litestream/references/PATTERNS.md
+++ b/skills/litestream/references/PATTERNS.md
@@ -1,0 +1,204 @@
+# Litestream Code Patterns Reference
+
+Condensed code patterns and anti-patterns for agents writing Litestream code.
+
+## Architectural Boundaries
+
+```
+DB Layer (db.go)           → Database state, restoration, monitoring
+Replica Layer (replica.go) → Replication mechanics only
+Storage Layer              → ReplicaClient implementations
+```
+
+### DO: Handle database state in DB layer
+
+```go
+func (db *DB) init() error {
+    if db.needsRestore() {
+        if err := db.restore(); err != nil {
+            return err
+        }
+    }
+    return db.replica.Start() // Replica focuses only on replication
+}
+```
+
+### DON'T: Put database state logic in Replica layer
+
+```go
+// WRONG
+func (r *Replica) Start() error {
+    if needsRestore() {  // Wrong layer!
+        restoreDatabase()
+    }
+}
+```
+
+## Atomic File Operations
+
+### DO: Write to temp file, then rename
+
+```go
+func writeFileAtomic(path string, data []byte) error {
+    dir := filepath.Dir(path)
+    tmpFile, err := os.CreateTemp(dir, ".tmp-*")
+    if err != nil {
+        return fmt.Errorf("create temp file: %w", err)
+    }
+    tmpPath := tmpFile.Name()
+
+    defer func() {
+        if tmpFile != nil {
+            tmpFile.Close()
+            os.Remove(tmpPath)
+        }
+    }()
+
+    if _, err := tmpFile.Write(data); err != nil {
+        return fmt.Errorf("write temp file: %w", err)
+    }
+    if err := tmpFile.Sync(); err != nil {
+        return fmt.Errorf("sync temp file: %w", err)
+    }
+    if err := tmpFile.Close(); err != nil {
+        return fmt.Errorf("close temp file: %w", err)
+    }
+    tmpFile = nil
+
+    if err := os.Rename(tmpPath, path); err != nil {
+        os.Remove(tmpPath)
+        return fmt.Errorf("rename to final path: %w", err)
+    }
+    return nil
+}
+```
+
+### DON'T: Write directly to final location
+
+```go
+// WRONG - Can leave partial files on failure
+os.WriteFile(path, data, 0644)
+```
+
+## Error Handling
+
+### DO: Return errors immediately
+
+```go
+func (db *DB) validatePosition() error {
+    dpos, err := db.Pos()
+    if err != nil {
+        return err
+    }
+    rpos := replica.Pos()
+    if dpos.TXID < rpos.TXID {
+        return fmt.Errorf("database position (%v) behind replica (%v)", dpos, rpos)
+    }
+    return nil
+}
+```
+
+### DON'T: Log and continue on critical errors
+
+```go
+// WRONG
+if err := processFile(file); err != nil {
+    log.Printf("error: %v", err) // Just logging!
+    // Continuing is dangerous
+}
+```
+
+### DO: Return errors from loops
+
+```go
+func (db *DB) processFiles() error {
+    for _, file := range files {
+        if err := processFile(file); err != nil {
+            return fmt.Errorf("process file %s: %w", file, err)
+        }
+    }
+    return nil
+}
+```
+
+## Locking Patterns
+
+### DO: Use Lock() for writes
+
+```go
+r.mu.Lock()
+defer r.mu.Unlock()
+r.pos = pos
+```
+
+### DON'T: Use RLock for write operations
+
+```go
+// WRONG - Race condition
+r.mu.RLock()
+defer r.mu.RUnlock()
+r.pos = pos // Writing with RLock!
+```
+
+### Lock Ordering
+
+Always acquire in order: Store.mu → DB.mu → DB.chkMu → Replica.mu
+
+## Compaction Patterns
+
+### DO: Read from local when available
+
+```go
+f, err := os.Open(db.LTXPath(info.Level, info.MinTXID, info.MaxTXID))
+if err == nil {
+    return f, nil // Local copy is complete and consistent
+}
+return replica.Client.OpenLTXFile(...) // Fall back to remote
+```
+
+### DON'T: Read from remote during compaction
+
+```go
+// WRONG - Can get partial/corrupt data from eventually consistent storage
+f, err := client.OpenLTXFile(ctx, level, minTXID, maxTXID, 0, 0)
+```
+
+### DO: Preserve earliest timestamp
+
+```go
+info.CreatedAt = oldestSourceFile.CreatedAt
+```
+
+### DON'T: Use current time during compaction
+
+```go
+// WRONG - Loses timestamp granularity for point-in-time restores
+info := &ltx.FileInfo{CreatedAt: time.Now()}
+```
+
+## Lock Page Handling
+
+The lock page at 1 GB (0x40000000) must always be skipped:
+
+```go
+lockPgno := ltx.LockPgno(pageSize)
+if pgno == lockPgno {
+    continue
+}
+```
+
+| Page Size | Lock Page Number |
+|-----------|------------------|
+| 4 KB      | 262145           |
+| 8 KB      | 131073           |
+| 16 KB     | 65537            |
+| 32 KB     | 32769            |
+
+## Common Pitfalls
+
+1. **Mixing architectural concerns**: DB state logic in Replica layer
+2. **Recreating existing functionality**: Use `db.verify()` for snapshots
+3. **Ignoring lock page**: Must skip during replication and compaction
+4. **Generic error types**: Return `os.ErrNotExist` for missing files
+5. **Blocking iterators**: Use lazy pagination for `LTXFiles`
+6. **Ignoring context**: Check `ctx.Done()` in long operations

--- a/skills/litestream/references/REPLICA_CLIENT_GUIDE.md
+++ b/skills/litestream/references/REPLICA_CLIENT_GUIDE.md
@@ -1,0 +1,238 @@
+# ReplicaClient Implementation Reference
+
+Condensed reference for agents implementing or modifying Litestream storage backends.
+
+## Interface Contract
+
+From `replica_client.go`:
+
+```go
+type ReplicaClient interface {
+    Type() string
+    Init(ctx context.Context) error
+    LTXFiles(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error)
+    OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error)
+    WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error)
+    DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) error
+    DeleteAll(ctx context.Context) error
+}
+```
+
+### Method Contracts
+
+**Type()**: Return identifier string (e.g., "s3", "gcs", "file").
+
+**Init()**: Initialize connection. Must be idempotent (no-op if already initialized).
+
+**LTXFiles()**: Return iterator sorted by MinTXID. `seek` starts from given TXID.
+`useMetadata=true` fetches accurate timestamps (required for point-in-time restore).
+`useMetadata=false` uses fast timestamps for normal operations.
+
+**OpenLTXFile()**: Open file for reading. Must support partial reads via `offset`/`size`.
+Return `os.ErrNotExist` if file is missing.
+
+**WriteLTXFile()**: Write file to storage. Set `CreatedAt` from backend
+metadata or upload time.
+
+**DeleteLTXFiles()**: Delete one or more files. Batch if possible.
+
+**DeleteAll()**: Delete all files for this database.
+
+## Implementation Checklist
+
+### Required
+
+- [ ] All interface methods implemented
+- [ ] `Init()` is idempotent
+- [ ] Partial reads supported (`offset`/`size` in `OpenLTXFile`)
+- [ ] `os.ErrNotExist` returned for missing files
+- [ ] Context cancellation handled in all methods
+- [ ] `CreatedAt` timestamps preserved in `WriteLTXFile`
+- [ ] Concurrent operations supported
+- [ ] Proper cleanup in `DeleteAll`
+
+### Optional
+
+- [ ] Connection pooling
+- [ ] Retry logic with exponential backoff
+- [ ] Request batching for deletes
+- [ ] Compression / encryption at rest
+- [ ] Bandwidth throttling
+
+## Eventual Consistency
+
+Many cloud backends (S3, R2, etc.) are eventually consistent:
+- Recently written files may not be immediately visible
+- Listed files may be only partially readable
+- Deletes may not take effect immediately
+
+### Pattern: Read Local First
+
+During compaction, always prefer local files:
+
+```go
+f, err := os.Open(db.LTXPath(info.Level, info.MinTXID, info.MaxTXID))
+if err == nil {
+    return f, nil
+}
+return replica.Client.OpenLTXFile(...)
+```
+
+### Pattern: Retry with Backoff
+
+```go
+backoff := 100 * time.Millisecond
+for i := 0; i < 5; i++ {
+    reader, err := c.openFile(ctx, path, offset, size)
+    if err == nil {
+        return reader, nil
+    }
+    if errors.Is(err, os.ErrNotExist) {
+        return nil, err // Don't retry definitive errors
+    }
+    select {
+    case <-ctx.Done():
+        return nil, ctx.Err()
+    case <-time.After(backoff):
+        backoff *= 2
+    }
+}
+```
+
+### Pattern: Lazy Iterator
+
+```go
+func (c *Client) LTXFiles(...) (ltx.FileIterator, error) {
+    return &lazyIterator{
+        client:   c,
+        level:    level,
+        seek:     seek,
+        pageSize: 1000, // Paginate, don't load all at once
+    }, nil
+}
+```
+
+## Error Handling
+
+### Standard Error Types
+
+```go
+// File not found
+return nil, os.ErrNotExist
+
+// Permission denied
+return nil, os.ErrPermission
+
+// Context cancelled
+return nil, ctx.Err()
+
+// Wrapped errors
+return nil, fmt.Errorf("s3 download failed: %w", err)
+```
+
+### Retryable Error Classification
+
+```go
+func isRetryable(err error) bool {
+    var netErr net.Error
+    if errors.As(err, &netErr) && netErr.Temporary() {
+        return true
+    }
+    // HTTP 429, 500, 502, 503, 504
+    if errors.Is(err, context.DeadlineExceeded) {
+        return true
+    }
+    return false
+}
+```
+
+## Common Mistakes
+
+### 1. Not Handling Partial Reads
+
+```go
+// WRONG - Ignores offset/size
+return c.storage.Download(path)
+
+// CORRECT
+if offset == 0 && size == 0 {
+    return c.storage.Download(path)
+}
+return c.storage.DownloadRange(path, offset, offset+size-1)
+```
+
+### 2. Not Preserving CreatedAt
+
+```go
+// WRONG
+return &ltx.FileInfo{CreatedAt: time.Now()}
+
+// CORRECT - Use backend metadata
+return &ltx.FileInfo{CreatedAt: modTime}
+```
+
+### 3. Wrong Error Types
+
+```go
+// WRONG
+return nil, fmt.Errorf("not found")
+
+// CORRECT
+if resp.StatusCode == 404 {
+    return nil, os.ErrNotExist
+}
+```
+
+### 4. Ignoring Context
+
+```go
+// WRONG - Could run forever
+for i := 0; i < 1000000; i++ {
+    doWork()
+}
+
+// CORRECT
+select {
+case <-ctx.Done():
+    return nil, ctx.Err()
+default:
+}
+```
+
+### 5. Loading All Files at Once
+
+```go
+// WRONG - Could be millions of files
+allFiles, _ := c.loadAllFiles(level)
+
+// CORRECT - Lazy pagination
+return &lazyIterator{pageSize: 1000}, nil
+```
+
+## Path Construction
+
+```go
+func (c *Client) ltxDir(level int) string {
+    if level == SnapshotLevel {
+        return path.Join(c.Path, "snapshots")
+    }
+    return path.Join(c.Path, "ltx", fmt.Sprintf("%04d", level))
+}
+```
+
+## Reference Implementations
+
+- **Simplest**: `file/replica_client.go` (direct file I/O, no network)
+- **Most complete**: `s3/replica_client.go` (multipart uploads, retries, signing)
+
+Start with the file backend for understanding, then study S3 for advanced
+patterns.
+
+## Testing Requirements
+
+- Unit tests with >80% coverage
+- Integration tests with build tag
+- Test partial reads, concurrent operations, missing files
+- Run with `-race` flag
+- Verify `os.ErrNotExist` for missing files
+- Test context cancellation

--- a/skills/litestream/references/SQLITE_INTERNALS.md
+++ b/skills/litestream/references/SQLITE_INTERNALS.md
@@ -1,0 +1,186 @@
+# SQLite Internals Reference
+
+Condensed reference for agents working with SQLite internals in Litestream.
+
+## SQLite File Structure
+
+```
+database.db       Main database file (pages)
+database.db-wal   Write-ahead log
+database.db-shm   Shared memory file (coordination)
+```
+
+## Write-Ahead Log (WAL)
+
+WAL is SQLite's method for atomic commits:
+- Changes written to WAL first, database unchanged until checkpoint
+- Readers merge WAL + database for consistent view
+- Litestream monitors WAL and converts frames to LTX format
+
+### WAL File Structure
+
+```
++------------------+
+| WAL Header       |  32 bytes
++------------------+
+| Frame 1 Header   |  24 bytes
+| Frame 1 Data     |  PageSize bytes
++------------------+
+| Frame 2 Header   |  24 bytes
+| Frame 2 Data     |  PageSize bytes
++------------------+
+| ...              |
+```
+
+### WAL Header (32 bytes)
+
+```
+Magic (4B) | FileFormat (4B) | PageSize (4B) | Checkpoint (4B) |
+Salt1 (4B) | Salt2 (4B) | Checksum1 (4B) | Checksum2 (4B)
+```
+
+Magic: `0x377f0682` or `0x377f0683`
+
+### WAL Frame Header (24 bytes)
+
+```
+PageNumber (4B) | DbSize (4B) | Salt1 (4B) | Salt2 (4B) |
+Checksum1 (4B) | Checksum2 (4B)
+```
+
+## The 1 GB Lock Page
+
+SQLite reserves a page at exactly 0x40000000 bytes (1 GB) for locking. This is
+the single most important SQLite detail for Litestream development.
+
+```go
+const PENDING_BYTE = 0x40000000
+
+func LockPgno(pageSize int) uint32 {
+    return uint32(PENDING_BYTE/pageSize) + 1
+}
+```
+
+| Page Size | Lock Page Number |
+|-----------|------------------|
+| 4 KB      | 262145           |
+| 8 KB      | 131073           |
+| 16 KB     | 65537            |
+| 32 KB     | 32769            |
+| 64 KB     | 16385            |
+
+Rules:
+- Cannot contain data; SQLite never writes user data here
+- Must be skipped during replication and compaction
+- Only affects databases > 1 GB
+- Page number changes with page size
+
+Implementation in Litestream:
+
+```go
+for pgno := uint32(1); pgno <= maxPgno; pgno++ {
+    if pgno == ltx.LockPgno(db.pageSize) {
+        continue
+    }
+    processPage(pgno)
+}
+```
+
+## Page Structure
+
+SQLite divides databases into fixed-size pages (typically 4096 bytes):
+- Page numbers are 1-based
+- Types: B-tree interior, B-tree leaf, overflow, freelist, lock byte page
+
+## Transaction Types
+
+1. **Deferred** (default): Lock acquired on first use
+2. **Immediate**: RESERVED lock acquired immediately
+3. **Exclusive**: EXCLUSIVE lock acquired immediately
+
+### Lock Hierarchy
+
+UNLOCKED → SHARED → RESERVED → PENDING → EXCLUSIVE
+
+- SHARED: Multiple readers allowed
+- RESERVED: Signals intent to write
+- PENDING: Blocks new SHARED locks
+- EXCLUSIVE: Single writer, no readers
+
+## Long-Running Read Transaction
+
+Litestream maintains a read transaction for consistency:
+
+```go
+func (db *DB) initReadTx() error {
+    tx, err := db.db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+    if err != nil {
+        return err
+    }
+    var dummy string
+    err = tx.QueryRow("SELECT ''").Scan(&dummy)
+    if err != nil {
+        tx.Rollback()
+        return err
+    }
+    db.rtx = tx
+    return nil
+}
+```
+
+Purpose:
+- Prevents checkpoint past our read point
+- Ensures consistent database view
+- Allows reading historical pages from WAL
+
+## Checkpoint Modes
+
+| Mode     | Behavior                                      |
+|----------|-----------------------------------------------|
+| PASSIVE  | Non-blocking; fails if readers present         |
+| FULL     | Waits for readers; blocks new readers          |
+| RESTART  | Like FULL + resets WAL start (removed in #724) |
+| TRUNCATE | Like RESTART + truncates WAL to zero           |
+
+### Litestream Checkpoint Strategy
+
+```
+WAL pages > TruncatePageN    → TRUNCATE (emergency)
+WAL pages > MinCheckpointPageN → PASSIVE
+CheckpointInterval elapsed    → PASSIVE
+```
+
+Note: RESTART mode permanently removed due to issue #724 (write-blocking).
+
+## Important SQLite Pragmas
+
+```sql
+PRAGMA journal_mode = WAL;         -- Required for Litestream
+PRAGMA page_size;                  -- Get page size
+PRAGMA page_count;                 -- Total pages in database
+PRAGMA freelist_count;             -- Free pages
+PRAGMA wal_checkpoint(PASSIVE);    -- Non-blocking checkpoint
+PRAGMA wal_autocheckpoint = 10000; -- High threshold (prevent interference)
+PRAGMA busy_timeout = 5000;        -- Wait 5s for locks
+PRAGMA synchronous = NORMAL;       -- Safe with WAL
+PRAGMA cache_size = -64000;        -- 64 MB cache
+PRAGMA integrity_check;            -- Verify database integrity
+```
+
+## Critical SQLite Behaviors
+
+1. **Automatic checkpoint**: Default at 1000 WAL pages; set high threshold to
+   prevent interference with Litestream's control
+2. **Busy timeout**: Default is 0 (immediate failure); set a reasonable timeout
+3. **Synchronous mode**: NORMAL is safe with WAL mode
+4. **Page cache**: In-memory cache; configure with negative KB or positive pages
+
+## WAL to LTX Conversion
+
+Litestream converts WAL frames to LTX:
+
+1. Read WAL header and validate magic number
+2. Iterate frames, reading page number and data
+3. Skip lock page (`pgno == LockPgno(pageSize)`)
+4. Calculate checksums
+5. Write as immutable LTX file with page index

--- a/skills/litestream/references/TESTING_GUIDE.md
+++ b/skills/litestream/references/TESTING_GUIDE.md
@@ -1,0 +1,188 @@
+# Litestream Testing Reference
+
+Condensed reference for agents writing and debugging Litestream tests.
+
+## Testing Philosophy
+
+1. Test at multiple levels: unit, integration, end-to-end
+2. Focus on edge cases: >1 GB databases, eventual consistency
+3. Use real SQLite: avoid mocking SQLite behavior
+4. Always run with `-race` flag
+5. Use fixed seeds and timestamps for deterministic tests
+
+## Essential Commands
+
+```bash
+# Full test suite with race detection
+go test -race -v ./...
+
+# Specific test areas
+go test -race -v -run TestReplica_Sync ./...
+go test -race -v -run TestDB_Sync ./...
+go test -race -v -run TestStore_CompactDB ./...
+
+# Coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+go tool cover -func=coverage.out | grep total
+
+# Integration tests (backend-specific)
+go test -v ./replica_client_test.go -integration s3
+go test -v ./replica_client_test.go -integration gcs
+```
+
+## Lock Page Testing
+
+The lock page at 1 GB must be skipped. Test with databases spanning this
+boundary using multiple page sizes:
+
+```bash
+./bin/litestream-test populate -db test.db -page-size 4096 -target-size 2GB
+./bin/litestream-test validate -source-db test.db -replica-url file:///tmp/replica
+```
+
+Test all page size variants:
+
+| Page Size | Lock Page | Test Target |
+|-----------|-----------|-------------|
+| 4 KB      | 262145    | >1.0 GB     |
+| 8 KB      | 131073    | >1.0 GB     |
+| 16 KB     | 65537     | >1.0 GB     |
+| 32 KB     | 32769     | >1.0 GB     |
+
+Verify lock page is not present in any LTX file after replication.
+
+## Race Condition Testing
+
+Race-prone areas (always run with `-race`):
+
+1. **Position updates**: Concurrent `SetPos()` + `Pos()` on Replica
+2. **WAL monitoring**: Concurrent writes + monitor + checkpoint
+3. **Compaction**: Concurrent compaction at different levels
+
+### Pattern: Concurrent Test
+
+```go
+func TestConcurrent(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+
+    var wg sync.WaitGroup
+    // Start writer, monitor, checkpoint goroutines
+    // Use ctx for shutdown, wg for cleanup
+    wg.Wait()
+}
+```
+
+## Common Test Failures
+
+### 1. Database Locked
+
+```go
+// WRONG - WAL mode not enabled
+db, _ := sql.Open("sqlite", "test.db")
+
+// CORRECT
+db, _ := sql.Open("sqlite", "test.db?_journal=WAL")
+```
+
+### 2. Timing Issues
+
+```go
+// WRONG - Data may not be replicated yet
+WriteData(db)
+result := ReadReplica()
+
+// CORRECT - Explicit sync
+WriteData(db)
+db.Sync(context.Background())
+result := ReadReplica()
+```
+
+### 3. Goroutine Leaks
+
+```go
+// WRONG - Goroutine outlives test
+go func() {
+    time.Sleep(10 * time.Second)
+    doWork()
+}()
+
+// CORRECT - Use context + WaitGroup
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+var wg sync.WaitGroup
+wg.Add(1)
+go func() {
+    defer wg.Done()
+    select {
+    case <-ctx.Done():
+        return
+    case <-time.After(10 * time.Second):
+        doWork()
+    }
+}()
+cancel()
+wg.Wait()
+```
+
+### 4. File Handle Leaks
+
+```go
+// Always use defer for cleanup
+f, err := os.Open("test.db")
+require.NoError(t, err)
+defer f.Close()
+```
+
+## Test Helper Patterns
+
+```go
+func NewTestDB(t testing.TB) *litestream.DB {
+    t.Helper()
+    path := filepath.Join(t.TempDir(), "test.db")
+    conn, err := sql.Open("sqlite", path+"?_journal=WAL")
+    require.NoError(t, err)
+    _, err = conn.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, data BLOB)")
+    require.NoError(t, err)
+    conn.Close()
+
+    db := litestream.NewDB(path)
+    db.MonitorInterval = 10 * time.Millisecond
+    db.MinCheckpointPageN = 100
+    err = db.Open()
+    require.NoError(t, err)
+    t.Cleanup(func() { db.Close(context.Background()) })
+    return db
+}
+```
+
+## Coverage Requirements
+
+| Package            | Target |
+|--------------------|--------|
+| Core (db, replica) | >80%   |
+| Replica clients    | >70%   |
+| Utilities          | >60%   |
+
+## Table-Driven Tests
+
+```go
+func TestCheckpoint(t *testing.T) {
+    tests := []struct {
+        name    string
+        mode    string
+        wantErr bool
+    }{
+        {"Passive", "PASSIVE", false},
+        {"Full", "FULL", false},
+        {"Truncate", "TRUNCATE", false},
+        {"Invalid", "INVALID", true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // ...
+        })
+    }
+}
+```

--- a/skills/litestream/scripts/validate-setup.sh
+++ b/skills/litestream/scripts/validate-setup.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# validate-setup.sh - Verify Litestream development environment
+# POSIX-compatible script for validating build tools and project health.
+
+set -e
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf "  [PASS] %s\n" "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf "  [FAIL] %s\n" "$1"
+}
+
+warn() {
+    WARN=$((WARN + 1))
+    printf "  [WARN] %s\n" "$1"
+}
+
+printf "Litestream Development Environment Validation\n"
+printf "==============================================\n\n"
+
+# Check Go installation
+printf "Checking Go...\n"
+if command -v go >/dev/null 2>&1; then
+    GO_VERSION=$(go version | sed 's/.*go\([0-9]*\.[0-9]*\).*/\1/')
+    GO_MAJOR=$(echo "$GO_VERSION" | cut -d. -f1)
+    GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f2)
+    if [ "$GO_MAJOR" -ge 1 ] && [ "$GO_MINOR" -ge 24 ]; then
+        pass "Go $(go version | sed 's/.*go/go/' | cut -d' ' -f1) installed (>= 1.24 required)"
+    else
+        fail "Go $GO_VERSION found but >= 1.24 required"
+    fi
+else
+    fail "Go not found in PATH"
+fi
+
+# Check project builds
+printf "\nChecking build...\n"
+if go build -o /dev/null ./cmd/litestream 2>/dev/null; then
+    pass "Project builds successfully"
+else
+    fail "Project build failed (go build -o /dev/null ./cmd/litestream)"
+fi
+
+# Check go vet
+printf "\nChecking go vet...\n"
+if go vet ./... 2>/dev/null; then
+    pass "go vet passes"
+else
+    fail "go vet reports issues (run: go vet ./...)"
+fi
+
+# Quick smoke test (run a fast subset of tests)
+printf "\nChecking tests (smoke test)...\n"
+if go test -race -short -count=1 ./... >/dev/null 2>&1; then
+    pass "Tests pass with race detector (-short mode)"
+else
+    # Try without race detector in case of environment issues
+    if go test -short -count=1 ./... >/dev/null 2>&1; then
+        warn "Tests pass but race detector may not be supported on this platform"
+    else
+        fail "Tests failing (run: go test -race -short ./...)"
+    fi
+fi
+
+# Check pre-commit (optional)
+printf "\nChecking optional tools...\n"
+if command -v pre-commit >/dev/null 2>&1; then
+    pass "pre-commit installed"
+else
+    warn "pre-commit not found (optional; install: pip install pre-commit)"
+fi
+
+# Check git
+if command -v git >/dev/null 2>&1; then
+    pass "git installed"
+else
+    fail "git not found in PATH"
+fi
+
+# Summary
+printf "\n==============================================\n"
+printf "Results: %d passed, %d failed, %d warnings\n" "$PASS" "$FAIL" "$WARN"
+
+if [ "$FAIL" -gt 0 ]; then
+    printf "\nEnvironment has issues that must be resolved.\n"
+    exit 1
+else
+    printf "\nEnvironment is ready for Litestream development.\n"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- Add an Agent Skill following the [agentskills.io](https://agentskills.io) open standard, giving LLM agents across 20+ platforms expert-level Litestream knowledge
- Main `SKILL.md` provides progressive disclosure: critical rules, architecture, code patterns, and debugging procedures in 307 body lines (under 500 limit)
- 6 condensed reference files cover architecture, code patterns, LTX format, SQLite internals, replica client implementation, and testing
- Includes `validate-setup.sh` POSIX-compatible script for environment validation

### Files Created

```
skills/litestream/
├── SKILL.md                          # Main skill entry point (323 lines total)
├── references/
│   ├── ARCHITECTURE.md               # System layers, components, state management
│   ├── PATTERNS.md                   # DO/DON'T code patterns
│   ├── LTX_FORMAT.md                 # File structure, naming, compaction levels
│   ├── SQLITE_INTERNALS.md           # WAL, lock page, checkpoints, pragmas
│   ├── REPLICA_CLIENT_GUIDE.md       # Interface contract, implementation checklist
│   └── TESTING_GUIDE.md              # Test commands, race detection, common failures
└── scripts/
    └── validate-setup.sh             # Development environment validation
```

### Compliance Verification

- `name` field (`litestream`) matches directory name
- Description: 486 chars (< 1024 limit)
- SKILL.md body: 307 lines (< 500 limit)
- All paths use forward slashes
- References are one level deep (no nested references)
- All 7 critical rules documented
- ReplicaClient interface defined
- Lock page table included

Closes #1052

## Test plan

- [x] Verify directory structure: `ls -R skills/litestream/`
- [x] Verify line counts: SKILL.md body < 500 lines, references 150-250 each
- [x] Verify description < 1024 chars
- [x] Verify project still builds: `go build -o /dev/null ./cmd/litestream`
- [x] Verify validate-setup.sh runs: `bash skills/litestream/scripts/validate-setup.sh`
- [x] Verify all 7 critical rules present in SKILL.md
- [x] Verify no nested references (reference files don't link to other references)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
