### PR TITLE
test(ci): add smoke tests for hardened scratch Docker image

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -119,6 +119,14 @@ jobs:
             echo "FAIL: Expected user 'nonroot:nonroot', got '$user'"
             exit 1
           fi
+          docker create --name uid-check litestream:hardened version
+          uid=$(docker export uid-check | tar -xf - --to-stdout etc/passwd | grep '^nonroot:' | cut -d: -f3)
+          docker rm uid-check
+          echo "nonroot UID: $uid"
+          if [ "$uid" != "65532" ]; then
+            echo "FAIL: Expected UID 65532, got '$uid'"
+            exit 1
+          fi
 
       - name: "Hardened: verify no shell exists"
         run: |


### PR DESCRIPTION
## Summary

- Replaces the `docker-build-test` job with `docker-smoke-test` in the CI commit workflow
- Builds **both** Docker targets: `default` (Debian) and `hardened` (scratch)
- Adds smoke tests for the hardened image: version command, non-root user (`nonroot:nonroot`), no shell, and CA certificates present
- Uses only standard `docker` commands (no external test tools) to keep CI dependencies minimal

Fixes #1130

## Test Plan

- [ ] CI `docker-smoke-test` job passes on this PR
- [ ] Default image builds and `version` command succeeds
- [ ] Hardened image builds and `version` command succeeds
- [ ] Hardened image user check validates `nonroot:nonroot`
- [ ] Hardened image confirms no `/bin/sh` shell exists
- [ ] Hardened image confirms CA certificates are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)