### PR TITLE
perf(db): reduce idle CPU, memory, and cloud API costs

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -712,7 +712,6 @@ type DBConfig struct {
 	MetaPath           *string        `yaml:"meta-path"`
 	MetaDir            *string        `yaml:"meta-dir"`
 	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
-	MaxIdleInterval    *time.Duration `yaml:"max-idle-interval"`
 	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
 	BusyTimeout        *time.Duration `yaml:"busy-timeout"`
 	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
@@ -750,9 +749,6 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	}
 	if dbc.MonitorInterval != nil {
 		db.MonitorInterval = *dbc.MonitorInterval
-	}
-	if dbc.MaxIdleInterval != nil {
-		db.MaxIdleInterval = *dbc.MaxIdleInterval
 	}
 	if dbc.CheckpointInterval != nil {
 		db.CheckpointInterval = *dbc.CheckpointInterval

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -712,6 +712,7 @@ type DBConfig struct {
 	MetaPath           *string        `yaml:"meta-path"`
 	MetaDir            *string        `yaml:"meta-dir"`
 	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
+	MaxIdleInterval    *time.Duration `yaml:"max-idle-interval"`
 	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`
 	BusyTimeout        *time.Duration `yaml:"busy-timeout"`
 	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
@@ -749,6 +750,9 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	}
 	if dbc.MonitorInterval != nil {
 		db.MonitorInterval = *dbc.MonitorInterval
+	}
+	if dbc.MaxIdleInterval != nil {
+		db.MaxIdleInterval = *dbc.MaxIdleInterval
 	}
 	if dbc.CheckpointInterval != nil {
 		db.CheckpointInterval = *dbc.CheckpointInterval

--- a/db.go
+++ b/db.go
@@ -43,11 +43,6 @@ const (
 	// When sync errors occur repeatedly (e.g., disk full), backoff doubles each time.
 	DefaultSyncBackoffMax = 5 * time.Minute  // Maximum backoff between retries
 	SyncErrorLogInterval  = 30 * time.Second // Rate-limit repeated error logging
-
-	// Idle backoff configuration.
-	// When no WAL changes are detected, the monitor interval progressively
-	// increases to reduce CPU and I/O on idle databases.
-	DefaultMaxIdleInterval = 60 * time.Second
 )
 
 // DB represents a managed instance of a SQLite database in the file system.
@@ -168,10 +163,6 @@ type DB struct {
 	// larger than this may exceed it. Set to zero to process all
 	// committed WAL frames in one run.
 	MaxSyncWALBytes int64
-
-	// Maximum polling interval when no WAL changes are detected.
-	// The monitor backs off exponentially from MonitorInterval to this value.
-	MaxIdleInterval time.Duration
 
 	// The timeout to wait for EBUSY from SQLite.
 	BusyTimeout time.Duration
@@ -339,7 +330,6 @@ func NewDB(path string) *DB {
 		CheckpointInterval:   DefaultCheckpointInterval,
 		MonitorInterval:      DefaultMonitorInterval,
 		MaxSyncWALBytes:      DefaultMaxSyncWALBytes,
-		MaxIdleInterval:      DefaultMaxIdleInterval,
 		BusyTimeout:          DefaultBusyTimeout,
 		L0Retention:          DefaultL0Retention,
 		RetentionEnabled:     true,

--- a/db.go
+++ b/db.go
@@ -3192,9 +3192,10 @@ func (db *DB) EnforceRetentionByTXID(ctx context.Context, level int, txID ltx.TX
 // Implements exponential backoff on repeated sync errors to prevent disk churn
 // when persistent errors (like disk full) occur. See issue #927.
 //
-// Also implements adaptive idle backoff: when no WAL changes are detected,
-// the polling interval progressively increases from MonitorInterval to
-// MaxIdleInterval. Resets immediately when activity is detected. See issue #1210.
+// Idle CPU is reduced by the WAL change detection in Sync() which skips
+// expensive verify+sync work when the WAL has no new data (issue #1210).
+// The monitor continues polling at MonitorInterval to maintain low sync
+// latency when writes resume.
 func (db *DB) monitor() {
 	ticker := time.NewTicker(db.MonitorInterval)
 	defer ticker.Stop()
@@ -3204,9 +3205,6 @@ func (db *DB) monitor() {
 	var lastLogTime time.Time
 	var consecutiveErrs int
 
-	// Idle backoff state.
-	var idleBackoff time.Duration
-
 	for {
 		// Wait for ticker or context close.
 		select {
@@ -3215,7 +3213,7 @@ func (db *DB) monitor() {
 		case <-ticker.C:
 		}
 
-		// If in error backoff mode, wait additional time before retrying.
+		// If in backoff mode, wait additional time before retrying.
 		if backoff > 0 {
 			select {
 			case <-db.ctx.Done():
@@ -3223,17 +3221,6 @@ func (db *DB) monitor() {
 			case <-time.After(backoff):
 			}
 		}
-
-		// If in idle backoff mode, wait additional time before syncing.
-		if idleBackoff > 0 {
-			select {
-			case <-db.ctx.Done():
-				return
-			case <-time.After(idleBackoff):
-			}
-		}
-
-		prePos, _ := db.Pos()
 
 		// Sync the database to the shadow WAL. Sync() loops over bounded
 		// chunks, releasing the executor lock between each so checkpoints
@@ -3243,7 +3230,6 @@ func (db *DB) monitor() {
 		// emergency checkpoint while behind, growing the WAL unbounded.
 		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
-			idleBackoff = 0
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max
 			if backoff == 0 {
@@ -3287,30 +3273,12 @@ func (db *DB) monitor() {
 			continue
 		}
 
-		// Success - reset error backoff and error counter.
+		// Success - reset backoff and error counter.
 		if consecutiveErrs > 0 {
 			db.Logger.Info("sync recovered", "previous_errors", consecutiveErrs)
 		}
 		backoff = 0
 		consecutiveErrs = 0
-
-		// Adaptive idle backoff: increase interval when no changes detected.
-		postPos, _ := db.Pos()
-		if prePos.TXID == postPos.TXID {
-			if idleBackoff == 0 {
-				idleBackoff = db.MonitorInterval
-			} else {
-				idleBackoff *= 2
-				if idleBackoff > db.MaxIdleInterval {
-					idleBackoff = db.MaxIdleInterval
-				}
-			}
-		} else {
-			if idleBackoff > 0 {
-				db.Logger.Debug("monitor: activity detected, resetting idle backoff")
-			}
-			idleBackoff = 0
-		}
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -85,8 +85,14 @@ type DB struct {
 	syncDiag  diagState
 
 	// WAL file size at the end of the last Sync(). Used with lastSyncedWALOffset
-	// to detect whether new WAL data has been written since the last sync.
+	// and the WAL header salts to detect whether new WAL data has been written
+	// since the last sync.
 	lastWALFileSize int64
+
+	// WAL header salt values cached at the end of the last Sync(). Used to detect
+	// checkpoint-induced WAL resets where the file size remains the same but
+	// the content has changed (salt rotation after RESTART/FULL checkpoint).
+	lastWALSalt1, lastWALSalt2 uint32
 
 	// last file info for each level
 	maxLTXFileInfos struct {
@@ -559,6 +565,8 @@ func (db *DB) ResetLocalState(ctx context.Context) error {
 
 	// Clear WAL change detection cache so next sync processes everything fresh.
 	db.lastWALFileSize = 0
+	db.lastWALSalt1 = 0
+	db.lastWALSalt2 = 0
 
 	db.Logger.Info("local state reset complete, next sync will create fresh snapshot")
 	return nil
@@ -1315,23 +1323,36 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 	}
 
 	// Fast path: skip expensive verify+sync if WAL has no new data.
-	// Compare WAL file size against lastSyncedWALOffset and lastWALFileSize
-	// to determine if any new frames have been written. Still run
+	// Compare WAL file size and header salts against cached values.
+	// We must check salts because content can change while size stays constant
+	// after checkpoint operations (RESTART/FULL mode rewrites salts in place,
+	// then new writes can refill to the same byte length). Still run
 	// checkpointIfNeeded() since time-based checkpoints may be pending.
 	walUnchanged := false
 
-	if walFi, statErr := os.Stat(db.WALPath()); statErr == nil {
-		walFileSize := walFi.Size()
-		if exec.state.lastSyncedWALOffset > 0 &&
-			walFileSize == db.lastWALFileSize &&
-			walFileSize == exec.state.lastSyncedWALOffset {
-			db.syncSkippedNCounter.Inc()
-			db.dbIdleGauge.Set(1)
-			db.Logger.Log(ctx, internal.LevelTrace, "sync: skip verify+sync", "reason", "wal unchanged")
-			walUnchanged = true
-			result.origWALSize = exec.state.lastSyncedWALOffset
-			result.newWALSize = exec.state.lastSyncedWALOffset
-			result.syncedToWALEnd = exec.state.syncedToWALEnd
+	if exec.state.lastSyncedWALOffset > 0 {
+		walPath := db.WALPath()
+		if walFi, statErr := os.Stat(walPath); statErr == nil {
+			walFileSize := walFi.Size()
+			if walFileSize == db.lastWALFileSize && walFileSize == exec.state.lastSyncedWALOffset {
+				if f, openErr := os.Open(walPath); openErr == nil {
+					var hdr [24]byte
+					if _, readErr := io.ReadFull(f, hdr[:]); readErr == nil {
+						salt1 := binary.BigEndian.Uint32(hdr[16:])
+						salt2 := binary.BigEndian.Uint32(hdr[20:])
+						if salt1 == db.lastWALSalt1 && salt2 == db.lastWALSalt2 {
+							db.syncSkippedNCounter.Inc()
+							db.dbIdleGauge.Set(1)
+							db.Logger.Log(ctx, internal.LevelTrace, "sync: skip verify+sync", "reason", "wal unchanged")
+							walUnchanged = true
+							result.origWALSize = exec.state.lastSyncedWALOffset
+							result.newWALSize = exec.state.lastSyncedWALOffset
+							result.syncedToWALEnd = exec.state.syncedToWALEnd
+						}
+					}
+					_ = f.Close()
+				}
+			}
 		}
 	}
 
@@ -1382,9 +1403,18 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 	}
 	db.walSizeGauge.Set(float64(exec.state.lastSyncedWALOffset))
 
-	// Update WAL file size cache for change detection.
-	if walFi, statErr := os.Stat(db.WALPath()); statErr == nil {
+	// Update WAL file size and salt cache for change detection.
+	walPath := db.WALPath()
+	if walFi, statErr := os.Stat(walPath); statErr == nil {
 		db.lastWALFileSize = walFi.Size()
+	}
+	if f, openErr := os.Open(walPath); openErr == nil {
+		var hdr [24]byte
+		if _, readErr := io.ReadFull(f, hdr[:]); readErr == nil {
+			db.lastWALSalt1 = binary.BigEndian.Uint32(hdr[16:])
+			db.lastWALSalt2 = binary.BigEndian.Uint32(hdr[20:])
+		}
+		_ = f.Close()
 	}
 
 	return result, nil

--- a/db.go
+++ b/db.go
@@ -51,6 +51,13 @@ const (
 	FullVerifyInterval = 1 * time.Minute
 )
 
+var monitorJitter = func(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(interval)))
+}
+
 // DB represents a managed instance of a SQLite database in the file system.
 //
 // Checkpoint Strategy:
@@ -3245,20 +3252,13 @@ func (db *DB) EnforceRetentionByTXID(ctx context.Context, level int, txID ltx.TX
 // The monitor continues polling at MonitorInterval to maintain low sync
 // latency when writes resume.
 func (db *DB) monitor() {
-	// Jitter the initial start time to spread wakeups across the interval.
-	// Without this, all databases opened simultaneously (e.g., Store.Open())
-	// create tickers at the same instant, causing synchronized bursts of
-	// syscalls every MonitorInterval. Profiling at 400 DBs shows this
-	// contributes ~24% of CPU overhead from scheduler contention.
-	jitter := time.Duration(rand.Int64N(int64(db.MonitorInterval)))
-	select {
-	case <-db.ctx.Done():
-		return
-	case <-time.After(jitter):
+	jitter := monitorJitter(db.MonitorInterval)
+	timer := time.NewTimer(db.MonitorInterval)
+	defer timer.Stop()
+	var applyJitter bool
+	if jitter > 0 {
+		applyJitter = true
 	}
-
-	ticker := time.NewTicker(db.MonitorInterval)
-	defer ticker.Stop()
 
 	// Backoff state for error handling.
 	var backoff time.Duration
@@ -3266,11 +3266,17 @@ func (db *DB) monitor() {
 	var consecutiveErrs int
 
 	for {
-		// Wait for ticker or context close.
 		select {
 		case <-db.ctx.Done():
 			return
-		case <-ticker.C:
+		case <-timer.C:
+		}
+
+		if applyJitter {
+			timer.Reset(jitter)
+			applyJitter = false
+		} else {
+			timer.Reset(db.MonitorInterval)
 		}
 
 		// If in backoff mode, wait additional time before retrying.

--- a/db.go
+++ b/db.go
@@ -43,6 +43,11 @@ const (
 	// When sync errors occur repeatedly (e.g., disk full), backoff doubles each time.
 	DefaultSyncBackoffMax = 5 * time.Minute  // Maximum backoff between retries
 	SyncErrorLogInterval  = 30 * time.Second // Rate-limit repeated error logging
+
+	// FullVerifyInterval is the maximum time between full LTX verification runs.
+	// Even when WAL is unchanged, we periodically run verifyAndSync() to detect
+	// corrupted/missing LTX files that could otherwise go unnoticed during idle.
+	FullVerifyInterval = 1 * time.Minute
 )
 
 // DB represents a managed instance of a SQLite database in the file system.
@@ -88,6 +93,12 @@ type DB struct {
 	// checkpoint-induced WAL resets where the file size remains the same but
 	// the content has changed (salt rotation after RESTART/FULL checkpoint).
 	lastWALSalt1, lastWALSalt2 uint32
+
+	// lastFullVerifyTime tracks when we last ran full LTX verification.
+	// Even when WAL is unchanged, we periodically run verifyAndSync() to
+	// detect corrupted/missing LTX files that could go unnoticed during
+	// idle periods.
+	lastFullVerifyTime time.Time
 
 	// last file info for each level
 	maxLTXFileInfos struct {
@@ -1323,9 +1334,13 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 	// after checkpoint operations (RESTART/FULL mode rewrites salts in place,
 	// then new writes can refill to the same byte length). Still run
 	// checkpointIfNeeded() since time-based checkpoints may be pending.
+	//
+	// Even when WAL is unchanged, we periodically run full verifyAndSync() to
+	// detect corrupted/missing LTX files that could go unnoticed during idle.
 	walUnchanged := false
+	needsFullVerify := time.Since(db.lastFullVerifyTime) >= FullVerifyInterval
 
-	if exec.state.lastSyncedWALOffset > 0 {
+	if exec.state.lastSyncedWALOffset > 0 && !needsFullVerify {
 		walPath := db.WALPath()
 		if walFi, statErr := os.Stat(walPath); statErr == nil {
 			walFileSize := walFi.Size()
@@ -1359,6 +1374,7 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 		if err != nil {
 			return result, err
 		}
+		db.lastFullVerifyTime = time.Now()
 	}
 	exec.applySyncResult(result)
 

--- a/db.go
+++ b/db.go
@@ -43,6 +43,11 @@ const (
 	// When sync errors occur repeatedly (e.g., disk full), backoff doubles each time.
 	DefaultSyncBackoffMax = 5 * time.Minute  // Maximum backoff between retries
 	SyncErrorLogInterval  = 30 * time.Second // Rate-limit repeated error logging
+
+	// Idle backoff configuration.
+	// When no WAL changes are detected, the monitor interval progressively
+	// increases to reduce CPU and I/O on idle databases.
+	DefaultMaxIdleInterval = 60 * time.Second
 )
 
 // DB represents a managed instance of a SQLite database in the file system.
@@ -78,6 +83,10 @@ type DB struct {
 	opened    bool          // true if Open() was called and Close() not yet called
 	syncState syncState
 	syncDiag  diagState
+
+	// WAL file size at the end of the last Sync(). Used with lastSyncedWALOffset
+	// to detect whether new WAL data has been written since the last sync.
+	lastWALFileSize int64
 
 	// last file info for each level
 	maxLTXFileInfos struct {
@@ -116,6 +125,8 @@ type DB struct {
 	checkpointNCounterVec       *prometheus.CounterVec
 	checkpointErrorNCounterVec  *prometheus.CounterVec
 	checkpointSecondsCounterVec *prometheus.CounterVec
+	syncSkippedNCounter         prometheus.Counter
+	dbIdleGauge                 prometheus.Gauge
 
 	// Minimum threshold of WAL size, in pages, before a passive checkpoint.
 	// A passive checkpoint will attempt a checkpoint but fail if there are
@@ -151,6 +162,10 @@ type DB struct {
 	// larger than this may exceed it. Set to zero to process all
 	// committed WAL frames in one run.
 	MaxSyncWALBytes int64
+
+	// Maximum polling interval when no WAL changes are detected.
+	// The monitor backs off exponentially from MonitorInterval to this value.
+	MaxIdleInterval time.Duration
 
 	// The timeout to wait for EBUSY from SQLite.
 	BusyTimeout time.Duration
@@ -318,6 +333,7 @@ func NewDB(path string) *DB {
 		CheckpointInterval:   DefaultCheckpointInterval,
 		MonitorInterval:      DefaultMonitorInterval,
 		MaxSyncWALBytes:      DefaultMaxSyncWALBytes,
+		MaxIdleInterval:      DefaultMaxIdleInterval,
 		BusyTimeout:          DefaultBusyTimeout,
 		L0Retention:          DefaultL0Retention,
 		RetentionEnabled:     true,
@@ -339,6 +355,8 @@ func NewDB(path string) *DB {
 	db.checkpointNCounterVec = checkpointNCounterVec.MustCurryWith(prometheus.Labels{"db": db.path})
 	db.checkpointErrorNCounterVec = checkpointErrorNCounterVec.MustCurryWith(prometheus.Labels{"db": db.path})
 	db.checkpointSecondsCounterVec = checkpointSecondsCounterVec.MustCurryWith(prometheus.Labels{"db": db.path})
+	db.syncSkippedNCounter = syncSkippedNCounterVec.WithLabelValues(db.path)
+	db.dbIdleGauge = dbIdleGaugeVec.WithLabelValues(db.path)
 
 	db.ctx, db.cancel = context.WithCancel(context.Background())
 
@@ -538,6 +556,9 @@ func (db *DB) ResetLocalState(ctx context.Context) error {
 	db.maxLTXFileInfos.Unlock()
 
 	db.invalidatePosCache()
+
+	// Clear WAL change detection cache so next sync processes everything fresh.
+	db.lastWALFileSize = 0
 
 	db.Logger.Info("local state reset complete, next sync will create fresh snapshot")
 	return nil
@@ -1293,18 +1314,42 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 		return result, fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	db.setSyncDiagPhase(diagPhaseVerifyAndSync, func(s *diagState) {
-		s.txID = exec.pos.TXID + 1
-	})
-	result, err = db.verifyAndSyncWithExecutor(ctx, false, exec, maxSyncWALBytes)
-	if err != nil {
-		return result, err
+	// Fast path: skip expensive verify+sync if WAL has no new data.
+	// Compare WAL file size against lastSyncedWALOffset and lastWALFileSize
+	// to determine if any new frames have been written. Still run
+	// checkpointIfNeeded() since time-based checkpoints may be pending.
+	walUnchanged := false
+
+	if walFi, statErr := os.Stat(db.WALPath()); statErr == nil {
+		walFileSize := walFi.Size()
+		if exec.state.lastSyncedWALOffset > 0 &&
+			walFileSize == db.lastWALFileSize &&
+			walFileSize == exec.state.lastSyncedWALOffset {
+			db.syncSkippedNCounter.Inc()
+			db.dbIdleGauge.Set(1)
+			db.Logger.Log(ctx, internal.LevelTrace, "sync: skip verify+sync", "reason", "wal unchanged")
+			walUnchanged = true
+			result.origWALSize = exec.state.lastSyncedWALOffset
+			result.newWALSize = exec.state.lastSyncedWALOffset
+			result.syncedToWALEnd = exec.state.syncedToWALEnd
+		}
+	}
+
+	if !walUnchanged {
+		db.setSyncDiagPhase(diagPhaseVerifyAndSync, func(s *diagState) {
+			s.txID = exec.pos.TXID + 1
+		})
+		result, err = db.verifyAndSyncWithExecutor(ctx, false, exec, maxSyncWALBytes)
+		if err != nil {
+			return result, err
+		}
 	}
 	exec.applySyncResult(result)
 
 	// Track that data was synced for time-based checkpoint decisions.
 	if result.synced {
 		exec.state.syncedSinceCheckpoint = true
+		db.dbIdleGauge.Set(0)
 	}
 
 	// Checkpoint checks normally wait until the WAL is fully synced, but the
@@ -1330,10 +1375,17 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 	db.txIDGauge.Set(float64(exec.pos.TXID))
 
 	// Update file size metrics.
-	if fi, err := os.Stat(db.path); err == nil {
-		db.dbSizeGauge.Set(float64(fi.Size()))
+	if !walUnchanged {
+		if fi, err := os.Stat(db.path); err == nil {
+			db.dbSizeGauge.Set(float64(fi.Size()))
+		}
 	}
 	db.walSizeGauge.Set(float64(exec.state.lastSyncedWALOffset))
+
+	// Update WAL file size cache for change detection.
+	if walFi, statErr := os.Stat(db.WALPath()); statErr == nil {
+		db.lastWALFileSize = walFi.Size()
+	}
 
 	return result, nil
 }
@@ -3139,6 +3191,10 @@ func (db *DB) EnforceRetentionByTXID(ctx context.Context, level int, txID ltx.TX
 //
 // Implements exponential backoff on repeated sync errors to prevent disk churn
 // when persistent errors (like disk full) occur. See issue #927.
+//
+// Also implements adaptive idle backoff: when no WAL changes are detected,
+// the polling interval progressively increases from MonitorInterval to
+// MaxIdleInterval. Resets immediately when activity is detected. See issue #1210.
 func (db *DB) monitor() {
 	ticker := time.NewTicker(db.MonitorInterval)
 	defer ticker.Stop()
@@ -3148,6 +3204,9 @@ func (db *DB) monitor() {
 	var lastLogTime time.Time
 	var consecutiveErrs int
 
+	// Idle backoff state.
+	var idleBackoff time.Duration
+
 	for {
 		// Wait for ticker or context close.
 		select {
@@ -3156,7 +3215,7 @@ func (db *DB) monitor() {
 		case <-ticker.C:
 		}
 
-		// If in backoff mode, wait additional time before retrying.
+		// If in error backoff mode, wait additional time before retrying.
 		if backoff > 0 {
 			select {
 			case <-db.ctx.Done():
@@ -3164,6 +3223,17 @@ func (db *DB) monitor() {
 			case <-time.After(backoff):
 			}
 		}
+
+		// If in idle backoff mode, wait additional time before syncing.
+		if idleBackoff > 0 {
+			select {
+			case <-db.ctx.Done():
+				return
+			case <-time.After(idleBackoff):
+			}
+		}
+
+		prePos, _ := db.Pos()
 
 		// Sync the database to the shadow WAL. Sync() loops over bounded
 		// chunks, releasing the executor lock between each so checkpoints
@@ -3173,6 +3243,7 @@ func (db *DB) monitor() {
 		// emergency checkpoint while behind, growing the WAL unbounded.
 		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
+			idleBackoff = 0
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max
 			if backoff == 0 {
@@ -3216,12 +3287,30 @@ func (db *DB) monitor() {
 			continue
 		}
 
-		// Success - reset backoff and error counter.
+		// Success - reset error backoff and error counter.
 		if consecutiveErrs > 0 {
 			db.Logger.Info("sync recovered", "previous_errors", consecutiveErrs)
 		}
 		backoff = 0
 		consecutiveErrs = 0
+
+		// Adaptive idle backoff: increase interval when no changes detected.
+		postPos, _ := db.Pos()
+		if prePos.TXID == postPos.TXID {
+			if idleBackoff == 0 {
+				idleBackoff = db.MonitorInterval
+			} else {
+				idleBackoff *= 2
+				if idleBackoff > db.MaxIdleInterval {
+					idleBackoff = db.MaxIdleInterval
+				}
+			}
+		} else {
+			if idleBackoff > 0 {
+				db.Logger.Debug("monitor: activity detected, resetting idle backoff")
+			}
+			idleBackoff = 0
+		}
 	}
 }
 
@@ -3393,5 +3482,15 @@ var (
 	compactionVerifyErrorCounterVec = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "litestream_compaction_verify_error_count",
 		Help: "Number of post-compaction verification failures",
+	}, []string{"db"})
+
+	syncSkippedNCounterVec = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "litestream_sync_skipped_total",
+		Help: "Number of sync operations skipped due to unchanged WAL",
+	}, []string{"db"})
+
+	dbIdleGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "litestream_db_idle",
+		Help: "Whether the database is idle (1) or active (0)",
 	}, []string{"db"})
 )

--- a/db.go
+++ b/db.go
@@ -537,6 +537,11 @@ func (db *DB) LTXDir() string {
 // This is useful for recovering from corrupted or missing LTX files.
 // The database file itself is not modified.
 func (db *DB) ResetLocalState(ctx context.Context) error {
+	if err := db.lockExec(ctx); err != nil {
+		return err
+	}
+	defer db.execSem.Release(1)
+
 	db.Logger.Info("resetting local litestream state",
 		"meta_path", db.metaPath,
 		"ltx_dir", db.LTXDir())

--- a/db.go
+++ b/db.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc64"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1320,20 +1321,16 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 	}
 	defer db.applySyncExecutor(exec, true)
 
-	// Ensure WAL has at least one frame in it.
-	db.setSyncDiagPhase(diagPhaseEnsureWAL, func(s *diagState) {
-		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
-	})
-	if err := db.ensureWALExists(ctx); err != nil {
-		return result, fmt.Errorf("ensure wal exists: %w", err)
-	}
-
 	// Fast path: skip expensive verify+sync if WAL has no new data.
-	// Compare WAL file size and header salts against cached values.
+	// When lastSyncedWALOffset > 0, we know the WAL exists from a prior sync,
+	// so we can skip ensureWALExists() and check for changes directly.
+	//
+	// We open the WAL file once and use f.Stat() to get the size, then read
+	// the header salts — this reduces the idle path from 6 syscalls (stat +
+	// stat + open + read + close + stat) to 3 (open + fstat + read + close).
+	//
 	// We must check salts because content can change while size stays constant
-	// after checkpoint operations (RESTART/FULL mode rewrites salts in place,
-	// then new writes can refill to the same byte length). Still run
-	// checkpointIfNeeded() since time-based checkpoints may be pending.
+	// after checkpoint operations (salt rotation after RESTART/FULL checkpoint).
 	//
 	// Even when WAL is unchanged, we periodically run full verifyAndSync() to
 	// detect corrupted/missing LTX files that could go unnoticed during idle.
@@ -1341,11 +1338,10 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 	needsFullVerify := time.Since(db.lastFullVerifyTime) >= FullVerifyInterval
 
 	if exec.state.lastSyncedWALOffset > 0 && !needsFullVerify {
-		walPath := db.WALPath()
-		if walFi, statErr := os.Stat(walPath); statErr == nil {
-			walFileSize := walFi.Size()
-			if walFileSize == db.lastWALFileSize && walFileSize == exec.state.lastSyncedWALOffset {
-				if f, openErr := os.Open(walPath); openErr == nil {
+		if f, openErr := os.Open(db.WALPath()); openErr == nil {
+			if walFi, statErr := f.Stat(); statErr == nil {
+				walFileSize := walFi.Size()
+				if walFileSize == db.lastWALFileSize && walFileSize == exec.state.lastSyncedWALOffset {
 					var hdr [24]byte
 					if _, readErr := io.ReadFull(f, hdr[:]); readErr == nil {
 						salt1 := binary.BigEndian.Uint32(hdr[16:])
@@ -1360,9 +1356,20 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 							result.syncedToWALEnd = exec.state.syncedToWALEnd
 						}
 					}
-					_ = f.Close()
 				}
 			}
+			_ = f.Close()
+		}
+	}
+
+	// Ensure WAL has at least one frame in it (only needed on first sync or
+	// when the fast path didn't apply).
+	if !walUnchanged {
+		db.setSyncDiagPhase(diagPhaseEnsureWAL, func(s *diagState) {
+			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+		})
+		if err := db.ensureWALExists(ctx); err != nil {
+			return result, fmt.Errorf("ensure wal exists: %w", err)
 		}
 	}
 
@@ -3238,6 +3245,18 @@ func (db *DB) EnforceRetentionByTXID(ctx context.Context, level int, txID ltx.TX
 // The monitor continues polling at MonitorInterval to maintain low sync
 // latency when writes resume.
 func (db *DB) monitor() {
+	// Jitter the initial start time to spread wakeups across the interval.
+	// Without this, all databases opened simultaneously (e.g., Store.Open())
+	// create tickers at the same instant, causing synchronized bursts of
+	// syscalls every MonitorInterval. Profiling at 400 DBs shows this
+	// contributes ~24% of CPU overhead from scheduler contention.
+	jitter := time.Duration(rand.Int64N(int64(db.MonitorInterval)))
+	select {
+	case <-db.ctx.Done():
+		return
+	case <-time.After(jitter):
+	}
+
 	ticker := time.NewTicker(db.MonitorInterval)
 	defer ticker.Stop()
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -80,6 +80,60 @@ func (c *testReplicaClient) LTXFiles(_ context.Context, level int, seek ltx.TXID
 	return ltx.NewFileInfoSliceIterator(infos), nil
 }
 
+func TestDB_Monitor_FirstSyncDoesNotWaitExtraInterval(t *testing.T) {
+	prevMonitorJitter := monitorJitter
+	monitorJitter = func(interval time.Duration) time.Duration { return interval - 5*time.Millisecond }
+	t.Cleanup(func() { monitorJitter = prevMonitorJitter })
+
+	dir := t.TempDir()
+	db := NewDB(filepath.Join(dir, "db"))
+	db.MonitorInterval = 60 * time.Millisecond
+	db.ShutdownSyncTimeout = 0
+	db.Replica = NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb, err := sql.Open("sqlite", db.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := sqldb.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000;`); err != nil {
+		t.Fatal(err)
+	}
+
+	notify := db.Notify()
+	start := time.Now()
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-notify:
+		if elapsed := time.Since(start); elapsed > db.MonitorInterval+40*time.Millisecond {
+			t.Fatalf("first sync took %s, expected no more than %s", elapsed, db.MonitorInterval+40*time.Millisecond)
+		}
+	case <-time.After(db.MonitorInterval + 40*time.Millisecond):
+		t.Fatalf("expected first sync within %s", db.MonitorInterval+40*time.Millisecond)
+	}
+}
+
 func (c *testReplicaClient) OpenLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, _, _ int64) (io.ReadCloser, error) {
 	internal.OperationTotalCounterVec.WithLabelValues(c.Type(), "GET").Inc()
 

--- a/db_test.go
+++ b/db_test.go
@@ -1995,26 +1995,17 @@ func TestDB_Sync_SkipsWhenWALUnchanged(t *testing.T) {
 	}
 }
 
-func TestDB_Monitor_IdleBackoff(t *testing.T) {
+func TestDB_Sync_IdleMetrics(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)
 
-	// Create initial data.
+	// Create initial data and sync.
 	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE foo (bar TEXT)`); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Sync(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-
-	// Configure fast monitor intervals for testing.
-	db.MonitorInterval = 10 * time.Millisecond
-	db.MaxIdleInterval = 100 * time.Millisecond
-
-	// Start the monitor by calling the internal method via Open/Close cycle.
-	// Instead, we'll test the idle backoff behavior indirectly:
-	// After first idle sync, subsequent syncs should not advance TXID.
-	// After a write, the next sync should advance TXID.
 
 	// Perform multiple idle syncs — TXID should not change.
 	pos0, _ := db.Pos()

--- a/db_test.go
+++ b/db_test.go
@@ -1901,3 +1901,142 @@ func TestDB_ResetLocalState(t *testing.T) {
 		t.Fatalf("expected zero TXID after reset, got %d", posAfter.TXID)
 	}
 }
+
+func TestDB_Sync_NotifyOnlyOnChange(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	// Create a table to ensure WAL has data.
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE foo (bar TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initial sync: notify channel should close (new data synced).
+	notify := db.Notify()
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-notify:
+	default:
+		t.Fatal("expected notify channel to close after initial sync with data")
+	}
+
+	// Second sync with no new writes: notify channel should stay open.
+	notify = db.Notify()
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-notify:
+		t.Fatal("expected notify channel to remain open when no data changed")
+	default:
+	}
+
+	// Write new data and sync again: notify channel should close.
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO foo (bar) VALUES ('baz')`); err != nil {
+		t.Fatal(err)
+	}
+	notify = db.Notify()
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-notify:
+	default:
+		t.Fatal("expected notify channel to close after sync with new data")
+	}
+}
+
+func TestDB_Sync_SkipsWhenWALUnchanged(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	// Create a table and perform initial sync.
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE foo (bar TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	pos0, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync again without any writes — should be a no-op (WAL unchanged).
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	pos1, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos1.TXID != pos0.TXID {
+		t.Fatalf("expected TXID to remain %v after idle sync, got %v", pos0.TXID, pos1.TXID)
+	}
+
+	// Now write data and sync — TXID should advance.
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO foo (bar) VALUES ('baz')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	pos2, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos2.TXID <= pos1.TXID {
+		t.Fatalf("expected TXID to advance after data write, got %v (was %v)", pos2.TXID, pos1.TXID)
+	}
+}
+
+func TestDB_Monitor_IdleBackoff(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	// Create initial data.
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE foo (bar TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure fast monitor intervals for testing.
+	db.MonitorInterval = 10 * time.Millisecond
+	db.MaxIdleInterval = 100 * time.Millisecond
+
+	// Start the monitor by calling the internal method via Open/Close cycle.
+	// Instead, we'll test the idle backoff behavior indirectly:
+	// After first idle sync, subsequent syncs should not advance TXID.
+	// After a write, the next sync should advance TXID.
+
+	// Perform multiple idle syncs — TXID should not change.
+	pos0, _ := db.Pos()
+	for i := 0; i < 5; i++ {
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pos1, _ := db.Pos()
+	if pos1.TXID != pos0.TXID {
+		t.Fatalf("expected TXID to remain %v after idle syncs, got %v", pos0.TXID, pos1.TXID)
+	}
+
+	// Write data and sync — should advance.
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO foo (bar) VALUES ('baz')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	pos2, _ := db.Pos()
+	if pos2.TXID <= pos1.TXID {
+		t.Fatalf("expected TXID to advance after write, got %v (was %v)", pos2.TXID, pos1.TXID)
+	}
+}

--- a/replica.go
+++ b/replica.go
@@ -398,16 +398,17 @@ func (r *Replica) monitor(ctx context.Context) {
 	var backoff time.Duration
 	var lastLogTime time.Time
 	var consecutiveErrs int
+	var waitForInterval bool
 
-	for initial := true; ; initial = false {
-		// Enforce a minimum time between synchronization.
-		if !initial {
+	for {
+		if waitForInterval {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
 			}
 		}
+		waitForInterval = true
 
 		// If in backoff mode, wait additional time before retrying.
 		if backoff > 0 {
@@ -439,6 +440,9 @@ func (r *Replica) monitor(ctx context.Context) {
 		// Synchronize the shadow wal into the replication directory.
 		if err := r.sync(ctx, r.MaxSyncLTXFiles); err != nil {
 			if errors.Is(err, errReplicaWaitForData) {
+				backoff = 0
+				consecutiveErrs = 0
+				waitForInterval = false
 				continue
 			}
 

--- a/replica_test.go
+++ b/replica_test.go
@@ -1124,6 +1124,38 @@ func TestReplica_ValidateLevel(t *testing.T) {
 		}
 	})
 }
+
+func TestReplica_Monitor_FreshDBWaitsOnNotify(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	c := file.NewReplicaClient(t.TempDir())
+	r := litestream.NewReplicaWithClient(db, c)
+	r.SyncInterval = 30 * time.Millisecond
+	db.Replica = r
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	if err := r.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(95 * time.Millisecond)
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(40 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.Pos().TXID != 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("replica did not upload new data within %s after notify", 40*time.Millisecond)
+}
 func TestReplica_RestoreV3(t *testing.T) {
 	t.Run("SnapshotOnly", func(t *testing.T) {
 		ctx := context.Background()

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,1 @@
+profiles/

--- a/tests/integration/profile_test.go
+++ b/tests/integration/profile_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -12,8 +13,12 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
@@ -135,4 +140,335 @@ func TestIdleCPUProfile(t *testing.T) {
 			t.Logf("close sql db %d: %v", i, err)
 		}
 	}
+}
+
+// MetricsSnapshot captures runtime metrics at a point in time.
+type MetricsSnapshot struct {
+	Timestamp       time.Time `json:"timestamp"`
+	ElapsedSec      float64   `json:"elapsed_sec"`
+	GoroutineCount  int       `json:"goroutine_count"`
+	HeapAllocBytes  uint64    `json:"heap_alloc_bytes"`
+	HeapObjects     uint64    `json:"heap_objects"`
+	SysBytes        uint64    `json:"sys_bytes"`
+	NumGC           uint32    `json:"num_gc"`
+	PauseTotalNs    uint64    `json:"pause_total_ns"`
+	HeapInuseBytes  uint64    `json:"heap_inuse_bytes"`
+	StackInuseBytes uint64    `json:"stack_inuse_bytes"`
+}
+
+// ProfileReport holds all metrics collected during a profile run.
+type ProfileReport struct {
+	DBCount   int               `json:"db_count"`
+	Duration  string            `json:"duration"`
+	StartTime time.Time         `json:"start_time"`
+	EndTime   time.Time         `json:"end_time"`
+	Snapshots []MetricsSnapshot `json:"snapshots"`
+}
+
+func collectMetricsSnapshot(start time.Time) MetricsSnapshot {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return MetricsSnapshot{
+		Timestamp:       time.Now(),
+		ElapsedSec:      time.Since(start).Seconds(),
+		GoroutineCount:  runtime.NumGoroutine(),
+		HeapAllocBytes:  m.HeapAlloc,
+		HeapObjects:     m.HeapObjects,
+		SysBytes:        m.Sys,
+		NumGC:           m.NumGC,
+		PauseTotalNs:    m.PauseTotalNs,
+		HeapInuseBytes:  m.HeapInuse,
+		StackInuseBytes: m.StackInuse,
+	}
+}
+
+// TestIdleProfileSuite runs automated profiling with metrics collection.
+// Unlike TestIdleCPUProfile (interactive), this test runs for a fixed duration,
+// collects profiles and metrics automatically, and saves them for comparison.
+//
+// Environment variables:
+//
+//	PROFILE_DB_COUNT    - number of idle databases (default: 100)
+//	PROFILE_DURATION    - profiling duration after warmup (default: 60s)
+//	PROFILE_OUTPUT_DIR  - output directory for profiles (default: ./profiles)
+//	PROFILE_WARMUP      - warmup period before profiling (default: 10s)
+//	PROFILE_TRACE       - set to "1" to capture runtime/trace (default: off)
+//	PROFILE_CPU_SECS    - CPU profile duration in seconds (default: 30)
+//
+// Usage:
+//
+//	PROFILE_DB_COUNT=400 PROFILE_DURATION=60s PROFILE_OUTPUT_DIR=./profiles/pr1211 \
+//	  go test -tags=profile -run TestIdleProfileSuite -timeout=5m -v ./tests/integration/
+func TestIdleProfileSuite(t *testing.T) {
+	// Parse configuration from environment.
+	dbCount := envInt(t, "PROFILE_DB_COUNT", 100)
+	duration := envDuration(t, "PROFILE_DURATION", 60*time.Second)
+	outputDir := envString("PROFILE_OUTPUT_DIR", "./profiles")
+	warmup := envDuration(t, "PROFILE_WARMUP", 10*time.Second)
+	enableTrace := os.Getenv("PROFILE_TRACE") == "1"
+	cpuSecs := envInt(t, "PROFILE_CPU_SECS", 30)
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatalf("create output dir: %v", err)
+	}
+
+	t.Logf("=== Idle Profile Suite ===")
+	t.Logf("  databases:  %d", dbCount)
+	t.Logf("  warmup:     %s", warmup)
+	t.Logf("  duration:   %s", duration)
+	t.Logf("  cpu_secs:   %d", cpuSecs)
+	t.Logf("  trace:      %v", enableTrace)
+	t.Logf("  output:     %s", outputDir)
+	t.Logf("")
+
+	// Create temporary root directory for all databases.
+	rootDir := t.TempDir()
+
+	// Start N databases with monitoring enabled.
+	type instance struct {
+		db    *litestream.DB
+		sqldb *sql.DB
+	}
+	instances := make([]instance, 0, dbCount)
+
+	t.Logf("creating %d databases...", dbCount)
+	createStart := time.Now()
+	for i := range dbCount {
+		dbPath := filepath.Join(rootDir, fmt.Sprintf("db%04d", i), "db")
+		replicaDir := filepath.Join(rootDir, fmt.Sprintf("db%04d", i), "replica")
+
+		if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		sqldb, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatalf("open sql db %d: %v", i, err)
+		}
+		if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+			t.Fatalf("set wal mode db %d: %v", i, err)
+		}
+		if _, err := sqldb.Exec(`CREATE TABLE data (id INTEGER PRIMARY KEY, value TEXT)`); err != nil {
+			t.Fatalf("create table db %d: %v", i, err)
+		}
+		if _, err := sqldb.Exec(`INSERT INTO data (value) VALUES ('seed')`); err != nil {
+			t.Fatalf("insert seed db %d: %v", i, err)
+		}
+
+		db := litestream.NewDB(dbPath)
+		db.Replica = litestream.NewReplica(db)
+		db.Replica.Client = file.NewReplicaClient(replicaDir)
+
+		if err := db.Open(); err != nil {
+			t.Fatalf("open litestream db %d: %v", i, err)
+		}
+
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatalf("initial sync db %d: %v", i, err)
+		}
+
+		instances = append(instances, instance{db: db, sqldb: sqldb})
+	}
+	t.Logf("created %d databases in %s", dbCount, time.Since(createStart).Round(time.Millisecond))
+
+	// Warmup: let monitors settle into steady state.
+	t.Logf("warming up for %s...", warmup)
+	time.Sleep(warmup)
+
+	// Collect metrics during the profiling window.
+	t.Logf("profiling for %s...", duration)
+	profileStart := time.Now()
+	report := ProfileReport{
+		DBCount:   dbCount,
+		Duration:  duration.String(),
+		StartTime: profileStart,
+	}
+
+	// Start CPU profile.
+	cpuFile, err := os.Create(filepath.Join(outputDir, "cpu.pprof"))
+	if err != nil {
+		t.Fatalf("create cpu profile: %v", err)
+	}
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		t.Fatalf("start cpu profile: %v", err)
+	}
+
+	// Start runtime/trace if enabled.
+	var traceFile *os.File
+	if enableTrace {
+		traceFile, err = os.Create(filepath.Join(outputDir, "trace.out"))
+		if err != nil {
+			t.Fatalf("create trace file: %v", err)
+		}
+		if err := trace.Start(traceFile); err != nil {
+			t.Fatalf("start trace: %v", err)
+		}
+	}
+
+	// Collect metrics snapshots every 5 seconds.
+	metricsTicker := time.NewTicker(5 * time.Second)
+	defer metricsTicker.Stop()
+
+	// Initial snapshot.
+	report.Snapshots = append(report.Snapshots, collectMetricsSnapshot(profileStart))
+
+	deadline := time.After(duration)
+
+	// Stop CPU profile after cpuSecs (or at end if shorter).
+	cpuDeadline := time.After(time.Duration(cpuSecs) * time.Second)
+	cpuStopped := false
+
+	// Stop trace after 10 seconds (traces get large quickly).
+	traceDeadline := time.After(10 * time.Second)
+	traceStopped := false
+
+loop:
+	for {
+		select {
+		case <-deadline:
+			break loop
+		case <-metricsTicker.C:
+			snap := collectMetricsSnapshot(profileStart)
+			report.Snapshots = append(report.Snapshots, snap)
+			t.Logf("  t=%5.0fs  goroutines=%d  heap=%dMB  stack=%dKB  gc=%d",
+				snap.ElapsedSec,
+				snap.GoroutineCount,
+				snap.HeapAllocBytes/(1024*1024),
+				snap.StackInuseBytes/1024,
+				snap.NumGC)
+		case <-cpuDeadline:
+			if !cpuStopped {
+				pprof.StopCPUProfile()
+				cpuFile.Close()
+				cpuStopped = true
+				t.Logf("  CPU profile saved (%ds)", cpuSecs)
+			}
+		case <-traceDeadline:
+			if enableTrace && !traceStopped {
+				trace.Stop()
+				traceFile.Close()
+				traceStopped = true
+				t.Log("  runtime trace saved (10s)")
+			}
+		}
+	}
+
+	// Stop profiles if still running.
+	if !cpuStopped {
+		pprof.StopCPUProfile()
+		cpuFile.Close()
+	}
+	if enableTrace && !traceStopped {
+		trace.Stop()
+		traceFile.Close()
+	}
+
+	// Final snapshot.
+	report.Snapshots = append(report.Snapshots, collectMetricsSnapshot(profileStart))
+	report.EndTime = time.Now()
+
+	// Save goroutine profile.
+	goroutineFile, err := os.Create(filepath.Join(outputDir, "goroutine.pprof"))
+	if err != nil {
+		t.Fatalf("create goroutine profile: %v", err)
+	}
+	if err := pprof.Lookup("goroutine").WriteTo(goroutineFile, 0); err != nil {
+		t.Fatalf("write goroutine profile: %v", err)
+	}
+	goroutineFile.Close()
+
+	// Save heap profile.
+	heapFile, err := os.Create(filepath.Join(outputDir, "heap.pprof"))
+	if err != nil {
+		t.Fatalf("create heap profile: %v", err)
+	}
+	runtime.GC()
+	if err := pprof.Lookup("heap").WriteTo(heapFile, 0); err != nil {
+		t.Fatalf("write heap profile: %v", err)
+	}
+	heapFile.Close()
+
+	// Save metrics report as JSON.
+	metricsFile, err := os.Create(filepath.Join(outputDir, "metrics.json"))
+	if err != nil {
+		t.Fatalf("create metrics file: %v", err)
+	}
+	enc := json.NewEncoder(metricsFile)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		t.Fatalf("encode metrics: %v", err)
+	}
+	metricsFile.Close()
+
+	// Print summary.
+	first := report.Snapshots[0]
+	last := report.Snapshots[len(report.Snapshots)-1]
+	t.Logf("")
+	t.Logf("=== Profile Summary ===")
+	t.Logf("  databases:       %d", dbCount)
+	t.Logf("  duration:        %s", duration)
+	t.Logf("  goroutines:      %d → %d", first.GoroutineCount, last.GoroutineCount)
+	t.Logf("  heap alloc:      %dMB → %dMB", first.HeapAllocBytes/(1024*1024), last.HeapAllocBytes/(1024*1024))
+	t.Logf("  heap objects:    %d → %d", first.HeapObjects, last.HeapObjects)
+	t.Logf("  stack inuse:     %dKB → %dKB", first.StackInuseBytes/1024, last.StackInuseBytes/1024)
+	t.Logf("  GC cycles:       %d → %d (+%d)", first.NumGC, last.NumGC, last.NumGC-first.NumGC)
+	t.Logf("  GC pause total:  %dms → %dms", first.PauseTotalNs/1e6, last.PauseTotalNs/1e6)
+	t.Logf("")
+	t.Logf("=== Output Files ===")
+	t.Logf("  %s/cpu.pprof", outputDir)
+	t.Logf("  %s/goroutine.pprof", outputDir)
+	t.Logf("  %s/heap.pprof", outputDir)
+	t.Logf("  %s/metrics.json", outputDir)
+	if enableTrace {
+		t.Logf("  %s/trace.out", outputDir)
+	}
+	t.Logf("")
+	t.Logf("Analyze with:")
+	t.Logf("  go tool pprof -http=:8181 %s/cpu.pprof", outputDir)
+	t.Logf("  go tool pprof -http=:8182 %s/heap.pprof", outputDir)
+	if enableTrace {
+		t.Logf("  go tool trace %s/trace.out", outputDir)
+	}
+
+	// Shutdown.
+	t.Logf("shutting down %d databases...", dbCount)
+	for i, inst := range instances {
+		if err := inst.db.Close(context.Background()); err != nil {
+			t.Logf("close litestream db %d: %v", i, err)
+		}
+		if err := inst.sqldb.Close(); err != nil {
+			t.Logf("close sql db %d: %v", i, err)
+		}
+	}
+}
+
+func envInt(t *testing.T, key string, defaultVal int) int {
+	s := os.Getenv(key)
+	if s == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		t.Fatalf("invalid %s: %v", key, err)
+	}
+	return n
+}
+
+func envDuration(t *testing.T, key string, defaultVal time.Duration) time.Duration {
+	s := os.Getenv(key)
+	if s == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		t.Fatalf("invalid %s: %v", key, err)
+	}
+	return d
+}
+
+func envString(key, defaultVal string) string {
+	if s := os.Getenv(key); s != "" {
+		return s
+	}
+	return defaultVal
 }


### PR DESCRIPTION
## Summary

Reduces unnecessary CPU, memory, and cloud storage API usage on idle databases while preserving prompt startup replication behavior.

Fixes #1210
Closes #992
Closes #1171

## Review Follow-up

Addressed the two review findings from this PR:

1. Fresh or reset databases now treat `no position, waiting for data` as a notify-wait state instead of a retry state, so the first real upload is not delayed behind exponential backoff or an extra `SyncInterval`.
2. Database monitor jitter no longer adds an extra full monitor interval before the first background sync. The first poll stays at `MonitorInterval`, and the phase shift is applied on the following wakeup.

## Additional Validation Fixes

While running local soak coverage for this PR, I fixed two soak-harness issues so the documented validation paths could actually run:

- undefined `criticalErrors` references in the soak tests
- incorrect S3 config indentation in `CreateSoakConfig()` for MinIO/S3-backed soak runs

## Validation

- `go test ./...`
- `go test ./... -run 'TestDB_Monitor_FirstSyncDoesNotWaitExtraInterval|TestReplica_Monitor_FreshDBWaitsOnNotify|TestStore_Integration'`
- `SOAK_DEBUG=1 go test -v -tags='integration,soak' -run=TestComprehensiveSoak -test.short -timeout=1h ./tests/integration`
- `SOAK_AUTO_PURGE=yes SOAK_DEBUG=1 go test -v -tags='integration,soak,docker' -run=TestMinIOSoak -test.short -timeout=20m ./tests/integration`

## Results

- Full Go test suite passed.
- Short file-based soak passed, including restore and integrity validation.
- Short MinIO soak now reaches real replication and restore, but the restored DB still fails integrity check with `wrong # of entries in index idx_load_test_timestamp`. That issue was surfaced during validation and is not addressed in this PR.
