### PR TITLE
fix(metrics) Fix sync, checkpoint error tracking

### DIFF
--- a/db.go
+++ b/db.go
@@ -859,7 +859,6 @@ func (db *DB) Sync(ctx context.Context) error {
 	close(db.notify)
 	db.notify = make(chan struct{})
 	// }
-	//
 
 	success = true
 	return nil


### PR DESCRIPTION
Sync and checkpoint error tracking is currently broken, even if operations are failing the error counter is never incremented. This is due to errors being returned explicitly and never assigned to the named return variable; the conditional inside the `defer` call always evaluates to `nil`. 

Reproduction:
https://go.dev/play/p/Vr8r9ADkAEy