### PR TITLE
Preserve compaction timestamps for PITR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 )
 
+replace github.com/superfly/ltx => ./third_party/ltx
+
 require (
 	cloud.google.com/go v0.111.0 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/replica.go
+++ b/replica.go
@@ -449,7 +449,7 @@ func (r *Replica) CreatedAt(ctx context.Context) (time.Time, error) {
 // Returns zero time if no LTX files exist.
 func (r *Replica) TimeBounds(ctx context.Context) (createdAt, updatedAt time.Time, err error) {
 	for level := SnapshotLevel; level >= 0; level-- {
-		itr, err := r.Client.LTXFiles(ctx, level, 0, false)
+		itr, err := r.Client.LTXFiles(ctx, level, 0, true)
 		if err != nil {
 			return createdAt, updatedAt, err
 		}

--- a/third_party/ltx/Dockerfile
+++ b/third_party/ltx/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /src/ltx
+COPY . .
+
+ARG LTX_VERSION=
+ARG LTX_COMMIT=
+
+RUN go build -ldflags "-s -w -X 'main.Version=${LTX_VERSION}' -X 'main.Commit=${LTX_COMMIT}' -extldflags '-static'" -o /usr/local/bin/ltx ./cmd/ltx
+
+
+FROM scratch
+COPY --from=builder /usr/local/bin/ltx /usr/local/bin/ltx
+ENTRYPOINT ["/usr/local/bin/ltx"]
+CMD []

--- a/third_party/ltx/LICENSE
+++ b/third_party/ltx/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/ltx/README.md
+++ b/third_party/ltx/README.md
@@ -1,0 +1,61 @@
+Lite Transaction File (LTX)
+=================================
+
+The LTX file format provides a way to store SQLite transactional data in
+a way that can be encrypted and compacted and is optimized for performance.
+
+## File Format
+
+An LTX file is composed of several sections:
+
+1. Header
+2. Page block
+3. Trailer
+
+The header contains metadata about the file, the page block contains page
+frames, and the trailer contains checksums of the file and the database end state.
+
+
+#### Header
+
+The header provides information about the number of page frames as well as
+database information such as the page size and database size. LTX files
+can be compacted together so each file contains the transaction ID (TXID) range
+that it represents. A timestamp provides users with a rough approximation of
+the time the transaction occurred and the checksum provides a basic integrity
+check.
+
+| Offset | Size | Description                             |
+| -------| ---- | --------------------------------------- |
+| 0      | 4    | Magic number. Always "LTX1".            |
+| 4      | 4    | Flags. Reserved. Always 0.              |
+| 8      | 4    | Page size, in bytes.                    |
+| 12     | 4    | Size of DB after transaction, in pages. |
+| 16     | 4    | Database ID.                            |
+| 20     | 8    | Minimum transaction ID.                 |
+| 28     | 8    | Maximum transaction ID.                 |
+| 36     | 8    | Timestamp (Milliseconds since epoch)    |
+| 44     | 8    | Pre-apply DB checksum (CRC-ISO-64)      |
+| 52     | 48   | Reserved.                               |
+
+
+#### Page block
+
+This block stores a series of page headers and page data.
+
+| Offset | Size | Description                 |
+| -------| ---- | --------------------------- |
+| 0      | 4    | Page number.                |
+| 4      | N    | Page data.                  |
+
+
+#### Trailer
+
+The trailer provides checksum for the LTX file data, a rolling checksum of the
+database state after the LTX file is applied, and the checksum of the trailer
+itself.
+
+| Offset | Size | Description                             |
+| -------| ---- | --------------------------------------- |
+| 0      | 8    | Post-apply DB checksum (CRC-ISO-64)     |
+| 8      | 8    | File checksum (CRC-ISO-64)              |

--- a/third_party/ltx/checksum.go
+++ b/third_party/ltx/checksum.go
@@ -1,0 +1,179 @@
+package ltx
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"hash/crc64"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// Checksum represents an LTX checksum.
+type Checksum uint64
+
+// ChecksumPages updates the provided checksums slice with the checksum of each
+// page in the specified file. The first (by page number) error encountered is
+// returned along with the number of the last page successfully checksummed.
+// Checksums for subsequent pages may be updated, regardless of an error being
+// returned.
+//
+// nWorkers specifies the amount of parallelism to use. A reasonable default
+// will be used if nWorkers is 0.
+func ChecksumPages(dbPath string, pageSize, nPages, nWorkers uint32, checksums []Checksum) (uint32, error) {
+	// Based on experimentation on a fly.io machine with a slow SSD, 512Mb is
+	// where checksumming starts to take >1s. As the database size increases, we
+	// get more benefit from an increasing number of workers. Doing a bunch of
+	// benchmarking on fly.io machines of difference sizes with a 1Gb database,
+	// 24 threads seems to be the sweet spot.
+	if nWorkers == 0 && pageSize*nPages > 512*1024*1024 {
+		nWorkers = 24
+	}
+
+	if nWorkers <= 1 {
+		return checksumPagesSerial(dbPath, 1, nPages, int64(pageSize), checksums)
+	}
+
+	perWorker := nPages / nWorkers
+	if nPages%nWorkers != 0 {
+		perWorker++
+	}
+
+	var (
+		wg   sync.WaitGroup
+		rets = make([]uint32, nWorkers)
+		errs = make([]error, nWorkers)
+	)
+
+	for w := uint32(0); w < nWorkers; w++ {
+		w := w
+		firstPage := w*perWorker + 1
+		lastPage := firstPage + perWorker - 1
+		if lastPage > nPages {
+			lastPage = nPages
+		}
+
+		wg.Add(1)
+		go func() {
+			rets[w], errs[w] = checksumPagesSerial(dbPath, firstPage, lastPage, int64(pageSize), checksums)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			return rets[i], err
+		}
+	}
+
+	return nPages, nil
+}
+
+func checksumPagesSerial(dbPath string, firstPage, lastPage uint32, pageSize int64, checksums []Checksum) (uint32, error) {
+	f, err := os.Open(dbPath)
+	if err != nil {
+		return firstPage - 1, err
+	}
+
+	_, err = f.Seek(int64(firstPage-1)*pageSize, io.SeekStart)
+	if err != nil {
+		return firstPage - 1, err
+	}
+
+	buf := make([]byte, pageSize+4)
+	h := NewHasher()
+
+	for pageNo := firstPage; pageNo <= lastPage; pageNo++ {
+		binary.BigEndian.PutUint32(buf, pageNo)
+
+		if _, err := io.ReadFull(f, buf[4:]); err != nil {
+			return pageNo - 1, err
+		}
+
+		h.Reset()
+		_, _ = h.Write(buf)
+		checksums[pageNo-1] = ChecksumFlag | Checksum(h.Sum64())
+	}
+
+	return lastPage, nil
+}
+
+// ChecksumPage returns a CRC64 checksum that combines the page number & page data.
+func ChecksumPage(pgno uint32, data []byte) Checksum {
+	return ChecksumPageWithHasher(NewHasher(), pgno, data)
+}
+
+// ChecksumPageWithHasher returns a CRC64 checksum that combines the page number & page data.
+func ChecksumPageWithHasher(h hash.Hash64, pgno uint32, data []byte) Checksum {
+	h.Reset()
+	_ = binary.Write(h, binary.BigEndian, pgno)
+	_, _ = h.Write(data)
+	return ChecksumFlag | Checksum(h.Sum64())
+}
+
+// ChecksumReader reads an entire database file from r and computes its rolling checksum.
+func ChecksumReader(r io.Reader, pageSize int) (Checksum, error) {
+	data := make([]byte, pageSize)
+
+	var chksum Checksum
+	for pgno := uint32(1); ; pgno++ {
+		if _, err := io.ReadFull(r, data); err == io.EOF {
+			break
+		} else if err != nil {
+			return chksum, err
+		}
+		chksum = ChecksumFlag | (chksum ^ ChecksumPage(pgno, data))
+	}
+	return chksum, nil
+}
+
+// ParseChecksum parses a 16-character hex string into a checksum.
+func ParseChecksum(s string) (Checksum, error) {
+	if len(s) != 16 {
+		return 0, fmt.Errorf("invalid formatted checksum length: %q", s)
+	}
+	v, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid checksum format: %q", s)
+	}
+	return Checksum(v), nil
+}
+
+// String returns c formatted as a fixed-width hex number.
+func (c Checksum) String() string {
+	return fmt.Sprintf("%016x", uint64(c))
+}
+
+func (c Checksum) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + c.String() + `"`), nil
+}
+
+func (c *Checksum) UnmarshalJSON(data []byte) (err error) {
+	var s *string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("cannot unmarshal checksum from JSON value")
+	}
+
+	// Set to zero if value is nil.
+	if s == nil {
+		*c = 0
+		return nil
+	}
+
+	chksum, err := ParseChecksum(*s)
+	if err != nil {
+		return fmt.Errorf("cannot parse checksum from JSON string: %q", *s)
+	}
+	*c = Checksum(chksum)
+
+	return nil
+}
+
+// NewHasher returns a new CRC64-ISO hasher.
+func NewHasher() hash.Hash64 {
+	return crc64.New(crc64.MakeTable(crc64.ISO))
+}

--- a/third_party/ltx/cmd/ltx/apply.go
+++ b/third_party/ltx/cmd/ltx/apply.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/superfly/ltx"
+)
+
+// ApplyCommand represents a command to apply a series of LTX files to a database file.
+type ApplyCommand struct{}
+
+// NewApplyCommand returns a new instance of ApplyCommand.
+func NewApplyCommand() *ApplyCommand {
+	return &ApplyCommand{}
+}
+
+// Run executes the command.
+func (c *ApplyCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-apply", flag.ContinueOnError)
+	dbPath := fs.String("db", "", "database path")
+	fs.Usage = func() {
+		fmt.Println(`
+The apply command applies one or more LTX files to a database file.
+
+Usage:
+
+	ltx apply [arguments] PATH [PATH...]
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		fs.Usage()
+		return flag.ErrHelp
+	} else if *dbPath == "" {
+		return fmt.Errorf("required: -db PATH")
+	}
+
+	// Open database file. Create if it doesn't exist.
+	dbFile, err := os.OpenFile(*dbPath, os.O_RDWR|os.O_CREATE, 0o666)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dbFile.Close() }()
+
+	// Apply LTX files in order.
+	for _, filename := range fs.Args() {
+		if err := c.applyLTXFile(ctx, dbFile, filename); err != nil {
+			return fmt.Errorf("%s: %s", filename, err)
+		}
+	}
+
+	// Sync and close resulting database file.
+	if err := dbFile.Sync(); err != nil {
+		return err
+	}
+	return dbFile.Close()
+}
+
+func (c *ApplyCommand) applyLTXFile(_ context.Context, dbFile *os.File, filename string) error {
+	ltxFile, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ltxFile.Close() }()
+
+	// Read LTX header and verify initial checksum matches.
+	dec := ltx.NewDecoder(ltxFile)
+	if err := dec.DecodeHeader(); err != nil {
+		return fmt.Errorf("decode ltx header: %w", err)
+	}
+
+	// Read checksum before applying.
+	if _, err := dbFile.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	preApplyChecksum, err := ltx.ChecksumReader(dbFile, int(dec.Header().PageSize))
+	if err != nil {
+		return fmt.Errorf("compute pre-apply checksum: %w", err)
+	} else if preApplyChecksum != dec.Header().PreApplyChecksum {
+		return fmt.Errorf("pre-apply checksum mismatch: %s <> %s", preApplyChecksum, dec.Header().PreApplyChecksum)
+	}
+
+	// Apply each page to the database.
+	data := make([]byte, dec.Header().PageSize)
+	for {
+		var pageHeader ltx.PageHeader
+		if err := dec.DecodePage(&pageHeader, data); err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("decode ltx page: %w", err)
+		}
+
+		offset := int64(pageHeader.Pgno-1) * int64(dec.Header().PageSize)
+		if _, err := dbFile.WriteAt(data, offset); err != nil {
+			return fmt.Errorf("write database page: %w", err)
+		}
+	}
+
+	// Close & verify file, print trailer.
+	if err := dec.Close(); err != nil {
+		return fmt.Errorf("close ltx file: %w", err)
+	}
+
+	// Recalculate database checksum and ensure it matches the LTX checksum.
+	if _, err := dbFile.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	postApplyChecksum, err := ltx.ChecksumReader(dbFile, int(dec.Header().PageSize))
+	if err != nil {
+		return fmt.Errorf("compute post-apply checksum: %w", err)
+	} else if postApplyChecksum != dec.Trailer().PostApplyChecksum {
+		return fmt.Errorf("post-apply checksum mismatch: %s <> %s", postApplyChecksum, dec.Trailer().PostApplyChecksum)
+	}
+
+	return nil
+}

--- a/third_party/ltx/cmd/ltx/checksum.go
+++ b/third_party/ltx/cmd/ltx/checksum.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/superfly/ltx"
+)
+
+// ChecksumCommand represents a command to compute the LTX checksum of a database file.
+type ChecksumCommand struct{}
+
+// NewChecksumCommand returns a new instance of ChecksumCommand.
+func NewChecksumCommand() *ChecksumCommand {
+	return &ChecksumCommand{}
+}
+
+// Run executes the command.
+func (c *ChecksumCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-checksum", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Println(`
+The checksum command computes the LTX checksum for a database file.
+
+Usage:
+
+	ltx checksum PATH
+`[1:],
+		)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		fs.Usage()
+		return flag.ErrHelp
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	f, err := os.Open(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Read database header to determine page size.
+	buf := make([]byte, 100)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return err
+	}
+	pageSize := int(binary.BigEndian.Uint16(buf[16:18]))
+	if pageSize == 1 {
+		pageSize = 65536
+	}
+
+	// Reseek to beginning and compute checksum.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	chksum, err := ltx.ChecksumReader(f, pageSize)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(chksum)
+	return nil
+}

--- a/third_party/ltx/cmd/ltx/dump.go
+++ b/third_party/ltx/cmd/ltx/dump.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/superfly/ltx"
+)
+
+// DumpCommand represents a command to print the contents of a single LTX file.
+type DumpCommand struct{}
+
+// NewDumpCommand returns a new instance of DumpCommand.
+func NewDumpCommand() *DumpCommand {
+	return &DumpCommand{}
+}
+
+// Run executes the command.
+func (c *DumpCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-dump", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Println(`
+The dump command writes out all data for a single LTX file.
+
+Usage:
+
+	ltx dump [arguments] PATH
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return fmt.Errorf("filename required")
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	f, err := os.Open(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	dec := ltx.NewDecoder(f)
+
+	// Read & print header information.
+	err = dec.DecodeHeader()
+	hdr := dec.Header()
+	fmt.Printf("# HEADER\n")
+	fmt.Printf("Version:   %d\n", hdr.Version)
+	fmt.Printf("Flags:     0x%08x\n", hdr.Flags)
+	fmt.Printf("Page size: %d\n", hdr.PageSize)
+	fmt.Printf("Commit:    %d\n", hdr.Commit)
+	fmt.Printf("Min TXID:  %s (%d)\n", hdr.MinTXID.String(), hdr.MinTXID)
+	fmt.Printf("Max TXID:  %s (%d)\n", hdr.MaxTXID.String(), hdr.MaxTXID)
+	fmt.Printf("Timestamp: %s (%d)\n", time.UnixMilli(int64(hdr.Timestamp)).UTC().Format(time.RFC3339Nano), hdr.Timestamp)
+	fmt.Printf("Pre-apply: %s\n", hdr.PreApplyChecksum)
+	fmt.Printf("WAL offset: %d\n", hdr.WALOffset)
+	fmt.Printf("WAL size:   %d\n", hdr.WALSize)
+	fmt.Printf("WAL salt:   %08x %08x\n", hdr.WALSalt1, hdr.WALSalt2)
+	fmt.Printf("\n")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("# PAGE DATA\n")
+	for i := 0; ; i++ {
+		var pageHeader ltx.PageHeader
+		data := make([]byte, hdr.PageSize)
+		if err := dec.DecodePage(&pageHeader, data); err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("decode page frame %d: %w", i, err)
+		}
+
+		fmt.Printf("Frame #%d: pgno=%d\n", i, pageHeader.Pgno)
+	}
+	fmt.Printf("\n")
+
+	// Close & verify file, print trailer.
+	err = dec.Close()
+	trailer := dec.Trailer()
+
+	fmt.Printf("# TRAILER\n")
+	fmt.Printf("Post-apply:    %s\n", trailer.PostApplyChecksum)
+	fmt.Printf("File Checksum: %s\n", trailer.FileChecksum)
+	fmt.Printf("\n")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/third_party/ltx/cmd/ltx/encode_db.go
+++ b/third_party/ltx/cmd/ltx/encode_db.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/superfly/ltx"
+)
+
+const (
+	SQLITE_DATABASE_HEADER_STRING = "SQLite format 3\x00"
+	SQLITE_DATABASE_HEADER_SIZE   = 100
+)
+
+// EncodeDBCommand represents a command to encode an SQLite database file as a single LTX file.
+type EncodeDBCommand struct{}
+
+// NewEncodeDBCommand returns a new instance of EncodeDBCommand.
+func NewEncodeDBCommand() *EncodeDBCommand {
+	return &EncodeDBCommand{}
+}
+
+// Run executes the command.
+func (c *EncodeDBCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-encode-db", flag.ContinueOnError)
+	outPath := fs.String("o", "", "output path")
+	fs.Usage = func() {
+		fmt.Println(`
+The encode-db command encodes an SQLite database into an LTX file.
+
+Usage:
+
+	ltx encode-db [arguments] PATH
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return fmt.Errorf("filename required")
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	} else if *outPath == "" {
+		return fmt.Errorf("required: -o PATH")
+	}
+
+	db, err := os.Open(fs.Arg(0))
+	if err != nil {
+		return fmt.Errorf("open DB file: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	out, err := os.OpenFile(*outPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open output file: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	rd, hdr, err := c.readSQLiteDatabaseHeader(db)
+	if err != nil {
+		return fmt.Errorf("read database header: %w", err)
+	}
+
+	var flags uint32
+	var postApplyChecksum ltx.Checksum
+	enc, err := ltx.NewEncoder(out)
+	if err != nil {
+		return fmt.Errorf("create ltx encoder: %w", err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:   1,
+		Flags:     flags,
+		PageSize:  hdr.pageSize,
+		Commit:    hdr.pageN,
+		MinTXID:   ltx.TXID(1),
+		MaxTXID:   ltx.TXID(1),
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		return fmt.Errorf("encode ltx header: %w", err)
+	}
+
+	buf := make([]byte, hdr.pageSize)
+	for pgno := uint32(1); pgno <= hdr.pageN; pgno++ {
+		if _, err := io.ReadFull(rd, buf); err != nil {
+			return fmt.Errorf("read page %d: %w", pgno, err)
+		}
+
+		if pgno == ltx.LockPgno(hdr.pageSize) {
+			continue
+		}
+
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, buf); err != nil {
+			return fmt.Errorf("encode page %d: %w", pgno, err)
+		}
+
+		postApplyChecksum = ltx.ChecksumFlag | (postApplyChecksum ^ ltx.ChecksumPage(pgno, buf))
+	}
+
+	enc.SetPostApplyChecksum(postApplyChecksum)
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("close ltx encoder: %w", err)
+	} else if err := out.Sync(); err != nil {
+		return fmt.Errorf("sync ltx file: %w", err)
+	} else if err := out.Close(); err != nil {
+		return fmt.Errorf("close ltx file: %w", err)
+	}
+
+	return nil
+}
+
+type sqliteDatabaseHeader struct {
+	pageSize uint32
+	pageN    uint32
+}
+
+func (c *EncodeDBCommand) readSQLiteDatabaseHeader(rd io.Reader) (ord io.Reader, hdr sqliteDatabaseHeader, err error) {
+	b := make([]byte, SQLITE_DATABASE_HEADER_SIZE)
+	if _, err := io.ReadFull(rd, b); err == io.ErrUnexpectedEOF {
+		return ord, hdr, fmt.Errorf("invalid database header")
+	} else if err == io.EOF {
+		return ord, hdr, fmt.Errorf("empty database")
+	} else if err != nil {
+		return ord, hdr, err
+	} else if !bytes.Equal(b[:len(SQLITE_DATABASE_HEADER_STRING)], []byte(SQLITE_DATABASE_HEADER_STRING)) {
+		return ord, hdr, fmt.Errorf("invalid database header")
+	}
+
+	hdr.pageSize = uint32(binary.BigEndian.Uint16(b[16:]))
+	hdr.pageN = binary.BigEndian.Uint32(b[28:])
+	if hdr.pageSize == 1 {
+		hdr.pageSize = 65536
+	}
+
+	ord = io.MultiReader(bytes.NewReader(b), rd)
+
+	return ord, hdr, nil
+}

--- a/third_party/ltx/cmd/ltx/list.go
+++ b/third_party/ltx/cmd/ltx/list.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superfly/ltx"
+)
+
+// ListCommand represents a command to print the header/trailer of one or more
+// LTX files in a table.
+type ListCommand struct{}
+
+// NewListCommand returns a new instance of ListCommand.
+func NewListCommand() *ListCommand {
+	return &ListCommand{}
+}
+
+// Run executes the command.
+func (c *ListCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-list", flag.ContinueOnError)
+	tsv := fs.Bool("tsv", false, "output as tab-separated values")
+	fs.Usage = func() {
+		fmt.Println(`
+The list command lists header & trailer information for a set of LTX files.
+
+Usage:
+
+	ltx list [arguments] PATH [PATH...]
+
+Arguments:
+`[1:])
+		fs.PrintDefaults()
+		fmt.Println()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return fmt.Errorf("at least one LTX file is required")
+	}
+
+	var w io.Writer = os.Stdout
+	if !*tsv {
+		tw := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+		defer func() { _ = tw.Flush() }()
+		w = tw
+	}
+
+	_, _ = fmt.Fprintln(w, "min_txid\tmax_txid\tcommit\tpages\tpreapply\tpostapply\ttimestamp\twal_offset\twal_size\twal_salt")
+	for _, arg := range fs.Args() {
+		if err := c.printFile(w, arg); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%s: %s\n", arg, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *ListCommand) printFile(w io.Writer, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.Verify(); err != nil {
+		return err
+	}
+
+	// Only show timestamp if it is actually set.
+	timestamp := time.UnixMilli(dec.Header().Timestamp).UTC().Format(time.RFC3339)
+	if dec.Header().Timestamp == 0 {
+		timestamp = ""
+	}
+
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\t%s\t%d\t%d\t%08x %08x\n",
+		dec.Header().MinTXID.String(),
+		dec.Header().MaxTXID.String(),
+		dec.Header().Commit,
+		dec.PageN(),
+		dec.Header().PreApplyChecksum,
+		dec.Trailer().PostApplyChecksum,
+		timestamp,
+		dec.Header().WALOffset,
+		dec.Header().WALSize,
+		dec.Header().WALSalt1, dec.Header().WALSalt2,
+	)
+
+	return nil
+}

--- a/third_party/ltx/cmd/ltx/main.go
+++ b/third_party/ltx/cmd/ltx/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Build information.
+var (
+	Version = ""
+	Commit  = ""
+)
+
+func main() {
+	m := NewMain()
+	if err := m.Run(context.Background(), os.Args[1:]); err == flag.ErrHelp {
+		os.Exit(1)
+	} else if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// Main represents the main program execution.
+type Main struct{}
+
+// NewMain returns a new instance of Main.
+func NewMain() *Main {
+	return &Main{}
+}
+
+// Run executes the program.
+func (m *Main) Run(ctx context.Context, args []string) (err error) {
+	// Extract command name.
+	var cmd string
+	if len(args) > 0 {
+		cmd, args = args[0], args[1:]
+	}
+
+	switch cmd {
+	case "apply":
+		return NewApplyCommand().Run(ctx, args)
+	case "checksum":
+		return NewChecksumCommand().Run(ctx, args)
+	case "dump":
+		return NewDumpCommand().Run(ctx, args)
+	case "encode-db":
+		return NewEncodeDBCommand().Run(ctx, args)
+	case "list":
+		return NewListCommand().Run(ctx, args)
+	case "verify":
+		return NewVerifyCommand().Run(ctx, args)
+	case "version":
+		if Version != "" {
+			fmt.Printf("ltx %s, commit=%s\n", Version, Commit)
+		} else if Commit != "" {
+			fmt.Printf("ltx commit=%s\n", Commit)
+		} else {
+			fmt.Println("ltx development build")
+		}
+		return nil
+	default:
+		if cmd == "" || cmd == "help" || strings.HasPrefix(cmd, "-") {
+			m.Usage()
+			return flag.ErrHelp
+		}
+		return fmt.Errorf("ltx %s: unknown command", cmd)
+	}
+}
+
+// Usage prints the help screen to STDOUT.
+func (m *Main) Usage() {
+	fmt.Println(`
+ltx is a command-line tool for inspecting LTX files.
+
+Usage:
+
+	ltx <command> [arguments]
+
+The commands are:
+
+	apply        applies a set of LTX files to a database
+	checksum     computes the LTX checksum of a database file
+	dump         writes out metadata and page headers for a set of LTX files
+	list         lists header & trailer fields for LTX files in a table
+	verify       reads & verifies checksums of a set of LTX files
+	version      prints the version
+`[1:])
+}

--- a/third_party/ltx/cmd/ltx/verify.go
+++ b/third_party/ltx/cmd/ltx/verify.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/superfly/ltx"
+)
+
+// VerifyCommand represents a command to verify the integrity of LTX files.
+type VerifyCommand struct{}
+
+// NewVerifyCommand returns a new instance of VerifyCommand.
+func NewVerifyCommand() *VerifyCommand {
+	return &VerifyCommand{}
+}
+
+// Run executes the command.
+func (c *VerifyCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-verify", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Println(`
+The verify command reads one or more LTX files and verifies its integrity.
+
+Usage:
+
+	ltx verify PATH [PATH...]
+
+`[1:],
+		)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return fmt.Errorf("at least one LTX file must be specified")
+	}
+
+	var okN, errorN int
+	for _, filename := range fs.Args() {
+		if err := c.verifyFile(ctx, filename); err != nil {
+			errorN++
+			fmt.Printf("%s: %s\n", filename, err)
+			continue
+		}
+
+		okN++
+	}
+
+	if errorN != 0 {
+		return fmt.Errorf("%d ok, %d invalid", okN, errorN)
+	}
+
+	fmt.Println("ok")
+	return nil
+}
+
+func (c *VerifyCommand) verifyFile(_ context.Context, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	return ltx.NewDecoder(f).Verify()
+}

--- a/third_party/ltx/compactor.go
+++ b/third_party/ltx/compactor.go
@@ -1,0 +1,243 @@
+package ltx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+)
+
+// CompactorStatus represents the current progress of compaction.
+type CompactorStatus struct {
+	N     uint32 // Last page number that was compacted
+	Total uint32 // Total pages to compact (from Commit field)
+}
+
+// IsZero returns true if the status has not been initialized.
+func (s CompactorStatus) IsZero() bool {
+	return s.N == 0 && s.Total == 0
+}
+
+// Pct returns the percentage of compaction complete (0.0 to 1.0).
+// Returns 0 if Total is zero.
+func (s CompactorStatus) Pct() float64 {
+	if s.Total == 0 {
+		return 0
+	}
+	return float64(s.N) / float64(s.Total)
+}
+
+// Compactor represents a compactor of LTX files.
+type Compactor struct {
+	enc    *Encoder
+	inputs []*compactorInput
+
+	n     atomic.Uint32 // last page that was compacted
+	total atomic.Uint32 // total pages (from last input's Commit)
+
+	// These flags will be set when encoding the header.
+	HeaderFlags uint32
+
+	// HeaderTimestamp overrides the timestamp used in the output header when set.
+	HeaderTimestamp *int64
+
+	// If true, the compactor will not validate that input files have contiguous
+	// transaction IDs. This is false by default but can be enabled when
+	// rebuilding snapshots with missing transactions.
+	AllowNonContiguousTXIDs bool
+}
+
+// NewCompactor returns a new instance of Compactor with default settings.
+func NewCompactor(w io.Writer, rdrs []io.Reader) (*Compactor, error) {
+	enc, err := NewEncoder(w)
+	if err != nil {
+		return nil, fmt.Errorf("create ltx encoder: %w", err)
+	}
+
+	c := &Compactor{enc: enc}
+	c.inputs = make([]*compactorInput, len(rdrs))
+	for i := range c.inputs {
+		c.inputs[i] = &compactorInput{dec: NewDecoder(rdrs[i])}
+	}
+	return c, nil
+}
+
+// Header returns the LTX header of the compacted file. Only valid after successful Compact().
+func (c *Compactor) Header() Header { return c.enc.Header() }
+
+// Trailer returns the LTX trailer of the compacted file. Only valid after successful Compact().
+func (c *Compactor) Trailer() Trailer { return c.enc.Trailer() }
+
+// Status returns the current compaction progress.
+// Safe to call concurrently from another goroutine.
+func (c *Compactor) Status() CompactorStatus {
+	return CompactorStatus{
+		N:     c.n.Load(),
+		Total: c.total.Load(),
+	}
+}
+
+// Compact merges the input readers into a single LTX writer.
+func (c *Compactor) Compact(ctx context.Context) (retErr error) {
+	if len(c.inputs) == 0 {
+		return fmt.Errorf("at least one input reader required")
+	}
+
+	// Read headers from all inputs.
+	for _, input := range c.inputs {
+		if err := input.dec.DecodeHeader(); err != nil {
+			return
+		}
+	}
+
+	// Validate that reader page sizes match & TXIDs are contiguous.
+	for i := 1; i < len(c.inputs); i++ {
+		prevHdr := c.inputs[i-1].dec.Header()
+		hdr := c.inputs[i].dec.Header()
+
+		if prevHdr.PageSize != hdr.PageSize {
+			return fmt.Errorf("input files have mismatched page sizes: %d != %d", prevHdr.PageSize, hdr.PageSize)
+		}
+		if !c.AllowNonContiguousTXIDs && !IsContiguous(prevHdr.MaxTXID, hdr.MinTXID, hdr.MaxTXID) {
+			return fmt.Errorf("non-contiguous transaction ids in input files: (%s,%s) -> (%s,%s)",
+				prevHdr.MinTXID.String(), prevHdr.MaxTXID.String(),
+				hdr.MinTXID.String(), hdr.MaxTXID.String(),
+			)
+		}
+	}
+
+	// Fetch the first and last headers from the sorted readers.
+	minHdr := c.inputs[0].dec.Header()
+	maxHdr := c.inputs[len(c.inputs)-1].dec.Header()
+
+	// Generate output header. Skip NodeID as it's not meaningful after compaction.
+	timestamp := maxHdr.Timestamp
+	if c.HeaderTimestamp != nil {
+		timestamp = *c.HeaderTimestamp
+	}
+	if err := c.enc.EncodeHeader(Header{
+		Version:          Version,
+		Flags:            c.HeaderFlags,
+		PageSize:         minHdr.PageSize,
+		Commit:           maxHdr.Commit,
+		MinTXID:          minHdr.MinTXID,
+		MaxTXID:          maxHdr.MaxTXID,
+		Timestamp:        timestamp,
+		PreApplyChecksum: minHdr.PreApplyChecksum,
+	}); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	// Set total page count for progress tracking.
+	c.total.Store(maxHdr.Commit)
+
+	// Write page headers & data.
+	if err := c.writePageBlock(ctx); err != nil {
+		return err
+	}
+
+	// Close readers to ensure they're valid.
+	for i, input := range c.inputs {
+		if err := input.dec.Close(); err != nil {
+			return fmt.Errorf("close reader %d: %w", i, err)
+		}
+	}
+
+	// Close encoder.
+	c.enc.SetPostApplyChecksum(c.inputs[len(c.inputs)-1].dec.Trailer().PostApplyChecksum)
+	if err := c.enc.Close(); err != nil {
+		return fmt.Errorf("close encoder: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Compactor) writePageBlock(ctx context.Context) error {
+	// Allocate buffers.
+	for _, input := range c.inputs {
+		input.buf.data = make([]byte, c.enc.Header().PageSize)
+	}
+
+	// Iterate over readers and merge together.
+	for {
+		// Read next page frame for each buffer.
+		pgno, err := c.fillPageBuffers(ctx)
+		if err != nil {
+			return err
+		} else if pgno == 0 {
+			break // no more page frames, exit.
+		}
+
+		// Write page from latest input.
+		if err := c.writePageBuffer(ctx, pgno); err != nil {
+			return err
+		}
+
+		// Update progress after each page is written.
+		c.n.Store(pgno)
+	}
+
+	return nil
+}
+
+// fillPageBuffers reads the next page frame into each input buffer.
+func (c *Compactor) fillPageBuffers(_ context.Context) (pgno uint32, err error) {
+	for i := range c.inputs {
+		input := c.inputs[i]
+
+		// Fill buffer if it is empty.
+		if input.buf.hdr.IsZero() {
+			if err := input.dec.DecodePage(&input.buf.hdr, input.buf.data); err == io.EOF {
+				continue // end of page block
+			} else if err != nil {
+				return 0, fmt.Errorf("read page header %d: %w", i, err)
+			}
+		}
+
+		// Find the lowest page number among the buffers.
+		if pgno == 0 || input.buf.hdr.Pgno < pgno {
+			pgno = input.buf.hdr.Pgno
+		}
+	}
+	return pgno, nil
+}
+
+// writePageBuffer writes the buffer with a matching pgno from the latest input.
+func (c *Compactor) writePageBuffer(_ context.Context, pgno uint32) error {
+	commit := c.enc.Header().Commit
+
+	var pageWritten bool
+	for i := len(c.inputs) - 1; i >= 0; i-- {
+		input := c.inputs[i]
+		// Skip if buffer does have matching page number.
+		if input.buf.hdr.Pgno != pgno {
+			continue
+		}
+
+		// Clear buffer.
+		hdr, data := input.buf.hdr, input.buf.data
+		input.buf.hdr = PageHeader{}
+
+		// If page number has not been written yet, copy from input file.
+		if pageWritten {
+			continue
+		} else if pgno > commit {
+			continue // out of range of final database size, skip
+		}
+		pageWritten = true
+
+		if err := c.enc.EncodePage(hdr, data); err != nil {
+			return fmt.Errorf("copy page %d header: %w", pgno, err)
+		}
+	}
+
+	return nil
+}
+
+type compactorInput struct {
+	dec *Decoder
+	buf struct {
+		hdr  PageHeader
+		data []byte
+	}
+}

--- a/third_party/ltx/decoder.go
+++ b/third_party/ltx/decoder.go
@@ -1,0 +1,346 @@
+package ltx
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/crc64"
+	"io"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+// Decoder represents a decoder of an LTX file.
+type Decoder struct {
+	r  io.Reader   // main reader
+	zr *lz4.Reader // lz4 reader
+
+	header    Header
+	trailer   Trailer
+	pageIndex map[uint32]PageIndexElem
+	state     string
+
+	chksum Checksum
+	hash   hash.Hash64
+	pageN  int   // pages read
+	n      int64 // bytes read
+}
+
+// NewDecoder returns a new instance of Decoder.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{
+		r:     r,
+		zr:    lz4.NewReader(r),
+		state: stateHeader,
+		hash:  crc64.New(crc64.MakeTable(crc64.ISO)),
+	}
+}
+
+// N returns the number of bytes read.
+func (dec *Decoder) N() int64 { return dec.n }
+
+// PageN returns the number of pages read.
+func (dec *Decoder) PageN() int { return dec.pageN }
+
+// Header returns a copy of the header.
+func (dec *Decoder) Header() Header { return dec.header }
+
+// Trailer returns a copy of the trailer. File checksum available after Close().
+func (dec *Decoder) Trailer() Trailer { return dec.trailer }
+
+// PostApplyPos returns the replication position after underlying the LTX file is applied.
+// Only valid after successful Close().
+func (dec *Decoder) PostApplyPos() Pos {
+	return Pos{
+		TXID:              dec.header.MaxTXID,
+		PostApplyChecksum: dec.trailer.PostApplyChecksum,
+	}
+}
+
+// PageIndex returns a mapping of page numbers to byte offsets and sizes of those pages.
+// This returns the raw reference and not a copy.
+func (dec *Decoder) PageIndex() map[uint32]PageIndexElem {
+	return dec.pageIndex
+}
+
+// Close verifies the reader is at the end of the file and that the checksum matches.
+func (dec *Decoder) Close() error {
+	if dec.state == stateClosed {
+		return nil // no-op
+	} else if dec.state != stateClose {
+		return fmt.Errorf("cannot close, expected %s", dec.state)
+	}
+
+	// Slurp the remaining data in to memory so we can use the ByteReader interface.
+	remainingBytes, err := io.ReadAll(dec.r)
+	if err != nil {
+		return fmt.Errorf("read all: %w", err)
+	}
+	remaining := bytes.NewReader(remainingBytes)
+
+	// Write everything but the file checksum to the hash.
+	dec.writeToHash(remainingBytes[:len(remainingBytes)-ChecksumSize])
+
+	// Read page index.
+	if dec.pageIndex, err = DecodePageIndex(remaining, 0, dec.header.MinTXID, dec.header.MaxTXID); err != nil {
+		return fmt.Errorf("read page index: %w", err)
+	}
+
+	// Read trailer.
+	b := make([]byte, TrailerSize)
+	if _, err := io.ReadFull(remaining, b); err != nil {
+		return err
+	} else if err := dec.trailer.UnmarshalBinary(b); err != nil {
+		return fmt.Errorf("unmarshal trailer: %w", err)
+	}
+
+	// TODO: Ensure last read page is equal to the commit for snapshot LTX files
+
+	// Compare file checksum with checksum in trailer.
+	if chksum := ChecksumFlag | Checksum(dec.hash.Sum64()); chksum != dec.trailer.FileChecksum {
+		return ErrChecksumMismatch
+	}
+
+	// Verify post-apply checksum for snapshot files if checksums are being tracked.
+	if dec.header.IsSnapshot() && !dec.header.NoChecksum() {
+		if dec.trailer.PostApplyChecksum != dec.chksum {
+			return fmt.Errorf("post-apply checksum in trailer (%s) does not match calculated checksum (%s)", dec.trailer.PostApplyChecksum, dec.chksum)
+		}
+	}
+
+	// Update state to mark as closed.
+	dec.state = stateClosed
+
+	return nil
+}
+
+// DecodeHeader reads the LTX file header frame and stores it internally.
+// Call Header() to retrieve the header after this is successfully called.
+func (dec *Decoder) DecodeHeader() error {
+	b := make([]byte, HeaderSize)
+	if _, err := io.ReadFull(dec.r, b); err != nil {
+		return err
+	} else if err := dec.header.UnmarshalBinary(b); err != nil {
+		return fmt.Errorf("unmarshal header: %w", err)
+	}
+
+	dec.writeToHash(b)
+	dec.state = statePage
+
+	if err := dec.header.Validate(); err != nil {
+		return err
+	}
+
+	// Initialize checksum if checksum tracking is enabled.
+	if !dec.header.NoChecksum() {
+		dec.chksum = ChecksumFlag
+	}
+
+	return nil
+}
+
+// DecodePage reads the next page header into hdr and associated page data.
+func (dec *Decoder) DecodePage(hdr *PageHeader, data []byte) error {
+	if dec.state == stateClosed {
+		return ErrDecoderClosed
+	} else if dec.state == stateClose {
+		return io.EOF
+	} else if dec.state != statePage {
+		return fmt.Errorf("cannot read page header, expected %s", dec.state)
+	} else if uint32(len(data)) != dec.header.PageSize {
+		return fmt.Errorf("invalid page buffer size: %d, expecting %d", len(data), dec.header.PageSize)
+	}
+
+	// Read and unmarshal page header.
+	b := make([]byte, PageHeaderSize)
+	if _, err := io.ReadFull(dec.r, b); err != nil {
+		return err
+	} else if err := hdr.UnmarshalBinary(b); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	dec.writeToHash(b)
+
+	// An empty page header indicates the end of the page block.
+	if hdr.IsZero() {
+		dec.state = stateClose
+		return io.EOF
+	}
+
+	if err := hdr.Validate(); err != nil {
+		return err
+	}
+
+	// Read page data next.
+	dec.zr.Reset(dec.r)
+	if _, err := io.ReadFull(dec.zr, data); err != nil {
+		return err
+	}
+	dec.writeToHash(data)
+	dec.pageN++
+
+	// Read off the LZ4 trailer frame to ensure we hit EOF.
+	if err := dec.readLZ4Trailer(); err != nil {
+		return fmt.Errorf("read lz4 trailer: %w", err)
+	}
+
+	// Calculate checksum while decoding snapshots if tracking checksums.
+	if dec.header.IsSnapshot() && !dec.header.NoChecksum() {
+		if hdr.Pgno != LockPgno(dec.header.PageSize) {
+			dec.chksum = ChecksumFlag | (dec.chksum ^ ChecksumPage(hdr.Pgno, data))
+		}
+	}
+
+	return nil
+}
+
+// Verify reads the entire file. Header & trailer can be accessed via methods
+// after the file is successfully verified. All other data is discarded.
+func (dec *Decoder) Verify() error {
+	if err := dec.DecodeHeader(); err != nil {
+		return fmt.Errorf("decode header: %w", err)
+	}
+
+	var pageHeader PageHeader
+	data := make([]byte, dec.header.PageSize)
+	for i := 0; ; i++ {
+		if err := dec.DecodePage(&pageHeader, data); err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("decode page %d: %w", i, err)
+		}
+	}
+
+	if err := dec.Close(); err != nil {
+		return fmt.Errorf("close reader: %w", err)
+	}
+	return nil
+}
+
+// DecodeDatabaseTo decodes the LTX file as a SQLite database to w.
+// The LTX file MUST be a snapshot file.
+func (dec *Decoder) DecodeDatabaseTo(w io.Writer) error {
+	if err := dec.DecodeHeader(); err != nil {
+		return fmt.Errorf("decode header: %w", err)
+	}
+
+	hdr := dec.Header()
+	lockPgno := hdr.LockPgno()
+	if !dec.header.IsSnapshot() {
+		return fmt.Errorf("cannot decode non-snapshot LTX file to SQLite database")
+	}
+
+	var pageHeader PageHeader
+	data := make([]byte, dec.header.PageSize)
+	for pgno := uint32(1); pgno <= hdr.Commit; pgno++ {
+		if pgno == lockPgno {
+			// Write empty page for lock page.
+			for i := range data {
+				data[i] = 0
+			}
+		} else {
+			// Otherwise read the page from the LTX decoder.
+			if err := dec.DecodePage(&pageHeader, data); err != nil {
+				return fmt.Errorf("decode page %d: %w", pgno, err)
+			} else if pageHeader.Pgno != pgno {
+				return fmt.Errorf("unexpected pgno while decoding page: read %d, expected %d", pageHeader.Pgno, pgno)
+			}
+		}
+
+		if _, err := w.Write(data); err != nil {
+			return fmt.Errorf("write page %d: %w", pgno, err)
+		}
+	}
+
+	// Issue one more final read and expect to see an EOF. This is required so
+	// that the decoder can successfully close and validate.
+	if err := dec.DecodePage(&pageHeader, data); err == nil {
+		return fmt.Errorf("unexpected page %d after commit %d", pageHeader.Pgno, hdr.Commit)
+	} else if err != io.EOF {
+		return fmt.Errorf("unexpected error decoding after end of database: %w", err)
+	}
+
+	if err := dec.Close(); err != nil {
+		return fmt.Errorf("close decoder: %w", err)
+	}
+	return nil
+}
+
+func (dec *Decoder) writeToHash(b []byte) {
+	_, _ = dec.hash.Write(b)
+	dec.n += int64(len(b))
+}
+
+// readLZ4Trailer reads the LZ4 trailer frame to ensure we hit EOF.
+func (dec *Decoder) readLZ4Trailer() error {
+	if _, err := io.ReadFull(dec.zr, make([]byte, 1)); err != io.EOF {
+		return fmt.Errorf("expected lz4 end frame")
+	}
+	return nil
+}
+
+// DecodeHeader decodes the header from r. Returns the header & read bytes.
+func DecodeHeader(r io.Reader) (hdr Header, data []byte, err error) {
+	data = make([]byte, HeaderSize)
+	n, err := io.ReadFull(r, data)
+	if err != nil {
+		return hdr, data[:n], err
+	} else if err := hdr.UnmarshalBinary(data); err != nil {
+		return hdr, data[:n], err
+	}
+	return hdr, data, nil
+}
+
+// DecodePageData decodes the page header & data from a single frame.
+func DecodePageData(b []byte) (hdr PageHeader, data []byte, err error) {
+	if err := hdr.UnmarshalBinary(b); err != nil {
+		return hdr, data, fmt.Errorf("unmarshal: %w", err)
+	}
+	if hdr.IsZero() {
+		return hdr, data, nil
+	}
+
+	zr := lz4.NewReader(bytes.NewReader(b[PageHeaderSize:]))
+	data, err = io.ReadAll(zr)
+	return hdr, data, err
+}
+
+// DecodePageIndex decodes the page index from r.
+func DecodePageIndex(r io.ByteReader, level int, minTXID, maxTXID TXID) (map[uint32]PageIndexElem, error) {
+	pageIndex := make(map[uint32]PageIndexElem)
+
+	for {
+		pgno, err := binary.ReadUvarint(r)
+		if err != nil {
+			return nil, fmt.Errorf("read page index pgno: %w", err)
+		} else if pgno == 0 {
+			break // End when we hit the end marker.
+		}
+
+		offset, err := binary.ReadUvarint(r)
+		if err != nil {
+			return nil, fmt.Errorf("read page index offset: %w", err)
+		}
+		size, err := binary.ReadUvarint(r)
+		if err != nil {
+			return nil, fmt.Errorf("read page index size: %w", err)
+		}
+
+		pageIndex[uint32(pgno)] = PageIndexElem{
+			Level:   level,
+			MinTXID: minTXID,
+			MaxTXID: maxTXID,
+			Offset:  int64(offset),
+			Size:    int64(size),
+		}
+	}
+
+	// Read size of page index.
+	var size uint64
+	if err := binary.Read(r.(io.Reader), binary.BigEndian, &size); err != nil {
+		return nil, fmt.Errorf("read page index size: %w", err)
+	}
+
+	return pageIndex, nil
+}

--- a/third_party/ltx/encoder.go
+++ b/third_party/ltx/encoder.go
@@ -1,0 +1,316 @@
+package ltx
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/crc64"
+	"io"
+	"slices"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+// Encoder implements an encoder for an LTX file.
+type Encoder struct {
+	w     io.Writer   // main writer
+	zw    *lz4.Writer // compressed writer
+	state string
+
+	header  Header
+	trailer Trailer
+	buf     bytes.Buffer
+	hash    hash.Hash64
+	index   map[uint32]PageIndexElem // page number to offset
+	n       int64                    // bytes written
+
+	// Track how many of each write has occurred to move state.
+	prevPgno     uint32
+	pagesWritten uint32
+}
+
+// NewEncoder returns a new instance of Encoder.
+func NewEncoder(w io.Writer) (*Encoder, error) {
+	enc := &Encoder{
+		w:     w,
+		state: stateHeader,
+		index: make(map[uint32]PageIndexElem),
+	}
+
+	// The compressed writer writes to a buffer so we can calculate the size
+	// of the compressed data for the page index.
+	zw := lz4.NewWriter(&enc.buf)
+	if err := zw.Apply(lz4.BlockSizeOption(lz4.Block64Kb)); err != nil { // minimize memory allocation
+		return nil, fmt.Errorf("cannot set lz4 block size: %w", err)
+	}
+	if err := zw.Apply(lz4.CompressionLevelOption(lz4.Fast)); err != nil {
+		return nil, fmt.Errorf("cannot set lz4 compression level: %w", err)
+	}
+	enc.zw = zw
+
+	return enc, nil
+}
+
+// N returns the number of bytes written.
+func (enc *Encoder) N() int64 { return enc.n }
+
+// Header returns a copy of the header.
+func (enc *Encoder) Header() Header { return enc.header }
+
+// Trailer returns a copy of the trailer. File checksum available after Close().
+func (enc *Encoder) Trailer() Trailer { return enc.trailer }
+
+// PostApplyPos returns the replication position after underlying the LTX file is applied.
+// Only valid after successful Close().
+func (enc *Encoder) PostApplyPos() Pos {
+	return Pos{
+		TXID:              enc.header.MaxTXID,
+		PostApplyChecksum: enc.trailer.PostApplyChecksum,
+	}
+}
+
+// SetPostApplyChecksum sets the post-apply checksum of the database.
+// Must call before Close().
+func (enc *Encoder) SetPostApplyChecksum(chksum Checksum) {
+	enc.trailer.PostApplyChecksum = chksum
+}
+
+// Close flushes the checksum to the header.
+func (enc *Encoder) Close() error {
+	if enc.state == stateClosed {
+		return nil // no-op
+	} else if enc.state != statePage {
+		return fmt.Errorf("cannot close, expected %s", enc.state)
+	}
+
+	// Marshal empty page header to mark end of page block.
+	b0, err := (&PageHeader{}).MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal empty page header: %w", err)
+	} else if _, err := enc.write(b0); err != nil {
+		return fmt.Errorf("write empty page header: %w", err)
+	}
+
+	// Close the compressed writer.
+	if err := enc.zw.Close(); err != nil {
+		return fmt.Errorf("cannot close lz4 writer: %w", err)
+	}
+
+	// Write index to file.
+	if err := enc.encodePageIndex(); err != nil {
+		return fmt.Errorf("write page index: %w", err)
+	}
+
+	// Marshal trailer to bytes.
+	b1, err := enc.trailer.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal trailer: %w", err)
+	}
+	enc.writeToHash(b1[:TrailerChecksumOffset])
+	enc.trailer.FileChecksum = ChecksumFlag | Checksum(enc.hash.Sum64())
+
+	// Validate trailer now that we have the file checksum.
+	if err := enc.trailer.Validate(enc.header); err != nil {
+		return fmt.Errorf("validate trailer: %w", err)
+	}
+
+	// If we are encoding a deletion LTX file then ensure that we have an empty checksum.
+	if enc.header.Commit == 0 && enc.trailer.PostApplyChecksum != ChecksumFlag {
+		return fmt.Errorf("post-apply checksum must be empty for zero-length database")
+	}
+
+	// Remarshal with correct checksum.
+	b1, err = enc.trailer.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal trailer: %w", err)
+	} else if _, err := enc.w.Write(b1); err != nil {
+		return fmt.Errorf("write trailer: %w", err)
+	}
+	enc.n += ChecksumSize
+
+	enc.state = stateClosed
+
+	return nil
+}
+
+func (enc *Encoder) encodePageIndex() error {
+	offset := enc.n
+
+	// Write elements in sorted page number order.
+	pgnos := make([]uint32, 0, len(enc.index))
+	for pgno := range enc.index {
+		pgnos = append(pgnos, pgno)
+	}
+	slices.Sort(pgnos)
+
+	// Write each element as a varint-encoded tuple.
+	buf := make([]byte, 0, 3*binary.MaxVarintLen64)
+	for _, pgno := range pgnos {
+		elem := enc.index[pgno]
+
+		buf = binary.AppendUvarint(buf[:0], uint64(pgno))
+		buf = binary.AppendUvarint(buf, uint64(elem.Offset))
+		buf = binary.AppendUvarint(buf, uint64(elem.Size))
+
+		if _, err := enc.write(buf); err != nil {
+			return fmt.Errorf("write page index element: %w", err)
+		}
+	}
+
+	// Write end marker.
+	buf = binary.AppendUvarint(buf[:0], uint64(0))
+	if _, err := enc.write(buf); err != nil {
+		return fmt.Errorf("write page index pgno: %w", err)
+	}
+
+	// Write size of page index.
+	buf = binary.BigEndian.AppendUint64(buf[:0], uint64(enc.n-offset))
+	if _, err := enc.write(buf); err != nil {
+		return fmt.Errorf("write page index size: %w", err)
+	}
+
+	return nil
+}
+
+// EncodeHeader writes hdr to the file's header block.
+func (enc *Encoder) EncodeHeader(hdr Header) error {
+	if enc.state == stateClosed {
+		return ErrEncoderClosed
+	} else if enc.state != stateHeader {
+		return fmt.Errorf("cannot encode header frame, expected %s", enc.state)
+	} else if err := hdr.Validate(); err != nil {
+		return err
+	}
+
+	enc.header = hdr
+
+	// Initialize hash.
+	enc.hash = crc64.New(crc64.MakeTable(crc64.ISO))
+
+	// Write header to underlying writer.
+	b, err := enc.header.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal header: %w", err)
+	} else if _, err := enc.write(b); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	// Move writer state to write page headers.
+	enc.state = statePage // file must have at least one page
+
+	return nil
+}
+
+// EncodePage writes hdr & data to the file's page block.
+func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
+	if enc.state == stateClosed {
+		return ErrEncoderClosed
+	} else if enc.state != statePage {
+		return fmt.Errorf("cannot encode page header, expected %s", enc.state)
+	} else if hdr.Pgno > enc.header.Commit {
+		return fmt.Errorf("page number %d out-of-bounds for commit size %d", hdr.Pgno, enc.header.Commit)
+	} else if err := hdr.Validate(); err != nil {
+		return err
+	} else if uint32(len(data)) != enc.header.PageSize {
+		return fmt.Errorf("invalid page buffer size: %d, expecting %d", len(data), enc.header.PageSize)
+	}
+
+	lockPgno := LockPgno(enc.header.PageSize)
+	if hdr.Pgno == lockPgno {
+		return fmt.Errorf("cannot encode lock page: pgno=%d", hdr.Pgno)
+	}
+
+	// Snapshots must start with page 1 and include all pages up to the commit size.
+	// Non-snapshot files can include any pages but they must be in order.
+	if enc.header.IsSnapshot() {
+		if enc.prevPgno == 0 && hdr.Pgno != 1 {
+			return fmt.Errorf("snapshot transaction file must start with page number 1")
+		}
+
+		if enc.prevPgno == lockPgno-1 {
+			if hdr.Pgno != enc.prevPgno+2 { // skip lock page
+				return fmt.Errorf("nonsequential page numbers in snapshot transaction (skip lock page): %d,%d", enc.prevPgno, hdr.Pgno)
+			}
+		} else if enc.prevPgno != 0 && hdr.Pgno != enc.prevPgno+1 {
+			return fmt.Errorf("nonsequential page numbers in snapshot transaction: %d,%d", enc.prevPgno, hdr.Pgno)
+		}
+	} else {
+		if enc.prevPgno >= hdr.Pgno {
+			return fmt.Errorf("out-of-order page numbers: %d,%d", enc.prevPgno, hdr.Pgno)
+		}
+	}
+
+	offset := enc.n
+
+	// Encode & write header.
+	b, err := hdr.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	} else if _, err := enc.write(b); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	// Write data to file.
+	if _, err = enc.writeCompressed(data); err != nil {
+		return fmt.Errorf("write page data: %w", err)
+	}
+
+	enc.pagesWritten++
+	enc.prevPgno = hdr.Pgno
+	enc.index[hdr.Pgno] = PageIndexElem{
+		Offset: offset,
+		Size:   enc.n - offset,
+	}
+
+	return nil
+}
+
+// write to the uncompressed writer & add to the checksum.
+func (enc *Encoder) write(b []byte) (n int, err error) {
+	n, err = enc.w.Write(b)
+	enc.writeToHash(b[:n])
+	return n, err
+}
+
+// write to the compressed writer & add to the checksum.
+// Returns the size of the compressed data.
+func (enc *Encoder) writeCompressed(b []byte) (n int, err error) {
+	// Reset the buffer & compressed writer.
+	enc.buf.Reset()
+	enc.zw.Reset(&enc.buf)
+
+	// Write to the compressed writer to the buffer and then write the buffer to the uncompressed writer.
+	// This is necessary so we can calculate the size of the compressed data for the page index.
+	if _, err = enc.zw.Write(b); err != nil {
+		return n, err
+	}
+
+	// Close the compressed writer to flush any remaining data.
+	if err := enc.zw.Close(); err != nil {
+		return n, fmt.Errorf("cannot close lz4 writer: %w", err)
+	}
+
+	compressed := enc.buf.Bytes()
+	n, err = enc.w.Write(compressed)
+
+	// Write the uncompressed data to the hash, but add the compressed length to the size.
+	_, _ = enc.hash.Write(b)
+	enc.n += int64(len(compressed))
+
+	return n, err
+}
+
+func (enc *Encoder) writeToHash(b []byte) {
+	_, _ = enc.hash.Write(b)
+	enc.n += int64(len(b))
+}
+
+type PageIndexElem struct {
+	Level   int
+	MinTXID TXID
+	MaxTXID TXID
+
+	Offset int64
+	Size   int64
+}

--- a/third_party/ltx/file_spec.go
+++ b/third_party/ltx/file_spec.go
@@ -1,0 +1,112 @@
+package ltx
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// FileSpec is an in-memory representation of an LTX file. Typically used for testing.
+type FileSpec struct {
+	Header  Header
+	Pages   []PageSpec
+	Trailer Trailer
+}
+
+// Write encodes a file spec to a file.
+func (s *FileSpec) WriteTo(dst io.Writer) (n int64, err error) {
+	enc, err := NewEncoder(dst)
+	if err != nil {
+		return 0, fmt.Errorf("create ltx encoder: %w", err)
+	}
+	if err := enc.EncodeHeader(s.Header); err != nil {
+		return 0, fmt.Errorf("encode header: %s", err)
+	}
+
+	for i, page := range s.Pages {
+		if err := enc.EncodePage(page.Header, page.Data); err != nil {
+			return 0, fmt.Errorf("encode page[%d]: %s", i, err)
+		}
+	}
+
+	enc.SetPostApplyChecksum(s.Trailer.PostApplyChecksum)
+
+	if err := enc.Close(); err != nil {
+		return 0, fmt.Errorf("close encoder: %s", err)
+	}
+
+	// Update checksums.
+	s.Trailer = enc.Trailer()
+
+	return enc.N(), nil
+}
+
+// ReadFromFile encodes a file spec to a file. Always return n of zero.
+func (s *FileSpec) ReadFrom(src io.Reader) (n int64, err error) {
+	dec := NewDecoder(src)
+
+	// Read header frame and initialize spec slices to correct size.
+	if err := dec.DecodeHeader(); err != nil {
+		return 0, fmt.Errorf("read header: %s", err)
+	}
+	s.Header = dec.Header()
+
+	// Read page frames.
+	for {
+		page := PageSpec{Data: make([]byte, s.Header.PageSize)}
+		if err := dec.DecodePage(&page.Header, page.Data); err == io.EOF {
+			break
+		} else if err != nil {
+			return 0, fmt.Errorf("read page header: %s", err)
+		}
+
+		s.Pages = append(s.Pages, page)
+	}
+
+	if err := dec.Close(); err != nil {
+		return 0, fmt.Errorf("close reader: %s", err)
+	}
+	s.Trailer = dec.Trailer()
+
+	return int64(dec.N()), nil
+}
+
+// GoString returns the Go representation of s.
+func (s *FileSpec) GoString() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "{\n")
+	fmt.Fprintf(&buf, "\tHeader: %#v,\n", s.Header)
+
+	if s.Pages == nil {
+		fmt.Fprintf(&buf, "\tPages: nil,\n")
+	} else {
+		fmt.Fprintf(&buf, "\tPages: []*PageSpec{,\n")
+		for i := range s.Pages {
+			fmt.Fprintf(&buf, "\t\t%#v,\n", &s.Pages[i])
+		}
+		fmt.Fprintf(&buf, "\t},\n")
+	}
+
+	fmt.Fprintf(&buf, "\tTrailer: %#v,\n", s.Trailer)
+	fmt.Fprintf(&buf, "}")
+
+	return buf.String()
+}
+
+// PageSpec is an in-memory representation of an LTX page frame. Typically used for testing.
+type PageSpec struct {
+	Header PageHeader
+	Data   []byte
+}
+
+// GoString returns the Go representation of s.
+func (s *PageSpec) GoString() string {
+	var data string
+	if len(s.Data) < 4 {
+		data = fmt.Sprintf(`"%x"`, s.Data)
+	} else {
+		data = fmt.Sprintf(`"%x..."`, s.Data[:4])
+	}
+	return fmt.Sprintf(`{Header:%#v, Data:[]byte(%s)}`, s.Header, data)
+}

--- a/third_party/ltx/go.mod
+++ b/third_party/ltx/go.mod
@@ -1,0 +1,5 @@
+module github.com/superfly/ltx
+
+go 1.24
+
+require github.com/pierrec/lz4/v4 v4.1.22

--- a/third_party/ltx/go.sum
+++ b/third_party/ltx/go.sum
@@ -1,0 +1,2 @@
+github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
+github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/third_party/ltx/ltx.go
+++ b/third_party/ltx/ltx.go
@@ -1,0 +1,625 @@
+// Package ltx reads and writes Liteserver Transaction (LTX) files.
+package ltx
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strconv"
+	"time"
+)
+
+const (
+	// Magic is the first 4 bytes of every LTX file.
+	Magic = "LTX1"
+
+	// Version is the current version of the LTX file format.
+	Version = 3
+)
+
+// Size constants.
+const (
+	HeaderSize     = 100
+	PageHeaderSize = 6
+	TrailerSize    = 16
+)
+
+// RFC3339Milli is the standard time format for LTX timestamps.
+// It uses fixed-width millisecond resolution which makes it sortable.
+const RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
+
+// Checksum size & positions.
+const (
+	ChecksumSize          = 8
+	TrailerChecksumOffset = TrailerSize - ChecksumSize
+)
+
+// Errors
+var (
+	ErrInvalidFile   = errors.New("invalid LTX file")
+	ErrDecoderClosed = errors.New("ltx decoder closed")
+	ErrEncoderClosed = errors.New("ltx encoder closed")
+
+	ErrNoChecksum            = errors.New("no file checksum")
+	ErrInvalidChecksumFormat = errors.New("invalid file checksum format")
+	ErrChecksumMismatch      = errors.New("file checksum mismatch")
+)
+
+// ChecksumFlag is a flag on the checksum to ensure it is non-zero.
+const ChecksumFlag Checksum = 1 << 63
+
+// internal reader/writer states
+const (
+	stateHeader = "header"
+	statePage   = "page"
+	stateClose  = "close"
+	stateClosed = "closed"
+)
+
+// Pos represents the transactional position of a database.
+type Pos struct {
+	TXID              TXID
+	PostApplyChecksum Checksum
+}
+
+// NewPos returns a new instance of Pos.
+func NewPos(txID TXID, postApplyChecksum Checksum) Pos {
+	return Pos{
+		TXID:              txID,
+		PostApplyChecksum: postApplyChecksum,
+	}
+}
+
+// ParsePos parses Pos from its string representation.
+func ParsePos(s string) (Pos, error) {
+	if len(s) != 33 {
+		return Pos{}, fmt.Errorf("invalid formatted position length: %q", s)
+	}
+
+	txid, err := ParseTXID(s[:16])
+	if err != nil {
+		return Pos{}, err
+	}
+
+	checksum, err := ParseChecksum(s[17:])
+	if err != nil {
+		return Pos{}, err
+	}
+
+	return Pos{
+		TXID:              txid,
+		PostApplyChecksum: checksum,
+	}, nil
+}
+
+// String returns a string representation of the position.
+func (p Pos) String() string {
+	return fmt.Sprintf("%s/%s", p.TXID, p.PostApplyChecksum)
+}
+
+// IsZero returns true if the position is empty.
+func (p Pos) IsZero() bool {
+	return p == (Pos{})
+}
+
+// PosMismatchError is returned when an LTX file is not contiguous with the current position.
+type PosMismatchError struct {
+	Pos Pos `json:"pos"`
+}
+
+// NewPosMismatchError returns a new instance of PosMismatchError.
+func NewPosMismatchError(pos Pos) *PosMismatchError {
+	return &PosMismatchError{Pos: pos}
+}
+
+// Error returns the string representation of the error.
+func (e *PosMismatchError) Error() string {
+	return fmt.Sprintf("ltx position mismatch (%s)", e.Pos)
+}
+
+// TXID represents a transaction ID.
+type TXID uint64
+
+// ParseTXID parses a 16-character hex string into a transaction ID.
+func ParseTXID(s string) (TXID, error) {
+	if len(s) != 16 {
+		return 0, fmt.Errorf("invalid formatted transaction id length: %q", s)
+	}
+	v, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid transaction id format: %q", s)
+	}
+	return TXID(v), nil
+}
+
+// String returns id formatted as a fixed-width hex number.
+func (t TXID) String() string {
+	return fmt.Sprintf("%016x", uint64(t))
+}
+
+func (t TXID) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + t.String() + `"`), nil
+}
+
+func (t *TXID) UnmarshalJSON(data []byte) (err error) {
+	var s *string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("cannot unmarshal TXID from JSON value")
+	}
+
+	// Set to zero if value is nil.
+	if s == nil {
+		*t = 0
+		return nil
+	}
+
+	txID, err := ParseTXID(*s)
+	if err != nil {
+		return fmt.Errorf("cannot parse TXID from JSON string: %q", *s)
+	}
+	*t = TXID(txID)
+
+	return nil
+}
+
+// Header flags.
+const (
+	HeaderFlagMask = uint32(HeaderFlagNoChecksum)
+
+	HeaderFlagNoChecksum = uint32(1 << 1)
+)
+
+// Header represents the header frame of an LTX file.
+type Header struct {
+	Version          int      // based on magic
+	Flags            uint32   // reserved flags
+	PageSize         uint32   // page size, in bytes
+	Commit           uint32   // db size after transaction, in pages
+	MinTXID          TXID     // minimum transaction ID
+	MaxTXID          TXID     // maximum transaction ID
+	Timestamp        int64    // milliseconds since unix epoch
+	PreApplyChecksum Checksum // rolling checksum of database before applying this LTX file
+	WALOffset        int64    // file offset from original WAL; zero if journal
+	WALSize          int64    // size of original WAL segment; zero if journal
+	WALSalt1         uint32   // header salt-1 from original WAL; zero if journal or compaction
+	WALSalt2         uint32   // header salt-2 from original WAL; zero if journal or compaction
+	NodeID           uint64   // node id where the LTX file was created, zero if unset
+}
+
+// IsSnapshot returns true if header represents a complete database snapshot.
+// This is true if the header includes the initial transaction. Snapshots must
+// include all pages in the database.
+func (h *Header) IsSnapshot() bool {
+	return h.MinTXID == 1
+}
+
+// LockPgno returns the lock page number based on the header's page size.
+func (h *Header) LockPgno() uint32 {
+	return LockPgno(h.PageSize)
+}
+
+// Validate returns an error if h is invalid.
+func (h *Header) Validate() error {
+	if h.Version != Version {
+		return fmt.Errorf("invalid version")
+	}
+	if !IsValidHeaderFlags(h.Flags) {
+		return fmt.Errorf("invalid flags: 0x%08x", h.Flags)
+	}
+	if !IsValidPageSize(h.PageSize) {
+		return fmt.Errorf("invalid page size: %d", h.PageSize)
+	}
+	if h.MinTXID == 0 {
+		return fmt.Errorf("minimum transaction id required")
+	}
+	if h.MaxTXID == 0 {
+		return fmt.Errorf("maximum transaction id required")
+	}
+	if h.MinTXID > h.MaxTXID {
+		return fmt.Errorf("transaction ids out of order: (%d,%d)", h.MinTXID, h.MaxTXID)
+	}
+
+	if h.WALOffset < 0 {
+		return fmt.Errorf("wal offset cannot be negative: %d", h.WALOffset)
+	}
+	if h.WALSize < 0 {
+		return fmt.Errorf("wal size cannot be negative: %d", h.WALSize)
+	}
+
+	if h.WALSalt1 != 0 || h.WALSalt2 != 0 {
+		if h.WALOffset == 0 {
+			return fmt.Errorf("wal offset required if salt exists")
+		}
+	}
+
+	if h.WALOffset == 0 && h.WALSize != 0 {
+		return fmt.Errorf("wal offset required if wal size exists")
+	}
+
+	// Snapshots are LTX files which have a minimum TXID of 1. This means they
+	// must have all database pages included in them and they have no previous checksum.
+	if h.IsSnapshot() {
+		if h.PreApplyChecksum != 0 {
+			return fmt.Errorf("pre-apply checksum must be zero on snapshots")
+		}
+	} else if h.NoChecksum() {
+		// Ensure no checksums are set if we aren't tracking them.
+		if h.PreApplyChecksum != 0 {
+			return fmt.Errorf("pre-apply checksum not allowed")
+		}
+	} else {
+		// Ensure checksum is set and well-formed if checksum tracking is enabled.
+		if h.PreApplyChecksum == 0 {
+			return fmt.Errorf("pre-apply checksum required on non-snapshot files")
+		}
+		if h.PreApplyChecksum&ChecksumFlag == 0 {
+			return fmt.Errorf("invalid pre-apply checksum format")
+		}
+	}
+
+	return nil
+}
+
+// NoChecksum returns true if the checksum is not being tracked for this LTX file.
+func (h Header) NoChecksum() bool {
+	return h.Flags&HeaderFlagNoChecksum != 0
+}
+
+// PreApplyPos returns the replication position before the LTX file is applies.
+func (h Header) PreApplyPos() Pos {
+	return Pos{
+		TXID:              h.MinTXID - 1,
+		PostApplyChecksum: h.PreApplyChecksum,
+	}
+}
+
+// MarshalBinary encodes h to a byte slice.
+func (h *Header) MarshalBinary() ([]byte, error) {
+	b := make([]byte, HeaderSize)
+	copy(b[0:4], Magic)
+	binary.BigEndian.PutUint32(b[4:], h.Flags)
+	binary.BigEndian.PutUint32(b[8:], h.PageSize)
+	binary.BigEndian.PutUint32(b[12:], h.Commit)
+	binary.BigEndian.PutUint64(b[16:], uint64(h.MinTXID))
+	binary.BigEndian.PutUint64(b[24:], uint64(h.MaxTXID))
+	binary.BigEndian.PutUint64(b[32:], uint64(h.Timestamp))
+	binary.BigEndian.PutUint64(b[40:], uint64(h.PreApplyChecksum))
+	binary.BigEndian.PutUint64(b[48:], uint64(h.WALOffset))
+	binary.BigEndian.PutUint64(b[56:], uint64(h.WALSize))
+	binary.BigEndian.PutUint32(b[64:], h.WALSalt1)
+	binary.BigEndian.PutUint32(b[68:], h.WALSalt2)
+	binary.BigEndian.PutUint64(b[72:], h.NodeID)
+	return b, nil
+}
+
+// UnmarshalBinary decodes h from a byte slice.
+func (h *Header) UnmarshalBinary(b []byte) error {
+	if len(b) < HeaderSize {
+		return io.ErrShortBuffer
+	}
+
+	h.Flags = binary.BigEndian.Uint32(b[4:])
+	h.PageSize = binary.BigEndian.Uint32(b[8:])
+	h.Commit = binary.BigEndian.Uint32(b[12:])
+	h.MinTXID = TXID(binary.BigEndian.Uint64(b[16:]))
+	h.MaxTXID = TXID(binary.BigEndian.Uint64(b[24:]))
+	h.Timestamp = int64(binary.BigEndian.Uint64(b[32:]))
+	h.PreApplyChecksum = Checksum(binary.BigEndian.Uint64(b[40:]))
+	h.WALOffset = int64(binary.BigEndian.Uint64(b[48:]))
+	h.WALSize = int64(binary.BigEndian.Uint64(b[56:]))
+	h.WALSalt1 = binary.BigEndian.Uint32(b[64:])
+	h.WALSalt2 = binary.BigEndian.Uint32(b[68:])
+	h.NodeID = binary.BigEndian.Uint64(b[72:])
+
+	if string(b[0:4]) != Magic {
+		return ErrInvalidFile
+	}
+	h.Version = Version
+
+	return nil
+}
+
+// PeekHeader reads & unmarshals the header from r.
+// It returns a new io.Reader that prepends the header data back on.
+func PeekHeader(r io.Reader) (Header, io.Reader, error) {
+	buf := make([]byte, HeaderSize)
+	n, err := io.ReadFull(r, buf)
+	r = io.MultiReader(bytes.NewReader(buf[:n]), r)
+	if err != nil {
+		return Header{}, r, err
+	}
+
+	var hdr Header
+	err = hdr.UnmarshalBinary(buf)
+	return hdr, r, err
+}
+
+// IsValidHeaderFlags returns true unless flags outside the valid mask are set.
+func IsValidHeaderFlags(flags uint32) bool {
+	return flags == (flags & HeaderFlagMask)
+}
+
+// Trailer represents the ending frame of an LTX file.
+type Trailer struct {
+	PostApplyChecksum Checksum // rolling checksum of database after this LTX file is applied
+	FileChecksum      Checksum // crc64 checksum of entire file
+}
+
+// Validate returns an error if t is invalid.
+func (t *Trailer) Validate(h Header) error {
+	if h.NoChecksum() {
+		if t.PostApplyChecksum != 0 {
+			return fmt.Errorf("post-apply checksum not allowed")
+		}
+	} else {
+		if t.PostApplyChecksum == 0 {
+			return fmt.Errorf("post-apply checksum required")
+		} else if t.PostApplyChecksum&ChecksumFlag == 0 {
+			return fmt.Errorf("invalid post-apply checksum format")
+		}
+	}
+
+	if t.FileChecksum == 0 {
+		return fmt.Errorf("file checksum required")
+	} else if t.FileChecksum&ChecksumFlag == 0 {
+		return fmt.Errorf("invalid file checksum format")
+	}
+	return nil
+}
+
+// MarshalBinary encodes h to a byte slice.
+func (t *Trailer) MarshalBinary() ([]byte, error) {
+	b := make([]byte, TrailerSize)
+	binary.BigEndian.PutUint64(b[0:], uint64(t.PostApplyChecksum))
+	binary.BigEndian.PutUint64(b[8:], uint64(t.FileChecksum))
+	return b, nil
+}
+
+// UnmarshalBinary decodes h from a byte slice.
+func (t *Trailer) UnmarshalBinary(b []byte) error {
+	if len(b) < TrailerSize {
+		return io.ErrShortBuffer
+	}
+
+	t.PostApplyChecksum = Checksum(binary.BigEndian.Uint64(b[0:]))
+	t.FileChecksum = Checksum(binary.BigEndian.Uint64(b[8:]))
+	return nil
+}
+
+// MaxPageSize is the maximum allowed page size for SQLite.
+const MaxPageSize = 65536
+
+// IsValidPageSize returns true if sz is between 512 and 64K and a power of two.
+func IsValidPageSize(sz uint32) bool {
+	for i := uint32(512); i <= MaxPageSize; i *= 2 {
+		if sz == i {
+			return true
+		}
+	}
+	return false
+}
+
+// PageHeader represents the header for a single page in an LTX file.
+type PageHeader struct {
+	Pgno  uint32
+	Flags uint16
+}
+
+// IsZero returns true if the header is empty.
+func (h *PageHeader) IsZero() bool {
+	return *h == (PageHeader{})
+}
+
+// Validate returns an error if h is invalid.
+func (h *PageHeader) Validate() error {
+	if h.Pgno == 0 {
+		return fmt.Errorf("page number required")
+	}
+	if h.Flags != 0 {
+		return fmt.Errorf("no flags allowed, reserved for future use")
+	}
+	return nil
+}
+
+// MarshalBinary encodes h to a byte slice.
+func (h *PageHeader) MarshalBinary() ([]byte, error) {
+	b := make([]byte, PageHeaderSize)
+	binary.BigEndian.PutUint32(b[0:], h.Pgno)
+	binary.BigEndian.PutUint16(b[4:], h.Flags)
+	return b, nil
+}
+
+// UnmarshalBinary decodes h from a byte slice.
+func (h *PageHeader) UnmarshalBinary(b []byte) error {
+	if len(b) < PageHeaderSize {
+		return io.ErrShortBuffer
+	}
+
+	h.Pgno = binary.BigEndian.Uint32(b[0:])
+	h.Flags = binary.BigEndian.Uint16(b[4:])
+	return nil
+}
+
+// ParseFilename parses a transaction range from an LTX file.
+func ParseFilename(name string) (minTXID, maxTXID TXID, err error) {
+	a := filenameRegex.FindStringSubmatch(name)
+	if a == nil {
+		return 0, 0, fmt.Errorf("invalid ltx filename: %s", name)
+	}
+
+	min, _ := strconv.ParseUint(a[1], 16, 64)
+	max, _ := strconv.ParseUint(a[2], 16, 64)
+	return TXID(min), TXID(max), nil
+}
+
+// FormatTimestamp returns t with a fixed-width, millisecond-resolution UTC format.
+func FormatTimestamp(t time.Time) string {
+	return t.UTC().Format(RFC3339Milli)
+}
+
+// ParseTimestamp parses a timestamp as RFC3339Milli (fixed-width) but will
+// fallback to RFC3339Nano if it fails. This is to support timestamps written
+// before the introduction of the standard time format.
+func ParseTimestamp(value string) (time.Time, error) {
+	// Attempt standard format first.
+	t, err := time.Parse(RFC3339Milli, value)
+	if err == nil {
+		return t, nil
+	}
+
+	// If the standard fails, fallback to stdlib format but truncate to milliseconds.
+	t2, err2 := time.Parse(time.RFC3339Nano, value)
+	if err2 != nil {
+		return t, err // use original error on failure.
+	}
+	return t2.Truncate(time.Millisecond), nil
+}
+
+var filenameRegex = regexp.MustCompile(`^([0-9a-f]{16})-([0-9a-f]{16})\.ltx$`)
+
+// FormatFilename returns an LTX filename representing a range of transactions.
+func FormatFilename(minTXID, maxTXID TXID) string {
+	return fmt.Sprintf("%s-%s.ltx", minTXID.String(), maxTXID.String())
+}
+
+const PENDING_BYTE = 0x40000000
+
+// LockPgno returns the page number where the PENDING_BYTE exists.
+func LockPgno(pageSize uint32) uint32 {
+	return uint32(PENDING_BYTE/int64(pageSize)) + 1
+}
+
+// FileIterator represents an iterator over a collection of LTX files.
+type FileIterator interface {
+	io.Closer
+
+	// Prepares the next LTX file for reading with the Item() method.
+	// Returns true if another item is available. Returns false if no more
+	// items are available or if an error occured.
+	Next() bool
+
+	// Returns an error that occurred during iteration.
+	Err() error
+
+	// Returns metadata for the currently positioned LTX file.
+	Item() *FileInfo
+}
+
+// SliceFileIterator returns all LTX files from an iterator as a slice.
+func SliceFileIterator(itr FileIterator) ([]*FileInfo, error) {
+	var a []*FileInfo
+	for itr.Next() {
+		a = append(a, itr.Item())
+	}
+	return a, itr.Close()
+}
+
+var _ FileIterator = (*FileInfoSliceIterator)(nil)
+
+// FileInfoSliceIterator represents an iterator for iterating over a slice of LTX files.
+type FileInfoSliceIterator struct {
+	init bool
+	a    []*FileInfo
+}
+
+// NewFileInfoSliceIterator returns a new instance of FileInfoSliceIterator.
+// This function will sort the slice in place before returning the iterator.
+func NewFileInfoSliceIterator(a []*FileInfo) *FileInfoSliceIterator {
+	slices.SortFunc(a, func(x, y *FileInfo) int {
+		if v := cmp.Compare(x.Level, y.Level); v != 0 {
+			return v
+		}
+		if v := cmp.Compare(x.MinTXID, y.MinTXID); v != 0 {
+			return v
+		}
+		return cmp.Compare(x.MaxTXID, y.MaxTXID)
+	})
+
+	return &FileInfoSliceIterator{a: a}
+}
+
+// Close always returns nil.
+func (itr *FileInfoSliceIterator) Close() error { return nil }
+
+// Next moves to the next wal segment. Returns true if another segment is available.
+func (itr *FileInfoSliceIterator) Next() bool {
+	if !itr.init {
+		itr.init = true
+		return len(itr.a) > 0
+	}
+	itr.a = itr.a[1:]
+	return len(itr.a) > 0
+}
+
+// Err always returns nil.
+func (itr *FileInfoSliceIterator) Err() error { return nil }
+
+// Item returns the metadata from the currently positioned wal segment.
+func (itr *FileInfoSliceIterator) Item() *FileInfo {
+	if len(itr.a) == 0 {
+		return nil
+	}
+	return itr.a[0]
+}
+
+// FileInfo represents file information about an LTX file.
+type FileInfo struct {
+	Level             int
+	MinTXID           TXID
+	MaxTXID           TXID
+	PreApplyChecksum  Checksum
+	PostApplyChecksum Checksum
+	Size              int64
+	CreatedAt         time.Time
+}
+
+// PreApplyPos returns the replication position before the LTX file is applied.
+func (info *FileInfo) PreApplyPos() Pos {
+	return Pos{
+		TXID:              info.MinTXID - 1,
+		PostApplyChecksum: info.PreApplyChecksum,
+	}
+}
+
+// PostApplyPos returns the replication position after the LTX file is applied.
+func (info *FileInfo) Pos() Pos {
+	return Pos{
+		TXID:              info.MaxTXID,
+		PostApplyChecksum: info.PostApplyChecksum,
+	}
+}
+
+// FileInfoSlice represents a slice of WAL segment metadata.
+type FileInfoSlice []*FileInfo
+
+func (a FileInfoSlice) Len() int { return len(a) }
+
+func (a FileInfoSlice) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+func (a FileInfoSlice) Less(i, j int) bool {
+	if a[i].Level != a[j].Level {
+		return a[i].Level < a[j].Level
+	}
+	return a[i].MinTXID < a[j].MinTXID
+}
+
+// MaxTXID returns the MaxTXID of the last element in the slice.
+// Returns zero if the slice is empty.
+func (a FileInfoSlice) MaxTXID() TXID {
+	if len(a) == 0 {
+		return 0
+	}
+	return a[len(a)-1].MaxTXID
+}
+
+// IsContiguous returns true if the transaction range is contiguous with the previous range.
+// This is used to validate that the transaction ranges are contiguous when rebuilding snapshots.
+func IsContiguous(prevMaxTXID, minTXID, maxTXID TXID) bool {
+	return minTXID <= prevMaxTXID+1 && maxTXID > prevMaxTXID
+}


### PR DESCRIPTION
## Summary
- Preserve earliest LTX timestamps during compaction so PITR bounds survive L0 retention.
- Use metadata timestamps when computing replica time bounds.

## Problem
Timestamp-based restore rejects valid times once L0 files expire even though L1+ contains the data. Investigation evidence:
- `ltx.Compactor` encodes the output header timestamp from the last input header (`maxHdr.Timestamp`), so compacted files report compaction time instead of the earliest source timestamp.
- `Replica.TimeBounds()` uses `CreatedAt` from `LTXFiles()` to validate restore timestamps.

## Solution
- Add a header timestamp override to the LTX compactor and set it to the oldest source file timestamp during compaction.
- Switch `Replica.TimeBounds()` to request metadata timestamps so remote backends use the preserved timestamps.

## Scope
**In scope:**
- Preserve earliest `CreatedAt` for compacted LTX files.
- Accurate time bounds for restore validation.

**Not in scope:**
- Changes to retention policy or restore planning beyond time-bound validation.

## Test Plan
- `go test ./...`

## Related
- Fixes #1038
