### PR TITLE
feat: add pprof endpoints to IPC server

### DIFF
--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"sync"
 	"time"
@@ -66,6 +67,13 @@ func NewServer(store *Store) *Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /start", s.handleStart)
 	mux.HandleFunc("POST /stop", s.handleStop)
+
+	// pprof endpoints
+	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+	mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 
 	s.httpServer = &http.Server{Handler: mux}
 


### PR DESCRIPTION
## Summary
- Adds standard pprof endpoints to the Unix socket IPC server
- Allows profiling without needing to run the HTTP server

## Usage
```bash
# CPU profile
curl --unix-socket /var/run/litestream.sock http://localhost/debug/pprof/profile > cpu.pprof

# Heap profile
curl --unix-socket /var/run/litestream.sock http://localhost/debug/pprof/heap > mem.pprof
```

## Test plan
- [x] Build and run litestream with socket enabled
- [x] Verify pprof endpoints respond via Unix socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)