### PR TITLE
fix(logging): downgrade replica sync messages from INFO to DEBUG

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -197,7 +197,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 		return result, errReplicaWaitForData
 	}
 
-	r.Logger().Info("replica sync",
+	r.Logger().Debug("replica sync",
 		slog.Group("txid",
 			slog.String("replica", r.Pos().TXID.String()),
 			slog.String("db", dpos.TXID.String()),
@@ -257,7 +257,7 @@ func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID
 	if err != nil {
 		return fmt.Errorf("write ltx file: %w", err)
 	}
-	r.Logger().Info("ltx file uploaded",
+	r.Logger().Debug("ltx file uploaded",
 		"level", info.Level,
 		"minTXID", info.MinTXID,
 		"maxTXID", info.MaxTXID,


### PR DESCRIPTION
## Description

Downgrade two high-frequency log messages from INFO to DEBUG level:
- `"replica sync"` — logged every sync interval (1s-5s)
- `"ltx file uploaded"` — logged on every LTX file upload

These are routine operational messages that flood logs at INFO level. The `"replica sync recovered"` message remains at INFO since it signals a meaningful state change.

## Motivation and Context

Users running Litestream with default logging see hundreds of identical `"replica sync"` lines per minute, making it hard to spot meaningful events.

Fixes #1203

## How Has This Been Tested?

- `go build ./...` — compiles cleanly
- `go test -race ./...` — all tests pass (including `TestReplica_ContextCancellationNoLogs` which asserts on these log messages, using a DEBUG-level logger)
- `golangci-lint run` — no new lint issues

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)