### PR TITLE
fix(security): upgrade Go toolchain to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/benbjohnson/litestream
 
 go 1.24.1
 
-toolchain go1.24.11
+toolchain go1.24.13
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Description

Upgrade Go toolchain from `go1.24.11` to `go1.24.13` to address three security vulnerabilities:

- **GO-2026-4341**: Memory exhaustion in `net/url` query parameter parsing (affects `replica_url.go`)
- **GO-2026-4340**: Incorrect encryption level in `crypto/tls` handshake
- **GO-2026-4337**: Unexpected session resumption in `crypto/tls`

## Motivation and Context

The Go standard library vulnerabilities affect Litestream's URL parsing code (`replica_url.go:102` and `replica_url.go:129`), where crafted query strings could cause memory exhaustion. The crypto/tls issues affect any TLS connections made by Litestream (e.g., to S3, GCS, Azure endpoints).

Fixes #1159
Fixes #1160
Fixes #1161
Fixes #1163

## How Has This Been Tested?

- `go build ./...` — compilation succeeds
- `go test ./...` — all tests pass
- `golangci-lint run` — no new lint issues (pre-existing errcheck warnings only)
- Pre-commit hooks pass (go-vet, go-staticcheck, go-imports)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)