### PR TITLE
feat: add $PID environment variable for config expansion

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -13,6 +13,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -511,7 +512,12 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 
 	// Expand environment variables, if enabled.
 	if expandEnv {
-		buf = []byte(os.ExpandEnv(string(buf)))
+		buf = []byte(os.Expand(string(buf), func(key string) string {
+			if key == "PID" {
+				return strconv.Itoa(os.Getpid())
+			}
+			return os.Getenv(key)
+		}))
 	}
 
 	// Save defaults before unmarshaling


### PR DESCRIPTION
## Summary
- Adds `$PID` as an automatically-set environment variable during config parsing
- Allows users to reference the Litestream process ID in config files
- Useful for creating unique replica paths when running multiple instances

## Test plan
- [x] Verify `$PID` expands to actual process ID in config paths
- [x] Verify existing env var expansion still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)