### PR TITLE
fix(vfs): persist hydration file across connection restarts

### DIFF
--- a/vfs.go
+++ b/vfs.go
@@ -910,7 +910,19 @@ func (h *Hydrator) saveMeta() error {
 		}
 		return fmt.Errorf("rename hydration meta: %w", err)
 	}
+	if err := syncDir(filepath.Dir(h.metaPath())); err != nil {
+		return fmt.Errorf("sync hydration meta directory: %w", err)
+	}
 	return nil
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
 }
 
 func NewVFSFile(client ReplicaClient, name string, logger *slog.Logger) *VFSFile {


### PR DESCRIPTION
## Summary

- Fixes #1121: `LITESTREAM_HYDRATION_PATH` files were deleted on close and truncated on open, forcing full re-hydration every restart
- Adds a `persistent` flag to the `Hydrator` that preserves the hydration file and saves the TXID to a companion `.meta` file (written atomically via temp+rename)
- On next open, if the `.meta` and hydration file both exist, resumes from the saved TXID position instead of doing a full restore
- Handles TXID regression: if the remote replica has been reset/rewound below the persisted TXID, discards the stale hydration file and does a full restore
- Handles stale `.meta`: if the `.meta` exists but the hydration file is missing, cleans up the `.meta` and starts fresh
- Temp file behavior (no `LITESTREAM_HYDRATION_PATH`) is unchanged — file is still deleted on close

## Test plan

- [x] `TestHydrator_Close_Persistent` — persistent file preserved, `.meta` written with correct TXID
- [x] `TestHydrator_Init_Resume` — opens without truncating, loads TXID from `.meta`
- [x] `TestHydrator_Close_TempFile` — temp file deleted, no `.meta` created
- [x] `TestHydrator_Init_StaleMeta` — `.meta` without hydration file triggers fresh creation
- [x] All existing hydration tests pass (`TestVFSFile_Hydration_*`)
- [x] `go build -tags vfs ./...` clean
- [x] `go test -tags vfs -race ./...` passes
- [x] Pre-commit hooks pass (go-imports, go-vet, staticcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)