### PR TITLE
fix(ci): authenticate GitHub API call in NATS test setup

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -319,12 +319,13 @@ jobs:
       - name: Create NATS Object Store Bucket
         run: |
           # Install NATS CLI - get latest version using jq for JSON parsing
-          NATS_VERSION=$(curl -fsSL https://api.github.com/repos/nats-io/natscli/releases/latest \
+          NATS_VERSION=$(curl -fsSL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/nats-io/natscli/releases/latest \
             | jq -r '.tag_name' \
             | sed 's/^v//')
           if [ -z "$NATS_VERSION" ] || [ "$NATS_VERSION" = "null" ]; then
-            echo "Failed to determine latest NATS CLI version"
-            exit 1
+            NATS_VERSION="0.3.1"
+            echo "Warning: Failed to fetch latest NATS CLI version, using fallback v${NATS_VERSION}"
           fi
           wget "https://github.com/nats-io/natscli/releases/download/v${NATS_VERSION}/nats-${NATS_VERSION}-linux-amd64.zip" -O nats.zip
           unzip nats.zip


### PR DESCRIPTION
## Description

Authenticate the GitHub API call used to fetch the latest NATS CLI version in the CI workflow, and add a pinned fallback version if the API call fails.

Two changes to `.github/workflows/commit.yml`:
- Add `Authorization: token ${{ secrets.GITHUB_TOKEN }}` header to the curl request (raises rate limit from 60 to 5,000 req/hour)
- Fall back to a pinned NATS CLI version (v0.3.1) instead of failing the build if the API call returns no result

## Motivation and Context

The NATS integration test intermittently fails in CI because the unauthenticated curl call to `api.github.com` hits GitHub's 60 req/hour rate limit, which is shared across all Actions runners on the same IP.

Fixes #1143

## How Has This Been Tested?

- Verified YAML syntax is valid
- `GITHUB_TOKEN` is a built-in GitHub Actions secret requiring no additional configuration
- The fallback path ensures CI never fails due to API rate limiting

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)