### PR TITLE
fix(db): count sync errors when db.init() fails

### DIFF
--- a/db.go
+++ b/db.go
@@ -947,14 +947,6 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	// Initialize database, if necessary. Exit if no DB exists.
-	if err := db.init(ctx); err != nil {
-		return err
-	} else if db.db == nil {
-		db.Logger.Debug("sync: no database found")
-		return nil
-	}
-
 	// Track total sync metrics.
 	t := time.Now()
 	defer func() {
@@ -964,6 +956,14 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		}
 		db.syncSecondsCounter.Add(float64(time.Since(t).Seconds()))
 	}()
+
+	// Initialize database, if necessary. Exit if no DB exists.
+	if err := db.init(ctx); err != nil {
+		return err
+	} else if db.db == nil {
+		db.Logger.Debug("sync: no database found")
+		return nil
+	}
 
 	// Ensure WAL has at least one frame in it.
 	if err := db.ensureWALExists(ctx); err != nil {


### PR DESCRIPTION
## Summary

- Move the metrics `defer` block before the `db.init()` call in `DB.Sync()` so that init failures are properly counted by `syncErrorNCounter`
- Previously, if `db.init()` failed (e.g., invalid credentials, corrupt path), the method returned before the defer was registered, so the error was never reflected in metrics

Fixes #1128

## Test Plan

- [x] Added `TestDB_Sync_InitErrorMetrics` — creates a DB with a directory at the DB path so `init()` fails, then verifies `syncErrorNCounter` is incremented
- [x] `go test -race ./...` passes
- [x] Pre-commit hooks pass (imports, vet, staticcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)