### PR TITLE
ci(pr-metrics): add PR build metrics workflow

### DIFF
--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -136,8 +136,8 @@ jobs:
           fi
           MINOR=$(echo "$CURRENT" | grep -oE '^[0-9]+\.[0-9]+')
 
-          LATEST=$(curl -sf 'https://go.dev/dl/?mode=json' | \
-            python3 -c "import sys,json; releases=json.load(sys.stdin); print(next(r['version'] for r in releases if r['stable'] and r['version'].startswith('go${MINOR}')))" 2>/dev/null | sed 's/^go//')
+          LATEST=$(curl -sf 'https://go.dev/dl/?mode=json&include=all' | \
+            python3 -c "import sys,json; releases=json.load(sys.stdin); print(next(r['version'] for r in releases if r['stable'] and r['version'].startswith('go${MINOR}.')))" 2>/dev/null | sed 's/^go//')
 
           if [ -z "$LATEST" ]; then
             echo "current=${CURRENT}" > go-toolchain.txt


### PR DESCRIPTION
## Description

Add a new GitHub Actions workflow (`pr-metrics.yml`) that posts build health metrics as a PR comment. The workflow runs 3 parallel jobs (build-base, build-pr, analyze-deps) and a reporting job that composes and posts/updates a single comment with:

- Binary size comparison (base vs PR) with delta in KB and percentage
- Dependency changes (added/removed modules from go.mod)
- Module graph edge count comparison
- `govulncheck` results in a collapsible details block
- Build time, Go version, and commit SHA

## Motivation and Context

There is currently no visibility into binary size changes, dependency additions, or vulnerability status during PR review. This workflow provides advisory-only metrics to inform reviewers without blocking merges.

Fixes #1152

## How Has This Been Tested?

- YAML validated with `actionlint` (only shellcheck style warnings, no errors)
- Workflow structure verified (triggers, permissions, job dependencies, artifact flow)
- Will self-test when this PR triggers the workflow

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)