### PR TITLE
fix(ci): publish latest-scratch Docker tag

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -60,14 +60,15 @@ jobs:
         with:
           images: litestream/litestream
           flavor: |
-            latest=false
+            latest=auto
+            suffix=-scratch
           tags: |
-            type=ref,event=branch,suffix=-scratch
-            type=ref,event=pr,suffix=-scratch
-            type=sha,suffix=-scratch
-            type=sha,format=long,suffix=-scratch
-            type=semver,pattern={{version}},suffix=-scratch
-            type=semver,pattern={{major}}.{{minor}},suffix=-scratch
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Description
Fix the Docker CI workflow so the documented `litestream/litestream:latest-scratch` tag is actually published to Docker Hub.

In the scratch image metadata step, `latest=false` prevented the `docker/metadata-action` from generating a `latest` tag. Changed to `latest=auto` with `suffix=-scratch` in the flavor, so the auto-generated latest tag gets the `-scratch` suffix. Moving the suffix to the flavor also simplifies the individual tag rules since it's applied globally.

## Motivation and Context
The [Docker guide](https://litestream.io/guides/docker/) documents `litestream/litestream:latest-scratch` but this tag was never published because CI suppressed it.

Fixes #1177

## How Has This Been Tested?
- Verified YAML syntax is valid (passes `check yaml` pre-commit hook)
- Reviewed `docker/metadata-action` documentation to confirm `suffix` in flavor applies to all tags including the auto-generated `latest` tag
- This is a CI-only change; full verification will occur when the next release is published and the workflow produces the `latest-scratch` tag on Docker Hub

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)