### PR TITLE
feat(sync): add replicated_txid to sync response

### DIFF
--- a/server.go
+++ b/server.go
@@ -367,9 +367,10 @@ func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, SyncResponse{
-		Status: status,
-		Path:   expandedPath,
-		TXID:   result.TXID,
+		Status:         status,
+		Path:           expandedPath,
+		TXID:           result.TXID,
+		ReplicatedTXID: result.ReplicatedTXID,
 	})
 }
 
@@ -382,9 +383,10 @@ type SyncRequest struct {
 
 // SyncResponse is the response body for the /sync endpoint.
 type SyncResponse struct {
-	Status string `json:"status"`
-	Path   string `json:"path"`
-	TXID   uint64 `json:"txid"`
+	Status         string `json:"status"`
+	Path           string `json:"path"`
+	TXID           uint64 `json:"txid"`
+	ReplicatedTXID uint64 `json:"replicated_txid"`
 }
 
 func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -609,6 +609,7 @@ func TestServer_HandleSync(t *testing.T) {
 		require.Equal(t, "synced", result.Status)
 		require.Equal(t, db.Path(), result.Path)
 		require.Greater(t, result.TXID, uint64(0))
+		require.Greater(t, result.ReplicatedTXID, uint64(0))
 	})
 
 	t.Run("NoChange", func(t *testing.T) {

--- a/store.go
+++ b/store.go
@@ -391,8 +391,9 @@ func (s *Store) DisableDB(ctx context.Context, path string) error {
 
 // SyncDBResult holds the result of a sync operation.
 type SyncDBResult struct {
-	TXID    uint64
-	Changed bool
+	TXID           uint64
+	ReplicatedTXID uint64
+	Changed        bool
 }
 
 // SyncDB forces an immediate sync for a database. If wait is true, blocks
@@ -429,9 +430,15 @@ func (s *Store) SyncDB(ctx context.Context, path string, wait bool) (SyncDBResul
 		return SyncDBResult{}, fmt.Errorf("read position after sync: %w", err)
 	}
 
+	var replicatedTXID uint64
+	if db.Replica != nil {
+		replicatedTXID = uint64(db.Replica.Pos().TXID)
+	}
+
 	return SyncDBResult{
-		TXID:    uint64(afterTXID),
-		Changed: afterTXID > beforeTXID,
+		TXID:           uint64(afterTXID),
+		ReplicatedTXID: replicatedTXID,
+		Changed:        afterTXID > beforeTXID,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Add a `replicated_txid` field to the sync API response (`SyncResponse` and `SyncDBResult`). After a sync completes, the response now includes the transaction ID confirmed replicated to remote storage via `db.Replica.Pos().TXID`.

This allows callers to verify that writes have been durably replicated, not just synced locally.

## Motivation and Context

Fixes #868

Issue #868 requested synchronous replication — the ability to confirm writes have been replicated to remote storage. The existing `sync --wait` command blocks until remote replication completes, but previously the response only included the local TXID. Adding `replicated_txid` gives users confirmation of what was actually replicated.

## How Has This Been Tested?

- `go build ./...` — compiles cleanly
- `go test -race -run TestServer_HandleSync -v` — all subtests pass
- `go test -race -run TestSyncCommand -v ./cmd/litestream/` — all subtests pass
- Updated `SuccessWithWait` test asserts `ReplicatedTXID > 0`
- Verified no-wait case returns `replicated_txid: 0` (expected since replica monitor is not triggered)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)