### PR TITLE
Handle S3 connection drops during restores of large databases

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -570,12 +570,16 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 
 		r.Logger().Debug("opening ltx file for restore", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
 
-		// Add file to be compacted.
+		// Open the LTX file and wrap it in a resumable reader that can
+		// automatically reconnect if the connection is dropped during
+		// long-running compaction. This is critical for large databases
+		// where S3/storage connections may time out while waiting for
+		// the compactor to process earlier files.
 		f, err := r.Client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
 		if err != nil {
 			return fmt.Errorf("open ltx file: %w", err)
 		}
-		rdrs = append(rdrs, f)
+		rdrs = append(rdrs, NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, r.Logger()))
 	}
 
 	if len(rdrs) == 0 {
@@ -1145,4 +1149,115 @@ func (r *Replica) ValidateLevel(ctx context.Context, level int) ([]ValidationErr
 	}
 
 	return errors, nil
+}
+
+// resumableReader wraps an io.ReadCloser from a remote storage backend with
+// automatic reconnection on read errors.
+//
+// During restore, the LTX compactor opens all LTX file streams upfront, then
+// processes pages in page-number order. Incremental LTX files that only contain
+// high-numbered pages may have their S3/storage streams sit idle for minutes
+// while the compactor works through lower-numbered pages from the snapshot.
+// Storage providers (S3, Tigris, etc.) may close these idle connections,
+// causing "unexpected EOF" errors.
+//
+// This reader detects two failure modes:
+//  1. Non-EOF errors (connection reset, timeout) - the stream broke mid-transfer.
+//  2. Premature EOF - the server closed the connection cleanly, but we haven't
+//     read all bytes yet (detected by comparing offset against known file size).
+//
+// On failure, it closes the dead stream and reopens from the current byte
+// offset using the storage backend's range request support (the offset parameter
+// of OpenLTXFile). Callers like io.ReadFull see a seamless byte stream because
+// partial reads are returned without error, prompting the caller to request
+// remaining bytes on the next Read call.
+type ResumableReader struct {
+	ctx     context.Context
+	client  ReplicaClient
+	level   int
+	minTXID ltx.TXID
+	maxTXID ltx.TXID
+	size    int64 // expected total file size from FileInfo; 0 means unknown
+	offset  int64
+	rc      io.ReadCloser
+	logger  *slog.Logger
+}
+
+// NewResumableReader creates a ResumableReader. Primarily exposed for testing.
+func NewResumableReader(ctx context.Context, client ReplicaClient, level int, minTXID, maxTXID ltx.TXID, size int64, rc io.ReadCloser, logger *slog.Logger) *ResumableReader {
+	return &ResumableReader{
+		ctx:     ctx,
+		client:  client,
+		level:   level,
+		minTXID: minTXID,
+		maxTXID: maxTXID,
+		size:    size,
+		rc:      rc,
+		logger:  logger,
+	}
+}
+
+const resumableReaderMaxRetries = 3
+
+func (r *ResumableReader) Read(p []byte) (int, error) {
+	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
+		// Reopen the stream from the current offset if the previous
+		// connection was closed (rc is nil after a retry).
+		if r.rc == nil {
+			rc, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
+			if err != nil {
+				return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+			}
+			r.rc = rc
+		}
+
+		n, err := r.rc.Read(p)
+		r.offset += int64(n)
+
+		if err == nil {
+			return n, nil
+		}
+
+		if err == io.EOF {
+			// Distinguish legitimate EOF (fully read) from premature EOF
+			// (server closed idle connection). When the file size is known
+			// and we haven't read it all, treat as a connection drop.
+			if r.size > 0 && r.offset < r.size {
+				r.logger.Debug("premature EOF on ltx file, reconnecting",
+					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
+					"offset", r.offset, "size", r.size, "attempt", attempt+1)
+				r.rc.Close()
+				r.rc = nil
+				if n > 0 {
+					// Return the bytes we did get. The caller (e.g. io.ReadFull)
+					// will call Read again, which will trigger the reopen above.
+					return n, nil
+				}
+				continue
+			}
+			return n, io.EOF
+		}
+
+		// Non-EOF error (connection reset, timeout, etc.). Close the dead
+		// stream so the next iteration reopens from the current offset.
+		r.logger.Debug("read error on ltx file, reconnecting",
+			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
+			"error", err, "offset", r.offset, "attempt", attempt+1)
+		r.rc.Close()
+		r.rc = nil
+		if n > 0 {
+			return n, nil
+		}
+		continue
+	}
+
+	return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d)",
+		r.level, r.minTXID, r.maxTXID, r.offset)
+}
+
+func (r *ResumableReader) Close() error {
+	if r.rc != nil {
+		return r.rc.Close()
+	}
+	return nil
 }

--- a/replica_test.go
+++ b/replica_test.go
@@ -1453,6 +1453,271 @@ func TestReplica_Restore_BothFormats(t *testing.T) {
 	})
 }
 
+func TestResumableReader(t *testing.T) {
+	// The resumableReader wraps a storage stream to handle connection drops
+	// during long restore operations. These tests simulate the failure modes
+	// that occur when S3/Tigris closes idle connections.
+
+	t.Run("NormalRead", func(t *testing.T) {
+		// Verify that a healthy stream passes through unchanged.
+		data := []byte("hello world")
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got %q, want %q", got, data)
+		}
+	})
+
+	t.Run("ReconnectOnError", func(t *testing.T) {
+		// Simulate a connection reset after reading 5 bytes of a 11-byte file.
+		// The reader should transparently reconnect from offset 5 and deliver
+		// the remaining bytes.
+		data := []byte("hello world")
+		callCount := 0
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				if callCount == 1 {
+					// First open: return a reader that errors after 5 bytes.
+					return io.NopCloser(&errorAfterN{data: data, n: 5, err: fmt.Errorf("connection reset")}), nil
+				}
+				// Reconnect: serve from the requested offset.
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got %q, want %q", got, data)
+		}
+		if callCount != 2 {
+			t.Fatalf("expected 2 OpenLTXFile calls (original + reconnect), got %d", callCount)
+		}
+	})
+
+	t.Run("ReconnectOnPrematureEOF", func(t *testing.T) {
+		// Simulate a server that closes the connection cleanly (returns io.EOF)
+		// before all bytes are transferred. The reader detects this by comparing
+		// bytes read against the known file size.
+		data := []byte("hello world")
+		callCount := 0
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				if callCount == 1 {
+					// First open: return only the first 5 bytes, then EOF.
+					return io.NopCloser(bytes.NewReader(data[:5])), nil
+				}
+				// Reconnect: serve from the requested offset.
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got %q, want %q", got, data)
+		}
+		if callCount != 2 {
+			t.Fatalf("expected 2 OpenLTXFile calls, got %d", callCount)
+		}
+	})
+
+	t.Run("ReadFullAcrossReconnect", func(t *testing.T) {
+		// Simulate io.ReadFull reading a 6-byte page header where the
+		// connection drops after 3 bytes. This is the exact scenario from
+		// the original bug: the LTX compactor calls io.ReadFull for a
+		// 6-byte PageHeader, but the stream is dead.
+		data := []byte("ABCDEF remainder of file")
+		callCount := 0
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				if callCount == 1 {
+					return io.NopCloser(&errorAfterN{data: data, n: 3, err: fmt.Errorf("connection reset")}), nil
+				}
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+
+		// Read exactly 6 bytes, like the LTX decoder does for page headers.
+		buf := make([]byte, 6)
+		_, err := io.ReadFull(r, buf)
+		if err != nil {
+			t.Fatalf("io.ReadFull failed: %v", err)
+		}
+		if !bytes.Equal(buf, []byte("ABCDEF")) {
+			t.Fatalf("got %q, want %q", buf, "ABCDEF")
+		}
+	})
+
+	t.Run("MaxRetriesExceeded", func(t *testing.T) {
+		// If the connection keeps failing, the reader should give up after
+		// the maximum retry count rather than looping forever.
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				return io.NopCloser(&errorAfterN{data: nil, n: 0, err: fmt.Errorf("persistent failure")}), nil
+			},
+		}
+
+		r := newTestResumableReader(client, 100, nil)
+		buf := make([]byte, 10)
+		_, err := r.Read(buf)
+		if err == nil {
+			t.Fatal("expected error after max retries, got nil")
+		}
+		if !strings.Contains(err.Error(), "max retries exceeded") {
+			t.Fatalf("expected 'max retries exceeded' error, got: %v", err)
+		}
+	})
+
+	t.Run("ReopenFailure", func(t *testing.T) {
+		// If the initial stream dies and the reopen also fails (e.g., 404),
+		// the error should propagate.
+		data := []byte("hello world")
+		callCount := 0
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				if callCount == 1 {
+					return io.NopCloser(&errorAfterN{data: data, n: 3, err: fmt.Errorf("connection reset")}), nil
+				}
+				return nil, fmt.Errorf("file not found")
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+
+		// First read gets 3 bytes, then error triggers reconnect attempt.
+		buf := make([]byte, 10)
+		n, err := r.Read(buf)
+		if n != 3 {
+			t.Fatalf("expected 3 bytes on first read, got %d", n)
+		}
+		// The error is suppressed on partial reads; next call hits reopen failure.
+		if err != nil {
+			t.Fatalf("expected nil error on partial read, got: %v", err)
+		}
+
+		// Second read should fail with reopen error.
+		_, err = r.Read(buf)
+		if err == nil {
+			t.Fatal("expected error on reopen failure, got nil")
+		}
+		if !strings.Contains(err.Error(), "reopen ltx file") {
+			t.Fatalf("expected 'reopen ltx file' error, got: %v", err)
+		}
+	})
+
+	t.Run("UnknownSize", func(t *testing.T) {
+		// When file size is unknown (size=0), premature EOF cannot be detected,
+		// so a clean EOF from a truncated stream is treated as legitimate.
+		data := []byte("hello world")
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				// Always return only first 5 bytes.
+				return io.NopCloser(bytes.NewReader(data[:5])), nil
+			},
+		}
+
+		r := newTestResumableReader(client, 0 /* unknown size */, data)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Without size info, we can't detect the truncation.
+		if !bytes.Equal(got, data[:5]) {
+			t.Fatalf("got %q, want %q", got, data[:5])
+		}
+	})
+
+	t.Run("CorrectOffsetOnReopen", func(t *testing.T) {
+		// Verify the reader passes the correct byte offset when reopening.
+		data := []byte("0123456789abcdef")
+		var reopenOffset int64
+		callCount := 0
+		client := &mock.ReplicaClient{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				if callCount == 1 {
+					return io.NopCloser(&errorAfterN{data: data, n: 7, err: fmt.Errorf("timeout")}), nil
+				}
+				reopenOffset = offset
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got %q, want %q", got, data)
+		}
+		if reopenOffset != 7 {
+			t.Fatalf("reopen offset = %d, want 7", reopenOffset)
+		}
+	})
+}
+
+// newTestResumableReader creates a resumableReader for testing. The initial
+// stream is opened from the client; data is only used for reference.
+func newTestResumableReader(client *mock.ReplicaClient, size int64, data []byte) *litestream.ResumableReader {
+	rc, _ := client.OpenLTXFile(context.Background(), 0, 1, 1, 0, 0)
+	return litestream.NewResumableReader(
+		context.Background(),
+		client,
+		0,    // level
+		1,    // minTXID
+		1,    // maxTXID
+		size, // expected file size
+		rc,
+		slog.Default(),
+	)
+}
+
+// errorAfterN is a reader that returns data normally for the first n bytes,
+// then returns the specified error. This simulates a connection that drops
+// mid-transfer.
+type errorAfterN struct {
+	data []byte
+	n    int // bytes to return before erroring
+	pos  int
+	err  error
+}
+
+func (r *errorAfterN) Read(p []byte) (int, error) {
+	if r.pos >= r.n {
+		return 0, r.err
+	}
+	remaining := r.n - r.pos
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	n := copy(p, r.data[r.pos:r.pos+len(p)])
+	r.pos += n
+	return n, nil
+}
+
 // createTestLTXSnapshot creates a minimal LTX snapshot for testing.
 func createTestLTXSnapshot(t *testing.T) []byte {
 	t.Helper()


### PR DESCRIPTION
Disclaimer: This was completely written by Claude Code using Opus 4.5. I reviewed the code and it seems sensible but I am not a Go developer, nor am I familiar with this code base. I verified that this fix does work and did enable me to download the database I was trying to restore.

## Description
During restore of large databases (~55 GB), the LTX compactor opens all S3 streams upfront but processes pages in page-number order. Incremental LTX files with high-numbered pages sit idle for minutes while lower pages are processed from the snapshot. Storage providers (S3, Tigris) close these idle connections, causing "unexpected EOF" errors.

Wrap each LTX file stream in a ResumableReader that detects connection drops (both non-EOF errors and premature EOF) and transparently reopens from the current byte offset using range requests. Partial reads are returned without error so callers like io.ReadFull continue seamlessly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to issue if applicable: -->
Fixes #1077

## How Has This Been Tested?
I ran the tests and was able to download the larger database that I was previously unable to restore. While downloading, I did see log lines like this, indicating the retries were triggering:

```json
{"time":"2026-02-03T10:42:32.603454-05:00","level":"DEBUG","msg":"read error on ltx file, reconnecting","db":"db.sqlite","replica":"s3","level":3,"min":"0000000000000060","max":"0000000000000062","error":"unexpected EOF","offset":30130176,"attempt":1}
```

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
