### PR TITLE
ci: enable automatic Homebrew tap updates on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,23 +79,24 @@ nfpms:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
-#brews:
-#  - name: litestream
-#    homepage: https://litestream.io
-#    description: Streaming replication for SQLite databases
-#    license: Apache-2.0
-#    repository:
-#      owner: benbjohnson
-#      name: homebrew-litestream
-#      branch: main
-#      install: |
-#      bin.install "litestream"
-#      etc.install "etc/litestream.yml" => "litestream.yml"
-#    test: |
-#      system "#{bin}/litestream", "version"
-#    commit_author:
-#      name: goreleaser
-#      email: bot@goreleaser.com
+brews:
+  - name: litestream
+    homepage: https://litestream.io
+    description: Streaming replication for SQLite databases
+    license: Apache-2.0
+    repository:
+      owner: benbjohnson
+      name: homebrew-litestream
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    install: |
+      bin.install "litestream"
+      etc.install "etc/litestream.yml" => "litestream.yml"
+    test: |
+      system "#{bin}/litestream", "version"
+    commit_author:
+      name: goreleaser
+      email: bot@goreleaser.com
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Uncomment and fix the GoReleaser brews config so that releases automatically push an updated formula to benbjohnson/homebrew-litestream.

In order for this to work, the Github action for this repo needs a `HOMEBREW_TAP_GITHUB_TOKEN` that is valid for modifying the tap repo.