### PR TITLE
fix(compactor): stop compaction at TXID gap to prevent repeated failures

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -125,9 +125,25 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		}
 	}()
 
-	var minTXID, maxTXID ltx.TXID
+	var minTXID, maxTXID, expectedMinTXID ltx.TXID
 	for itr.Next() {
 		info := itr.Item()
+
+		// expectedMinTXID is zero until the first file is processed, then
+		// set to MaxTXID+1 after each file. We skip the contiguity check
+		// for the first file because LTXFiles filtering semantics vary
+		// across backends (e.g., file client filters by MinTXID, S3 by
+		// prefix) so we accept whatever the iterator returns first.
+		if expectedMinTXID != 0 && info.MinTXID != expectedMinTXID {
+			if info.MinTXID < expectedMinTXID {
+				return nil, fmt.Errorf("overlapping transaction ids in source files at level %d: expected min %s, got %s", srcLevel, expectedMinTXID, info.MinTXID)
+			}
+			c.logger.Warn("stopping compaction at TXID gap",
+				"level", srcLevel,
+				"expected_min_txid", expectedMinTXID,
+				"actual_min_txid", info.MinTXID)
+			break
+		}
 
 		if minTXID == 0 || info.MinTXID < minTXID {
 			minTXID = info.MinTXID
@@ -139,6 +155,7 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		if c.LocalFileOpener != nil {
 			if f, err := c.LocalFileOpener(srcLevel, info.MinTXID, info.MaxTXID); err == nil {
 				rdrs = append(rdrs, f)
+				expectedMinTXID = info.MaxTXID + 1
 				continue
 			} else if !os.IsNotExist(err) {
 				return nil, fmt.Errorf("open local ltx file: %w", err)
@@ -150,6 +167,7 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 			return nil, fmt.Errorf("open ltx file: %w", err)
 		}
 		rdrs = append(rdrs, internal.NewResumableReader(ctx, c.client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, c.logger))
+		expectedMinTXID = info.MaxTXID + 1
 	}
 	if len(rdrs) == 0 {
 		return nil, ErrNoCompaction

--- a/compactor.go
+++ b/compactor.go
@@ -130,12 +130,15 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		}
 	}()
 
-	// When the destination level already has files, the source must continue
-	// exactly at seekTXID or the destination level would become
-	// non-contiguous. Without a destination file the first source file is
+	// When L1 already has files, L0 must continue exactly at seekTXID or L1
+	// would become non-contiguous: L0 retention only deletes files already
+	// compacted into L1, so a missing seek file is always a real gap. Above
+	// L0 the check must not apply — snapshot retention legitimately deletes
+	// source files past a lagging destination level, and the snapshot covers
+	// the missing range. Without a destination file the first source file is
 	// accepted as-is since earlier files may have been removed by retention.
 	var expectedMinTXID ltx.TXID
-	if prevMaxInfo.MaxTXID > 0 {
+	if srcLevel == 0 && prevMaxInfo.MaxTXID > 0 {
 		expectedMinTXID = seekTXID
 	}
 

--- a/compactor.go
+++ b/compactor.go
@@ -51,6 +51,11 @@ type Compactor struct {
 	// CacheSetter optionally stores MaxLTXFileInfo for a level.
 	// If nil, max file info is not cached.
 	CacheSetter func(level int, info *ltx.FileInfo)
+
+	// SourceGapHandler is invoked when a TXID gap is detected in the source
+	// level during compaction. Used to trigger recovery, such as re-uploading
+	// missing L0 files from disk.
+	SourceGapHandler func(srcLevel int, expectedMinTXID, actualMinTXID ltx.TXID)
 }
 
 // NewCompactor creates a new Compactor with the given client and logger.
@@ -125,15 +130,19 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		}
 	}()
 
-	var minTXID, maxTXID, expectedMinTXID ltx.TXID
+	// When the destination level already has files, the source must continue
+	// exactly at seekTXID or the destination level would become
+	// non-contiguous. Without a destination file the first source file is
+	// accepted as-is since earlier files may have been removed by retention.
+	var expectedMinTXID ltx.TXID
+	if prevMaxInfo.MaxTXID > 0 {
+		expectedMinTXID = seekTXID
+	}
+
+	var minTXID, maxTXID ltx.TXID
 	for itr.Next() {
 		info := itr.Item()
 
-		// expectedMinTXID is zero until the first file is processed, then
-		// set to MaxTXID+1 after each file. We skip the contiguity check
-		// for the first file because LTXFiles filtering semantics vary
-		// across backends (e.g., file client filters by MinTXID, S3 by
-		// prefix) so we accept whatever the iterator returns first.
 		if expectedMinTXID != 0 && info.MinTXID != expectedMinTXID {
 			if info.MinTXID < expectedMinTXID {
 				return nil, fmt.Errorf("overlapping transaction ids in source files at level %d: expected min %s, got %s", srcLevel, expectedMinTXID, info.MinTXID)
@@ -142,6 +151,9 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 				"level", srcLevel,
 				"expected_min_txid", expectedMinTXID,
 				"actual_min_txid", info.MinTXID)
+			if c.SourceGapHandler != nil {
+				c.SourceGapHandler(srcLevel, expectedMinTXID, info.MinTXID)
+			}
 			break
 		}
 

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -48,6 +48,74 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 	})
 
+	t.Run("L0GapStopsAtGap", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		createTestLTXFile(t, client, 0, 1, 1)
+		createTestLTXFile(t, client, 0, 2, 2)
+		createTestLTXFile(t, client, 0, 3, 3)
+		// gap: TXID 4 missing
+		createTestLTXFile(t, client, 0, 5, 5)
+		createTestLTXFile(t, client, 0, 6, 6)
+
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 1 || info.MaxTXID != 3 {
+			t.Errorf("TXID range=%d-%d, want 1-3", info.MinTXID, info.MaxTXID)
+		}
+
+		// Fill the gap and re-compact
+		createTestLTXFile(t, client, 0, 4, 4)
+
+		info, err = compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 4 || info.MaxTXID != 6 {
+			t.Errorf("TXID range=%d-%d, want 4-6", info.MinTXID, info.MaxTXID)
+		}
+	})
+
+	t.Run("L0GapAtStart", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		// Files 3,4,5 with gap at start (1,2 missing).
+		// The file client filters by minTXID >= seekTXID, so with no L1
+		// files these are all returned. The compactor should compact
+		// whatever contiguous set is available.
+		createTestLTXFile(t, client, 0, 3, 3)
+		createTestLTXFile(t, client, 0, 4, 4)
+		createTestLTXFile(t, client, 0, 5, 5)
+
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 3 || info.MaxTXID != 5 {
+			t.Errorf("TXID range=%d-%d, want 3-5", info.MinTXID, info.MaxTXID)
+		}
+	})
+
+	t.Run("L0OverlapReturnsError", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		createTestLTXFile(t, client, 0, 1, 3)
+		createTestLTXFile(t, client, 0, 2, 4) // overlap: MinTXID 2 < expected 4
+
+		_, err := compactor.Compact(context.Background(), 1)
+		if err == nil {
+			t.Fatal("expected error for overlapping files, got nil")
+		}
+		if !containsString(err.Error(), "overlapping") {
+			t.Errorf("expected overlapping error, got: %v", err)
+		}
+	})
+
 	t.Run("L1ToL2", func(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
 		compactor := litestream.NewCompactor(client, slog.Default())

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -3,6 +3,7 @@ package litestream_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -52,6 +53,12 @@ func TestCompactor_Compact(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
 		compactor := litestream.NewCompactor(client, slog.Default())
 
+		var gapLevel int
+		var gapExpected, gapActual ltx.TXID
+		compactor.SourceGapHandler = func(srcLevel int, expectedMinTXID, actualMinTXID ltx.TXID) {
+			gapLevel, gapExpected, gapActual = srcLevel, expectedMinTXID, actualMinTXID
+		}
+
 		createTestLTXFile(t, client, 0, 1, 1)
 		createTestLTXFile(t, client, 0, 2, 2)
 		createTestLTXFile(t, client, 0, 3, 3)
@@ -65,6 +72,9 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 		if info.MinTXID != 1 || info.MaxTXID != 3 {
 			t.Errorf("TXID range=%d-%d, want 1-3", info.MinTXID, info.MaxTXID)
+		}
+		if gapLevel != 0 || gapExpected != 4 || gapActual != 5 {
+			t.Errorf("gap handler: level=%d expected=%s actual=%s, want level=0 expected=4 actual=5", gapLevel, gapExpected, gapActual)
 		}
 
 		// Fill the gap and re-compact
@@ -90,6 +100,45 @@ func TestCompactor_Compact(t *testing.T) {
 		createTestLTXFile(t, client, 0, 3, 3)
 		createTestLTXFile(t, client, 0, 4, 4)
 		createTestLTXFile(t, client, 0, 5, 5)
+
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 3 || info.MaxTXID != 5 {
+			t.Errorf("TXID range=%d-%d, want 3-5", info.MinTXID, info.MaxTXID)
+		}
+	})
+
+	t.Run("L0GapAtSeek", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		var gapLevel int
+		var gapExpected, gapActual ltx.TXID
+		compactor.SourceGapHandler = func(srcLevel int, expectedMinTXID, actualMinTXID ltx.TXID) {
+			gapLevel, gapExpected, gapActual = srcLevel, expectedMinTXID, actualMinTXID
+		}
+
+		// L1 already covers 1-2, so compaction seeks L0 from TXID 3.
+		createTestLTXFile(t, client, 1, 1, 2)
+		createTestLTXFile(t, client, 0, 1, 1)
+		createTestLTXFile(t, client, 0, 2, 2)
+		// gap: TXID 3 missing
+		createTestLTXFile(t, client, 0, 4, 4)
+		createTestLTXFile(t, client, 0, 5, 5)
+
+		// Compacting 4-5 would leave L1 non-contiguous, so nothing is
+		// compacted until the gap is healed.
+		if _, err := compactor.Compact(context.Background(), 1); !errors.Is(err, litestream.ErrNoCompaction) {
+			t.Fatalf("err=%v, want ErrNoCompaction", err)
+		}
+		if gapLevel != 0 || gapExpected != 3 || gapActual != 4 {
+			t.Errorf("gap handler: level=%d expected=%s actual=%s, want level=0 expected=3 actual=4", gapLevel, gapExpected, gapActual)
+		}
+
+		// Fill the gap and verify compaction resumes with the full range.
+		createTestLTXFile(t, client, 0, 3, 3)
 
 		info, err := compactor.Compact(context.Background(), 1)
 		if err != nil {

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -149,6 +149,35 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 	})
 
+	t.Run("L1SeekGapStillCompacts", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		var gapCalled bool
+		compactor.SourceGapHandler = func(srcLevel int, expectedMinTXID, actualMinTXID ltx.TXID) {
+			gapCalled = true
+		}
+
+		// Snapshot retention can legitimately delete L1 files above a
+		// lagging L2 max (TXIDs 3-4 here), so a gap at the seek position
+		// is valid above L0 and must not block compaction: the snapshot
+		// covers the missing range.
+		createTestLTXFile(t, client, 2, 1, 2)
+		createTestLTXFile(t, client, 1, 5, 5)
+		createTestLTXFile(t, client, 1, 6, 6)
+
+		info, err := compactor.Compact(context.Background(), 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 5 || info.MaxTXID != 6 {
+			t.Errorf("TXID range=%d-%d, want 5-6", info.MinTXID, info.MaxTXID)
+		}
+		if gapCalled {
+			t.Error("gap handler must not fire above L0")
+		}
+	})
+
 	t.Run("L0OverlapReturnsError", func(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
 		compactor := litestream.NewCompactor(client, slog.Default())

--- a/db.go
+++ b/db.go
@@ -358,6 +358,14 @@ func NewDB(path string) *DB {
 		defer db.maxLTXFileInfos.Unlock()
 		db.maxLTXFileInfos.m[level] = info
 	}
+	db.compactor.SourceGapHandler = func(srcLevel int, expectedMinTXID, actualMinTXID ltx.TXID) {
+		// Only L0 gaps are recoverable: the replica re-uploads the missing
+		// files from disk once its position is invalidated.
+		if srcLevel != 0 || db.Replica == nil {
+			return
+		}
+		db.Replica.InvalidatePos()
+	}
 
 	return db
 }

--- a/db_test.go
+++ b/db_test.go
@@ -447,6 +447,83 @@ func TestDB_Compact(t *testing.T) {
 		}
 	})
 
+	// Ensure a TXID gap in remote L0 heals through replica re-upload so
+	// compaction can complete on the next pass. See issue #1151.
+	t.Run("L0GapHealsViaReplica", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		for i := range 2 {
+			if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (?)`, i); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Sync(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		dpos, err := db.Pos()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dpos.TXID < 4 {
+			t.Fatalf("expected at least 4 transactions, got %s", dpos.TXID)
+		}
+
+		// Remove an interior L0 file to simulate an upload that never
+		// became durable.
+		gapTXID := dpos.TXID - 1
+		if err := db.Replica.Client.DeleteLTXFiles(t.Context(), []*ltx.FileInfo{
+			{Level: 0, MinTXID: gapTXID, MaxTXID: gapTXID},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		// Compaction stops at the gap and compacts only the contiguous prefix.
+		info, err := db.Compact(t.Context(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := info.MaxTXID, gapTXID-1; got != want {
+			t.Fatalf("compacted MaxTXID=%s, want %s", got, want)
+		}
+
+		// The gap must have invalidated the replica position so the next
+		// sync re-uploads the missing file from disk.
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		rd, err := db.Replica.Client.OpenLTXFile(t.Context(), 0, gapTXID, gapTXID, 0, 0)
+		if err != nil {
+			t.Fatalf("missing L0 file was not re-uploaded: %v", err)
+		}
+		_ = rd.Close()
+
+		// The next compaction pass covers the remainder.
+		info, err = db.Compact(t.Context(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := info.MinTXID, gapTXID; got != want {
+			t.Fatalf("compacted MinTXID=%s, want %s", got, want)
+		}
+		if got, want := info.MaxTXID, dpos.TXID; got != want {
+			t.Fatalf("compacted MaxTXID=%s, want %s", got, want)
+		}
+	})
+
 	// Ensure that higher level compactions pull from the correct levels.
 	t.Run("L2+", func(t *testing.T) {
 		db, sqldb := testingutil.MustOpenDBs(t)

--- a/replica.go
+++ b/replica.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,6 +41,7 @@ type Replica struct {
 
 	syncSem     *semaphore.Weighted
 	syncWaiters atomic.Int64 // diagnostic instrumentation: goroutines queued on syncSem
+	posInvalid  atomic.Bool  // position must be recalculated on next sync
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -180,6 +182,12 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 		return result, context.Cause(ctx)
 	}
 
+	// Recalculate the position when it has been invalidated externally,
+	// such as when compaction detects a TXID gap in remote L0 files.
+	if r.posInvalid.Swap(false) {
+		r.SetPos(ltx.Pos{})
+	}
+
 	// Calculate current replica position, if unknown.
 	if r.Pos().IsZero() {
 		pos, err := r.calcPos(ctx)
@@ -270,13 +278,53 @@ func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID
 	return nil
 }
 
-// calcPos returns the last position saved to the replica for level 0.
+// calcPos returns the position replication should resume from for level 0.
+// Files already compacted into level 1 are ignored. If a TXID gap exists in
+// the remaining L0 files, the returned position stops just before the gap so
+// the missing files are re-uploaded from disk; resuming from the maximum
+// TXID would leave the gap in place permanently and block compaction.
 func (r *Replica) calcPos(ctx context.Context) (pos ltx.Pos, err error) {
-	info, err := r.MaxLTXFileInfo(ctx, 0)
+	l1Info, err := r.MaxLTXFileInfo(ctx, 1)
 	if err != nil {
-		return pos, fmt.Errorf("max ltx file: %w", err)
+		return pos, fmt.Errorf("max l1 ltx file: %w", err)
 	}
-	return ltx.Pos{TXID: info.MaxTXID}, nil
+
+	itr, err := r.Client.LTXFiles(ctx, 0, 0, false)
+	if err != nil {
+		return pos, fmt.Errorf("l0 ltx files: %w", err)
+	}
+	defer itr.Close()
+
+	var infos []ltx.FileInfo
+	for itr.Next() {
+		infos = append(infos, *itr.Item())
+	}
+	if err := itr.Close(); err != nil {
+		return pos, fmt.Errorf("close l0 iterator: %w", err)
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].MinTXID < infos[j].MinTXID })
+
+	txID := l1Info.MaxTXID
+	for _, info := range infos {
+		if info.MaxTXID <= txID {
+			continue // already compacted into L1
+		}
+		if txID != 0 && info.MinTXID > txID+1 {
+			r.Logger().Warn("txid gap detected in remote L0 files, resuming replication before gap",
+				"expected", (txID + 1).String(),
+				"actual", info.MinTXID.String())
+			break
+		}
+		txID = info.MaxTXID
+	}
+	return ltx.Pos{TXID: txID}, nil
+}
+
+// InvalidatePos marks the replica position for recalculation on the next
+// sync. Used when a TXID gap is detected in remote L0 files so the next sync
+// re-uploads the missing files from disk.
+func (r *Replica) InvalidatePos() {
+	r.posInvalid.Store(true)
 }
 
 // MaxLTXFileInfo returns metadata about the last LTX file for a given level.

--- a/replica_test.go
+++ b/replica_test.go
@@ -22,6 +22,63 @@ import (
 	"github.com/benbjohnson/litestream/mock"
 )
 
+func TestReplica_InvalidatePos_HealsL0Gap(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 2 {
+		if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (?)`, i); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Replica.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	dpos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dpos.TXID < 4 {
+		t.Fatalf("expected at least 4 transactions, got %s", dpos.TXID)
+	}
+
+	// Remove an interior L0 file to simulate an upload that never became durable.
+	gapTXID := dpos.TXID - 1
+	if err := db.Replica.Client.DeleteLTXFiles(t.Context(), []*ltx.FileInfo{
+		{Level: 0, MinTXID: gapTXID, MaxTXID: gapTXID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	db.Replica.InvalidatePos()
+	if err := db.Replica.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	rd, err := db.Replica.Client.OpenLTXFile(t.Context(), 0, gapTXID, gapTXID, 0, 0)
+	if err != nil {
+		t.Fatalf("missing L0 file was not re-uploaded: %v", err)
+	}
+	_ = rd.Close()
+
+	if got, want := db.Replica.Pos().TXID, dpos.TXID; got != want {
+		t.Fatalf("replica pos=%s, want %s", got, want)
+	}
+}
+
 func TestReplica_Sync(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)


### PR DESCRIPTION
## Summary

Per review feedback: stopping compaction at the gap was not enough — the recovery path in `Replica.Sync()` could not heal an interior L0 gap, so the gap persisted forever. This PR makes the system self-heal:

- **Gap-aware position recalculation**: `calcPos()` previously resumed from the *maximum* remote L0 TXID, so a missing interior file (e.g. `b1c7` missing while `b1c8` exists) was never re-uploaded. It now scans remote L0 for contiguity above the L1 boundary and resumes just before the first gap, so the normal sync loop re-uploads the missing files from disk. Local copies are guaranteed to exist because L0 retention only deletes files already compacted into L1 — and L1 can never advance past the gap.
- **Feedback loop from compaction to replication**: nothing previously triggered a position recalculation — sync succeeds in the gap state, only compaction fails. `Compactor` gains a `SourceGapHandler` callback, wired by `DB` to `Replica.InvalidatePos()`, so detecting a gap during compaction forces the next sync to recalculate and heal.
- **Seek-position gap detection**: `Compact()` now also detects a gap at the seek position (first source file starting past the destination level max). Previously this case silently produced a non-contiguous destination level.
- Compaction still stops at a mid-list gap and compacts the contiguous prefix, so progress continues while the gap heals.

End-to-end recovery: compaction detects gap → replica position invalidated → next sync re-uploads missing file from local disk → next compaction pass completes.

Fixes #1151

## Test Plan

- [x] `TestDB_Compact/L0GapHealsViaReplica` — full loop: interior remote L0 file deleted, compaction compacts prefix and invalidates replica position, sync re-uploads the missing file, second compaction covers the remainder
- [x] `TestReplica_InvalidatePos_HealsL0Gap` — `InvalidatePos()` + `Sync()` re-uploads a deleted interior L0 file and catches position up to the DB
- [x] `TestCompactor_Compact/L0GapAtSeek` — gap right after the L1 boundary returns `ErrNoCompaction` and fires the gap handler instead of writing a non-contiguous L1 file
- [x] `TestCompactor_Compact/L0GapStopsAtGap` — mid-list gap compacts the contiguous prefix and fires the gap handler
- [x] Verified the heal tests fail without the `calcPos` change (re-upload never happens)
- [x] Full test suite passes with `-race`; `pre-commit run --all-files` passes


## Follow-ups (from adversarial review)

- #1456 — abs/gs `LTXFiles` seek only matches the exact-TXID file (pre-existing; on those backends the heal cannot fire for a gap at the seek boundary until fixed)
- #1457 — heal re-uploads the entire suffix; will be narrowed to only-missing files (stacks on this PR)
- #1458 — no recovery when the local copy of a gap file is missing (stacks on this PR)
- #1459 — VFS cannot self-heal L0 gaps (tracking)

Known limitation: re-upload assumes the single-writer invariant; dual-writer lineage protection is out of scope (#1457).
