### PR TITLE
fix(sync): fix SnapshotReader goroutine race and fsync ordering

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -3880,5 +3881,220 @@ func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
 	}
 	if count != 30*20 {
 		t.Fatalf("row count=%d, want %d", count, 30*20)
+	}
+}
+
+// TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints verifies that a
+// snapshot's content matches its advertised position while checkpoints and
+// writes run concurrently. The position capture and chkMu read lock must be
+// atomic with respect to checkpoints: if a checkpoint can run between them,
+// the snapshot reads post-position pages from the database file while its
+// header still claims the earlier transaction — the #1164 corruption class.
+func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.MinCheckpointPageN = 1000000
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE kv (id INTEGER PRIMARY KEY, v INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO kv VALUES (1, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// valueAt records which kv value was current at each synced position so
+	// snapshots can be checked against the state their header advertises.
+	var valueMu sync.Mutex
+	valueAt := map[ltx.TXID]int64{}
+	recordPos := func(v int64) error {
+		pos, err := db.Pos()
+		if err != nil {
+			return err
+		}
+		valueMu.Lock()
+		valueAt[pos.TXID] = v
+		valueMu.Unlock()
+		return nil
+	}
+	if err := recordPos(0); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for v := int64(1); ; v++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := sqldb.Exec(`UPDATE kv SET v = ? WHERE id = 1`, v); err != nil {
+				errCh <- err
+				return
+			}
+			if err := db.Sync(ctx); err != nil {
+				errCh <- err
+				return
+			}
+			if err := recordPos(v); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// TRUNCATE resets the WAL so subsequent snapshots must read
+			// cold pages from the database file — the path that exposes
+			// a checkpoint racing the position capture.
+			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil && !isSQLiteBusyError(err) {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 15; i++ {
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		default:
+		}
+
+		pos, r, err := db.SnapshotReader(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dec := ltx.NewDecoder(r)
+		if err := dec.DecodeHeader(); err != nil {
+			t.Fatal(err)
+		}
+		hdr := dec.Header()
+		if hdr.MaxTXID != pos.TXID {
+			t.Fatalf("snapshot header txid=%s, want advertised position %s", hdr.MaxTXID, pos.TXID)
+		}
+
+		restorePath := filepath.Join(t.TempDir(), fmt.Sprintf("restore-%d.db", i))
+		rf, err := os.Create(restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pageData := make([]byte, hdr.PageSize)
+		for {
+			var phdr ltx.PageHeader
+			if err := dec.DecodePage(&phdr, pageData); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := rf.WriteAt(pageData, int64(phdr.Pgno-1)*int64(hdr.PageSize)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := dec.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := rf.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
+
+		restoredDB, err := sql.Open("sqlite", restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var integrity string
+		if err := restoredDB.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+			t.Fatal(err)
+		}
+		var got int64
+		if err := restoredDB.QueryRow(`SELECT v FROM kv WHERE id = 1`).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		restoredDB.Close()
+		if integrity != "ok" {
+			t.Fatalf("snapshot %d integrity check failed: %s", i, integrity)
+		}
+
+		// Find the kv value recorded at the greatest synced position at or
+		// before the snapshot position. Skip if recording lags behind the
+		// snapshot position; intermediate unmapped TXIDs (checkpoint
+		// bookkeeping) never change kv.
+		valueMu.Lock()
+		var want int64
+		var bestTXID, maxTXID ltx.TXID
+		for txid, val := range valueAt {
+			if txid > maxTXID {
+				maxTXID = txid
+			}
+			if txid <= pos.TXID && txid >= bestTXID {
+				bestTXID, want = txid, val
+			}
+		}
+		valueMu.Unlock()
+		if pos.TXID > maxTXID {
+			continue
+		}
+		if got != want {
+			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s): content inconsistent with advertised position",
+				pos.TXID, got, want, bestTXID)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
 	}
 }

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3641,3 +3641,244 @@ func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
 		t.Fatal("read lock not released after Close with canceled context")
 	}
 }
+
+func TestSyncRestoreIntegrity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.MinCheckpointPageN = 50
+	db.CheckpointInterval = 100 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close(context.Background()) })
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := `
+		CREATE TABLE IF NOT EXISTS data (
+			ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+			_uid TEXT NOT NULL,
+			_resource_version INTEGER NOT NULL,
+			_updated_at DATETIME NOT NULL,
+			name TEXT,
+			data_json BLOB,
+			is_active INTEGER,
+			UNIQUE (_uid, _resource_version)
+		);
+		CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
+		CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
+	`
+	if _, err := sqldb.Exec(schema); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		for j := 0; j < 10; j++ {
+			uid := fmt.Sprintf("uid-%d-%d", i, j)
+			_, err := sqldb.ExecContext(ctx,
+				`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
+				 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
+				uid, fmt.Sprintf("item-%d-%d", i, j),
+				[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
+				j%2,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatalf("sync iteration %d: %v", i, err)
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatalf("close sqlite db: %v", err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreDB.Replica = NewReplica(restoreDB)
+	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
+	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatalf("open restored db: %v", err)
+	}
+	defer func() { _ = restoredDB.Close() }()
+
+	rows, err := restoredDB.QueryContext(ctx, `PRAGMA integrity_check`)
+	if err != nil {
+		t.Fatalf("integrity check: %v", err)
+	}
+	defer rows.Close()
+
+	var results []string
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			t.Fatal(err)
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("integrity check returned no results")
+	}
+	if results[0] != "ok" {
+		t.Fatalf("integrity check failed on restored database: %v", results)
+	}
+
+	var count int
+	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM data`).Scan(&count); err != nil {
+		t.Fatalf("count data: %v", err)
+	}
+	expectedRows := iterations * 10
+	if count != expectedRows {
+		t.Fatalf("restored row count=%d, want %d", count, expectedRows)
+	}
+}
+
+func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.MinCheckpointPageN = 20
+	db.TruncatePageN = 200
+	db.CheckpointInterval = 50 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close(context.Background()) })
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	for i := 0; i < 30; i++ {
+		for j := 0; j < 20; j++ {
+			_, err := sqldb.ExecContext(ctx,
+				`INSERT INTO t (val, extra) VALUES (?, ?)`,
+				fmt.Sprintf("val-%d-%d", i, j),
+				bytes.Repeat([]byte{byte(i)}, 512),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatalf("sync %d: %v", i, err)
+		}
+
+		if i%5 == 4 {
+			if _, err := sqldb.ExecContext(ctx, `PRAGMA wal_checkpoint(PASSIVE)`); err != nil {
+				t.Logf("passive checkpoint %d: %v", i, err)
+			}
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatalf("close sqlite db: %v", err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreDB.Replica = NewReplica(restoreDB)
+	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
+	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = restoredDB.Close() }()
+
+	var result string
+	if err := restoredDB.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result != "ok" {
+		t.Fatalf("integrity check failed: %s", result)
+	}
+
+	var count int
+	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM t`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 30*20 {
+		t.Fatalf("row count=%d, want %d", count, 30*20)
+	}
+}

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3643,24 +3643,39 @@ func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
 	}
 }
 
-func TestSyncRestoreIntegrity(t *testing.T) {
+// syncRestoreIntegrityConfig parameterizes runSyncRestoreIntegrity with the
+// pieces that differ between the sync/restore integrity test variants.
+type syncRestoreIntegrityConfig struct {
+	configure  func(db *DB)
+	schema     string
+	iterations int
+	insertRows func(t *testing.T, ctx context.Context, sqldb *sql.DB, iteration int)
+	afterSync  func(t *testing.T, ctx context.Context, sqldb *sql.DB, iteration int)
+	countQuery string
+	wantRows   int
+}
+
+// runSyncRestoreIntegrity opens a replicated database, runs insert/sync
+// iterations, closes everything, restores from the replica, and verifies
+// integrity and row count of the restored database.
+func runSyncRestoreIntegrity(t *testing.T, cfg syncRestoreIntegrityConfig) {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
 
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
+	dbPath := filepath.Join(t.TempDir(), "test.db")
 	replicaDir := t.TempDir()
 
 	db := NewDB(dbPath)
 	db.MonitorInterval = 0
 	db.ShutdownSyncTimeout = 0
-	db.MinCheckpointPageN = 50
-	db.CheckpointInterval = 100 * time.Millisecond
 	db.Replica = NewReplica(db)
 	db.Replica.Client = &testReplicaClient{dir: replicaDir}
 	db.Replica.MonitorEnabled = false
 	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg.configure(db)
 	if err := db.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -3677,45 +3692,21 @@ func TestSyncRestoreIntegrity(t *testing.T) {
 	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
 		t.Fatal(err)
 	}
-
-	schema := `
-		CREATE TABLE IF NOT EXISTS data (
-			ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
-			_uid TEXT NOT NULL,
-			_resource_version INTEGER NOT NULL,
-			_updated_at DATETIME NOT NULL,
-			name TEXT,
-			data_json BLOB,
-			is_active INTEGER,
-			UNIQUE (_uid, _resource_version)
-		);
-		CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
-		CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
-	`
-	if _, err := sqldb.Exec(schema); err != nil {
+	if _, err := sqldb.Exec(cfg.schema); err != nil {
 		t.Fatal(err)
 	}
 
 	ctx := context.Background()
 
-	const iterations = 20
-	for i := 0; i < iterations; i++ {
-		for j := 0; j < 10; j++ {
-			uid := fmt.Sprintf("uid-%d-%d", i, j)
-			_, err := sqldb.ExecContext(ctx,
-				`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
-				 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
-				uid, fmt.Sprintf("item-%d-%d", i, j),
-				[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
-				j%2,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
+	for i := 0; i < cfg.iterations; i++ {
+		cfg.insertRows(t, ctx, sqldb, i)
 
 		if err := db.Sync(ctx); err != nil {
 			t.Fatalf("sync iteration %d: %v", i, err)
+		}
+
+		if cfg.afterSync != nil {
+			cfg.afterSync(t, ctx, sqldb, i)
 		}
 	}
 
@@ -3769,118 +3760,95 @@ func TestSyncRestoreIntegrity(t *testing.T) {
 	}
 
 	var count int
-	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM data`).Scan(&count); err != nil {
-		t.Fatalf("count data: %v", err)
+	if err := restoredDB.QueryRowContext(ctx, cfg.countQuery).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
 	}
-	expectedRows := iterations * 10
-	if count != expectedRows {
-		t.Fatalf("restored row count=%d, want %d", count, expectedRows)
+	if count != cfg.wantRows {
+		t.Fatalf("restored row count=%d, want %d", count, cfg.wantRows)
 	}
 }
 
-func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping in short mode")
-	}
-
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
-	replicaDir := t.TempDir()
-
-	db := NewDB(dbPath)
-	db.MonitorInterval = 0
-	db.ShutdownSyncTimeout = 0
-	db.MinCheckpointPageN = 20
-	db.TruncatePageN = 200
-	db.CheckpointInterval = 50 * time.Millisecond
-	db.Replica = NewReplica(db)
-	db.Replica.Client = &testReplicaClient{dir: replicaDir}
-	db.Replica.MonitorEnabled = false
-	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
-	if err := db.Open(); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = db.Close(context.Background()) })
-
-	sqldb, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = sqldb.Close() }()
-	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`); err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := context.Background()
-
-	for i := 0; i < 30; i++ {
-		for j := 0; j < 20; j++ {
-			_, err := sqldb.ExecContext(ctx,
-				`INSERT INTO t (val, extra) VALUES (?, ?)`,
-				fmt.Sprintf("val-%d-%d", i, j),
-				bytes.Repeat([]byte{byte(i)}, 512),
-			)
-			if err != nil {
-				t.Fatal(err)
+func TestSyncRestoreIntegrity(t *testing.T) {
+	runSyncRestoreIntegrity(t, syncRestoreIntegrityConfig{
+		configure: func(db *DB) {
+			db.MinCheckpointPageN = 50
+			db.CheckpointInterval = 100 * time.Millisecond
+		},
+		schema: `
+			CREATE TABLE IF NOT EXISTS data (
+				ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+				_uid TEXT NOT NULL,
+				_resource_version INTEGER NOT NULL,
+				_updated_at DATETIME NOT NULL,
+				name TEXT,
+				data_json BLOB,
+				is_active INTEGER,
+				UNIQUE (_uid, _resource_version)
+			);
+			CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
+			CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
+		`,
+		iterations: 20,
+		insertRows: func(t *testing.T, ctx context.Context, sqldb *sql.DB, i int) {
+			t.Helper()
+			for j := 0; j < 10; j++ {
+				uid := fmt.Sprintf("uid-%d-%d", i, j)
+				_, err := sqldb.ExecContext(ctx,
+					`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
+					 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
+					uid, fmt.Sprintf("item-%d-%d", i, j),
+					[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
+					j%2,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
-		}
+		},
+		countQuery: `SELECT COUNT(*) FROM data`,
+		wantRows:   20 * 10,
+	})
+}
 
-		if err := db.Sync(ctx); err != nil {
-			t.Fatalf("sync %d: %v", i, err)
-		}
-
-		if i%5 == 4 {
+func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
+	var checkpointN int
+	runSyncRestoreIntegrity(t, syncRestoreIntegrityConfig{
+		configure: func(db *DB) {
+			db.MinCheckpointPageN = 20
+			db.TruncatePageN = 200
+			db.CheckpointInterval = 50 * time.Millisecond
+		},
+		schema:     `CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`,
+		iterations: 30,
+		insertRows: func(t *testing.T, ctx context.Context, sqldb *sql.DB, i int) {
+			t.Helper()
+			for j := 0; j < 20; j++ {
+				_, err := sqldb.ExecContext(ctx,
+					`INSERT INTO t (val, extra) VALUES (?, ?)`,
+					fmt.Sprintf("val-%d-%d", i, j),
+					bytes.Repeat([]byte{byte(i)}, 512),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		},
+		afterSync: func(t *testing.T, ctx context.Context, sqldb *sql.DB, i int) {
+			t.Helper()
+			if i%5 != 4 {
+				return
+			}
 			if _, err := sqldb.ExecContext(ctx, `PRAGMA wal_checkpoint(PASSIVE)`); err != nil {
 				t.Logf("passive checkpoint %d: %v", i, err)
+				return
 			}
-		}
-	}
-
-	if err := db.Sync(ctx); err != nil {
-		t.Fatalf("final sync: %v", err)
-	}
-	if err := sqldb.Close(); err != nil {
-		t.Fatalf("close sqlite db: %v", err)
-	}
-	if err := db.Close(ctx); err != nil {
-		t.Fatalf("close db: %v", err)
-	}
-
-	restorePath := filepath.Join(t.TempDir(), "restored.db")
-	restoreDB := NewDB(restorePath)
-	restoreDB.Replica = NewReplica(restoreDB)
-	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
-	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
-	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
-		t.Fatalf("restore: %v", err)
-	}
-
-	restoredDB, err := sql.Open("sqlite", restorePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = restoredDB.Close() }()
-
-	var result string
-	if err := restoredDB.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&result); err != nil {
-		t.Fatal(err)
-	}
-	if result != "ok" {
-		t.Fatalf("integrity check failed: %s", result)
-	}
-
-	var count int
-	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM t`).Scan(&count); err != nil {
-		t.Fatal(err)
-	}
-	if count != 30*20 {
-		t.Fatalf("row count=%d, want %d", count, 30*20)
+			checkpointN++
+		},
+		countQuery: `SELECT COUNT(*) FROM t`,
+		wantRows:   30 * 20,
+	})
+	if checkpointN == 0 {
+		t.Fatal("no passive checkpoints succeeded; variant did not exercise the checkpoint path")
 	}
 }
 
@@ -4003,6 +3971,7 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 		}
 	}()
 
+	var loMatchN, hiMatchN int
 	for i := range 15 {
 		select {
 		case err := <-errCh:
@@ -4068,29 +4037,48 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 			t.Fatalf("snapshot %d integrity check failed: %s", i, integrity)
 		}
 
-		// Find the kv value recorded at the greatest synced position at or
-		// before the snapshot position. Skip if recording lags behind the
-		// snapshot position; intermediate unmapped TXIDs (checkpoint
-		// bookkeeping) never change kv.
+		// The snapshot content must match the kv value recorded at a mapped
+		// TXID bracketing the snapshot position: the nearest at or before it,
+		// or the nearest after it. The writer records its commit under
+		// db.Pos() read after Sync returns, so a concurrent TRUNCATE boundary
+		// snapshot can mint the next TXID first and the commit lands under
+		// that later TXID while the commit's own TXID stays unmapped. Skip if
+		// recording lags behind the snapshot position entirely.
 		valueMu.Lock()
-		var want int64
-		var bestTXID, maxTXID ltx.TXID
+		var wantLo, wantHi int64
+		var loTXID, hiTXID, maxTXID ltx.TXID
 		for txid, val := range valueAt {
 			if txid > maxTXID {
 				maxTXID = txid
 			}
-			if txid <= pos.TXID && txid >= bestTXID {
-				bestTXID, want = txid, val
+			if txid <= pos.TXID && txid >= loTXID {
+				loTXID, wantLo = txid, val
+			}
+			if txid > pos.TXID && (hiTXID == 0 || txid < hiTXID) {
+				hiTXID, wantHi = txid, val
 			}
 		}
 		valueMu.Unlock()
 		if pos.TXID > maxTXID {
 			continue
 		}
-		if got != want {
-			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s): content inconsistent with advertised position",
-				pos.TXID, got, want, bestTXID)
+		switch {
+		case loTXID != 0 && got == wantLo:
+			loMatchN++
+		case hiTXID != 0 && got == wantHi:
+			hiMatchN++
+		default:
+			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s) or %d (recorded at txid %s): content inconsistent with advertised position",
+				pos.TXID, got, wantLo, loTXID, wantHi, hiTXID)
 		}
+	}
+
+	// A hi-bracket match is ambiguous: it tolerates the rare recording race
+	// but is also what a snapshot with content ahead of its advertised
+	// position produces. The race is a narrow window while a chkMu handoff
+	// regression is systematic, so require at least one unambiguous match.
+	if loMatchN == 0 {
+		t.Fatalf("no snapshot matched the value recorded at or before its position (hi-bracket matches=%d): content may be ahead of advertised position", hiMatchN)
 	}
 
 	close(stop)

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3930,7 +3930,7 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := db.Sync(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -3993,14 +3993,17 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 			// TRUNCATE resets the WAL so subsequent snapshots must read
 			// cold pages from the database file — the path that exposes
 			// a checkpoint racing the position capture.
-			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil && !isSQLiteBusyError(err) {
-				errCh <- err
-				return
+			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
+				if !isSQLiteBusyError(err) {
+					errCh <- err
+					return
+				}
+				time.Sleep(time.Millisecond)
 			}
 		}
 	}()
 
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		select {
 		case err := <-errCh:
 			t.Fatal(err)

--- a/replica.go
+++ b/replica.go
@@ -970,6 +970,9 @@ func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileIn
 	}
 
 	if hdr.Commit > 0 {
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("sync before truncate: %w", err)
+		}
 		newSize := int64(hdr.Commit) * int64(pageSize)
 		if err := f.Truncate(newSize); err != nil {
 			return fmt.Errorf("truncate: %w", err)

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -410,5 +411,147 @@ func TestCheckIntegrity_CorruptDB(t *testing.T) {
 	err = checkIntegrity(context.Background(), dbPath, IntegrityCheckFull)
 	if err == nil {
 		t.Fatal("expected integrity check to fail on corrupt database")
+	}
+}
+
+func TestApplyLTXFile_TruncatesAfterWrite(t *testing.T) {
+	const pageSize = 4096
+
+	info := &ltx.FileInfo{Level: 0, MinTXID: 10, MaxTXID: 10}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   info.MinTXID,
+		MaxTXID:   info.MaxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	page1 := make([]byte, pageSize)
+	copy(page1, []byte("SQLite format 3\000"))
+	page1[18], page1[19] = 0x01, 0x01
+	binary.BigEndian.PutUint16(page1[16:18], pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1); err != nil {
+		t.Fatal(err)
+	}
+	page2 := bytes.Repeat([]byte{0xAB}, pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, page2); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ltxData := buf.Bytes()
+	client := &followTestReplicaClient{}
+	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(ltxData)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	if err := r.applyLTXFile(context.Background(), f, info, pageSize); err != nil {
+		t.Fatalf("applyLTXFile: %v", err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSize := int64(2) * int64(pageSize)
+	if fi.Size() != expectedSize {
+		t.Fatalf("file size=%d, want %d", fi.Size(), expectedSize)
+	}
+
+	readBuf := make([]byte, pageSize)
+	if _, err := f.ReadAt(readBuf, int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(readBuf, page2) {
+		t.Fatal("page 2 data mismatch after applyLTXFile")
+	}
+}
+
+func TestApplyLTXFile_MultiplePages(t *testing.T) {
+	const pageSize = 4096
+	const numPages = 5
+
+	info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    numPages,
+		MinTXID:   info.MinTXID,
+		MaxTXID:   info.MaxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := make([][]byte, numPages)
+	for i := uint32(0); i < numPages; i++ {
+		pages[i] = bytes.Repeat([]byte{byte(0x10 + i)}, pageSize)
+		if i == 0 {
+			copy(pages[i], []byte("SQLite format 3\000"))
+			pages[i][18], pages[i][19] = 0x01, 0x01
+		}
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: i + 1}, pages[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ltxData := buf.Bytes()
+	client := &followTestReplicaClient{}
+	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(ltxData)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	if err := r.applyLTXFile(context.Background(), f, info, pageSize); err != nil {
+		t.Fatalf("applyLTXFile: %v", err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSize := int64(numPages) * int64(pageSize)
+	if fi.Size() != expectedSize {
+		t.Fatalf("file size=%d, want %d", fi.Size(), expectedSize)
+	}
+
+	readBuf := make([]byte, pageSize)
+	for i := uint32(0); i < numPages; i++ {
+		if _, err := f.ReadAt(readBuf, int64(i)*int64(pageSize)); err != nil {
+			t.Fatalf("read page %d: %v", i+1, err)
+		}
+		if i > 0 && !bytes.Equal(readBuf, pages[i]) {
+			t.Fatalf("page %d data mismatch", i+1)
+		}
 	}
 }

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -315,6 +315,50 @@ func mustBuildIncrementalLTX(tb testing.TB, minTXID, maxTXID ltx.TXID, pageSize,
 	return buf.Bytes()
 }
 
+// mustBuildSnapshotLTX encodes an LTX file containing the given pages
+// numbered sequentially from pgno 1 with commit set to the page count.
+func mustBuildSnapshotLTX(tb testing.TB, minTXID, maxTXID ltx.TXID, pageSize uint32, pages [][]byte) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    uint32(len(pages)),
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		tb.Fatal(err)
+	}
+	for i, page := range pages {
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: uint32(i + 1)}, page); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+// newSQLiteHeaderPage returns a page containing a minimal SQLite file header.
+func newSQLiteHeaderPage(pageSize uint32) []byte {
+	page := make([]byte, pageSize)
+	copy(page, "SQLite format 3\x00")
+	binary.BigEndian.PutUint16(page[16:18], uint16(pageSize))
+	page[18], page[19] = 0x01, 0x01
+	return page
+}
+
 func mustCreateWritableDBFile(tb testing.TB) *os.File {
 	tb.Helper()
 
@@ -419,39 +463,11 @@ func TestApplyLTXFile_TruncatesAfterWrite(t *testing.T) {
 
 	info := &ltx.FileInfo{Level: 0, MinTXID: 10, MaxTXID: 10}
 
-	var buf bytes.Buffer
-	enc, err := ltx.NewEncoder(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	hdr := ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    2,
-		MinTXID:   info.MinTXID,
-		MaxTXID:   info.MaxTXID,
-		Timestamp: time.Now().UnixMilli(),
-	}
-	if err := enc.EncodeHeader(hdr); err != nil {
-		t.Fatal(err)
-	}
-	page1 := make([]byte, pageSize)
-	copy(page1, []byte("SQLite format 3\000"))
-	page1[18], page1[19] = 0x01, 0x01
-	binary.BigEndian.PutUint16(page1[16:18], pageSize)
-	if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1); err != nil {
-		t.Fatal(err)
-	}
 	page2 := bytes.Repeat([]byte{0xAB}, pageSize)
-	if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, page2); err != nil {
-		t.Fatal(err)
-	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	ltxData := buf.Bytes()
+	ltxData := mustBuildSnapshotLTX(t, info.MinTXID, info.MaxTXID, pageSize, [][]byte{
+		newSQLiteHeaderPage(pageSize),
+		page2,
+	})
 	client := &followTestReplicaClient{}
 	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(ltxData)), nil
@@ -489,40 +505,12 @@ func TestApplyLTXFile_MultiplePages(t *testing.T) {
 
 	info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
 
-	var buf bytes.Buffer
-	enc, err := ltx.NewEncoder(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	hdr := ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    numPages,
-		MinTXID:   info.MinTXID,
-		MaxTXID:   info.MaxTXID,
-		Timestamp: time.Now().UnixMilli(),
-	}
-	if err := enc.EncodeHeader(hdr); err != nil {
-		t.Fatal(err)
-	}
-
 	pages := make([][]byte, numPages)
-	for i := uint32(0); i < numPages; i++ {
+	for i := range pages {
 		pages[i] = bytes.Repeat([]byte{byte(0x10 + i)}, pageSize)
-		if i == 0 {
-			copy(pages[i], []byte("SQLite format 3\000"))
-			pages[i][18], pages[i][19] = 0x01, 0x01
-		}
-		if err := enc.EncodePage(ltx.PageHeader{Pgno: i + 1}, pages[i]); err != nil {
-			t.Fatal(err)
-		}
 	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	ltxData := buf.Bytes()
+	pages[0] = newSQLiteHeaderPage(pageSize)
+	ltxData := mustBuildSnapshotLTX(t, info.MinTXID, info.MaxTXID, pageSize, pages)
 	client := &followTestReplicaClient{}
 	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(ltxData)), nil


### PR DESCRIPTION
> 📍 **Stack map:** part of a stacked series — see the [canonical PR map](https://gist.github.com/corylanou/f2709d9868cad1943c63096bf978e881) for review order, scope, and current blockers.

## Summary

Fixes the issue #1164 corruption hazards in a small stacked PR:

- `applyLTXFile()` now calls `f.Sync()` before `f.Truncate()`, so restored page writes are durable before the database file is shortened to the LTX commit size.
- Adds `TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints`, which pins the atomicity between `SnapshotReader`'s position capture and its `chkMu` read lock. The lock is acquired while the executor semaphore is still held (the arrangement introduced in #1292), so no checkpoint can run between reading the position and encoding the snapshot. The test reproduces the #1164 corruption class on the first iteration if that handoff is ever broken.
- Adds sequential sync/restore integrity coverage (`TestSyncRestoreIntegrity`, `TestSyncRestoreIntegrity_WithCheckpoints`) and apply-LTX restore tests.

**Note:** an earlier revision of this PR moved `chkMu.RLock()` into the snapshot goroutine. That change was authored against `main` (where the lock was released when `SnapshotReader` returned, before the encode finished) but on this stack #1292 already holds the lock across the full encode via the `snapshotReadPosition` handoff — re-applying it here reopened the checkpoint window it was meant to close. The commit was dropped; the new concurrency test now guards that invariant instead.

This PR stacks on #1289 through #1292 via `issue-1280-checkpoint-snapshot-hardening`.

Ref #1164
Ref #1199
Ref #1281

## Scope

**In scope:**
- Product fix in `replica.go` (fsync-before-truncate)
- Snapshot-vs-checkpoint consistency regression test in `db_internal_test.go`
- Focused internal/unit coverage for apply-LTX restore behavior and sync/restore integrity

**Not in scope:**
- Full integration soak coverage
- `tests/integration/soak_replicate_restore_test.go`, which moved to #1302

## Test Plan

```bash
go build -o bin/litestream ./cmd/litestream
go test -race ./... -run "SnapshotReader|ApplyLTX|Snapshot|SyncRestoreIntegrity"
go test -race -count=1 ./...
```

Verified `TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints` fails immediately ("snapshot at txid N contains v=X, want Y: content inconsistent with advertised position") when the dropped lock-restructure commit is re-applied, and passes on this branch.
