### PR TITLE
feat(config): add Kubernetes COSI BucketInfo JSON configuration support

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -353,12 +353,17 @@ func applyBucketInfoToReplica(rc *ReplicaConfig) error {
 		return nil
 	}
 
-	info, err := ReadBucketInfo(rc.BucketInfoPath)
+	path, err := expand(rc.BucketInfoPath)
+	if err != nil {
+		return fmt.Errorf("replica %q: expand bucket-info path: %w", rc.Path, err)
+	}
+
+	info, err := ReadBucketInfo(path)
 	if err != nil {
 		return fmt.Errorf("replica %q: %w", rc.Path, err)
 	}
 
-	rc.ApplyBucketInfo(info)
+	rc.ApplyBucketInfo(info, rc.URL != "")
 
 	if rc.Type == "" && rc.URL == "" {
 		rc.Type = "s3"


### PR DESCRIPTION
## Description

Add support for Kubernetes COSI (Container Object Storage Interface) BucketInfo JSON files to configure S3 replicas. A new `bucket-info` YAML field on `ReplicaSettings` accepts a file path to a COSI BucketInfo JSON file. When present, Litestream reads the JSON and applies S3 connection values (endpoint, region, bucket, credentials) as defaults — explicit YAML values always take precedence.

Example usage:
```yaml
dbs:
  - path: /data/my.db
    replicas:
      - bucket-info: /var/run/secrets/cosi/BucketInfo
        path: my-db-replica
```

The field participates in `SetDefaults()` propagation, so it can also be set globally:
```yaml
bucket-info: /var/run/secrets/cosi/BucketInfo

dbs:
  - path: /data/my.db
    replicas:
      - path: my-db-replica
```

### Changes

- **`cmd/litestream/cosi.go`** (new): `COSIBucketInfo` structs, `ReadBucketInfo()` parser, `ApplyBucketInfo()` method
- **`cmd/litestream/main.go`**: Added `BucketInfoPath` field to `ReplicaSettings`, propagation in `SetDefaults()`, and `applyBucketInfo()` call in `ParseConfig()` between `propagateGlobalSettings()` and `Validate()`
- **`cmd/litestream/cosi_test.go`** (new): 10 test cases covering parsing, field application, override behavior, and auto-type detection

## Motivation and Context

COSI drivers create Kubernetes Secrets containing JSON with bucket connection details. Currently users must use External Secrets Operator to transpose these values into Litestream-compatible config. This feature lets Litestream read the JSON file directly, simplifying Kubernetes deployments.

Fixes #987

## How Has This Been Tested?

- `go build ./...` — compiles successfully
- `go test -race ./...` — all tests pass (including 10 new COSI tests)
- `go vet ./...` — no issues
- Pre-commit hooks pass (go-imports, go-vet, go-staticcheck)

New tests cover:
- Valid BucketInfo parsing, file not found, invalid JSON, missing S3 protocol, secretS3-only
- Values applied to empty settings, explicit settings preserved, nil info handled
- End-to-end config parsing with bucket-info path
- YAML values override BucketInfo values
- Replica type auto-detected as "s3"

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)