### PR TITLE
fix(restore): expose -follow-interval CLI flag for follow mode

### DIFF
--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -29,6 +29,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
 	fs.BoolVar(&opt.Follow, "f", false, "follow mode")
+	fs.DurationVar(&opt.FollowInterval, "follow-interval", opt.FollowInterval, "polling interval for follow mode")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -201,6 +202,10 @@ Arguments:
 	    new changes. Similar to tail -f. The restored database should
 	    only be opened in read-only mode by consumers.
 	    Cannot be used with -txid or -timestamp.
+
+	-follow-interval DURATION
+	    Polling interval for follow mode.
+	    Defaults to 1s.
 
 	-parallelism NUM
 	    Determines the number of WAL files downloaded in parallel.

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	litestream "github.com/benbjohnson/litestream"
+)
+
+func TestRestoreCommand_FollowIntervalFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantVal time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "Default",
+			args:    []string{"/tmp/db"},
+			wantVal: time.Second,
+		},
+		{
+			name:    "CustomValue",
+			args:    []string{"-follow-interval", "500ms", "/tmp/db"},
+			wantVal: 500 * time.Millisecond,
+		},
+		{
+			name:    "LongerInterval",
+			args:    []string{"-follow-interval", "5s", "/tmp/db"},
+			wantVal: 5 * time.Second,
+		},
+		{
+			name:    "InvalidDuration",
+			args:    []string{"-follow-interval", "notaduration", "/tmp/db"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := litestream.NewRestoreOptions()
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			fs.DurationVar(&opt.FollowInterval, "follow-interval", opt.FollowInterval, "polling interval for follow mode")
+
+			err := fs.Parse(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if opt.FollowInterval != tt.wantVal {
+				t.Fatalf("FollowInterval=%v, want %v", opt.FollowInterval, tt.wantVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Register the `-follow-interval` CLI flag on the `restore` command so users can tune the polling interval when using `-f` follow mode. Also adds the flag's documentation to the usage/help text.

## Motivation and Context

PR #1102 added `-f` follow mode for continuous restore but never wired the `FollowInterval` field (already present in `RestoreOptions` with a `1s` default) to a CLI flag. Users had no way to change the polling interval from the command line.

Fixes #1138

## How Has This Been Tested?

- `go build ./...` compiles successfully
- Added `TestRestoreCommand_FollowIntervalFlag` with table-driven subtests covering default value, custom values (`500ms`, `5s`), and invalid duration input
- `go test ./...` — all tests pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)