### PR TITLE
docs: surface error handling rules in agent-facing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Litestream is a disaster recovery tool for SQLite that runs as a background proc
 - **IPC socket disabled by default**: Control socket is off by default. Enable with `socket.enabled: true` in config. See `server.go`
 - **`$PID` config expansion**: Config files support `$PID` to expand to the current process ID, plus standard `$ENV_VAR` expansion. See `cmd/litestream/main.go`
 - **`litestream ltx -level`**: Use `-level 0`–`9` or `-level all` to inspect specific compaction levels. See `cmd/litestream/ltx.go`
+- **Return errors, don't log them**: Always return errors to callers. Never `log.Printf(err)` and continue — this silently hides failures in a disaster recovery tool. Only use DEBUG log for best-effort operations where failure doesn't affect correctness and a valid fallback exists (e.g., reading SHM mxFrame optimization hint). See [docs/PATTERNS.md](docs/PATTERNS.md#error-handling)
 
 ## Layer Boundaries
 

--- a/AI_PR_GUIDE.md
+++ b/AI_PR_GUIDE.md
@@ -10,6 +10,7 @@ Before submitting a PR:
 - [ ] **Define scope clearly** - State what this PR does AND does not do
 - [ ] **Include runnable test commands** - Not just descriptions, actual `go test` commands
 - [ ] **Reference related issues/PRs** - Show awareness of related work
+- [ ] **Error handling**: Does the code return errors to callers? Watch for `log.Printf(err)` followed by `continue` or `return nil` — this silently swallows failures.
 
 ## What Makes PRs Succeed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Claude-specific optimizations for Litestream. See [AGENTS.md](AGENTS.md) for project documentation.
 
+## Critical Coding Rules
+
+- **Always return errors, never log and continue.** The only exception is DEBUG logging for best-effort operations that don't affect correctness. This is the #1 cause of PR review feedback. See [docs/PATTERNS.md](docs/PATTERNS.md#error-handling) for the full decision framework.
+
 ## Context Window
 
 With Claude's large context window, load documentation as needed:

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -132,6 +132,22 @@ func writeFileDirect(path string, data []byte) error {
 
 ## Error Handling
 
+### Decision Rule
+
+When you handle an error, ask: "Does the caller need to know about this failure?"
+
+- **Yes → return the error.** This is the default for virtually all cases in Litestream.
+  - The result is needed for correctness
+  - Failure could corrupt data or state
+  - You're in a loop processing items
+
+- **No → DEBUG log only.** This is rare. Only when ALL of these are true:
+  - A valid fallback path exists that doesn't depend on the result
+  - Failure cannot affect correctness
+  - The operation is purely supplementary (e.g., reading an optimization hint)
+
+When in doubt, return the error. In a disaster recovery tool, silent failures are worse than noisy ones.
+
 ### DO: Return errors immediately
 
 ```go


### PR DESCRIPTION
## Description

Surface error handling rules in prominent positions across agent-facing documentation to prevent recurring PR review feedback. Adds ~22 lines across 4 files:

- **AGENTS.md**: Added "Return errors, don't log them" to Critical Rules section
- **CLAUDE.md**: Added new Critical Coding Rules section (the #1 cause of PR review feedback)
- **docs/PATTERNS.md**: Added decision framework ("Does the caller need to know about this failure?") before existing error handling examples
- **AI_PR_GUIDE.md**: Added error handling check to the PR checklist

## Motivation and Context

AI-generated PRs repeatedly log errors instead of returning them (PR #1136, #1087, others). The error handling guidance exists in docs/PATTERNS.md but is structurally invisible to AI agents — not in Critical Rules, not in CLAUDE.md, not in the review checklist. Per Anthropic's research, agent instruction compliance degrades with instruction count, and agents attend most to prominent positions.

Fixes #1153

## How Has This Been Tested?

- `pre-commit run --all-files` — all checks pass
- Reviewed all 4 files for clarity, consistency, and correct cross-references
- Verified markdown links point to correct anchors

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)