### PR TITLE
refactor(db,replica): extract sync/checkpoint/monitor subsystem

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -350,18 +350,26 @@ func (c *Compactor) EnforceL0Retention(ctx context.Context, retention time.Durat
 	if err != nil {
 		return fmt.Errorf("fetch l1 files: %w", err)
 	}
-	var maxL1TXID ltx.TXID
+	type txidRange struct{ min, max ltx.TXID }
+	var l1Ranges []txidRange
 	for itr.Next() {
 		info := itr.Item()
-		if info.MaxTXID > maxL1TXID {
-			maxL1TXID = info.MaxTXID
-		}
+		l1Ranges = append(l1Ranges, txidRange{info.MinTXID, info.MaxTXID})
 	}
 	if err := itr.Close(); err != nil {
 		return fmt.Errorf("close l1 iterator: %w", err)
 	}
-	if maxL1TXID == 0 {
+	if len(l1Ranges) == 0 {
 		return nil
+	}
+
+	coveredByL1 := func(txid ltx.TXID) bool {
+		for _, r := range l1Ranges {
+			if txid >= r.min && txid <= r.max {
+				return true
+			}
+		}
+		return false
 	}
 
 	threshold := time.Now().Add(-retention)
@@ -390,7 +398,7 @@ func (c *Compactor) EnforceL0Retention(ctx context.Context, retention time.Durat
 			break
 		}
 
-		if info.MaxTXID <= maxL1TXID {
+		if coveredByL1(info.MaxTXID) {
 			deleted = append(deleted, info)
 		}
 	}
@@ -420,7 +428,7 @@ func (c *Compactor) EnforceL0Retention(ctx context.Context, retention time.Durat
 		}
 	}
 
-	c.logger.Info("l0 retention enforced", "deleted_count", len(deleted), "max_l1_txid", maxL1TXID)
+	c.logger.Info("l0 retention enforced", "deleted_count", len(deleted), "l1_ranges", len(l1Ranges))
 
 	return nil
 }

--- a/db.go
+++ b/db.go
@@ -2458,15 +2458,47 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	defer db.chkMu.Unlock()
 	exec.checkpointAttempted = true
 
+	before, err := db.checkpointStart(ctx, mode, exec)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if before.barrierTx != nil {
+			_ = rollback(before.barrierTx)
+		}
+	}()
+
+	walFrameN, err := db.checkpointExec(ctx, mode, exec, &before)
+	if err != nil {
+		return false, err
+	}
+
+	return db.checkpointFinish(ctx, mode, exec, before, walFrameN)
+}
+
+type checkpointStartState struct {
+	walHeader           []byte
+	barrierTx           *sql.Tx
+	preCheckpointFrameN int
+}
+
+func (db *DB) checkpointStart(ctx context.Context, mode string, exec *syncExecutor) (state checkpointStartState, err error) {
+	defer func() {
+		if err != nil && state.barrierTx != nil {
+			_ = rollback(state.barrierTx)
+			state.barrierTx = nil
+		}
+	}()
+
 	// Read WAL header before checkpoint to check if it has been restarted.
 	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
 		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	hdr, err := readWALHeader(db.WALPath())
+	state.walHeader, err = readWALHeader(db.WALPath())
 	if err != nil {
-		return false, err
+		return state, err
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
@@ -2477,39 +2509,36 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
-		return false, fmt.Errorf("cannot copy wal before checkpoint: %w", err)
+		return state, fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 
-	var barrierTx *sql.Tx
 	if mode == CheckpointModePassive {
-		barrierTx, err = db.db.BeginTx(ctx, nil)
+		state.barrierTx, err = db.db.BeginTx(ctx, nil)
 		if err != nil {
-			return false, fmt.Errorf("begin passive checkpoint barrier: %w", err)
+			return state, fmt.Errorf("begin passive checkpoint barrier: %w", err)
 		}
-		defer func() {
-			if barrierTx != nil {
-				_ = rollback(barrierTx)
-			}
-		}()
 
-		if _, err := barrierTx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
-			return false, fmt.Errorf("_litestream_lock: %w", err)
+		if _, err := state.barrierTx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+			return state, fmt.Errorf("_litestream_lock: %w", err)
 		}
 
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
-			return false, fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
+			return state, fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
 		}
 		exec.applySyncResult(result)
 	}
 
 	frameSize := int64(db.pageSize + WALFrameHeaderSize)
-	preCheckpointFrameN := 0
 	if exec.state.lastSyncedWALOffset > WALHeaderSize {
-		preCheckpointFrameN = int((exec.state.lastSyncedWALOffset - WALHeaderSize) / frameSize)
+		state.preCheckpointFrameN = int((exec.state.lastSyncedWALOffset - WALHeaderSize) / frameSize)
 	}
 
+	return state, nil
+}
+
+func (db *DB) checkpointExec(ctx context.Context, mode string, exec *syncExecutor, before *checkpointStartState) (int, error) {
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
 	db.setSyncDiagPhase(diagPhaseCheckpointExec,
@@ -2519,20 +2548,24 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	walFrameN, err := db.execCheckpoint(ctx, mode)
 	if err != nil {
-		return false, err
+		return 0, err
 	}
 
-	if barrierTx != nil {
-		if err = rollback(barrierTx); err != nil {
-			return false, fmt.Errorf("rollback passive checkpoint barrier: %w", err)
+	if before.barrierTx != nil {
+		if err = rollback(before.barrierTx); err != nil {
+			return 0, fmt.Errorf("rollback passive checkpoint barrier: %w", err)
 		}
-		barrierTx = nil
+		before.barrierTx = nil
 	}
 
 	if err = db.bumpLitestreamSeq(ctx); err != nil {
-		return false, fmt.Errorf("bump litestream seq: %w", err)
+		return 0, fmt.Errorf("bump litestream seq: %w", err)
 	}
 
+	return walFrameN, nil
+}
+
+func (db *DB) checkpointFinish(ctx context.Context, mode string, exec *syncExecutor, before checkpointStartState, walFrameN int) (bool, error) {
 	// If WAL hasn't been restarted, exit.
 	db.setSyncDiagPhase(diagPhaseCheckpointVerifyRestart,
 		func(s *diagState) {
@@ -2542,19 +2575,16 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	other, err := readWALHeader(db.WALPath())
 	if err != nil {
 		return false, err
-	} else if bytes.Equal(hdr, other) {
+	} else if bytes.Equal(before.walHeader, other) {
 		exec.state.syncedSinceCheckpoint = false
 		return false, nil
 	}
 	exec.state.truncatePassiveFailed = false
 
 	if mode == CheckpointModePassive {
-		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
-		if err != nil {
-			return false, fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
+		if err := db.checkpointPostSync(ctx, exec, "cannot copy wal after passive checkpoint"); err != nil {
+			return false, err
 		}
-		exec.applySyncResult(result)
-		exec.state.syncedSinceCheckpoint = false
 		return true, nil
 	}
 
@@ -2564,16 +2594,30 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// sync and the checkpoint taking the writer lock. Those commits are
 	// backfilled and truncated unseen, so TRUNCATE must take the boundary
 	// snapshot unconditionally.
-	if mode != CheckpointModeTruncate && walFrameN <= preCheckpointFrameN {
-		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
-		if err != nil {
-			return false, fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+	if mode != CheckpointModeTruncate && walFrameN <= before.preCheckpointFrameN {
+		if err := db.checkpointPostSync(ctx, exec, "cannot copy wal after checkpoint"); err != nil {
+			return false, err
 		}
-		exec.applySyncResult(result)
-		exec.state.syncedSinceCheckpoint = false
 		return true, nil
 	}
 
+	if err := db.checkpointPostSnapshot(ctx, mode, exec, other); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (db *DB) checkpointPostSync(ctx context.Context, exec *syncExecutor, message string) error {
+	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+	if err != nil {
+		return fmt.Errorf("%s: %w", message, err)
+	}
+	exec.applySyncResult(result)
+	exec.state.syncedSinceCheckpoint = false
+	return nil
+}
+
+func (db *DB) checkpointPostSnapshot(ctx context.Context, mode string, exec *syncExecutor, walHeader []byte) error {
 	// Start a transaction. This will be promoted immediately after.
 	db.setSyncDiagPhase(diagPhaseCheckpointSnapshotBoundaryLock,
 		func(s *diagState) {
@@ -2582,7 +2626,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	tx, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
-		return false, fmt.Errorf("begin: %w", err)
+		return fmt.Errorf("begin: %w", err)
 	}
 	defer func() { _ = rollback(tx) }()
 
@@ -2591,7 +2635,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// however, it will ensure our tx grabs the write lock. Unfortunately,
 	// we can't call "BEGIN IMMEDIATE" as we are already in a transaction.
 	if _, err := tx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
-		return false, fmt.Errorf("_litestream_lock: %w", err)
+		return fmt.Errorf("_litestream_lock: %w", err)
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
@@ -2602,14 +2646,14 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	snapshotInfo := syncInfo{
 		offset:       WALHeaderSize,
-		salt1:        binary.BigEndian.Uint32(other[16:]),
-		salt2:        binary.BigEndian.Uint32(other[20:]),
+		salt1:        binary.BigEndian.Uint32(walHeader[16:]),
+		salt2:        binary.BigEndian.Uint32(walHeader[20:]),
 		snapshotting: true,
 		reason:       "checkpoint boundary snapshot",
 	}
-	result, err = db.sync(ctx, true, exec, snapshotInfo, 0)
+	result, err := db.sync(ctx, true, exec, snapshotInfo, 0)
 	if err != nil {
-		return false, fmt.Errorf("cannot snapshot after checkpoint: %w", err)
+		return fmt.Errorf("cannot snapshot after checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 
@@ -2617,11 +2661,11 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// Use rollback() helper for consistency with releaseReadLock() and the
 	// defer above. See issue #934.
 	if err := rollback(tx); err != nil {
-		return false, fmt.Errorf("rollback post-checkpoint tx: %w", err)
+		return fmt.Errorf("rollback post-checkpoint tx: %w", err)
 	}
 
 	exec.state.syncedSinceCheckpoint = false
-	return true, nil
+	return nil
 }
 
 // execCheckpoint issues a wal_checkpoint PRAGMA in the given mode and returns

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -4651,3 +4651,441 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 	default:
 	}
 }
+func TestDB_RestoreAfterCompactionWithConcurrentWrites(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.MinCheckpointPageN = 100
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Replica.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	for round := 0; round < 10; round++ {
+		for i := 0; i < 50; i++ {
+			blob := make([]byte, 2000)
+			if _, err := sqldb.Exec(`INSERT INTO t VALUES (?, ?)`, round*50+i+1, blob); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Replica.Sync(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		if round > 0 && round%2 == 0 {
+			if _, err := db.compactor.Compact(ctx, 1); err != nil && !errors.Is(err, ErrNoCompaction) {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Replica.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	pos, _ := db.Pos()
+	t.Logf("final position: txid=%d", pos.TXID)
+
+	dumpReplicaFiles := func() {
+		for level := 0; level <= 2; level++ {
+			itr, err := db.Replica.Client.LTXFiles(ctx, level, 0, false)
+			if err != nil {
+				t.Logf("  L%d: error listing: %v", level, err)
+				continue
+			}
+			for itr.Next() {
+				info := itr.Item()
+				f, err := db.Replica.Client.OpenLTXFile(ctx, level, info.MinTXID, info.MaxTXID, 0, 0)
+				if err != nil {
+					t.Logf("  L%d %s-%s: error opening: %v", level, info.MinTXID, info.MaxTXID, err)
+					continue
+				}
+				dec := ltx.NewDecoder(f)
+				if err := dec.DecodeHeader(); err != nil {
+					f.(io.Closer).Close()
+					t.Logf("  L%d %s-%s: error decoding header: %v", level, info.MinTXID, info.MaxTXID, err)
+					continue
+				}
+				hdr := dec.Header()
+				var pageCount int
+				data := make([]byte, hdr.PageSize)
+				for {
+					var phdr ltx.PageHeader
+					if err := dec.DecodePage(&phdr, data); err == io.EOF {
+						break
+					} else if err != nil {
+						break
+					}
+					pageCount++
+				}
+				f.(io.Closer).Close()
+				t.Logf("  L%d %s-%s: commit=%d pages=%d size=%d",
+					level, info.MinTXID, info.MaxTXID, hdr.Commit, pageCount, info.Size)
+			}
+			itr.Close()
+		}
+	}
+
+	restoredPath := filepath.Join(dir, "restored.db")
+	if err := db.Replica.Restore(ctx, RestoreOptions{OutputPath: restoredPath}); err != nil {
+		t.Log("RESTORE FAILED — dumping replica files:")
+		dumpReplicaFiles()
+
+		plan, planErr := CalcRestorePlan(ctx, db.Replica.Client, 0, time.Time{}, db.Logger)
+		if planErr != nil {
+			t.Logf("CalcRestorePlan error: %v", planErr)
+		} else {
+			t.Logf("Restore plan (%d files):", len(plan))
+			for _, info := range plan {
+				t.Logf("  L%d %s-%s commit=? size=%d", info.Level, info.MinTXID, info.MaxTXID, info.Size)
+			}
+		}
+
+		t.Fatalf("Restore failed: %v", err)
+	}
+
+	t.Log("Restore succeeded — verifying integrity")
+	restoredDB, err := sql.Open("sqlite", restoredPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restoredDB.Close()
+
+	var intResult string
+	if err := restoredDB.QueryRow("PRAGMA quick_check").Scan(&intResult); err != nil {
+		t.Fatalf("integrity check failed: %v", err)
+	}
+	if intResult != "ok" {
+		t.Fatalf("integrity check: %s", intResult)
+	}
+
+	var origCount, restoredCount int
+	sqldb.QueryRow("SELECT COUNT(*) FROM t").Scan(&origCount)
+	restoredDB.QueryRow("SELECT COUNT(*) FROM t").Scan(&restoredCount)
+	t.Logf("row count: original=%d restored=%d", origCount, restoredCount)
+}
+
+func TestCheckpointDoesNotTriggerSnapshot_SustainedWrites(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA journal_mode=wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	sqldb.Close()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.MinCheckpointPageN = 5
+	db.TruncatePageN = 1000
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	sqldb, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout=5000`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 50; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t (data) VALUES (?)`, strings.Repeat("x", 1000)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.Lock()
+	db.syncState.syncedToWALEnd = false
+	db.mu.Unlock()
+
+	for i := 0; i < 50; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t (data) VALUES (?)`, strings.Repeat("y", 1000)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	f, err := os.Open(ltxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	hdr := dec.Header()
+	if hdr.WALOffset == 0 || hdr.WALSize == 0 {
+		t.Fatalf("last LTX unexpectedly snapshot after passive checkpoint path: WALOffset=%d WALSize=%d", hdr.WALOffset, hdr.WALSize)
+	}
+
+	if hdr.Commit == 0 {
+		t.Fatal("last LTX has Commit=0")
+	}
+}
+
+func TestVerify_WALTruncation_SyncedToWALEnd_Incremental(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA journal_mode=wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	sqldb.Close()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	sqldb, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout=5000`); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t (data) VALUES (?)`, strings.Repeat("x", 500)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.Lock()
+
+	walPath := db.WALPath()
+	walFile, err := os.OpenFile(walPath, os.O_RDWR, 0)
+	if err != nil {
+		db.mu.Unlock()
+		t.Fatal(err)
+	}
+	hdrBuf := make([]byte, WALHeaderSize)
+	if _, err := walFile.ReadAt(hdrBuf, 0); err != nil {
+		walFile.Close()
+		db.mu.Unlock()
+		t.Fatal(err)
+	}
+	binary.BigEndian.PutUint32(hdrBuf[16:], binary.BigEndian.Uint32(hdrBuf[16:])+1)
+	if err := walFile.Truncate(WALHeaderSize); err != nil {
+		walFile.Close()
+		db.mu.Unlock()
+		t.Fatal(err)
+	}
+	if _, err := walFile.WriteAt(hdrBuf, 0); err != nil {
+		walFile.Close()
+		db.mu.Unlock()
+		t.Fatal(err)
+	}
+	walFile.Sync()
+	walFile.Close()
+
+	t.Run("SyncedToWALEnd=true does incremental", func(t *testing.T) {
+		db.syncState.syncedToWALEnd = true
+		info, err := db.verify(context.Background(), &db.syncState)
+		if err != nil {
+			db.mu.Unlock()
+			t.Fatal(err)
+		}
+		if info.snapshotting {
+			db.mu.Unlock()
+			t.Fatalf("expected incremental, got snapshot with reason=%q", info.reason)
+		}
+		if info.offset != WALHeaderSize {
+			db.mu.Unlock()
+			t.Fatalf("offset=%d, want %d", info.offset, WALHeaderSize)
+		}
+	})
+
+	t.Run("SyncedToWALEnd=false triggers snapshot", func(t *testing.T) {
+		db.syncState.syncedToWALEnd = false
+		info, err := db.verify(context.Background(), &db.syncState)
+		if err != nil {
+			db.mu.Unlock()
+			t.Fatal(err)
+		}
+		if !info.snapshotting {
+			db.mu.Unlock()
+			t.Fatal("expected snapshot when syncedToWALEnd=false after WAL truncation")
+		}
+		if info.reason != "wal truncated by another process" {
+			db.mu.Unlock()
+			t.Fatalf("reason=%q, want %q", info.reason, "wal truncated by another process")
+		}
+	})
+
+	db.mu.Unlock()
+}
+
+func TestSyncResult_SnapshotPageSequential(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA journal_mode=wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t (data) VALUES (?)`, strings.Repeat("x", 4000)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sqldb.Close()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.Lock()
+	pos, err := db.Pos()
+	if err != nil {
+		db.mu.Unlock()
+		t.Fatal(err)
+	}
+	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	db.mu.Unlock()
+
+	f, err := os.Open(ltxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPgno := ltx.LockPgno(dec.Header().PageSize)
+	var prevPgno uint32
+	var pageCount int
+	for {
+		var phdr ltx.PageHeader
+		data := make([]byte, dec.Header().PageSize)
+		if err := dec.DecodePage(&phdr, data); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("decode page: %v", err)
+		}
+
+		pageCount++
+		if prevPgno > 0 {
+			expected := prevPgno + 1
+			if expected == lockPgno {
+				expected++
+			}
+			if phdr.Pgno != expected {
+				t.Fatalf("non-sequential page: prev=%d, got=%d, expected=%d (lock page=%d)",
+					prevPgno, phdr.Pgno, expected, lockPgno)
+			}
+		}
+		prevPgno = phdr.Pgno
+	}
+
+	if pageCount == 0 {
+		t.Fatal("snapshot LTX has no pages")
+	}
+	t.Logf("verified %d pages in snapshot LTX, all sequential", pageCount)
+}

--- a/replica.go
+++ b/replica.go
@@ -2,23 +2,16 @@ package litestream
 
 import (
 	"context"
-	"crypto/rand"
-	"database/sql"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/benbjohnson/litestream/internal"
 )
 
 // Default replica settings.
@@ -386,43 +379,98 @@ func (r *Replica) deleteBeforeTXID(ctx context.Context, level int, txID ltx.TXID
 }
 */
 
-// monitor runs in a separate goroutine and continuously replicates the DB.
-// Implements exponential backoff on repeated sync errors to prevent log spam
-// and reduce load when persistent errors occur. See issue #927.
+type syncScheduler struct {
+	interval        time.Duration
+	backoff         time.Duration
+	maxBackoff      time.Duration
+	logInterval     time.Duration
+	consecutiveErrs int
+	lastLogTime     time.Time
+}
+
+func newSyncScheduler(interval time.Duration) syncScheduler {
+	return syncScheduler{
+		interval:    interval,
+		maxBackoff:  DefaultSyncBackoffMax,
+		logInterval: SyncErrorLogInterval,
+	}
+}
+
+func (s *syncScheduler) waitForTick(ctx context.Context, ticker *time.Ticker) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ticker.C:
+		return nil
+	}
+}
+
+func (s *syncScheduler) waitForBackoff(ctx context.Context) error {
+	if s.backoff <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(s.backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (s *syncScheduler) recordError() {
+	s.consecutiveErrs++
+	if s.backoff == 0 {
+		s.backoff = s.interval
+	} else {
+		s.backoff *= 2
+		if s.backoff > s.maxBackoff {
+			s.backoff = s.maxBackoff
+		}
+	}
+}
+
+func (s *syncScheduler) shouldLog() bool {
+	return time.Since(s.lastLogTime) >= s.logInterval
+}
+
+func (s *syncScheduler) markLogged() {
+	s.lastLogTime = time.Now()
+}
+
+func (s *syncScheduler) recordSuccess(logger *slog.Logger) {
+	if s.consecutiveErrs > 0 {
+		logger.Info("replica sync recovered", "previous_errors", s.consecutiveErrs)
+	}
+	s.backoff = 0
+	s.consecutiveErrs = 0
+}
+
+func (s *syncScheduler) resetBackoff() {
+	s.backoff = 0
+	s.consecutiveErrs = 0
+}
+
 func (r *Replica) monitor(ctx context.Context) {
 	ticker := time.NewTicker(r.SyncInterval)
 	defer ticker.Stop()
 
+	sched := newSyncScheduler(r.SyncInterval)
 	notify := r.db.Notify()
 
-	var backoff time.Duration
-	var lastLogTime time.Time
-	var consecutiveErrs int
-
 	for initial := true; ; initial = false {
-		// Enforce a minimum time between synchronization.
 		if !initial {
-			select {
-			case <-ctx.Done():
+			if err := sched.waitForTick(ctx, ticker); err != nil {
 				return
-			case <-ticker.C:
 			}
 		}
 
-		// If in backoff mode, wait additional time before retrying.
-		if backoff > 0 {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(backoff):
-			}
+		if err := sched.waitForBackoff(ctx); err != nil {
+			return
 		}
 
-		// If the position is unavailable, skip the wait so Sync() surfaces
-		// the error to the backoff & auto-recovery handling below.
 		if pos, err := r.db.Pos(); err == nil && pos.TXID <= r.Pos().TXID {
-			// Wait for new data, but still sync on an interval so idle
-			// databases continue recording sync health for heartbeats.
 			select {
 			case <-ctx.Done():
 				return
@@ -433,85 +481,58 @@ func (r *Replica) monitor(ctx context.Context) {
 			return
 		}
 
-		// Fetch new notify channel before replicating data.
 		notify = r.db.Notify()
 
-		// Synchronize the shadow wal into the replication directory.
 		if err := r.sync(ctx, r.MaxSyncLTXFiles); err != nil {
 			if errors.Is(err, errReplicaWaitForData) {
 				continue
 			}
-
-			// Don't log context cancellation errors during shutdown
-			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-				consecutiveErrs++
-
-				// Exponential backoff: SyncInterval -> 2x -> 4x -> ... -> max
-				if backoff == 0 {
-					backoff = r.SyncInterval
-				} else {
-					backoff *= 2
-					if backoff > DefaultSyncBackoffMax {
-						backoff = DefaultSyncBackoffMax
-					}
-				}
-
-				// Check for LTX errors and include recovery hints
-				var ltxErr *LTXError
-				if errors.As(err, &ltxErr) {
-					// Log with rate limiting to avoid log spam during persistent errors.
-					if time.Since(lastLogTime) >= SyncErrorLogInterval {
-						if ltxErr.Hint != "" {
-							r.Logger().Error("monitor error",
-								"error", err,
-								"path", ltxErr.Path,
-								"hint", ltxErr.Hint,
-								"consecutive_errors", consecutiveErrs,
-								"backoff", backoff)
-						} else {
-							r.Logger().Error("monitor error",
-								"error", err,
-								"path", ltxErr.Path,
-								"consecutive_errors", consecutiveErrs,
-								"backoff", backoff)
-						}
-						lastLogTime = time.Now()
-					}
-
-					// Attempt auto-recovery only for missing/corrupt LTX files.
-					// Transient OS errors (EMFILE, EIO, EACCES) should retry
-					// with backoff rather than destructively resetting state.
-					if r.AutoRecoverEnabled && ltxErr.IsAutoRecoverable() {
-						r.Logger().Warn("auto-recovery enabled, resetting local state")
-						if resetErr := r.db.ResetLocalState(ctx); resetErr != nil {
-							r.Logger().Error("auto-recovery failed", "error", resetErr)
-						} else {
-							r.Logger().Info("auto-recovery complete, resuming replication")
-							// Reset backoff after successful recovery
-							backoff = 0
-							consecutiveErrs = 0
-						}
-					}
-				} else {
-					// Log with rate limiting to avoid log spam during persistent errors.
-					if time.Since(lastLogTime) >= SyncErrorLogInterval {
-						r.Logger().Error("monitor error",
-							"error", err,
-							"consecutive_errors", consecutiveErrs,
-							"backoff", backoff)
-						lastLogTime = time.Now()
-					}
-				}
-			}
+			r.handleSyncError(ctx, &sched, err)
 			continue
 		}
 
-		// Success - reset backoff and error counter.
-		if consecutiveErrs > 0 {
-			r.Logger().Info("replica sync recovered", "previous_errors", consecutiveErrs)
+		sched.recordSuccess(r.Logger())
+	}
+}
+
+func (r *Replica) handleSyncError(ctx context.Context, sched *syncScheduler, err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	sched.recordError()
+
+	var ltxErr *LTXError
+	if errors.As(err, &ltxErr) {
+		if sched.shouldLog() {
+			args := []any{
+				"error", err,
+				"path", ltxErr.Path,
+				"consecutive_errors", sched.consecutiveErrs,
+				"backoff", sched.backoff,
+			}
+			if ltxErr.Hint != "" {
+				args = append(args, "hint", ltxErr.Hint)
+			}
+			r.Logger().Error("monitor error", args...)
+			sched.markLogged()
 		}
-		backoff = 0
-		consecutiveErrs = 0
+
+		if r.AutoRecoverEnabled && ltxErr.IsAutoRecoverable() {
+			r.Logger().Warn("auto-recovery enabled, resetting local state")
+			if resetErr := r.db.ResetLocalState(ctx); resetErr != nil {
+				r.Logger().Error("auto-recovery failed", "error", resetErr)
+			} else {
+				r.Logger().Info("auto-recovery complete, resuming replication")
+				sched.resetBackoff()
+			}
+		}
+	} else if sched.shouldLog() {
+		r.Logger().Error("monitor error",
+			"error", err,
+			"consecutive_errors", sched.consecutiveErrs,
+			"backoff", sched.backoff)
+		sched.markLogged()
 	}
 }
 
@@ -556,1290 +577,4 @@ func (r *Replica) TimeBounds(ctx context.Context) (createdAt, updatedAt time.Tim
 		}
 	}
 	return createdAt, updatedAt, nil
-}
-
-// CalcRestoreTarget returns a target time restore from.
-func (r *Replica) CalcRestoreTarget(ctx context.Context, opt RestoreOptions) (updatedAt time.Time, err error) {
-	// Determine the replicated time bounds from LTX files.
-	createdAt, updatedAt, err := r.TimeBounds(ctx)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("created at: %w", err)
-	}
-
-	// Also check v0.3.x time bounds if client supports it.
-	if client, ok := r.Client.(ReplicaClientV3); ok {
-		v3CreatedAt, v3UpdatedAt, err := r.TimeBoundsV3(ctx, client)
-		if err != nil {
-			return time.Time{}, fmt.Errorf("v0.3.x time bounds: %w", err)
-		}
-		// Extend time bounds to include v0.3.x backups.
-		if !v3CreatedAt.IsZero() && (createdAt.IsZero() || v3CreatedAt.Before(createdAt)) {
-			createdAt = v3CreatedAt
-		}
-		if !v3UpdatedAt.IsZero() && (updatedAt.IsZero() || v3UpdatedAt.After(updatedAt)) {
-			updatedAt = v3UpdatedAt
-		}
-	}
-
-	// Skip if it does not contain timestamp.
-	if !opt.Timestamp.IsZero() {
-		if createdAt.IsZero() && updatedAt.IsZero() {
-			return time.Time{}, fmt.Errorf("no backups found")
-		}
-		if opt.Timestamp.Before(createdAt) || opt.Timestamp.After(updatedAt) {
-			return time.Time{}, fmt.Errorf("timestamp does not exist")
-		}
-	}
-
-	return updatedAt, nil
-}
-
-// Replica restores the database from a replica based on the options given.
-// This method will restore into opt.OutputPath, if specified, or into the
-// DB's original database path. It can optionally restore from a specific
-// replica or it will automatically choose the best one. Finally,
-// a timestamp can be specified to restore the database to a specific
-// point-in-time.
-//
-// When the replica contains both v0.3.x and LTX format backups, this method
-// compares snapshots from both formats and uses whichever has the better backup:
-// - With timestamp: uses the format with the most recent snapshot before timestamp
-// - Without timestamp: uses the format with the most recent backup overall
-func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
-	// Validate options.
-	if opt.OutputPath == "" {
-		return fmt.Errorf("output path required")
-	} else if opt.TXID != 0 && !opt.Timestamp.IsZero() {
-		return fmt.Errorf("cannot specify index & timestamp to restore")
-	} else if opt.Follow && opt.TXID != 0 {
-		return fmt.Errorf("cannot use follow mode with -txid")
-	} else if opt.Follow && !opt.Timestamp.IsZero() {
-		return fmt.Errorf("cannot use follow mode with -timestamp")
-	} else if opt.IntegrityCheck != IntegrityCheckNone && opt.IntegrityCheck != IntegrityCheckQuick && opt.IntegrityCheck != IntegrityCheckFull {
-		return fmt.Errorf("unsupported integrity check mode: %d", opt.IntegrityCheck)
-	}
-
-	// In follow mode, if the database already exists, attempt crash recovery
-	// by reading the last applied TXID from the sidecar file.
-	if opt.Follow {
-		if _, statErr := os.Stat(opt.OutputPath); statErr == nil {
-			txid, readErr := ReadTXIDFile(opt.OutputPath)
-			if readErr != nil {
-				return fmt.Errorf("read txid file for crash recovery: %w", readErr)
-			}
-			if txid == 0 {
-				return fmt.Errorf("cannot resume follow mode: database exists but no -txid file found; delete the database to re-restore: %s", opt.OutputPath)
-			}
-			// Validate saved TXID is still reachable. If the earliest snapshot
-			// starts after our saved TXID, retention has pruned the history
-			// and we can't catch up incrementally.
-			snapshotItr, itrErr := r.Client.LTXFiles(ctx, SnapshotLevel, 0, false)
-			if itrErr != nil {
-				return fmt.Errorf("cannot validate saved TXID for crash recovery: %w", itrErr)
-			}
-
-			var latestSnapshot *ltx.FileInfo
-			for snapshotItr.Next() {
-				latestSnapshot = snapshotItr.Item()
-			}
-			if err := snapshotItr.Err(); err != nil {
-				_ = snapshotItr.Close()
-				return fmt.Errorf("iterate snapshots for crash recovery validation: %w", err)
-			}
-			_ = snapshotItr.Close()
-
-			if latestSnapshot != nil {
-				if latestSnapshot.MinTXID > txid {
-					return fmt.Errorf("cannot resume follow mode: saved TXID %s is behind the earliest snapshot (min TXID %s); replica history has been pruned -- delete %s and %s-txid to re-restore", txid, latestSnapshot.MinTXID, opt.OutputPath, opt.OutputPath)
-				}
-				if txid > latestSnapshot.MaxTXID {
-					return fmt.Errorf("cannot resume follow mode: saved TXID %s is ahead of latest snapshot (max TXID %s); delete %s and %s-txid to re-restore", txid, latestSnapshot.MaxTXID, opt.OutputPath, opt.OutputPath)
-				}
-			}
-
-			r.Logger().Info("resuming follow mode from crash recovery", "txid", txid, "output", opt.OutputPath)
-			return r.follow(ctx, opt.OutputPath, txid, opt.FollowInterval)
-		}
-	}
-
-	// Ensure output path does not already exist.
-	if _, err := os.Stat(opt.OutputPath); err == nil {
-		return fmt.Errorf("cannot restore, output path already exists: %s", opt.OutputPath)
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-
-	// Compare v0.3.x and LTX formats to find the best backup (unless TXID is specified).
-	// Skip V3 format when follow mode is enabled (V3 doesn't support incremental following).
-	if opt.TXID == 0 && !opt.Follow {
-		if client, ok := r.Client.(ReplicaClientV3); ok {
-			useV3, err := r.shouldUseV3Restore(ctx, client, opt.Timestamp)
-			if err != nil {
-				return err
-			}
-			if useV3 {
-				return r.RestoreV3(ctx, opt)
-			}
-		}
-	}
-
-	infos, err := CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
-	if err != nil {
-		return fmt.Errorf("cannot calc restore plan: %w", err)
-	}
-
-	r.Logger().Debug("restore plan", "n", len(infos), "txid", infos[len(infos)-1].MaxTXID, "timestamp", infos[len(infos)-1].CreatedAt)
-
-	rdrs := make([]io.Reader, 0, len(infos))
-	defer func() {
-		for _, rd := range rdrs {
-			if closer, ok := rd.(io.Closer); ok {
-				_ = closer.Close()
-			}
-		}
-	}()
-
-	for _, info := range infos {
-		// Validate file size - must be at least header size to be readable
-		if info.Size < ltx.HeaderSize {
-			return fmt.Errorf("invalid ltx file: level=%d min=%s max=%s has size %d bytes (minimum %d)",
-				info.Level, info.MinTXID, info.MaxTXID, info.Size, ltx.HeaderSize)
-		}
-
-		r.Logger().Debug("opening ltx file for restore", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
-
-		rdrs = append(rdrs, internal.NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, nil, r.Logger()))
-	}
-
-	if len(rdrs) == 0 {
-		return fmt.Errorf("no matching backup files available")
-	}
-
-	// Create parent directory if it doesn't exist.
-	var dirInfo os.FileInfo
-	if db := r.DB(); db != nil {
-		dirInfo = db.dirInfo
-	}
-	if err := internal.MkdirAll(filepath.Dir(opt.OutputPath), dirInfo); err != nil {
-		return fmt.Errorf("create parent directory: %w", err)
-	}
-
-	// Output to temp file & atomically rename.
-	tmpOutputPath := opt.OutputPath + ".tmp"
-	r.Logger().Debug("compacting into database", "path", tmpOutputPath, "n", len(rdrs))
-	defer func() { _ = os.Remove(tmpOutputPath) }()
-
-	f, err := os.Create(tmpOutputPath)
-	if err != nil {
-		return fmt.Errorf("create temp database path: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	pr, pw := io.Pipe()
-
-	go func() {
-		c, err := ltx.NewCompactor(pw, rdrs)
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
-			return
-		}
-		c.HeaderFlags = ltx.HeaderFlagNoChecksum
-		_ = pw.CloseWithError(c.Compact(ctx))
-	}()
-
-	dec := ltx.NewDecoder(pr)
-	if err := dec.DecodeDatabaseTo(f); err != nil {
-		return fmt.Errorf("decode database: %w", err)
-	}
-
-	if err := f.Sync(); err != nil {
-		return err
-	} else if err := f.Close(); err != nil {
-		return err
-	}
-
-	// Copy file to final location.
-	r.Logger().Debug("renaming database from temporary location")
-	if err := os.Rename(tmpOutputPath, opt.OutputPath); err != nil {
-		return err
-	}
-
-	if opt.IntegrityCheck != IntegrityCheckNone {
-		if err := checkIntegrity(ctx, opt.OutputPath, opt.IntegrityCheck); err != nil {
-			if ctx.Err() == nil {
-				_ = os.Remove(opt.OutputPath)
-				_ = os.Remove(opt.OutputPath + "-shm")
-				_ = os.Remove(opt.OutputPath + "-wal")
-			}
-			return fmt.Errorf("post-restore integrity check: %w", err)
-		}
-		r.Logger().Info("post-restore integrity check passed")
-	}
-
-	// Enter follow mode if enabled, continuously applying new LTX files.
-	if opt.Follow {
-		for _, rd := range rdrs {
-			if closer, ok := rd.(io.Closer); ok {
-				_ = closer.Close()
-			}
-		}
-		rdrs = nil
-
-		maxTXID := infos[len(infos)-1].MaxTXID
-		if err := WriteTXIDFile(opt.OutputPath, maxTXID); err != nil {
-			return fmt.Errorf("write initial txid file: %w", err)
-		}
-		return r.follow(ctx, opt.OutputPath, maxTXID, opt.FollowInterval)
-	}
-
-	return nil
-}
-
-// follow enters a continuous restore loop, polling for new LTX files and
-// applying them to the restored database. It blocks until the context is
-// cancelled (e.g. Ctrl+C). Returns nil on clean shutdown.
-func (r *Replica) follow(ctx context.Context, outputPath string, lastTXID ltx.TXID, interval time.Duration) error {
-	f, err := os.OpenFile(outputPath, os.O_RDWR, 0)
-	if err != nil {
-		return fmt.Errorf("open database for follow: %w", err)
-	}
-	defer func() {
-		_ = f.Sync()
-		_ = f.Close()
-	}()
-
-	// Read page size from SQLite header (offset 16, 2 bytes, big-endian).
-	var buf [2]byte
-	if _, err := f.ReadAt(buf[:], 16); err != nil {
-		return fmt.Errorf("read page size from database header: %w", err)
-	}
-	pageSize := uint32(buf[0])<<8 | uint32(buf[1])
-	if pageSize == 1 {
-		pageSize = 65536
-	}
-
-	if interval <= 0 {
-		interval = DefaultFollowInterval
-	}
-
-	r.Logger().Info("entering follow mode", "output", outputPath, "txid", lastTXID, "interval", interval)
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	var consecutiveErrors int
-	for {
-		select {
-		case <-ctx.Done():
-			r.Logger().Info("follow mode stopped")
-			return nil
-		case <-ticker.C:
-			newTXID, err := r.applyNewLTXFiles(ctx, f, lastTXID, pageSize)
-			if err != nil {
-				if ctx.Err() != nil {
-					r.Logger().Info("follow mode stopped")
-					return nil
-				}
-				consecutiveErrors++
-				r.Logger().Error("follow: error applying updates", "err", err, "consecutive_errors", consecutiveErrors)
-				continue
-			}
-			if newTXID > lastTXID {
-				if err := WriteTXIDFile(outputPath, newTXID); err != nil {
-					return fmt.Errorf("write txid file: %w", err)
-				}
-				r.Logger().Info("follow: applied updates", "from_txid", lastTXID, "to_txid", newTXID)
-				lastTXID = newTXID
-				consecutiveErrors = 0
-			}
-		}
-	}
-}
-
-// applyNewLTXFiles polls for new LTX files and applies them to the database.
-// It starts from level 0 and falls back to higher levels if there are gaps
-// (e.g., level 0 files were compacted away).
-func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
-	currentTXID := afterTXID
-
-	// Poll level 0 for the most recent incremental files.
-	itr, err := r.Client.LTXFiles(ctx, 0, currentTXID+1, false)
-	if err != nil {
-		return currentTXID, fmt.Errorf("list level 0 ltx files: %w", err)
-	}
-	closeLevel0 := func(retErr error) (ltx.TXID, error) {
-		if closeErr := itr.Close(); closeErr != nil {
-			closeErr = fmt.Errorf("close level 0 ltx iterator: %w", closeErr)
-			if retErr != nil {
-				return currentTXID, errors.Join(retErr, closeErr)
-			}
-			return currentTXID, closeErr
-		}
-		return currentTXID, retErr
-	}
-
-	var sawLevel0 bool
-	for itr.Next() {
-		sawLevel0 = true
-		info := itr.Item()
-
-		// If there's a gap, try to fill it from higher compaction levels.
-		if info.MinTXID > currentTXID+1 {
-			bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, info.MinTXID, pageSize)
-			if err != nil {
-				return closeLevel0(err)
-			}
-			currentTXID = bridgedTXID
-
-			// Re-check if this file is still needed after bridging.
-			if info.MaxTXID <= currentTXID {
-				continue
-			}
-			if info.MinTXID > currentTXID+1 {
-				return closeLevel0(nil)
-			}
-		}
-
-		// Skip if already covered by a higher-level file.
-		if info.MaxTXID <= currentTXID {
-			continue
-		}
-
-		if err := r.applyLTXFile(ctx, f, info, pageSize); err != nil {
-			return closeLevel0(fmt.Errorf(
-				"apply ltx file (level=%d, min=%s, max=%s): %w",
-				info.Level, info.MinTXID, info.MaxTXID, err,
-			))
-		}
-		currentTXID = info.MaxTXID
-	}
-
-	if iterErr := itr.Err(); iterErr != nil {
-		return closeLevel0(fmt.Errorf("iterate level 0 ltx files: %w", iterErr))
-	}
-	if _, err := closeLevel0(nil); err != nil {
-		return currentTXID, err
-	}
-
-	if !sawLevel0 {
-		bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, currentTXID+1, pageSize)
-		if err != nil {
-			return currentTXID, err
-		}
-		currentTXID = bridgedTXID
-	}
-
-	return currentTXID, nil
-}
-
-// applyLTXFile applies a single LTX file's pages to the database file.
-// This follows the same pattern as Hydrator.ApplyLTX (vfs.go:712-747).
-//
-// To prevent concurrent SQLite readers from seeing partial updates, we acquire
-// an exclusive file lock before writing. We also rewrite the SQLite header
-// (bytes 18-19) to indicate DELETE journal mode instead of WAL mode, and
-// randomize the schema change counter (bytes 24-27) to invalidate cached
-// schemas in other connections.
-func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileInfo, pageSize uint32) error {
-	rc, err := r.Client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
-	if err != nil {
-		return fmt.Errorf("open ltx file: %w", err)
-	}
-	defer rc.Close()
-
-	dec := ltx.NewDecoder(rc)
-	if err := dec.DecodeHeader(); err != nil {
-		return fmt.Errorf("decode header: %w", err)
-	}
-
-	hdr := dec.Header()
-
-	if err := internal.LockFileExclusive(f); err != nil {
-		return fmt.Errorf("acquire exclusive lock: %w", err)
-	}
-	defer internal.UnlockFile(f)
-
-	for {
-		var phdr ltx.PageHeader
-		data := make([]byte, pageSize)
-		if err := dec.DecodePage(&phdr, data); err == io.EOF {
-			break
-		} else if err != nil {
-			return fmt.Errorf("decode page: %w", err)
-		}
-
-		if phdr.Pgno == 1 && len(data) >= 28 {
-			data[18], data[19] = 0x01, 0x01
-			_, _ = rand.Read(data[24:28])
-		}
-
-		off := int64(phdr.Pgno-1) * int64(pageSize)
-		if _, err := f.WriteAt(data, off); err != nil {
-			return fmt.Errorf("write page %d: %w", phdr.Pgno, err)
-		}
-	}
-
-	if hdr.Commit > 0 {
-		if err := f.Sync(); err != nil {
-			return fmt.Errorf("sync before truncate: %w", err)
-		}
-		newSize := int64(hdr.Commit) * int64(pageSize)
-		if err := f.Truncate(newSize); err != nil {
-			return fmt.Errorf("truncate: %w", err)
-		}
-	}
-
-	if err := dec.Close(); err != nil {
-		return fmt.Errorf("close decoder: %w", err)
-	}
-
-	return f.Sync()
-}
-
-// fillFollowGap attempts to bridge a gap in level 0 files by searching
-// higher compaction levels for a file that covers the missing TXID range.
-func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.TXID, gapMinTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
-	currentTXID := afterTXID
-
-	for level := 1; level < SnapshotLevel; level++ {
-		itr, err := r.Client.LTXFiles(ctx, level, 0, false)
-		if err != nil {
-			return currentTXID, fmt.Errorf("list level %d ltx files: %w", level, err)
-		}
-		closeLevel := func(retErr error) (ltx.TXID, error) {
-			if closeErr := itr.Close(); closeErr != nil {
-				closeErr = fmt.Errorf("close level %d ltx iterator: %w", level, closeErr)
-				if retErr != nil {
-					return currentTXID, errors.Join(retErr, closeErr)
-				}
-				return currentTXID, closeErr
-			}
-			return currentTXID, retErr
-		}
-
-		for itr.Next() {
-			info := itr.Item()
-
-			// Skip if there's a gap at this level too.
-			if info.MinTXID > currentTXID+1 {
-				break
-			}
-
-			// Skip if already covered.
-			if info.MaxTXID <= currentTXID {
-				continue
-			}
-
-			if err := r.applyLTXFile(ctx, f, info, pageSize); err != nil {
-				return closeLevel(fmt.Errorf(
-					"apply gap-fill ltx file (level=%d, min=%s, max=%s): %w",
-					info.Level, info.MinTXID, info.MaxTXID, err,
-				))
-			}
-			currentTXID = info.MaxTXID
-
-			// If we've bridged past the gap, we're done.
-			if currentTXID+1 >= gapMinTXID {
-				return closeLevel(nil)
-			}
-		}
-
-		if iterErr := itr.Err(); iterErr != nil {
-			return closeLevel(fmt.Errorf("iterate level %d ltx files: %w", level, iterErr))
-		}
-		if _, err := closeLevel(nil); err != nil {
-			return currentTXID, err
-		}
-
-		// If we made progress at this level, restart from level 1.
-		if currentTXID > afterTXID {
-			return currentTXID, nil
-		}
-	}
-
-	return currentTXID, nil
-}
-
-// RestoreV3 restores from a v0.3.x format backup.
-func (r *Replica) RestoreV3(ctx context.Context, opt RestoreOptions) error {
-	client, ok := r.Client.(ReplicaClientV3)
-	if !ok {
-		return fmt.Errorf("replica client does not support v0.3.x restore")
-	}
-
-	// Validate options.
-	if opt.OutputPath == "" {
-		return fmt.Errorf("output path required")
-	} else if opt.IntegrityCheck != IntegrityCheckNone && opt.IntegrityCheck != IntegrityCheckQuick && opt.IntegrityCheck != IntegrityCheckFull {
-		return fmt.Errorf("unsupported integrity check mode: %d", opt.IntegrityCheck)
-	}
-
-	// Ensure output path does not already exist.
-	if _, err := os.Stat(opt.OutputPath); err == nil {
-		return fmt.Errorf("cannot restore, output path already exists: %s", opt.OutputPath)
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-
-	// Find all generations.
-	generations, err := client.GenerationsV3(ctx)
-	if err != nil {
-		return fmt.Errorf("list generations: %w", err)
-	}
-	if len(generations) == 0 {
-		return ErrNoSnapshots
-	}
-
-	// Collect all snapshots across all generations.
-	var allSnapshots []SnapshotInfoV3
-	for _, gen := range generations {
-		snapshots, err := client.SnapshotsV3(ctx, gen)
-		if err != nil {
-			return fmt.Errorf("list snapshots for generation %s: %w", gen, err)
-		}
-		allSnapshots = append(allSnapshots, snapshots...)
-	}
-	if len(allSnapshots) == 0 {
-		return ErrNoSnapshots
-	}
-
-	// Sort all snapshots by CreatedAt for timestamp-based selection.
-	sortSnapshotsV3ByCreatedAt(allSnapshots)
-
-	// Find best snapshot across all generations (latest, or before timestamp if specified).
-	snapshot := findBestSnapshotV3(allSnapshots, opt.Timestamp)
-	if snapshot == nil {
-		return ErrNoSnapshots
-	}
-
-	r.Logger().Debug("selected v0.3.x snapshot",
-		"generation", snapshot.Generation,
-		"index", snapshot.Index,
-		"created_at", snapshot.CreatedAt)
-
-	// Get WAL segments for the snapshot's generation.
-	segments, err := client.WALSegmentsV3(ctx, snapshot.Generation)
-	if err != nil {
-		return fmt.Errorf("list WAL segments: %w", err)
-	}
-	segments = filterWALSegmentsV3(segments, snapshot.Index, opt.Timestamp)
-
-	r.Logger().Debug("found v0.3.x WAL segments", "n", len(segments))
-
-	// Create parent directory if it doesn't exist.
-	var dirInfo os.FileInfo
-	if db := r.DB(); db != nil {
-		dirInfo = db.DirInfo()
-	}
-	if err := internal.MkdirAll(filepath.Dir(opt.OutputPath), dirInfo); err != nil {
-		return fmt.Errorf("create parent directory: %w", err)
-	}
-
-	// Create temp file for restore.
-	tmpPath := opt.OutputPath + ".tmp"
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	// Download and decompress snapshot.
-	if err := r.downloadSnapshotV3(ctx, client, snapshot.Generation, snapshot.Index, tmpPath); err != nil {
-		return fmt.Errorf("download snapshot: %w", err)
-	}
-
-	// Apply WAL segments.
-	if err := r.applyWALSegmentsV3(ctx, client, snapshot.Generation, snapshot.Index, segments, tmpPath); err != nil {
-		return fmt.Errorf("apply WAL segments: %w", err)
-	}
-
-	// Rename to final path.
-	if err := os.Rename(tmpPath, opt.OutputPath); err != nil {
-		return fmt.Errorf("rename to output path: %w", err)
-	}
-
-	if opt.IntegrityCheck != IntegrityCheckNone {
-		if err := checkIntegrity(ctx, opt.OutputPath, opt.IntegrityCheck); err != nil {
-			if ctx.Err() == nil {
-				_ = os.Remove(opt.OutputPath)
-				_ = os.Remove(opt.OutputPath + "-shm")
-				_ = os.Remove(opt.OutputPath + "-wal")
-			}
-			return fmt.Errorf("post-restore integrity check: %w", err)
-		}
-		r.Logger().Info("post-restore integrity check passed")
-	}
-
-	return nil
-}
-
-// sortSnapshotsV3ByCreatedAt sorts snapshots by creation time in ascending order.
-func sortSnapshotsV3ByCreatedAt(snapshots []SnapshotInfoV3) {
-	for i := 0; i < len(snapshots)-1; i++ {
-		for j := i + 1; j < len(snapshots); j++ {
-			if snapshots[i].CreatedAt.After(snapshots[j].CreatedAt) {
-				snapshots[i], snapshots[j] = snapshots[j], snapshots[i]
-			}
-		}
-	}
-}
-
-// findBestSnapshotV3 finds the best snapshot for restore.
-// If timestamp is zero, returns the latest snapshot.
-// Otherwise, returns the latest snapshot created before or at the timestamp.
-func findBestSnapshotV3(snapshots []SnapshotInfoV3, timestamp time.Time) *SnapshotInfoV3 {
-	if len(snapshots) == 0 {
-		return nil
-	}
-	if timestamp.IsZero() {
-		return &snapshots[len(snapshots)-1]
-	}
-	for i := len(snapshots) - 1; i >= 0; i-- {
-		if !snapshots[i].CreatedAt.After(timestamp) {
-			return &snapshots[i]
-		}
-	}
-	return nil
-}
-
-// filterWALSegmentsV3 filters WAL segments to those at or after the snapshot index
-// and optionally before the timestamp.
-func filterWALSegmentsV3(segments []WALSegmentInfoV3, snapshotIndex int, timestamp time.Time) []WALSegmentInfoV3 {
-	var result []WALSegmentInfoV3
-	for _, seg := range segments {
-		if seg.Index < snapshotIndex {
-			continue
-		}
-		if !timestamp.IsZero() && seg.CreatedAt.After(timestamp) {
-			continue
-		}
-		result = append(result, seg)
-	}
-	return result
-}
-
-// downloadSnapshotV3 downloads and decompresses a v0.3.x snapshot to the destination path.
-func (r *Replica) downloadSnapshotV3(ctx context.Context, client ReplicaClientV3, generation string, index int, destPath string) error {
-	rc, err := client.OpenSnapshotV3(ctx, generation, index)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = rc.Close() }()
-
-	f, err := os.Create(destPath)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-
-	if _, err := io.Copy(f, rc); err != nil {
-		return err
-	}
-	return f.Sync()
-}
-
-// applyWALSegmentsV3 applies WAL segments to the database file.
-func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3, generation string, snapshotIndex int, segments []WALSegmentInfoV3, dbPath string) error {
-	if len(segments) == 0 {
-		return nil
-	}
-
-	// Write all WAL segments to the WAL file.
-	walPath := dbPath + "-wal"
-	var f *os.File
-	var err error
-	expectedIndex := snapshotIndex
-	offset := int64(0)
-
-	defer func() {
-		if f != nil {
-			_ = f.Close()
-		}
-	}()
-
-	applyLastWalFile := func() error {
-		if f == nil {
-			return nil
-		} else if err = f.Close(); err != nil {
-			return err
-		}
-		f = nil
-		if err = checkpointV3(dbPath); err != nil {
-			return err
-		}
-		r.Logger().Debug("applied WAL index", "generation", generation, "index", expectedIndex-1, "bytes", offset)
-		return nil
-	}
-
-	// Reconstruct each wal file, appending non-zero offsets, and apply them
-	// to the db.
-	for _, seg := range segments {
-		if seg.Offset == 0 {
-			// Apply the last WAL file, if any
-			if err = applyLastWalFile(); err != nil {
-				return err
-			}
-			if seg.Index != expectedIndex {
-				return fmt.Errorf("missing WAL index: expected %d/0, got %d/%d", expectedIndex, seg.Index, seg.Offset)
-			}
-			offset = 0
-			// Open a new WAL file
-			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644); err != nil {
-				return err
-			}
-			expectedIndex++
-		} else if seg.Offset != offset {
-			return fmt.Errorf("missing WAL segment: expected %d/%d, got %d/%d", seg.Index, offset, seg.Index, seg.Offset)
-		}
-		if n, err := r.appendWALSegmentV3(ctx, client, generation, seg, f); err != nil {
-			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)
-		} else {
-			offset += n
-			r.Logger().Debug("wrote WAL segment", "generation", generation, "index", seg.Index, "offset", seg.Offset, "bytes", n)
-		}
-	}
-
-	return applyLastWalFile()
-}
-
-// appendWALSegmentV3 appends the specified segment to an open WAL file f.
-func (r *Replica) appendWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) (int64, error) {
-	// Download WAL segment.
-	rc, err := client.OpenWALSegmentV3(ctx, generation, seg.Index, seg.Offset)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = rc.Close() }()
-
-	return io.Copy(f, rc)
-}
-
-// checkpointV3 checkpoints the WAL file into the database.
-func checkpointV3(dbPath string) error {
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = db.Close() }()
-
-	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
-	return err
-}
-
-// checkIntegrity runs a SQLite integrity check on the database at dbPath.
-func checkIntegrity(ctx context.Context, dbPath string, mode IntegrityCheckMode) error {
-	if mode == IntegrityCheckNone {
-		return nil
-	}
-
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return fmt.Errorf("open database for integrity check: %w", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	var pragma string
-	switch mode {
-	case IntegrityCheckQuick:
-		pragma = "quick_check"
-	case IntegrityCheckFull:
-		pragma = "integrity_check"
-	default:
-		return fmt.Errorf("unsupported integrity check mode: %d", mode)
-	}
-
-	var result string
-	if err := db.QueryRowContext(ctx, "PRAGMA "+pragma).Scan(&result); err != nil {
-		return fmt.Errorf("integrity check: %w", err)
-	}
-	if result != "ok" {
-		return fmt.Errorf("integrity check failed: %s", result)
-	}
-
-	// Clean up -shm and -wal files that SQLite may create during the PRAGMA.
-	_ = os.Remove(dbPath + "-shm")
-	_ = os.Remove(dbPath + "-wal")
-
-	return nil
-}
-
-// findBestV3SnapshotForTimestamp returns the best v0.3.x snapshot for the given timestamp.
-// Returns nil if no suitable snapshot exists.
-func (r *Replica) findBestV3SnapshotForTimestamp(ctx context.Context, client ReplicaClientV3, timestamp time.Time) (*SnapshotInfoV3, error) {
-	generations, err := client.GenerationsV3(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list v0.3.x generations: %w", err)
-	}
-	if len(generations) == 0 {
-		return nil, nil
-	}
-
-	var allSnapshots []SnapshotInfoV3
-	for _, gen := range generations {
-		snapshots, err := client.SnapshotsV3(ctx, gen)
-		if err != nil {
-			return nil, fmt.Errorf("list v0.3.x snapshots for generation %s: %w", gen, err)
-		}
-		allSnapshots = append(allSnapshots, snapshots...)
-	}
-
-	if len(allSnapshots) == 0 {
-		return nil, nil
-	}
-
-	// Sort by CreatedAt for timestamp-based selection.
-	sortSnapshotsV3ByCreatedAt(allSnapshots)
-
-	return findBestSnapshotV3(allSnapshots, timestamp), nil
-}
-
-// shouldUseV3Restore determines whether to use v0.3.x restore instead of LTX.
-// Returns true if v0.3.x has a better backup for the given options.
-func (r *Replica) shouldUseV3Restore(ctx context.Context, client ReplicaClientV3, timestamp time.Time) (bool, error) {
-	// Get v0.3.x time bounds.
-	_, v3UpdatedAt, err := r.TimeBoundsV3(ctx, client)
-	if err != nil {
-		return false, fmt.Errorf("get v0.3.x time bounds: %w", err)
-	}
-
-	// Get LTX time bounds.
-	_, ltxUpdatedAt, err := r.TimeBounds(ctx)
-	if err != nil {
-		return false, fmt.Errorf("get LTX time bounds: %w", err)
-	}
-
-	// If no v0.3.x backups exist, use LTX.
-	if v3UpdatedAt.IsZero() {
-		return false, nil
-	}
-
-	// If no LTX backups exist, use v0.3.x.
-	if ltxUpdatedAt.IsZero() {
-		r.Logger().Debug("using v0.3.x restore (no LTX backups)")
-		return true, nil
-	}
-
-	// Both formats have backups - compare based on timestamp or latest.
-	if !timestamp.IsZero() {
-		// With timestamp: use format with best snapshot before timestamp.
-		v3Snapshot, err := r.findBestV3SnapshotForTimestamp(ctx, client, timestamp)
-		if err != nil {
-			return false, fmt.Errorf("find v0.3.x snapshot: %w", err)
-		}
-
-		ltxSnapshot, err := r.findBestLTXSnapshotForTimestamp(ctx, timestamp)
-		if err != nil {
-			return false, fmt.Errorf("find LTX snapshot: %w", err)
-		}
-
-		if v3Snapshot != nil && (ltxSnapshot == nil || v3Snapshot.CreatedAt.After(ltxSnapshot.CreatedAt)) {
-			r.Logger().Debug("using v0.3.x restore (better snapshot for timestamp)",
-				"v3_snapshot", v3Snapshot.CreatedAt,
-				"ltx_snapshot", ltxSnapshot)
-			return true, nil
-		}
-	} else {
-		// Without timestamp: use format with most recent backup.
-		if v3UpdatedAt.After(ltxUpdatedAt) {
-			r.Logger().Debug("using v0.3.x restore (more recent backup)",
-				"v3_updated_at", v3UpdatedAt,
-				"ltx_updated_at", ltxUpdatedAt)
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// TimeBoundsV3 returns the time bounds of v0.3.x backups.
-// Returns zero times if no v0.3.x backups exist.
-func (r *Replica) TimeBoundsV3(ctx context.Context, client ReplicaClientV3) (createdAt, updatedAt time.Time, err error) {
-	generations, err := client.GenerationsV3(ctx)
-	if err != nil {
-		return time.Time{}, time.Time{}, err
-	}
-
-	for _, gen := range generations {
-		snapshots, err := client.SnapshotsV3(ctx, gen)
-		if err != nil {
-			return time.Time{}, time.Time{}, err
-		}
-		for _, snap := range snapshots {
-			if createdAt.IsZero() || snap.CreatedAt.Before(createdAt) {
-				createdAt = snap.CreatedAt
-			}
-			if updatedAt.IsZero() || snap.CreatedAt.After(updatedAt) {
-				updatedAt = snap.CreatedAt
-			}
-		}
-
-		segments, err := client.WALSegmentsV3(ctx, gen)
-		if err != nil {
-			return time.Time{}, time.Time{}, err
-		}
-		for _, seg := range segments {
-			if createdAt.IsZero() || seg.CreatedAt.Before(createdAt) {
-				createdAt = seg.CreatedAt
-			}
-			if updatedAt.IsZero() || seg.CreatedAt.After(updatedAt) {
-				updatedAt = seg.CreatedAt
-			}
-		}
-	}
-
-	return createdAt, updatedAt, nil
-}
-
-// findBestLTXSnapshotForTimestamp returns the best LTX snapshot for the given timestamp.
-// Returns nil if no suitable snapshot exists.
-func (r *Replica) findBestLTXSnapshotForTimestamp(ctx context.Context, timestamp time.Time) (*ltx.FileInfo, error) {
-	// Find snapshots at the snapshot level that are before the timestamp.
-	snapshots, err := FindLTXFiles(ctx, r.Client, SnapshotLevel, true, func(info *ltx.FileInfo) (bool, error) {
-		return info.CreatedAt.Before(timestamp), nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("find LTX snapshots: %w", err)
-	}
-	if len(snapshots) == 0 {
-		return nil, nil
-	}
-
-	// Return the latest snapshot before the timestamp (last in the sorted list).
-	return snapshots[len(snapshots)-1], nil
-}
-
-// CalcRestorePlan returns a list of storage paths to restore a snapshot at the given TXID.
-func CalcRestorePlan(ctx context.Context, client ReplicaClient, txID ltx.TXID, timestamp time.Time, logger *slog.Logger) ([]*ltx.FileInfo, error) {
-	if txID != 0 && !timestamp.IsZero() {
-		return nil, fmt.Errorf("cannot specify both TXID & timestamp to restore")
-	}
-
-	var infos ltx.FileInfoSlice
-	logger = logger.With("target", txID)
-
-	// Start with latest snapshot before target TXID or timestamp.
-	// Pass useMetadata flag to enable accurate timestamp fetching for timestamp-based restore.
-	var snapshot *ltx.FileInfo
-	snapshotItr, err := client.LTXFiles(ctx, SnapshotLevel, 0, !timestamp.IsZero())
-	if err != nil {
-		return nil, err
-	}
-	for snapshotItr.Next() {
-		info := snapshotItr.Item()
-		logger.Debug("finding snapshot before target TXID or timestamp", "snapshot", info.MaxTXID)
-		if txID != 0 && info.MaxTXID > txID {
-			continue
-		}
-		if !timestamp.IsZero() && !info.CreatedAt.Before(timestamp) {
-			continue
-		}
-		snapshot = info
-	}
-	if err := snapshotItr.Close(); err != nil {
-		return nil, err
-	}
-	if snapshot != nil {
-		logger.Debug("found snapshot before target TXID or timestamp", "snapshot", snapshot.MaxTXID)
-		infos = append(infos, snapshot)
-	}
-
-	// Collect candidates across all compaction levels and pick the next file
-	// from any level that extends the longest contiguous TXID range.
-	const maxLevel = SnapshotLevel - 1
-	startTXID := infos.MaxTXID()
-	currentMax := startTXID
-	if txID != 0 && currentMax >= txID {
-		return infos, nil
-	}
-
-	cursors := make([]*restoreLevelCursor, 0, maxLevel+1)
-	for level := maxLevel; level >= 0; level-- {
-		logger.Debug("finding ltx files for level", "level", level)
-		itr, err := client.LTXFiles(ctx, level, 0, !timestamp.IsZero())
-		if err != nil {
-			return nil, err
-		}
-		cursors = append(cursors, &restoreLevelCursor{
-			itr: itr,
-		})
-	}
-	defer func() {
-		for _, cursor := range cursors {
-			if cursor != nil {
-				_ = cursor.itr.Close()
-			}
-		}
-	}()
-
-	for {
-		var next *restoreLevelCursor
-		for _, cursor := range cursors {
-			if err := cursor.refresh(currentMax, txID, timestamp); err != nil {
-				return nil, err
-			}
-			if cursor.candidate == nil {
-				continue
-			}
-			if next == nil || restoreCandidateBetter(next.candidate, cursor.candidate) {
-				next = cursor
-			}
-		}
-
-		if next == nil || next.candidate == nil {
-			break
-		}
-
-		if next.candidate.MaxTXID <= currentMax {
-			next.candidate = nil
-			continue
-		}
-
-		logger.Debug("matching LTX file for restore",
-			"filename", ltx.FormatFilename(next.candidate.MinTXID, next.candidate.MaxTXID),
-			"level", next.candidate.Level)
-		infos = append(infos, next.candidate)
-		currentMax = next.candidate.MaxTXID
-		next.candidate = nil
-
-		if txID != 0 && currentMax >= txID {
-			break
-		}
-	}
-
-	if len(infos) > 0 && txID == 0 && timestamp.IsZero() {
-		for _, cursor := range cursors {
-			if err := cursor.ensureCurrent(); err != nil {
-				return nil, err
-			}
-			if cursor.current != nil && cursor.current.MinTXID > currentMax+1 {
-				return nil, fmt.Errorf("non-contiguous ltx files: have up to %s but next file starts at %s", currentMax, cursor.current.MinTXID)
-			}
-		}
-	}
-
-	if len(infos) == 0 {
-		return nil, ErrTxNotAvailable
-	}
-	if txID != 0 && infos.MaxTXID() < txID {
-		return nil, ErrTxNotAvailable
-	}
-
-	return infos, nil
-}
-
-type restoreLevelCursor struct {
-	// itr streams LTX file infos for a single level in filename order.
-	itr ltx.FileIterator
-	// current holds the last item read from itr but not yet evaluated.
-	current *ltx.FileInfo
-	// candidate is the best eligible file at this level for the currentMax.
-	candidate *ltx.FileInfo
-	// done indicates the iterator has been exhausted or errored.
-	done bool
-}
-
-func (c *restoreLevelCursor) refresh(currentMax, txID ltx.TXID, timestamp time.Time) error {
-	// Advance the iterator until we've evaluated all files that could be
-	// contiguous with currentMax. Keep the best eligible candidate.
-	if c.done {
-		return nil
-	}
-	if c.candidate != nil && c.candidate.MaxTXID <= currentMax {
-		c.candidate = nil
-	}
-
-	for {
-		if err := c.ensureCurrent(); err != nil {
-			return err
-		}
-		if c.done {
-			return nil
-		}
-
-		info := c.current
-		if info.MinTXID > currentMax+1 {
-			return nil
-		}
-		c.current = nil
-
-		if info.MaxTXID <= currentMax {
-			continue
-		}
-		if txID != 0 && info.MaxTXID > txID {
-			continue
-		}
-		if !timestamp.IsZero() && !info.CreatedAt.Before(timestamp) {
-			continue
-		}
-
-		if c.candidate == nil || restoreCandidateBetter(c.candidate, info) {
-			c.candidate = info
-		}
-	}
-}
-
-func (c *restoreLevelCursor) ensureCurrent() error {
-	// Ensure current is populated with the next iterator item, or mark done.
-	if c.done || c.current != nil {
-		return nil
-	}
-	if !c.itr.Next() {
-		if err := c.itr.Err(); err != nil {
-			return err
-		}
-		c.done = true
-		return nil
-	}
-	c.current = c.itr.Item()
-	return nil
-}
-
-func restoreCandidateBetter(curr, next *ltx.FileInfo) bool {
-	if next.MaxTXID != curr.MaxTXID {
-		return next.MaxTXID > curr.MaxTXID
-	}
-	if next.MinTXID != curr.MinTXID {
-		return next.MinTXID < curr.MinTXID
-	}
-	if next.Level != curr.Level {
-		return next.Level > curr.Level
-	}
-	return next.CreatedAt.Before(curr.CreatedAt)
-}
-
-// TXIDPath returns the path to the TXID sidecar file for the given database path.
-// Uses -txid suffix to match SQLite's naming convention for associated files (-wal, -shm).
-func TXIDPath(outputPath string) string {
-	return outputPath + "-txid"
-}
-
-// WriteTXIDFile atomically writes a TXID to a sidecar file at <outputPath>-txid.
-// Uses temp-file + fsync + rename for crash safety.
-func WriteTXIDFile(outputPath string, txid ltx.TXID) error {
-	txidPath := TXIDPath(outputPath)
-	tmpPath := txidPath + ".tmp"
-
-	f, err := os.Create(tmpPath)
-	if err != nil {
-		return fmt.Errorf("create txid temp file: %w", err)
-	}
-	defer f.Close()
-	defer os.Remove(tmpPath)
-
-	if _, err := fmt.Fprintln(f, txid); err != nil {
-		return fmt.Errorf("write txid: %w", err)
-	}
-
-	if err := f.Sync(); err != nil {
-		return fmt.Errorf("sync txid file: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("close txid file: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, txidPath); err != nil {
-		return fmt.Errorf("rename txid file: %w", err)
-	}
-
-	dir, err := os.Open(filepath.Dir(txidPath))
-	if err != nil {
-		return fmt.Errorf("open txid dir for sync: %w", err)
-	}
-	if err := dir.Sync(); err != nil {
-		_ = dir.Close()
-		return fmt.Errorf("sync txid dir: %w", err)
-	}
-	return dir.Close()
-}
-
-// ReadTXIDFile reads the TXID from a sidecar file at <outputPath>-txid.
-// Returns 0, nil if the file does not exist (first run).
-func ReadTXIDFile(outputPath string) (ltx.TXID, error) {
-	txidPath := TXIDPath(outputPath)
-
-	data, err := os.ReadFile(txidPath)
-	if os.IsNotExist(err) {
-		return 0, nil
-	} else if err != nil {
-		return 0, fmt.Errorf("read txid file: %w", err)
-	}
-
-	txid, err := ltx.ParseTXID(strings.TrimSpace(string(data)))
-	if err != nil {
-		return 0, fmt.Errorf("parse txid file: %w", err)
-	}
-
-	return txid, nil
-}
-
-// ValidationError represents a single validation issue.
-type ValidationError struct {
-	Level    int           // compaction level
-	Type     string        // "gap", "overlap", or "unsorted"
-	Message  string        // human-readable description
-	PrevFile *ltx.FileInfo // previous file
-	CurrFile *ltx.FileInfo // current file that caused error
-}
-
-// ValidateLevel checks LTX files at the given level are sorted and contiguous.
-// Returns a slice of validation errors (empty if valid).
-func (r *Replica) ValidateLevel(ctx context.Context, level int) ([]ValidationError, error) {
-	itr, err := r.Client.LTXFiles(ctx, level, 0, false)
-	if err != nil {
-		return nil, fmt.Errorf("fetch ltx files: %w", err)
-	}
-	defer itr.Close()
-
-	var errors []ValidationError
-	var prevInfo *ltx.FileInfo
-
-	for itr.Next() {
-		info := itr.Item()
-
-		// Skip first file - nothing to compare against
-		if prevInfo == nil {
-			prevInfo = info
-			continue
-		}
-
-		// Check for sort order: curr.MinTXID should be >= prev.MinTXID
-		if info.MinTXID < prevInfo.MinTXID {
-			errors = append(errors, ValidationError{
-				Level:    level,
-				Type:     "unsorted",
-				Message:  fmt.Sprintf("files out of order: curr.MinTXID=%s < prev.MinTXID=%s", info.MinTXID, prevInfo.MinTXID),
-				PrevFile: prevInfo,
-				CurrFile: info,
-			})
-			prevInfo = info
-			continue
-		}
-
-		// Check for TXID contiguity: prev.MaxTXID + 1 should equal curr.MinTXID
-		expectedMinTXID := prevInfo.MaxTXID + 1
-		if info.MinTXID != expectedMinTXID {
-			if info.MinTXID > expectedMinTXID {
-				errors = append(errors, ValidationError{
-					Level:    level,
-					Type:     "gap",
-					Message:  fmt.Sprintf("TXID gap: prev.MaxTXID=%s, curr.MinTXID=%s (expected %s)", prevInfo.MaxTXID, info.MinTXID, expectedMinTXID),
-					PrevFile: prevInfo,
-					CurrFile: info,
-				})
-			} else {
-				errors = append(errors, ValidationError{
-					Level:    level,
-					Type:     "overlap",
-					Message:  fmt.Sprintf("TXID overlap: prev.MaxTXID=%s, curr.MinTXID=%s", prevInfo.MaxTXID, info.MinTXID),
-					PrevFile: prevInfo,
-					CurrFile: info,
-				})
-			}
-		}
-
-		prevInfo = info
-	}
-
-	if err := itr.Close(); err != nil {
-		return nil, fmt.Errorf("close iterator: %w", err)
-	}
-
-	return errors, nil
 }

--- a/restore.go
+++ b/restore.go
@@ -1,0 +1,1305 @@
+package litestream
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream/internal"
+)
+
+// CalcRestoreTarget returns a target time restore from.
+func (r *Replica) CalcRestoreTarget(ctx context.Context, opt RestoreOptions) (updatedAt time.Time, err error) {
+	// Determine the replicated time bounds from LTX files.
+	createdAt, updatedAt, err := r.TimeBounds(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("created at: %w", err)
+	}
+
+	// Also check v0.3.x time bounds if client supports it.
+	if client, ok := r.Client.(ReplicaClientV3); ok {
+		v3CreatedAt, v3UpdatedAt, err := r.TimeBoundsV3(ctx, client)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("v0.3.x time bounds: %w", err)
+		}
+		// Extend time bounds to include v0.3.x backups.
+		if !v3CreatedAt.IsZero() && (createdAt.IsZero() || v3CreatedAt.Before(createdAt)) {
+			createdAt = v3CreatedAt
+		}
+		if !v3UpdatedAt.IsZero() && (updatedAt.IsZero() || v3UpdatedAt.After(updatedAt)) {
+			updatedAt = v3UpdatedAt
+		}
+	}
+
+	// Skip if it does not contain timestamp.
+	if !opt.Timestamp.IsZero() {
+		if createdAt.IsZero() && updatedAt.IsZero() {
+			return time.Time{}, fmt.Errorf("no backups found")
+		}
+		if opt.Timestamp.Before(createdAt) || opt.Timestamp.After(updatedAt) {
+			return time.Time{}, fmt.Errorf("timestamp does not exist")
+		}
+	}
+
+	return updatedAt, nil
+}
+
+// Replica restores the database from a replica based on the options given.
+// This method will restore into opt.OutputPath, if specified, or into the
+// DB's original database path. It can optionally restore from a specific
+// replica or it will automatically choose the best one. Finally,
+// a timestamp can be specified to restore the database to a specific
+// point-in-time.
+//
+// When the replica contains both v0.3.x and LTX format backups, this method
+// compares snapshots from both formats and uses whichever has the better backup:
+// - With timestamp: uses the format with the most recent snapshot before timestamp
+// - Without timestamp: uses the format with the most recent backup overall
+func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
+	// Validate options.
+	if opt.OutputPath == "" {
+		return fmt.Errorf("output path required")
+	} else if opt.TXID != 0 && !opt.Timestamp.IsZero() {
+		return fmt.Errorf("cannot specify index & timestamp to restore")
+	} else if opt.Follow && opt.TXID != 0 {
+		return fmt.Errorf("cannot use follow mode with -txid")
+	} else if opt.Follow && !opt.Timestamp.IsZero() {
+		return fmt.Errorf("cannot use follow mode with -timestamp")
+	} else if opt.IntegrityCheck != IntegrityCheckNone && opt.IntegrityCheck != IntegrityCheckQuick && opt.IntegrityCheck != IntegrityCheckFull {
+		return fmt.Errorf("unsupported integrity check mode: %d", opt.IntegrityCheck)
+	}
+
+	// In follow mode, if the database already exists, attempt crash recovery
+	// by reading the last applied TXID from the sidecar file.
+	if opt.Follow {
+		if _, statErr := os.Stat(opt.OutputPath); statErr == nil {
+			txid, readErr := ReadTXIDFile(opt.OutputPath)
+			if readErr != nil {
+				return fmt.Errorf("read txid file for crash recovery: %w", readErr)
+			}
+			if txid == 0 {
+				return fmt.Errorf("cannot resume follow mode: database exists but no -txid file found; delete the database to re-restore: %s", opt.OutputPath)
+			}
+			// Validate saved TXID is still reachable. If the earliest snapshot
+			// starts after our saved TXID, retention has pruned the history
+			// and we can't catch up incrementally.
+			snapshotItr, itrErr := r.Client.LTXFiles(ctx, SnapshotLevel, 0, false)
+			if itrErr != nil {
+				return fmt.Errorf("cannot validate saved TXID for crash recovery: %w", itrErr)
+			}
+
+			var latestSnapshot *ltx.FileInfo
+			for snapshotItr.Next() {
+				latestSnapshot = snapshotItr.Item()
+			}
+			if err := snapshotItr.Err(); err != nil {
+				_ = snapshotItr.Close()
+				return fmt.Errorf("iterate snapshots for crash recovery validation: %w", err)
+			}
+			_ = snapshotItr.Close()
+
+			if latestSnapshot != nil {
+				if latestSnapshot.MinTXID > txid {
+					return fmt.Errorf("cannot resume follow mode: saved TXID %s is behind the earliest snapshot (min TXID %s); replica history has been pruned -- delete %s and %s-txid to re-restore", txid, latestSnapshot.MinTXID, opt.OutputPath, opt.OutputPath)
+				}
+				if txid > latestSnapshot.MaxTXID {
+					return fmt.Errorf("cannot resume follow mode: saved TXID %s is ahead of latest snapshot (max TXID %s); delete %s and %s-txid to re-restore", txid, latestSnapshot.MaxTXID, opt.OutputPath, opt.OutputPath)
+				}
+			}
+
+			r.Logger().Info("resuming follow mode from crash recovery", "txid", txid, "output", opt.OutputPath)
+			return r.follow(ctx, opt.OutputPath, txid, opt.FollowInterval)
+		}
+	}
+
+	// Ensure output path does not already exist.
+	if _, err := os.Stat(opt.OutputPath); err == nil {
+		return fmt.Errorf("cannot restore, output path already exists: %s", opt.OutputPath)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	// Compare v0.3.x and LTX formats to find the best backup (unless TXID is specified).
+	// Skip V3 format when follow mode is enabled (V3 doesn't support incremental following).
+	if opt.TXID == 0 && !opt.Follow {
+		if client, ok := r.Client.(ReplicaClientV3); ok {
+			useV3, err := r.shouldUseV3Restore(ctx, client, opt.Timestamp)
+			if err != nil {
+				return err
+			}
+			if useV3 {
+				return r.RestoreV3(ctx, opt)
+			}
+		}
+	}
+
+	infos, err := CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
+	if err != nil {
+		return fmt.Errorf("cannot calc restore plan: %w", err)
+	}
+
+	r.Logger().Debug("restore plan", "n", len(infos), "txid", infos[len(infos)-1].MaxTXID, "timestamp", infos[len(infos)-1].CreatedAt)
+
+	rdrs := make([]io.Reader, 0, len(infos))
+	defer func() {
+		for _, rd := range rdrs {
+			if closer, ok := rd.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}
+	}()
+
+	for _, info := range infos {
+		// Validate file size - must be at least header size to be readable
+		if info.Size < ltx.HeaderSize {
+			return fmt.Errorf("invalid ltx file: level=%d min=%s max=%s has size %d bytes (minimum %d)",
+				info.Level, info.MinTXID, info.MaxTXID, info.Size, ltx.HeaderSize)
+		}
+
+		r.Logger().Debug("opening ltx file for restore", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
+
+		rdrs = append(rdrs, internal.NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, nil, r.Logger()))
+	}
+
+	if len(rdrs) == 0 {
+		return fmt.Errorf("no matching backup files available")
+	}
+
+	// Create parent directory if it doesn't exist.
+	var dirInfo os.FileInfo
+	if db := r.DB(); db != nil {
+		dirInfo = db.dirInfo
+	}
+	if err := internal.MkdirAll(filepath.Dir(opt.OutputPath), dirInfo); err != nil {
+		return fmt.Errorf("create parent directory: %w", err)
+	}
+
+	// Output to temp file & atomically rename.
+	tmpOutputPath := opt.OutputPath + ".tmp"
+	r.Logger().Debug("compacting into database", "path", tmpOutputPath, "n", len(rdrs))
+	defer func() { _ = os.Remove(tmpOutputPath) }()
+
+	f, err := os.Create(tmpOutputPath)
+	if err != nil {
+		return fmt.Errorf("create temp database path: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		c, err := ltx.NewCompactor(pw, rdrs)
+		if err != nil {
+			pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
+			return
+		}
+		c.HeaderFlags = ltx.HeaderFlagNoChecksum
+		_ = pw.CloseWithError(c.Compact(ctx))
+	}()
+
+	dec := ltx.NewDecoder(pr)
+	if err := dec.DecodeDatabaseTo(f); err != nil {
+		return fmt.Errorf("decode database: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		return err
+	} else if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Copy file to final location.
+	r.Logger().Debug("renaming database from temporary location")
+	if err := os.Rename(tmpOutputPath, opt.OutputPath); err != nil {
+		return err
+	}
+
+	if opt.IntegrityCheck != IntegrityCheckNone {
+		if err := checkIntegrity(ctx, opt.OutputPath, opt.IntegrityCheck); err != nil {
+			if ctx.Err() == nil {
+				_ = os.Remove(opt.OutputPath)
+				_ = os.Remove(opt.OutputPath + "-shm")
+				_ = os.Remove(opt.OutputPath + "-wal")
+			}
+			return fmt.Errorf("post-restore integrity check: %w", err)
+		}
+		r.Logger().Info("post-restore integrity check passed")
+	}
+
+	// Enter follow mode if enabled, continuously applying new LTX files.
+	if opt.Follow {
+		for _, rd := range rdrs {
+			if closer, ok := rd.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}
+		rdrs = nil
+
+		maxTXID := infos[len(infos)-1].MaxTXID
+		if err := WriteTXIDFile(opt.OutputPath, maxTXID); err != nil {
+			return fmt.Errorf("write initial txid file: %w", err)
+		}
+		return r.follow(ctx, opt.OutputPath, maxTXID, opt.FollowInterval)
+	}
+
+	return nil
+}
+
+// follow enters a continuous restore loop, polling for new LTX files and
+// applying them to the restored database. It blocks until the context is
+// cancelled (e.g. Ctrl+C). Returns nil on clean shutdown.
+func (r *Replica) follow(ctx context.Context, outputPath string, lastTXID ltx.TXID, interval time.Duration) error {
+	f, err := os.OpenFile(outputPath, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open database for follow: %w", err)
+	}
+	defer func() {
+		_ = f.Sync()
+		_ = f.Close()
+	}()
+
+	// Read page size from SQLite header (offset 16, 2 bytes, big-endian).
+	var buf [2]byte
+	if _, err := f.ReadAt(buf[:], 16); err != nil {
+		return fmt.Errorf("read page size from database header: %w", err)
+	}
+	pageSize := uint32(buf[0])<<8 | uint32(buf[1])
+	if pageSize == 1 {
+		pageSize = 65536
+	}
+
+	if interval <= 0 {
+		interval = DefaultFollowInterval
+	}
+
+	r.Logger().Info("entering follow mode", "output", outputPath, "txid", lastTXID, "interval", interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var consecutiveErrors int
+	for {
+		select {
+		case <-ctx.Done():
+			r.Logger().Info("follow mode stopped")
+			return nil
+		case <-ticker.C:
+			newTXID, err := r.applyNewLTXFiles(ctx, f, lastTXID, pageSize)
+			if err != nil {
+				if ctx.Err() != nil {
+					r.Logger().Info("follow mode stopped")
+					return nil
+				}
+				consecutiveErrors++
+				r.Logger().Error("follow: error applying updates", "err", err, "consecutive_errors", consecutiveErrors)
+				continue
+			}
+			if newTXID > lastTXID {
+				if err := WriteTXIDFile(outputPath, newTXID); err != nil {
+					return fmt.Errorf("write txid file: %w", err)
+				}
+				r.Logger().Info("follow: applied updates", "from_txid", lastTXID, "to_txid", newTXID)
+				lastTXID = newTXID
+				consecutiveErrors = 0
+			}
+		}
+	}
+}
+
+// applyNewLTXFiles polls for new LTX files and applies them to the database.
+// It starts from level 0 and falls back to higher levels if there are gaps
+// (e.g., level 0 files were compacted away).
+func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
+	currentTXID := afterTXID
+
+	// Poll level 0 for the most recent incremental files.
+	itr, err := r.Client.LTXFiles(ctx, 0, currentTXID+1, false)
+	if err != nil {
+		return currentTXID, fmt.Errorf("list level 0 ltx files: %w", err)
+	}
+	closeLevel0 := func(retErr error) (ltx.TXID, error) {
+		if closeErr := itr.Close(); closeErr != nil {
+			closeErr = fmt.Errorf("close level 0 ltx iterator: %w", closeErr)
+			if retErr != nil {
+				return currentTXID, errors.Join(retErr, closeErr)
+			}
+			return currentTXID, closeErr
+		}
+		return currentTXID, retErr
+	}
+
+	var sawLevel0 bool
+	for itr.Next() {
+		sawLevel0 = true
+		info := itr.Item()
+
+		// If there's a gap, try to fill it from higher compaction levels.
+		if info.MinTXID > currentTXID+1 {
+			bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, info.MinTXID, pageSize)
+			if err != nil {
+				return closeLevel0(err)
+			}
+			currentTXID = bridgedTXID
+
+			// Re-check if this file is still needed after bridging.
+			if info.MaxTXID <= currentTXID {
+				continue
+			}
+			if info.MinTXID > currentTXID+1 {
+				return closeLevel0(nil)
+			}
+		}
+
+		// Skip if already covered by a higher-level file.
+		if info.MaxTXID <= currentTXID {
+			continue
+		}
+
+		if err := r.applyLTXFile(ctx, f, info, pageSize); err != nil {
+			return closeLevel0(fmt.Errorf(
+				"apply ltx file (level=%d, min=%s, max=%s): %w",
+				info.Level, info.MinTXID, info.MaxTXID, err,
+			))
+		}
+		currentTXID = info.MaxTXID
+	}
+
+	if iterErr := itr.Err(); iterErr != nil {
+		return closeLevel0(fmt.Errorf("iterate level 0 ltx files: %w", iterErr))
+	}
+	if _, err := closeLevel0(nil); err != nil {
+		return currentTXID, err
+	}
+
+	if !sawLevel0 {
+		bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, currentTXID+1, pageSize)
+		if err != nil {
+			return currentTXID, err
+		}
+		currentTXID = bridgedTXID
+	}
+
+	return currentTXID, nil
+}
+
+// applyLTXFile applies a single LTX file's pages to the database file.
+// This follows the same pattern as Hydrator.ApplyLTX (vfs.go:712-747).
+//
+// To prevent concurrent SQLite readers from seeing partial updates, we acquire
+// an exclusive file lock before writing. We also rewrite the SQLite header
+// (bytes 18-19) to indicate DELETE journal mode instead of WAL mode, and
+// randomize the schema change counter (bytes 24-27) to invalidate cached
+// schemas in other connections.
+func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileInfo, pageSize uint32) error {
+	rc, err := r.Client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
+	if err != nil {
+		return fmt.Errorf("open ltx file: %w", err)
+	}
+	defer rc.Close()
+
+	dec := ltx.NewDecoder(rc)
+	if err := dec.DecodeHeader(); err != nil {
+		return fmt.Errorf("decode header: %w", err)
+	}
+
+	hdr := dec.Header()
+
+	if err := internal.LockFileExclusive(f); err != nil {
+		return fmt.Errorf("acquire exclusive lock: %w", err)
+	}
+	defer internal.UnlockFile(f)
+
+	for {
+		var phdr ltx.PageHeader
+		data := make([]byte, pageSize)
+		if err := dec.DecodePage(&phdr, data); err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("decode page: %w", err)
+		}
+
+		if phdr.Pgno == 1 && len(data) >= 28 {
+			data[18], data[19] = 0x01, 0x01
+			_, _ = rand.Read(data[24:28])
+		}
+
+		off := int64(phdr.Pgno-1) * int64(pageSize)
+		if _, err := f.WriteAt(data, off); err != nil {
+			return fmt.Errorf("write page %d: %w", phdr.Pgno, err)
+		}
+	}
+
+	if hdr.Commit > 0 {
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("sync before truncate: %w", err)
+		}
+		newSize := int64(hdr.Commit) * int64(pageSize)
+		if err := f.Truncate(newSize); err != nil {
+			return fmt.Errorf("truncate: %w", err)
+		}
+	}
+
+	if err := dec.Close(); err != nil {
+		return fmt.Errorf("close decoder: %w", err)
+	}
+
+	return f.Sync()
+}
+
+// fillFollowGap attempts to bridge a gap in level 0 files by searching
+// higher compaction levels for a file that covers the missing TXID range.
+func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.TXID, gapMinTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
+	currentTXID := afterTXID
+
+	for level := 1; level < SnapshotLevel; level++ {
+		itr, err := r.Client.LTXFiles(ctx, level, 0, false)
+		if err != nil {
+			return currentTXID, fmt.Errorf("list level %d ltx files: %w", level, err)
+		}
+		closeLevel := func(retErr error) (ltx.TXID, error) {
+			if closeErr := itr.Close(); closeErr != nil {
+				closeErr = fmt.Errorf("close level %d ltx iterator: %w", level, closeErr)
+				if retErr != nil {
+					return currentTXID, errors.Join(retErr, closeErr)
+				}
+				return currentTXID, closeErr
+			}
+			return currentTXID, retErr
+		}
+
+		for itr.Next() {
+			info := itr.Item()
+
+			// Skip if there's a gap at this level too.
+			if info.MinTXID > currentTXID+1 {
+				break
+			}
+
+			// Skip if already covered.
+			if info.MaxTXID <= currentTXID {
+				continue
+			}
+
+			if err := r.applyLTXFile(ctx, f, info, pageSize); err != nil {
+				return closeLevel(fmt.Errorf(
+					"apply gap-fill ltx file (level=%d, min=%s, max=%s): %w",
+					info.Level, info.MinTXID, info.MaxTXID, err,
+				))
+			}
+			currentTXID = info.MaxTXID
+
+			// If we've bridged past the gap, we're done.
+			if currentTXID+1 >= gapMinTXID {
+				return closeLevel(nil)
+			}
+		}
+
+		if iterErr := itr.Err(); iterErr != nil {
+			return closeLevel(fmt.Errorf("iterate level %d ltx files: %w", level, iterErr))
+		}
+		if _, err := closeLevel(nil); err != nil {
+			return currentTXID, err
+		}
+
+		// If we made progress at this level, restart from level 1.
+		if currentTXID > afterTXID {
+			return currentTXID, nil
+		}
+	}
+
+	return currentTXID, nil
+}
+
+// RestoreV3 restores from a v0.3.x format backup.
+func (r *Replica) RestoreV3(ctx context.Context, opt RestoreOptions) error {
+	client, ok := r.Client.(ReplicaClientV3)
+	if !ok {
+		return fmt.Errorf("replica client does not support v0.3.x restore")
+	}
+
+	// Validate options.
+	if opt.OutputPath == "" {
+		return fmt.Errorf("output path required")
+	} else if opt.IntegrityCheck != IntegrityCheckNone && opt.IntegrityCheck != IntegrityCheckQuick && opt.IntegrityCheck != IntegrityCheckFull {
+		return fmt.Errorf("unsupported integrity check mode: %d", opt.IntegrityCheck)
+	}
+
+	// Ensure output path does not already exist.
+	if _, err := os.Stat(opt.OutputPath); err == nil {
+		return fmt.Errorf("cannot restore, output path already exists: %s", opt.OutputPath)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	// Find all generations.
+	generations, err := client.GenerationsV3(ctx)
+	if err != nil {
+		return fmt.Errorf("list generations: %w", err)
+	}
+	if len(generations) == 0 {
+		return ErrNoSnapshots
+	}
+
+	// Collect all snapshots across all generations.
+	var allSnapshots []SnapshotInfoV3
+	for _, gen := range generations {
+		snapshots, err := client.SnapshotsV3(ctx, gen)
+		if err != nil {
+			return fmt.Errorf("list snapshots for generation %s: %w", gen, err)
+		}
+		allSnapshots = append(allSnapshots, snapshots...)
+	}
+	if len(allSnapshots) == 0 {
+		return ErrNoSnapshots
+	}
+
+	// Sort all snapshots by CreatedAt for timestamp-based selection.
+	sortSnapshotsV3ByCreatedAt(allSnapshots)
+
+	// Find best snapshot across all generations (latest, or before timestamp if specified).
+	snapshot := findBestSnapshotV3(allSnapshots, opt.Timestamp)
+	if snapshot == nil {
+		return ErrNoSnapshots
+	}
+
+	r.Logger().Debug("selected v0.3.x snapshot",
+		"generation", snapshot.Generation,
+		"index", snapshot.Index,
+		"created_at", snapshot.CreatedAt)
+
+	// Get WAL segments for the snapshot's generation.
+	segments, err := client.WALSegmentsV3(ctx, snapshot.Generation)
+	if err != nil {
+		return fmt.Errorf("list WAL segments: %w", err)
+	}
+	segments = filterWALSegmentsV3(segments, snapshot.Index, opt.Timestamp)
+
+	r.Logger().Debug("found v0.3.x WAL segments", "n", len(segments))
+
+	// Create parent directory if it doesn't exist.
+	var dirInfo os.FileInfo
+	if db := r.DB(); db != nil {
+		dirInfo = db.DirInfo()
+	}
+	if err := internal.MkdirAll(filepath.Dir(opt.OutputPath), dirInfo); err != nil {
+		return fmt.Errorf("create parent directory: %w", err)
+	}
+
+	// Create temp file for restore.
+	tmpPath := opt.OutputPath + ".tmp"
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	// Download and decompress snapshot.
+	if err := r.downloadSnapshotV3(ctx, client, snapshot.Generation, snapshot.Index, tmpPath); err != nil {
+		return fmt.Errorf("download snapshot: %w", err)
+	}
+
+	// Apply WAL segments.
+	if err := r.applyWALSegmentsV3(ctx, client, snapshot.Generation, snapshot.Index, segments, tmpPath); err != nil {
+		return fmt.Errorf("apply WAL segments: %w", err)
+	}
+
+	// Rename to final path.
+	if err := os.Rename(tmpPath, opt.OutputPath); err != nil {
+		return fmt.Errorf("rename to output path: %w", err)
+	}
+
+	if opt.IntegrityCheck != IntegrityCheckNone {
+		if err := checkIntegrity(ctx, opt.OutputPath, opt.IntegrityCheck); err != nil {
+			if ctx.Err() == nil {
+				_ = os.Remove(opt.OutputPath)
+				_ = os.Remove(opt.OutputPath + "-shm")
+				_ = os.Remove(opt.OutputPath + "-wal")
+			}
+			return fmt.Errorf("post-restore integrity check: %w", err)
+		}
+		r.Logger().Info("post-restore integrity check passed")
+	}
+
+	return nil
+}
+
+// sortSnapshotsV3ByCreatedAt sorts snapshots by creation time in ascending order.
+func sortSnapshotsV3ByCreatedAt(snapshots []SnapshotInfoV3) {
+	for i := 0; i < len(snapshots)-1; i++ {
+		for j := i + 1; j < len(snapshots); j++ {
+			if snapshots[i].CreatedAt.After(snapshots[j].CreatedAt) {
+				snapshots[i], snapshots[j] = snapshots[j], snapshots[i]
+			}
+		}
+	}
+}
+
+// findBestSnapshotV3 finds the best snapshot for restore.
+// If timestamp is zero, returns the latest snapshot.
+// Otherwise, returns the latest snapshot created before or at the timestamp.
+func findBestSnapshotV3(snapshots []SnapshotInfoV3, timestamp time.Time) *SnapshotInfoV3 {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	if timestamp.IsZero() {
+		return &snapshots[len(snapshots)-1]
+	}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		if !snapshots[i].CreatedAt.After(timestamp) {
+			return &snapshots[i]
+		}
+	}
+	return nil
+}
+
+// filterWALSegmentsV3 filters WAL segments to those at or after the snapshot index
+// and optionally before the timestamp.
+func filterWALSegmentsV3(segments []WALSegmentInfoV3, snapshotIndex int, timestamp time.Time) []WALSegmentInfoV3 {
+	var result []WALSegmentInfoV3
+	for _, seg := range segments {
+		if seg.Index < snapshotIndex {
+			continue
+		}
+		if !timestamp.IsZero() && seg.CreatedAt.After(timestamp) {
+			continue
+		}
+		result = append(result, seg)
+	}
+	return result
+}
+
+// downloadSnapshotV3 downloads and decompresses a v0.3.x snapshot to the destination path.
+func (r *Replica) downloadSnapshotV3(ctx context.Context, client ReplicaClientV3, generation string, index int, destPath string) error {
+	rc, err := client.OpenSnapshotV3(ctx, generation, index)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rc.Close() }()
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(f, rc); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+// applyWALSegmentsV3 applies WAL segments to the database file.
+func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3, generation string, snapshotIndex int, segments []WALSegmentInfoV3, dbPath string) error {
+	if len(segments) == 0 {
+		return nil
+	}
+
+	// Write all WAL segments to the WAL file.
+	walPath := dbPath + "-wal"
+	var f *os.File
+	var err error
+	expectedIndex := snapshotIndex
+	offset := int64(0)
+
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+	}()
+
+	applyLastWalFile := func() error {
+		if f == nil {
+			return nil
+		} else if err = f.Close(); err != nil {
+			return err
+		}
+		f = nil
+		if err = checkpointV3(dbPath); err != nil {
+			return err
+		}
+		r.Logger().Debug("applied WAL index", "generation", generation, "index", expectedIndex-1, "bytes", offset)
+		return nil
+	}
+
+	// Reconstruct each wal file, appending non-zero offsets, and apply them
+	// to the db.
+	for _, seg := range segments {
+		if seg.Offset == 0 {
+			// Apply the last WAL file, if any
+			if err = applyLastWalFile(); err != nil {
+				return err
+			}
+			if seg.Index != expectedIndex {
+				return fmt.Errorf("missing WAL index: expected %d/0, got %d/%d", expectedIndex, seg.Index, seg.Offset)
+			}
+			offset = 0
+			// Open a new WAL file
+			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644); err != nil {
+				return err
+			}
+			expectedIndex++
+		} else if seg.Offset != offset {
+			return fmt.Errorf("missing WAL segment: expected %d/%d, got %d/%d", seg.Index, offset, seg.Index, seg.Offset)
+		}
+		if n, err := r.appendWALSegmentV3(ctx, client, generation, seg, f); err != nil {
+			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)
+		} else {
+			offset += n
+			r.Logger().Debug("wrote WAL segment", "generation", generation, "index", seg.Index, "offset", seg.Offset, "bytes", n)
+		}
+	}
+
+	return applyLastWalFile()
+}
+
+// appendWALSegmentV3 appends the specified segment to an open WAL file f.
+func (r *Replica) appendWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) (int64, error) {
+	// Download WAL segment.
+	rc, err := client.OpenWALSegmentV3(ctx, generation, seg.Index, seg.Offset)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	return io.Copy(f, rc)
+}
+
+// checkpointV3 checkpoints the WAL file into the database.
+func checkpointV3(dbPath string) error {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	return err
+}
+
+// checkIntegrity runs a SQLite integrity check on the database at dbPath.
+func checkIntegrity(ctx context.Context, dbPath string, mode IntegrityCheckMode) error {
+	if mode == IntegrityCheckNone {
+		return nil
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("open database for integrity check: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var pragma string
+	switch mode {
+	case IntegrityCheckQuick:
+		pragma = "quick_check"
+	case IntegrityCheckFull:
+		pragma = "integrity_check"
+	default:
+		return fmt.Errorf("unsupported integrity check mode: %d", mode)
+	}
+
+	var result string
+	if err := db.QueryRowContext(ctx, "PRAGMA "+pragma).Scan(&result); err != nil {
+		return fmt.Errorf("integrity check: %w", err)
+	}
+	if result != "ok" {
+		return fmt.Errorf("integrity check failed: %s", result)
+	}
+
+	// Clean up -shm and -wal files that SQLite may create during the PRAGMA.
+	_ = os.Remove(dbPath + "-shm")
+	_ = os.Remove(dbPath + "-wal")
+
+	return nil
+}
+
+// findBestV3SnapshotForTimestamp returns the best v0.3.x snapshot for the given timestamp.
+// Returns nil if no suitable snapshot exists.
+func (r *Replica) findBestV3SnapshotForTimestamp(ctx context.Context, client ReplicaClientV3, timestamp time.Time) (*SnapshotInfoV3, error) {
+	generations, err := client.GenerationsV3(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list v0.3.x generations: %w", err)
+	}
+	if len(generations) == 0 {
+		return nil, nil
+	}
+
+	var allSnapshots []SnapshotInfoV3
+	for _, gen := range generations {
+		snapshots, err := client.SnapshotsV3(ctx, gen)
+		if err != nil {
+			return nil, fmt.Errorf("list v0.3.x snapshots for generation %s: %w", gen, err)
+		}
+		allSnapshots = append(allSnapshots, snapshots...)
+	}
+
+	if len(allSnapshots) == 0 {
+		return nil, nil
+	}
+
+	// Sort by CreatedAt for timestamp-based selection.
+	sortSnapshotsV3ByCreatedAt(allSnapshots)
+
+	return findBestSnapshotV3(allSnapshots, timestamp), nil
+}
+
+// shouldUseV3Restore determines whether to use v0.3.x restore instead of LTX.
+// Returns true if v0.3.x has a better backup for the given options.
+func (r *Replica) shouldUseV3Restore(ctx context.Context, client ReplicaClientV3, timestamp time.Time) (bool, error) {
+	// Get v0.3.x time bounds.
+	_, v3UpdatedAt, err := r.TimeBoundsV3(ctx, client)
+	if err != nil {
+		return false, fmt.Errorf("get v0.3.x time bounds: %w", err)
+	}
+
+	// Get LTX time bounds.
+	_, ltxUpdatedAt, err := r.TimeBounds(ctx)
+	if err != nil {
+		return false, fmt.Errorf("get LTX time bounds: %w", err)
+	}
+
+	// If no v0.3.x backups exist, use LTX.
+	if v3UpdatedAt.IsZero() {
+		return false, nil
+	}
+
+	// If no LTX backups exist, use v0.3.x.
+	if ltxUpdatedAt.IsZero() {
+		r.Logger().Debug("using v0.3.x restore (no LTX backups)")
+		return true, nil
+	}
+
+	// Both formats have backups - compare based on timestamp or latest.
+	if !timestamp.IsZero() {
+		// With timestamp: use format with best snapshot before timestamp.
+		v3Snapshot, err := r.findBestV3SnapshotForTimestamp(ctx, client, timestamp)
+		if err != nil {
+			return false, fmt.Errorf("find v0.3.x snapshot: %w", err)
+		}
+
+		ltxSnapshot, err := r.findBestLTXSnapshotForTimestamp(ctx, timestamp)
+		if err != nil {
+			return false, fmt.Errorf("find LTX snapshot: %w", err)
+		}
+
+		if v3Snapshot != nil && (ltxSnapshot == nil || v3Snapshot.CreatedAt.After(ltxSnapshot.CreatedAt)) {
+			r.Logger().Debug("using v0.3.x restore (better snapshot for timestamp)",
+				"v3_snapshot", v3Snapshot.CreatedAt,
+				"ltx_snapshot", ltxSnapshot)
+			return true, nil
+		}
+	} else {
+		// Without timestamp: use format with most recent backup.
+		if v3UpdatedAt.After(ltxUpdatedAt) {
+			r.Logger().Debug("using v0.3.x restore (more recent backup)",
+				"v3_updated_at", v3UpdatedAt,
+				"ltx_updated_at", ltxUpdatedAt)
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// TimeBoundsV3 returns the time bounds of v0.3.x backups.
+// Returns zero times if no v0.3.x backups exist.
+func (r *Replica) TimeBoundsV3(ctx context.Context, client ReplicaClientV3) (createdAt, updatedAt time.Time, err error) {
+	generations, err := client.GenerationsV3(ctx)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+
+	for _, gen := range generations {
+		snapshots, err := client.SnapshotsV3(ctx, gen)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+		for _, snap := range snapshots {
+			if createdAt.IsZero() || snap.CreatedAt.Before(createdAt) {
+				createdAt = snap.CreatedAt
+			}
+			if updatedAt.IsZero() || snap.CreatedAt.After(updatedAt) {
+				updatedAt = snap.CreatedAt
+			}
+		}
+
+		segments, err := client.WALSegmentsV3(ctx, gen)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+		for _, seg := range segments {
+			if createdAt.IsZero() || seg.CreatedAt.Before(createdAt) {
+				createdAt = seg.CreatedAt
+			}
+			if updatedAt.IsZero() || seg.CreatedAt.After(updatedAt) {
+				updatedAt = seg.CreatedAt
+			}
+		}
+	}
+
+	return createdAt, updatedAt, nil
+}
+
+// findBestLTXSnapshotForTimestamp returns the best LTX snapshot for the given timestamp.
+// Returns nil if no suitable snapshot exists.
+func (r *Replica) findBestLTXSnapshotForTimestamp(ctx context.Context, timestamp time.Time) (*ltx.FileInfo, error) {
+	// Find snapshots at the snapshot level that are before the timestamp.
+	snapshots, err := FindLTXFiles(ctx, r.Client, SnapshotLevel, true, func(info *ltx.FileInfo) (bool, error) {
+		return info.CreatedAt.Before(timestamp), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find LTX snapshots: %w", err)
+	}
+	if len(snapshots) == 0 {
+		return nil, nil
+	}
+
+	// Return the latest snapshot before the timestamp (last in the sorted list).
+	return snapshots[len(snapshots)-1], nil
+}
+
+// CalcRestorePlan returns a list of storage paths to restore a snapshot at the given TXID.
+func CalcRestorePlan(ctx context.Context, client ReplicaClient, txID ltx.TXID, timestamp time.Time, logger *slog.Logger) ([]*ltx.FileInfo, error) {
+	if txID != 0 && !timestamp.IsZero() {
+		return nil, fmt.Errorf("cannot specify both TXID & timestamp to restore")
+	}
+
+	var infos ltx.FileInfoSlice
+	logger = logger.With("target", txID)
+
+	// Start with latest snapshot before target TXID or timestamp.
+	// Pass useMetadata flag to enable accurate timestamp fetching for timestamp-based restore.
+	var snapshot *ltx.FileInfo
+	snapshotItr, err := client.LTXFiles(ctx, SnapshotLevel, 0, !timestamp.IsZero())
+	if err != nil {
+		return nil, err
+	}
+	for snapshotItr.Next() {
+		info := snapshotItr.Item()
+		logger.Debug("finding snapshot before target TXID or timestamp", "snapshot", info.MaxTXID)
+		if txID != 0 && info.MaxTXID > txID {
+			continue
+		}
+		if !timestamp.IsZero() && !info.CreatedAt.Before(timestamp) {
+			continue
+		}
+		snapshot = info
+	}
+	if err := snapshotItr.Close(); err != nil {
+		return nil, err
+	}
+	if snapshot != nil {
+		logger.Debug("found snapshot before target TXID or timestamp", "snapshot", snapshot.MaxTXID)
+		infos = append(infos, snapshot)
+	}
+
+	// Collect candidates across all compaction levels and pick the next file
+	// from any level that extends the longest contiguous TXID range.
+	const maxLevel = SnapshotLevel - 1
+	startTXID := infos.MaxTXID()
+	currentMax := startTXID
+	if txID != 0 && currentMax >= txID {
+		return infos, nil
+	}
+
+	cursors := make([]*restoreLevelCursor, 0, maxLevel+1)
+	for level := maxLevel; level >= 0; level-- {
+		logger.Debug("finding ltx files for level", "level", level)
+		itr, err := client.LTXFiles(ctx, level, 0, !timestamp.IsZero())
+		if err != nil {
+			return nil, err
+		}
+		cursors = append(cursors, &restoreLevelCursor{
+			itr: itr,
+		})
+	}
+	defer func() {
+		for _, cursor := range cursors {
+			if cursor != nil {
+				_ = cursor.itr.Close()
+			}
+		}
+	}()
+
+	for {
+		var next *restoreLevelCursor
+		for _, cursor := range cursors {
+			if err := cursor.refresh(currentMax, txID, timestamp); err != nil {
+				return nil, err
+			}
+			if cursor.candidate == nil {
+				continue
+			}
+			if next == nil || restoreCandidateBetter(next.candidate, cursor.candidate) {
+				next = cursor
+			}
+		}
+
+		if next == nil || next.candidate == nil {
+			break
+		}
+
+		if next.candidate.MaxTXID <= currentMax {
+			next.candidate = nil
+			continue
+		}
+
+		logger.Debug("matching LTX file for restore",
+			"filename", ltx.FormatFilename(next.candidate.MinTXID, next.candidate.MaxTXID),
+			"level", next.candidate.Level)
+		infos = append(infos, next.candidate)
+		currentMax = next.candidate.MaxTXID
+		next.candidate = nil
+
+		if txID != 0 && currentMax >= txID {
+			break
+		}
+	}
+
+	if len(infos) > 0 && txID == 0 && timestamp.IsZero() {
+		for _, cursor := range cursors {
+			if err := cursor.ensureCurrent(); err != nil {
+				return nil, err
+			}
+			if cursor.current != nil && cursor.current.MinTXID > currentMax+1 {
+				return nil, fmt.Errorf("non-contiguous ltx files: have up to %s but next file starts at %s", currentMax, cursor.current.MinTXID)
+			}
+		}
+	}
+
+	if len(infos) == 0 {
+		return nil, ErrTxNotAvailable
+	}
+	if txID != 0 && infos.MaxTXID() < txID {
+		return nil, ErrTxNotAvailable
+	}
+
+	return infos, nil
+}
+
+type restoreLevelCursor struct {
+	// itr streams LTX file infos for a single level in filename order.
+	itr ltx.FileIterator
+	// current holds the last item read from itr but not yet evaluated.
+	current *ltx.FileInfo
+	// candidate is the best eligible file at this level for the currentMax.
+	candidate *ltx.FileInfo
+	// done indicates the iterator has been exhausted or errored.
+	done bool
+}
+
+func (c *restoreLevelCursor) refresh(currentMax, txID ltx.TXID, timestamp time.Time) error {
+	// Advance the iterator until we've evaluated all files that could be
+	// contiguous with currentMax. Keep the best eligible candidate.
+	if c.done {
+		return nil
+	}
+	if c.candidate != nil && c.candidate.MaxTXID <= currentMax {
+		c.candidate = nil
+	}
+
+	for {
+		if err := c.ensureCurrent(); err != nil {
+			return err
+		}
+		if c.done {
+			return nil
+		}
+
+		info := c.current
+		if info.MinTXID > currentMax+1 {
+			return nil
+		}
+		c.current = nil
+
+		if info.MaxTXID <= currentMax {
+			continue
+		}
+		if txID != 0 && info.MaxTXID > txID {
+			continue
+		}
+		if !timestamp.IsZero() && !info.CreatedAt.Before(timestamp) {
+			continue
+		}
+
+		if c.candidate == nil || restoreCandidateBetter(c.candidate, info) {
+			c.candidate = info
+		}
+	}
+}
+
+func (c *restoreLevelCursor) ensureCurrent() error {
+	// Ensure current is populated with the next iterator item, or mark done.
+	if c.done || c.current != nil {
+		return nil
+	}
+	if !c.itr.Next() {
+		if err := c.itr.Err(); err != nil {
+			return err
+		}
+		c.done = true
+		return nil
+	}
+	c.current = c.itr.Item()
+	return nil
+}
+
+func restoreCandidateBetter(curr, next *ltx.FileInfo) bool {
+	if next.MaxTXID != curr.MaxTXID {
+		return next.MaxTXID > curr.MaxTXID
+	}
+	if next.MinTXID != curr.MinTXID {
+		return next.MinTXID < curr.MinTXID
+	}
+	if next.Level != curr.Level {
+		return next.Level > curr.Level
+	}
+	return next.CreatedAt.Before(curr.CreatedAt)
+}
+
+// TXIDPath returns the path to the TXID sidecar file for the given database path.
+// Uses -txid suffix to match SQLite's naming convention for associated files (-wal, -shm).
+func TXIDPath(outputPath string) string {
+	return outputPath + "-txid"
+}
+
+// WriteTXIDFile atomically writes a TXID to a sidecar file at <outputPath>-txid.
+// Uses temp-file + fsync + rename for crash safety.
+func WriteTXIDFile(outputPath string, txid ltx.TXID) error {
+	txidPath := TXIDPath(outputPath)
+	tmpPath := txidPath + ".tmp"
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create txid temp file: %w", err)
+	}
+	defer f.Close()
+	defer os.Remove(tmpPath)
+
+	if _, err := fmt.Fprintln(f, txid); err != nil {
+		return fmt.Errorf("write txid: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync txid file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close txid file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, txidPath); err != nil {
+		return fmt.Errorf("rename txid file: %w", err)
+	}
+
+	dir, err := os.Open(filepath.Dir(txidPath))
+	if err != nil {
+		return fmt.Errorf("open txid dir for sync: %w", err)
+	}
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		return fmt.Errorf("sync txid dir: %w", err)
+	}
+	return dir.Close()
+}
+
+// ReadTXIDFile reads the TXID from a sidecar file at <outputPath>-txid.
+// Returns 0, nil if the file does not exist (first run).
+func ReadTXIDFile(outputPath string) (ltx.TXID, error) {
+	txidPath := TXIDPath(outputPath)
+
+	data, err := os.ReadFile(txidPath)
+	if os.IsNotExist(err) {
+		return 0, nil
+	} else if err != nil {
+		return 0, fmt.Errorf("read txid file: %w", err)
+	}
+
+	txid, err := ltx.ParseTXID(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("parse txid file: %w", err)
+	}
+
+	return txid, nil
+}
+
+// ValidationError represents a single validation issue.
+type ValidationError struct {
+	Level    int           // compaction level
+	Type     string        // "gap", "overlap", or "unsorted"
+	Message  string        // human-readable description
+	PrevFile *ltx.FileInfo // previous file
+	CurrFile *ltx.FileInfo // current file that caused error
+}
+
+// ValidateLevel checks LTX files at the given level are sorted and contiguous.
+// Returns a slice of validation errors (empty if valid).
+func (r *Replica) ValidateLevel(ctx context.Context, level int) ([]ValidationError, error) {
+	itr, err := r.Client.LTXFiles(ctx, level, 0, false)
+	if err != nil {
+		return nil, fmt.Errorf("fetch ltx files: %w", err)
+	}
+	defer itr.Close()
+
+	var errors []ValidationError
+	var prevInfo *ltx.FileInfo
+
+	for itr.Next() {
+		info := itr.Item()
+
+		// Skip first file - nothing to compare against
+		if prevInfo == nil {
+			prevInfo = info
+			continue
+		}
+
+		// Check for sort order: curr.MinTXID should be >= prev.MinTXID
+		if info.MinTXID < prevInfo.MinTXID {
+			errors = append(errors, ValidationError{
+				Level:    level,
+				Type:     "unsorted",
+				Message:  fmt.Sprintf("files out of order: curr.MinTXID=%s < prev.MinTXID=%s", info.MinTXID, prevInfo.MinTXID),
+				PrevFile: prevInfo,
+				CurrFile: info,
+			})
+			prevInfo = info
+			continue
+		}
+
+		// Check for TXID contiguity: prev.MaxTXID + 1 should equal curr.MinTXID
+		expectedMinTXID := prevInfo.MaxTXID + 1
+		if info.MinTXID != expectedMinTXID {
+			if info.MinTXID > expectedMinTXID {
+				errors = append(errors, ValidationError{
+					Level:    level,
+					Type:     "gap",
+					Message:  fmt.Sprintf("TXID gap: prev.MaxTXID=%s, curr.MinTXID=%s (expected %s)", prevInfo.MaxTXID, info.MinTXID, expectedMinTXID),
+					PrevFile: prevInfo,
+					CurrFile: info,
+				})
+			} else {
+				errors = append(errors, ValidationError{
+					Level:    level,
+					Type:     "overlap",
+					Message:  fmt.Sprintf("TXID overlap: prev.MaxTXID=%s, curr.MinTXID=%s", prevInfo.MaxTXID, info.MinTXID),
+					PrevFile: prevInfo,
+					CurrFile: info,
+				})
+			}
+		}
+
+		prevInfo = info
+	}
+
+	if err := itr.Close(); err != nil {
+		return nil, fmt.Errorf("close iterator: %w", err)
+	}
+
+	return errors, nil
+}

--- a/store.go
+++ b/store.go
@@ -571,7 +571,14 @@ func (s *Store) monitorCompactionLevel(ctx context.Context, lvl *CompactionLevel
 				db.Logger.Error("compaction failed", "level", lvl.Level, "error", err)
 			}
 
-			if lvl.Level == SnapshotLevel {
+			// Enforce retention unless the snapshot compaction actually failed.
+			// ErrNoCompaction and ErrCompactionTooEarly are not failures —
+			// retention should still run to prune expired snapshots.
+			compactionFailed := err != nil &&
+				!errors.Is(err, ErrNoCompaction) &&
+				!errors.Is(err, ErrCompactionTooEarly) &&
+				!errors.Is(err, ErrDBNotReady)
+			if lvl.Level == SnapshotLevel && !compactionFailed {
 				if err := s.EnforceSnapshotRetention(ctx, db); err != nil &&
 					!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					db.Logger.Error("retention enforcement failed", "error", err)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -60,6 +60,8 @@ Long-running soak tests live alongside the other integration tests and share the
 | Test | Tags | Defaults | Purpose | Extra Requirements |
 | --- | --- | --- | --- | --- |
 | `TestComprehensiveSoak` | `integration,soak` | 2h duration, 50 MB DB, 500 writes/s | File-backed end-to-end stress | Litestream binaries in `./bin` |
+| `TestRapidCheckpointSoak` | `integration,soak` | 30m duration, 20 MB DB, external `PASSIVE` checkpoints | Long-running checkpoint pressure with restore validation | Litestream binaries in `./bin` |
+| `TestRestartRecoverySoak` | `integration,soak` | 30m duration, 20 MB DB, periodic Litestream restarts | Restart recovery under active replication load | Litestream binaries in `./bin` |
 | `TestMinIOSoak` | `integration,soak,docker` | 2h duration, 5 MB DB (short=2 m), 100 writes/s | S3-compatible replication via MinIO | Docker daemon, `docker` CLI |
 | `TestSoakReplicateRestore` | `integration,soak,docker` | 5m duration (short=1 m), 100 writes/s, restore every 30s | Issue #1164 repro: stop→restore→integrity_check cycles against MinIO | Docker daemon, `docker` CLI |
 | `TestOvernightS3Soak` | `integration,soak,aws` | 8h duration, 50 MB DB | Real S3 replication & restore | AWS credentials, `aws` CLI |
@@ -89,6 +91,20 @@ File-based soak (short mode with preserved artifacts and debug logging):
 ```bash
 SOAK_KEEP_TEMP=1 SOAK_DEBUG=1 go test -v -tags="integration,soak" \
   -run=TestComprehensiveSoak -test.short -timeout=1h ./tests/integration
+```
+
+Targeted checkpoint soak:
+
+```bash
+go test -v -tags="integration,soak" \
+  -run=TestRapidCheckpointSoak -test.short -timeout=30m ./tests/integration
+```
+
+Targeted restart soak:
+
+```bash
+go test -v -tags="integration,soak" \
+  -run=TestRestartRecoverySoak -test.short -timeout=30m ./tests/integration
 ```
 
 MinIO soak (short mode, auto-purges bucket, preserves results):

--- a/tests/integration/comprehensive_soak_test.go
+++ b/tests/integration/comprehensive_soak_test.go
@@ -247,8 +247,7 @@ func TestComprehensiveSoak(t *testing.T) {
 		}
 		t.Log("")
 		t.Log("Review the logs for details:")
-		logPath, _ := db.GetLitestreamLog()
-		t.Logf("  %s", logPath)
+		t.Logf("  %s", db.LitestreamLogPath())
 		t.Fail()
 	}
 

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -79,6 +79,10 @@ func combinedOutput(stdoutBuf, stderrBuf *bytes.Buffer) string {
 	return strings.TrimSpace(sb.String())
 }
 
+func openLitestreamLogFile(tempDir string) (*os.File, error) {
+	return os.OpenFile(filepath.Join(tempDir, "litestream.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+}
+
 func SetupTestDB(t *testing.T, name string) *TestDB {
 	t.Helper()
 
@@ -231,8 +235,7 @@ func (db *TestDB) GenerateLoadWithOptions(ctx context.Context, writeRate int, du
 }
 
 func (db *TestDB) StartLitestream() error {
-	logPath := filepath.Join(db.TempDir, "litestream.log")
-	logFile, err := os.Create(logPath)
+	logFile, err := openLitestreamLogFile(db.TempDir)
 	if err != nil {
 		return fmt.Errorf("create log file: %w", err)
 	}
@@ -249,6 +252,9 @@ func (db *TestDB) StartLitestream() error {
 		logFile.Close()
 		return fmt.Errorf("start litestream: %w", err)
 	}
+	if err := logFile.Close(); err != nil {
+		return fmt.Errorf("close log file: %w", err)
+	}
 
 	db.LitestreamCmd = cmd
 	db.LitestreamPID = cmd.Process.Pid
@@ -264,8 +270,7 @@ func (db *TestDB) StartLitestream() error {
 }
 
 func (db *TestDB) StartLitestreamWithConfig(configPath string) error {
-	logPath := filepath.Join(db.TempDir, "litestream.log")
-	logFile, err := os.Create(logPath)
+	logFile, err := openLitestreamLogFile(db.TempDir)
 	if err != nil {
 		return fmt.Errorf("create log file: %w", err)
 	}
@@ -282,6 +287,9 @@ func (db *TestDB) StartLitestreamWithConfig(configPath string) error {
 		logFile.Close()
 		return fmt.Errorf("start litestream: %w", err)
 	}
+	if err := logFile.Close(); err != nil {
+		return fmt.Errorf("close log file: %w", err)
+	}
 
 	db.LitestreamCmd = cmd
 	db.LitestreamPID = cmd.Process.Pid
@@ -289,6 +297,13 @@ func (db *TestDB) StartLitestreamWithConfig(configPath string) error {
 	time.Sleep(2 * time.Second)
 
 	return nil
+}
+
+func (db *TestDB) RestartLitestreamWithConfig(configPath string) error {
+	if err := db.StopLitestream(); err != nil {
+		return err
+	}
+	return db.StartLitestreamWithConfig(configPath)
 }
 
 func (db *TestDB) StopLitestream() error {
@@ -408,6 +423,22 @@ func (db *TestDB) GetRowCount(table string) (int, error) {
 	return count, nil
 }
 
+func getRowCountFromPath(dbPath, table string) (int, error) {
+	sqlDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return 0, err
+	}
+	defer sqlDB.Close()
+
+	var count int
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
+	if err := sqlDB.QueryRow(query).Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func (db *TestDB) GetDatabaseSize() (int64, error) {
 	info, err := os.Stat(db.Path)
 	if err != nil {
@@ -450,12 +481,15 @@ func (db *TestDB) WaitForReplicaFiles(minFiles int, timeout time.Duration) (int,
 }
 
 func (db *TestDB) GetLitestreamLog() (string, error) {
-	logPath := filepath.Join(db.TempDir, "litestream.log")
-	content, err := os.ReadFile(logPath)
+	content, err := os.ReadFile(db.LitestreamLogPath())
 	if err != nil {
 		return "", err
 	}
 	return string(content), nil
+}
+
+func (db *TestDB) LitestreamLogPath() string {
+	return filepath.Join(db.TempDir, "litestream.log")
 }
 
 func (db *TestDB) CheckForErrors() ([]string, error) {

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -265,10 +265,12 @@ func AssertL0PageCount(t *testing.T, report *LTXBehaviorReport, pageSize int, ma
 		}
 	}
 
-	// Allow a percentage of oversized files. Occasional full-DB snapshots are
-	// expected from scheduled L9 snapshots that land in L0. The original bug
-	// showed >50% oversized, so 15% catches systematic issues.
-	maxOversizedPct := 0.15 // 15%
+	// Allow a percentage of oversized files. Post-checkpoint snapshots create
+	// full-DB L0 files (~1 per checkpoint), and scheduled L9 snapshots also
+	// land in L0. Under high write load with ~121 checkpoints and ~300 total
+	// L0 files, up to ~40% can be snapshot-sized. The original bug showed
+	// >50% oversized with no checkpoints, so 50% catches systematic issues.
+	maxOversizedPct := 0.50 // 50%
 	oversizedPct := float64(oversized) / float64(len(sizes))
 
 	source := "log"
@@ -421,7 +423,8 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 func isExpectedRecoverySnapshot(reason string) bool {
 	return strings.Contains(reason, "repair snapshot") ||
 		strings.Contains(reason, "compaction detected missing") ||
-		strings.Contains(reason, "wal header salt reset")
+		strings.Contains(reason, "wal header salt reset") ||
+		strings.Contains(reason, "post-checkpoint snapshot")
 }
 
 // PrintBehaviorReport prints a human-readable summary of the behavioral report.

--- a/tests/integration/minio_soak_test.go
+++ b/tests/integration/minio_soak_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -289,8 +288,7 @@ func TestMinIOSoak(t *testing.T) {
 		}
 		t.Log("")
 		t.Log("Review the logs for details:")
-		logPath, _ := db.GetLitestreamLog()
-		t.Logf("  %s", logPath)
+		t.Logf("  %s", db.LitestreamLogPath())
 		t.Fail()
 	}
 
@@ -342,21 +340,4 @@ func countMinIOLTXFiles(t *testing.T, containerID, bucket string) int {
 	}
 
 	return ltxCount
-}
-
-// getRowCountFromPath gets row count from a database file path
-func getRowCountFromPath(dbPath, table string) (int, error) {
-	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		return 0, err
-	}
-	defer db.Close()
-
-	var count int
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
-	if err := db.QueryRow(query).Scan(&count); err != nil {
-		return 0, err
-	}
-
-	return count, nil
 }

--- a/tests/integration/overnight_s3_soak_test.go
+++ b/tests/integration/overnight_s3_soak_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -298,8 +297,7 @@ func TestOvernightS3Soak(t *testing.T) {
 		}
 		t.Log("")
 		t.Log("Review the logs for details:")
-		logPath, _ := db.GetLitestreamLog()
-		t.Logf("  %s", logPath)
+		t.Logf("  %s", db.LitestreamLogPath())
 		t.Fail()
 	}
 
@@ -327,21 +325,4 @@ func logS3Metrics(t *testing.T, db *TestDB, s3URL string) {
 	if s3Size := GetS3StorageSize(t, s3URL); s3Size > 0 {
 		t.Logf("    Total storage: %.2f MB", float64(s3Size)/(1024*1024))
 	}
-}
-
-// getRowCountFromPath gets row count from a database file path
-func getRowCountFromPath(dbPath, table string) (int, error) {
-	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		return 0, err
-	}
-	defer db.Close()
-
-	var count int
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
-	if err := db.QueryRow(query).Scan(&count); err != nil {
-		return 0, err
-	}
-
-	return count, nil
 }

--- a/tests/integration/soak_helpers.go
+++ b/tests/integration/soak_helpers.go
@@ -586,8 +586,8 @@ func performGracefulShutdown(t *testing.T, testInfo *TestInfo) {
 	t.Log("Test artifacts preserved at:")
 	t.Logf("  %s", testInfo.DB.TempDir)
 
-	if logPath, err := testInfo.DB.GetLitestreamLog(); err == nil {
-		t.Logf("  Log: %s", logPath)
+	if testInfo.DB != nil {
+		t.Logf("  Log: %s", testInfo.DB.LitestreamLogPath())
 	}
 
 	t.Log("")
@@ -969,10 +969,7 @@ func AnalyzeSoakTest(t *testing.T, db *TestDB, duration time.Duration) *SoakTest
 	}
 
 	// Parse litestream log
-	logPath, _ := db.GetLitestreamLog()
-	if logPath != "" {
-		parseLog(logPath, analysis)
-	}
+	parseLog(db.LitestreamLogPath(), analysis)
 
 	return analysis
 }

--- a/tests/integration/targeted_soak_test.go
+++ b/tests/integration/targeted_soak_test.go
@@ -1,0 +1,297 @@
+//go:build integration && soak
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestRapidCheckpointSoak(t *testing.T) {
+	RequireBinaries(t)
+
+	shortMode := testing.Short()
+	duration := 30 * time.Minute
+	initialSize := "20MB"
+	writeRate := 150
+	workers := 4
+	checkpointInterval := 15 * time.Second
+	if shortMode {
+		duration = 2 * time.Minute
+		initialSize = "5MB"
+		writeRate = 75
+		workers = 2
+		checkpointInterval = 5 * time.Second
+	}
+
+	db, configPath := setupLocalSoakDB(t, "rapid-checkpoint-soak", initialSize, shortMode)
+
+	if err := db.StartLitestreamWithConfig(configPath); err != nil {
+		t.Fatalf("start litestream: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	testInfo := &TestInfo{
+		StartTime: time.Now(),
+		Duration:  duration,
+		DB:        db,
+		cancel:    cancel,
+	}
+	setupSignalHandler(t, cancel, testInfo)
+
+	loadDone := make(chan error, 1)
+	go func() {
+		loadDone <- db.GenerateLoadWithOptions(ctx, writeRate, duration, "wave", workers, 4096)
+	}()
+
+	var attemptedCheckpoints atomic.Int64
+	var progressedCheckpoints atomic.Int64
+	checkpointDone := make(chan error, 1)
+	go func() {
+		checkpointDone <- runCheckpointLoop(ctx, db.Path, checkpointInterval, &attemptedCheckpoints, &progressedCheckpoints)
+	}()
+
+	monitorFileSoak(t, db, ctx, testInfo, "rapid-checkpoint-soak", func() {
+		t.Logf("  External checkpoints: %d attempted, %d progressed", attemptedCheckpoints.Load(), progressedCheckpoints.Load())
+	})
+
+	if err := <-loadDone; err != nil && ctx.Err() == nil {
+		t.Fatalf("load generation failed: %v", err)
+	}
+	if err := <-checkpointDone; err != nil {
+		t.Fatalf("checkpoint loop failed: %v", err)
+	}
+
+	waitForFinalFlush(shortMode)
+
+	if err := db.StopLitestream(); err != nil {
+		t.Fatalf("stop litestream: %v", err)
+	}
+
+	if attemptedCheckpoints.Load() == 0 {
+		t.Fatal("no external checkpoints were attempted during soak")
+	}
+
+	errStats := getErrorStats(db)
+	if errStats.CriticalCount > 0 {
+		t.Fatalf("critical errors detected: %d", errStats.CriticalCount)
+	}
+
+	events, err := ParseLTXEvents(db.LitestreamLogPath())
+	if err != nil {
+		t.Fatalf("parse LTX events: %v", err)
+	}
+	report := BuildBehaviorReport(events, time.Since(testInfo.StartTime))
+	PrintBehaviorReport(t, report)
+
+	restoredPath := filepath.Join(db.TempDir, "rapid-checkpoint-restored.db")
+	verifyRestoredLoadTest(t, db, restoredPath)
+	PrintSoakTestAnalysis(t, AnalyzeSoakTest(t, db, duration))
+}
+
+func TestRestartRecoverySoak(t *testing.T) {
+	RequireBinaries(t)
+
+	shortMode := testing.Short()
+	duration := 30 * time.Minute
+	initialSize := "20MB"
+	writeRate := 200
+	workers := 4
+	restartInterval := 3 * time.Minute
+	if shortMode {
+		duration = 2 * time.Minute
+		initialSize = "5MB"
+		writeRate = 100
+		workers = 2
+		restartInterval = 20 * time.Second
+	}
+
+	db, configPath := setupLocalSoakDB(t, "restart-recovery-soak", initialSize, shortMode)
+
+	if err := db.StartLitestreamWithConfig(configPath); err != nil {
+		t.Fatalf("start litestream: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	testInfo := &TestInfo{
+		StartTime: time.Now(),
+		Duration:  duration,
+		DB:        db,
+		cancel:    cancel,
+	}
+	setupSignalHandler(t, cancel, testInfo)
+
+	loadDone := make(chan error, 1)
+	go func() {
+		loadDone <- db.GenerateLoadWithOptions(ctx, writeRate, duration, "wave", workers, 4096)
+	}()
+
+	var restartCount atomic.Int64
+	restartDone := make(chan error, 1)
+	go func() {
+		restartDone <- runRestartLoop(ctx, db, configPath, restartInterval, &restartCount)
+	}()
+
+	monitorFileSoak(t, db, ctx, testInfo, "restart-recovery-soak", func() {
+		t.Logf("  Litestream restarts: %d", restartCount.Load())
+	})
+
+	if err := <-loadDone; err != nil && ctx.Err() == nil {
+		t.Fatalf("load generation failed: %v", err)
+	}
+	if err := <-restartDone; err != nil {
+		t.Fatalf("restart loop failed: %v", err)
+	}
+
+	waitForFinalFlush(shortMode)
+
+	if err := db.StopLitestream(); err != nil {
+		t.Fatalf("stop litestream: %v", err)
+	}
+
+	if restartCount.Load() == 0 {
+		t.Fatal("no Litestream restarts completed during soak")
+	}
+
+	errStats := getErrorStats(db)
+	if errStats.CriticalCount > 0 {
+		t.Fatalf("critical errors detected: %d", errStats.CriticalCount)
+	}
+
+	restoredPath := filepath.Join(db.TempDir, "restart-recovery-restored.db")
+	verifyRestoredLoadTest(t, db, restoredPath)
+	PrintSoakTestAnalysis(t, AnalyzeSoakTest(t, db, duration))
+}
+
+func setupLocalSoakDB(t *testing.T, name, initialSize string, shortMode bool) (*TestDB, string) {
+	t.Helper()
+
+	db := SetupTestDB(t, name)
+	t.Cleanup(db.Cleanup)
+
+	if err := db.Create(); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	if err := db.Populate(initialSize); err != nil {
+		t.Fatalf("populate database: %v", err)
+	}
+
+	replicaURL := fmt.Sprintf("file://%s", filepath.ToSlash(db.ReplicaPath))
+	configPath := CreateSoakConfig(db.Path, replicaURL, nil, shortMode)
+	db.ConfigPath = configPath
+	return db, configPath
+}
+
+func monitorFileSoak(t *testing.T, db *TestDB, ctx context.Context, testInfo *TestInfo, testName string, extraLog func()) {
+	t.Helper()
+
+	refreshStats := func() {
+		testInfo.RowCount, _ = db.GetRowCount("load_test")
+		testInfo.FileCount, _ = db.GetReplicaFileCount()
+	}
+
+	logMetrics := func() {
+		LogSoakMetrics(t, db, testName)
+		if extraLog != nil {
+			extraLog()
+		}
+	}
+
+	MonitorSoakTest(t, db, ctx, testInfo, refreshStats, logMetrics)
+}
+
+func runCheckpointLoop(ctx context.Context, dbPath string, interval time.Duration, attempted, progressed *atomic.Int64) error {
+	sqlDB, err := sql.Open("sqlite3", dbPath+"?_busy_timeout=1000")
+	if err != nil {
+		return err
+	}
+	defer sqlDB.Close()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			attempted.Add(1)
+
+			var busy, logFrameN, checkpointedFrameN int
+			if err := sqlDB.QueryRowContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)").Scan(&busy, &logFrameN, &checkpointedFrameN); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return err
+			}
+			if busy == 0 && checkpointedFrameN > 0 {
+				progressed.Add(1)
+			}
+		}
+	}
+}
+
+func runRestartLoop(ctx context.Context, db *TestDB, configPath string, restartInterval time.Duration, restartCount *atomic.Int64) error {
+	ticker := time.NewTicker(restartInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := db.RestartLitestreamWithConfig(configPath); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return err
+			}
+			restartCount.Add(1)
+		}
+	}
+}
+
+func waitForFinalFlush(shortMode bool) {
+	if shortMode {
+		time.Sleep(20 * time.Second)
+		return
+	}
+	time.Sleep(45 * time.Second)
+}
+
+func verifyRestoredLoadTest(t *testing.T, db *TestDB, restoredPath string) {
+	t.Helper()
+
+	if err := db.Restore(restoredPath); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	sourceCount, err := db.GetRowCount("load_test")
+	if err != nil {
+		t.Fatalf("source row count: %v", err)
+	}
+	restoredCount, err := getRowCountFromPath(restoredPath, "load_test")
+	if err != nil {
+		t.Fatalf("restored row count: %v", err)
+	}
+
+	if sourceCount != restoredCount {
+		t.Fatalf("row count mismatch: source=%d restored=%d", sourceCount, restoredCount)
+	}
+
+	restoredDB := &TestDB{Path: restoredPath, t: t}
+	if err := restoredDB.IntegrityCheck(); err != nil {
+		t.Fatalf("integrity check failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Refactor the sync/checkpoint/monitoring subsystem per #1221, and fix a pre-existing page loss bug uncovered during soak testing.

### Refactoring (Phases 1, 3, 4, 6 of #1221)

**Phase 1 — SyncResult return type (`db.go`):** `verifyAndSync()` and `sync()` return a `syncResult` struct instead of mutating `db.lastSyncedWALOffset`, `db.syncedToWALEnd`, `db.pos`, and `db.maxLTXFileInfos` as side effects. New `applySyncResult()` centralizes all state application in one visible call site.

**Phase 3 — Checkpoint phase extraction (`db.go`):** Extract `checkpoint()` into named phase methods (`checkpointPreSync`, `checkpointExec`, `checkpointPostSync`), making the checkpoint protocol explicit.

**Phase 4 — ReplicaScheduler (`replica.go`):** Extract `syncScheduler` type from `Replica.monitor()`, separating scheduling/backoff from sync correctness and error recovery. Extract `handleSyncError()` for LTX error detection, auto-recovery, and rate-limited logging. `monitor()` shrinks from 114 lines to a 30-line coordination loop.

**Phase 6 — Restore separation (`replica.go` → `restore.go`):** Move ~1200 lines of restore-related code to its own file. `replica.go` shrinks from ~1775 to ~590 lines.

### Bug Fix: Page loss under sustained writes

Soak testing at 500 writes/sec revealed a pre-existing bug where pages existed in the database but were never captured in any L0 file, causing restore failures with "nonsequential page numbers" errors. The root cause:

During `execCheckpoint()`, litestream releases its read transaction (`db.rtx`) to allow the SQLite checkpoint to run. In this window, the **application's** SQLite auto-checkpoint (`wal_autocheckpoint`, default 1000 frames) can independently move WAL frames to the DB and trigger a WAL restart. Pages moved during this uncontrolled window were never captured in any L0 file because the post-checkpoint sync used flag-based heuristics (`syncedToWALEnd`) that had become stale.

**Fix:** The post-checkpoint sync now always creates a snapshot — reading ALL pages from the DB under the write lock. This is correct by construction: no flags, no detection heuristics, no edge cases. The snapshot captures every page regardless of what happened during the checkpoint window.

**Supporting fixes:**
- **TRUNCATE → PASSIVE downgrade:** When the pre-sync can't reach WAL end (sustained writes), downgrade TRUNCATE to PASSIVE. PASSIVE copies frames without truncating, so uncaptured frames remain in the WAL for the next sync.
- **Snapshot on PrevFrameMismatch:** When the WAL changes between `verify()` and `sync()`, force a snapshot to capture pages from old WAL frames.
- **Clear `syncedToWALEnd` before checkpoint:** Prevents the stale flag from suppressing necessary snapshots after the checkpoint window.
- **L0 retention TXID range coverage:** L0 retention now checks actual L1 TXID ranges instead of a single `maxL1TXID` threshold, preventing deletion of L0 files in gaps between L1 files.
- **Retention gating:** `EnforceSnapshotRetention` only skips on actual compaction failures, not on `ErrNoCompaction`/`ErrCompactionTooEarly`.
- **Snapshot page count validation:** `writeLTXFromDB()` verifies all pages 1..commit are written, catching page gaps at creation time.

### Phases deferred to follow-up PRs

- **Phase 2 (SyncState/executor split):** Lock scope narrowing needs careful concurrency analysis.
- **Phase 5 (VFSFile decomposition):** 40+ fields, 30+ methods crossing multiple field groups.

## Motivation and Context

Since January 2026, recurring bugs cluster around the same code paths in `db.go` and `replica.go`. The #1210 idle optimization required 7 follow-up commits because the coupling between change detection, notification, checkpoint, and verification was implicit. This refactor makes state transitions explicit and concerns separated. The page loss bug was pre-existing and reproduced 100% under sustained 500 writes/sec — it was uncovered by the soak testing done to validate the refactoring.

Fixes #1221

## How Has This Been Tested?

- `go test -race -count=1 ./...` — all packages pass
- Pre-commit hooks pass (go-imports, go-vet, go-staticcheck)
- Codex code review completed — 2 findings addressed (removed debug validation from restore hot path, fixed retention gating for quiet databases)
- Soak tests pass across all three load profiles (2 consecutive clean runs):
  - **low-volume** (10 writes/sec): restoration OK, integrity OK, 0 violations
  - **burst-volume** (500 writes/sec bursts): restoration OK, integrity OK, 0 violations
  - **high-volume** (500 writes/sec sustained): restoration OK, integrity OK, 0 missing pages, 0 violations

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)