### PR TITLE
docs: add cross-reference for pending litestream.io user docs

### DIFF
--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -1,0 +1,23 @@
+# Pending User-Facing Documentation
+
+This file tracks open issues on [benbjohnson/litestream.io](https://github.com/benbjohnson/litestream.io) that need user-facing documentation for features recently added to Litestream.
+
+## Open Issues
+
+| Issue | Title | Related Litestream PR | Category |
+|-------|-------|-----------------------|----------|
+| [#240](https://github.com/benbjohnson/litestream.io/issues/240) | `skip-remote-deletion` config option | #1094 | Config |
+| [#241](https://github.com/benbjohnson/litestream.io/issues/241) | SyncStatus, SyncAndWait, EnsureExists API | #1092 | Library API |
+| [#242](https://github.com/benbjohnson/litestream.io/issues/242) | Embedded CA bundle eliminates certificate setup | #1099 | Docker |
+| [#243](https://github.com/benbjohnson/litestream.io/issues/243) | S3 URL query parameters and R2 defaults | #1100, #1101 | S3/Cloud |
+| [#244](https://github.com/benbjohnson/litestream.io/issues/244) | Distributed leasing documentation | #1073 | S3/Cloud |
+| [#245](https://github.com/benbjohnson/litestream.io/issues/245) | `-level` flag for ltx command | #1072 | Reference |
+| [#246](https://github.com/benbjohnson/litestream.io/issues/246) | IPC Unix socket endpoints | #1021 | Reference |
+| [#247](https://github.com/benbjohnson/litestream.io/issues/247) | `$PID` environment variable in config | #1070 | Config |
+| [#248](https://github.com/benbjohnson/litestream.io/issues/248) | `validation-interval` config option | — | Config |
+| [#249](https://github.com/benbjohnson/litestream.io/issues/249) | Automatic v0.3.x backup restore | #1074, #1075 | Restore |
+| [#250](https://github.com/benbjohnson/litestream.io/issues/250) | MCP tools for v0.5.x changes | — | MCP |
+
+## AI Documentation Status
+
+Internal AI documentation (this repo) is tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106).


### PR DESCRIPTION
## Summary
- New `docs/PENDING_USER_DOCS.md` tracking 11 open issues on `benbjohnson/litestream.io` (#240-#250)
- Maps each user-facing doc issue to the related Litestream PR and category
- Cross-references internal AI docs tracking issue #1106

Refs #1106 (Task 10)

## Test plan
- [x] Verified all litestream.io issue numbers and titles via `gh issue list`
- [x] Build passes: `go build ./cmd/litestream`
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)