### PR TITLE
feat(s3): add LITESTREAM_S3_ENDPOINT env var for URL-based restore

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -218,7 +218,9 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 	if endpoint == "" {
 		if v := os.Getenv("LITESTREAM_S3_ENDPOINT"); v != "" {
 			endpoint, _ = litestream.EnsureEndpointScheme(v)
-			forcePathStyle = true
+			if !forcePathStyleSet {
+				forcePathStyle = true
+			}
 		}
 	}
 

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2050,6 +2050,13 @@ func TestNewReplicaClientFromURL_EndpointEnvVar(t *testing.T) {
 			wantForcePathStyle: true,
 		},
 		{
+			name:               "env_var_respects_force_path_style_false",
+			url:                "s3://mybucket/path?force-path-style=false",
+			envEndpoint:        "http://localhost:9000",
+			wantEndpoint:       "http://localhost:9000",
+			wantForcePathStyle: false,
+		},
+		{
 			name:               "no_env_var_no_endpoint",
 			url:                "s3://mybucket/path",
 			envEndpoint:        "",
@@ -2060,9 +2067,7 @@ func TestNewReplicaClientFromURL_EndpointEnvVar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envEndpoint != "" {
-				t.Setenv("LITESTREAM_S3_ENDPOINT", tt.envEndpoint)
-			}
+			t.Setenv("LITESTREAM_S3_ENDPOINT", tt.envEndpoint)
 
 			client, err := litestream.NewReplicaClientFromURL(tt.url)
 			if err != nil {


### PR DESCRIPTION
## Description

Add support for the `LITESTREAM_S3_ENDPOINT` environment variable in `NewReplicaClientFromURL()`, allowing users to specify a custom S3-compatible endpoint when using bare `s3://` URLs without a config file.

Changes:
- Read `LITESTREAM_S3_ENDPOINT` env var as a fallback when no endpoint is set from the URL host or query params
- Apply `EnsureEndpointScheme()` to add https/http scheme when missing
- Default to `forcePathStyle = true` for env-var-specified endpoints (custom endpoints typically need path-style)
- Move provider detection after env var reading so provider-specific defaults apply to env-var-specified endpoints too

## Motivation and Context

Fixes #666

Users running `litestream restore s3://bucket/path` against S3-compatible providers (Hetzner, MinIO, etc.) currently have no way to specify the endpoint without a config file. The code already reads `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from env vars but not an endpoint. This forces users to either create a config file or use the `?endpoint=` query parameter in the URL.

With this change:
```sh
LITESTREAM_S3_ENDPOINT=https://fsn1.your-objectstorage.com \
  litestream restore -o /tmp/test.db s3://mybucket/mydb
```

## How Has This Been Tested?

- `go build ./cmd/litestream` — builds successfully
- `go test -race ./...` — all tests pass
- Added `TestNewReplicaClientFromURL_EndpointEnvVar` with 4 test cases:
  - Env var sets endpoint and forces path style
  - Env var without scheme gets `https://` added automatically
  - URL `?endpoint=` query param takes priority over env var
  - No env var results in no endpoint (baseline)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)