### PR TITLE
refactor(db): return sync results explicitly

### DIFF
--- a/db.go
+++ b/db.go
@@ -1019,17 +1019,18 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	origWALSize, newWALSize, synced, err := db.verifyAndSync(ctx, false)
+	result, err := db.verifyAndSync(ctx, false)
 	if err != nil {
 		return err
 	}
+	db.applySyncResult(result)
 
 	// Track that data was synced for time-based checkpoint decisions.
-	if synced {
+	if result.synced {
 		db.syncedSinceCheckpoint = true
 	}
 
-	if err := db.checkpointIfNeeded(ctx, origWALSize, newWALSize); err != nil {
+	if err := db.checkpointIfNeeded(ctx, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
 
@@ -1044,7 +1045,7 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	if fi, err := os.Stat(db.path); err == nil {
 		db.dbSizeGauge.Set(float64(fi.Size()))
 	}
-	db.walSizeGauge.Set(float64(newWALSize))
+	db.walSizeGauge.Set(float64(result.newWALSize))
 
 	// Notify replicas of WAL changes.
 	// if changed {
@@ -1055,16 +1056,17 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	return nil
 }
 
-func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (origWALSize, newWALSize int64, synced bool, err error) {
+func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult, error) {
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
 	// This avoids using file size which may include stale frames with old salt
 	// values after a checkpoint. See issue #997.
-	origWALSize = db.lastSyncedWALOffset
+	origWALSize := db.lastSyncedWALOffset
 	if origWALSize == 0 {
 		// First sync - use file size as fallback
+		var err error
 		origWALSize, err = db.walFileSize()
 		if err != nil {
-			return 0, 0, false, fmt.Errorf("stat wal before sync: %w", err)
+			return syncResult{}, fmt.Errorf("stat wal before sync: %w", err)
 		}
 	}
 
@@ -1073,20 +1075,16 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (origWALSiz
 	// been overwritten by another process.
 	info, err := db.verify(ctx)
 	if err != nil {
-		return 0, 0, false, fmt.Errorf("cannot verify wal state: %w", err)
+		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
-	synced, err = db.sync(ctx, checkpointing, info)
+	result, err := db.sync(ctx, checkpointing, info)
 	if err != nil {
-		return 0, 0, false, fmt.Errorf("sync: %w", err)
+		return syncResult{}, fmt.Errorf("sync: %w", err)
 	}
 
-	// Use the logical WAL offset (from LTX) for checkpoint decisions.
-	// After sync, db.lastSyncedWALOffset is updated to reflect the actual
-	// content position, not the file size.
-	newWALSize = db.lastSyncedWALOffset
-
-	return origWALSize, newWALSize, synced, nil
+	result.origWALSize = origWALSize
+	return result, nil
 }
 
 // checkpointIfNeeded performs a checkpoint based on configured thresholds.
@@ -1514,13 +1512,40 @@ type syncInfo struct {
 	reason       string // reason for snapshot
 }
 
+type syncResult struct {
+	origWALSize    int64
+	newWALSize     int64
+	synced         bool
+	syncedToWALEnd bool
+	pos            *ltx.Pos
+	l0FileInfo     *ltx.FileInfo
+}
+
+func (db *DB) applySyncResult(result syncResult) {
+	db.lastSyncedWALOffset = result.newWALSize
+	db.syncedToWALEnd = result.syncedToWALEnd
+	if result.pos != nil {
+		db.pos.Lock()
+		db.pos.value = result.pos
+		db.pos.Unlock()
+	}
+	if result.l0FileInfo != nil {
+		db.maxLTXFileInfos.Lock()
+		db.maxLTXFileInfos.m[0] = result.l0FileInfo
+		db.maxLTXFileInfos.Unlock()
+	}
+}
+
 // sync copies pending bytes from the real WAL to LTX.
 // Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
-func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (synced bool, err error) {
+func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (result syncResult, err error) {
+	result.newWALSize = db.lastSyncedWALOffset
+	result.syncedToWALEnd = db.syncedToWALEnd
+
 	// Determine the next sequential transaction ID.
 	pos, err := db.Pos()
 	if err != nil {
-		return false, fmt.Errorf("pos: %w", err)
+		return result, fmt.Errorf("pos: %w", err)
 	}
 	txID := pos.TXID + 1
 
@@ -1549,14 +1574,14 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 
 	fi, err := db.f.Stat()
 	if err != nil {
-		return false, err
+		return result, err
 	}
 	mode := fi.Mode()
 	commit := uint32(fi.Size() / int64(db.pageSize))
 
 	walFile, err := os.Open(db.WALPath())
 	if err != nil {
-		return false, err
+		return result, err
 	}
 	defer walFile.Close()
 
@@ -1564,7 +1589,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 	var rd *WALReader
 	if info.offset == WALHeaderSize {
 		if rd, err = NewWALReader(walFile, walReaderLogger); err != nil {
-			return false, fmt.Errorf("new wal reader: %w", err)
+			return result, fmt.Errorf("new wal reader: %w", err)
 		}
 	} else {
 		// If we cannot verify the previous frame
@@ -1573,17 +1598,17 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 			db.Logger.Log(ctx, internal.LevelTrace, "prev frame mismatch, snapshotting", "err", pfmError.Err)
 			info.offset = WALHeaderSize
 			if rd, err = NewWALReader(walFile, walReaderLogger); err != nil {
-				return false, fmt.Errorf("new wal reader, after reset")
+				return result, fmt.Errorf("new wal reader, after reset")
 			}
 		} else if err != nil {
-			return false, fmt.Errorf("new wal reader with offset: %w", err)
+			return result, fmt.Errorf("new wal reader with offset: %w", err)
 		}
 	}
 
 	// Build a mapping of changed page numbers and their latest content.
 	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
 	if err != nil {
-		return false, fmt.Errorf("page map: %w", err)
+		return result, fmt.Errorf("page map: %w", err)
 	}
 	if walCommit > 0 {
 		commit = walCommit
@@ -1603,17 +1628,17 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 	// Exit if we have no new WAL pages and we aren't snapshotting.
 	if !info.snapshotting && sz == 0 {
 		db.Logger.Log(ctx, internal.LevelTrace, "sync: skip", "reason", "no new wal pages")
-		return false, nil
+		return result, nil
 	}
 
 	tmpFilename := filename + ".tmp"
 	if err := internal.MkdirAll(filepath.Dir(tmpFilename), db.dirInfo); err != nil {
-		return false, err
+		return result, err
 	}
 
 	ltxFile, err := os.OpenFile(tmpFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
-		return false, fmt.Errorf("open temp ltx file: %w", err)
+		return result, fmt.Errorf("open temp ltx file: %w", err)
 	}
 	defer func() { _ = os.Remove(tmpFilename) }()
 	defer func() { _ = ltxFile.Close() }()
@@ -1632,7 +1657,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 	timestamp := time.Now()
 	enc, err := ltx.NewEncoder(ltxFile)
 	if err != nil {
-		return false, fmt.Errorf("new ltx encoder: %w", err)
+		return result, fmt.Errorf("new ltx encoder: %w", err)
 	}
 	if err := enc.EncodeHeader(ltx.Header{
 		Version:   ltx.Version,
@@ -1647,32 +1672,32 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 		WALSalt1:  rd.salt1,
 		WALSalt2:  rd.salt2,
 	}); err != nil {
-		return false, fmt.Errorf("encode ltx header: %w", err)
+		return result, fmt.Errorf("encode ltx header: %w", err)
 	}
 
 	// If we need a full snapshot, then copy from the database & WAL.
 	// Otherwise, just copy incrementally from the WAL.
 	if info.snapshotting {
 		if err := db.writeLTXFromDB(ctx, enc, walFile, commit, pageMap); err != nil {
-			return false, fmt.Errorf("write ltx from db: %w", err)
+			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
 		if err := db.writeLTXFromWAL(ctx, enc, walFile, pageMap); err != nil {
-			return false, fmt.Errorf("write ltx from wal: %w", err)
+			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
 
 	// Encode final trailer to the end of the LTX file.
 	if err := enc.Close(); err != nil {
-		return false, fmt.Errorf("close ltx encoder: %w", err)
+		return result, fmt.Errorf("close ltx encoder: %w", err)
 	}
 
 	// Sync & close LTX file.
 	if err := ltxFile.Sync(); err != nil {
-		return false, fmt.Errorf("sync ltx file: %w", err)
+		return result, fmt.Errorf("sync ltx file: %w", err)
 	}
 	if err := ltxFile.Close(); err != nil {
-		return false, fmt.Errorf("close ltx file: %w", err)
+		return result, fmt.Errorf("close ltx file: %w", err)
 	}
 
 	// Atomically rename file to final path.
@@ -1681,45 +1706,40 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (sync
 		delete(db.maxLTXFileInfos.m, 0) // clear cache if in unknown state
 		db.maxLTXFileInfos.Unlock()
 		db.invalidatePosCache()
-		return false, fmt.Errorf("rename ltx file: %w", err)
+		return result, fmt.Errorf("rename ltx file: %w", err)
 	}
 
-	// Update file info cache for L0.
-	db.maxLTXFileInfos.Lock()
-	db.maxLTXFileInfos.m[0] = &ltx.FileInfo{
+	result.synced = true
+	result.l0FileInfo = &ltx.FileInfo{
 		Level:     0,
 		MinTXID:   txID,
 		MaxTXID:   txID,
 		CreatedAt: time.Now(),
 		Size:      enc.N(),
 	}
-	db.maxLTXFileInfos.Unlock()
 
-	// Update cached position from the encoder.
 	encPos := enc.PostApplyPos()
-	db.pos.Lock()
-	db.pos.value = &encPos
-	db.pos.Unlock()
+	result.pos = &encPos
 
 	// Track the logical end of WAL content for checkpoint decisions.
 	// This is the WALOffset + WALSize from the LTX we just created.
 	// Using this instead of file size prevents issue #997 where stale
 	// frames with old salt values cause perpetual checkpoint triggering.
 	finalOffset := info.offset + sz
-	db.lastSyncedWALOffset = finalOffset
+	result.newWALSize = finalOffset
 
 	// Track if we synced to the exact end of the WAL file.
 	// This is used by verify() to distinguish expected checkpoint truncation
 	// from unexpected external WAL modifications. See issue #927.
 	if walSize, err := db.walFileSize(); err == nil {
-		db.syncedToWALEnd = finalOffset == walSize
+		result.syncedToWALEnd = finalOffset == walSize
 	} else {
-		db.syncedToWALEnd = false
+		result.syncedToWALEnd = false
 	}
 
 	db.Logger.Debug("db sync", "status", "ok")
 
-	return true, nil
+	return result, nil
 }
 
 func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.File, commit uint32, pageMap map[uint32]int64) error {
@@ -1821,9 +1841,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
-	if _, _, _, err := db.verifyAndSync(ctx, true); err != nil {
+	result, err := db.verifyAndSync(ctx, true)
+	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
+	db.applySyncResult(result)
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
@@ -1857,9 +1879,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
-	if _, _, _, err := db.verifyAndSync(ctx, true); err != nil {
+	result, err = db.verifyAndSync(ctx, true)
+	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 	}
+	db.applySyncResult(result)
 
 	// Release write lock before exiting.
 	// Use rollback() helper for consistency with releaseReadLock() and the

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2125,3 +2125,69 @@ func TestDB_Pos_VerifyErrorReturnsLTXError(t *testing.T) {
 		t.Fatal("corruption error should be auto-recoverable")
 	}
 }
+
+func TestApplySyncResult(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "test.db"))
+
+	t.Run("WALState", func(t *testing.T) {
+		db.mu.Lock()
+		defer db.mu.Unlock()
+
+		db.applySyncResult(syncResult{newWALSize: 12345, syncedToWALEnd: true})
+		if got := db.lastSyncedWALOffset; got != 12345 {
+			t.Fatalf("lastSyncedWALOffset=%d, want 12345", got)
+		}
+		if !db.syncedToWALEnd {
+			t.Fatal("syncedToWALEnd=false, want true")
+		}
+	})
+
+	t.Run("Pos", func(t *testing.T) {
+		db.mu.Lock()
+		defer db.mu.Unlock()
+
+		pos := ltx.Pos{TXID: 42}
+		db.applySyncResult(syncResult{pos: &pos})
+
+		db.pos.Lock()
+		got := db.pos.value
+		db.pos.Unlock()
+		if got == nil || got.TXID != 42 {
+			t.Fatalf("pos=%v, want TXID=42", got)
+		}
+	})
+
+	t.Run("NilPosPreservesExisting", func(t *testing.T) {
+		db.mu.Lock()
+		defer db.mu.Unlock()
+
+		existing := ltx.Pos{TXID: 99}
+		db.pos.Lock()
+		db.pos.value = &existing
+		db.pos.Unlock()
+
+		db.applySyncResult(syncResult{})
+
+		db.pos.Lock()
+		got := db.pos.value
+		db.pos.Unlock()
+		if got == nil || got.TXID != 99 {
+			t.Fatalf("pos=%v, want TXID=99", got)
+		}
+	})
+
+	t.Run("L0FileInfo", func(t *testing.T) {
+		db.mu.Lock()
+		defer db.mu.Unlock()
+
+		info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
+		db.applySyncResult(syncResult{l0FileInfo: info})
+
+		db.maxLTXFileInfos.Lock()
+		got := db.maxLTXFileInfos.m[0]
+		db.maxLTXFileInfos.Unlock()
+		if got != info {
+			t.Fatalf("l0FileInfo=%v, want %v", got, info)
+		}
+	})
+}

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2191,3 +2191,129 @@ func TestApplySyncResult(t *testing.T) {
 		}
 	})
 }
+
+func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = db.Close(context.Background())
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO t VALUES (1, 'before')`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.Exec(`INSERT INTO t VALUES (2, 'after')`); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	oldWALOffset := db.lastSyncedWALOffset
+	oldSyncedToWALEnd := db.syncedToWALEnd
+
+	db.pos.Lock()
+	if db.pos.value == nil {
+		db.pos.Unlock()
+		t.Fatal("cached pos is nil after initial sync")
+	}
+	oldPos := *db.pos.value
+	db.pos.Unlock()
+
+	db.maxLTXFileInfos.Lock()
+	oldL0 := db.maxLTXFileInfos.m[0]
+	db.maxLTXFileInfos.Unlock()
+	if oldL0 == nil {
+		t.Fatal("cached l0 file info is nil after initial sync")
+	}
+
+	result, err := db.verifyAndSync(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("verifyAndSync did not report a sync after new writes")
+	}
+	if result.newWALSize == oldWALOffset {
+		t.Fatalf("newWALSize=%d, want change from %d", result.newWALSize, oldWALOffset)
+	}
+	if result.pos == nil || result.pos.TXID <= oldPos.TXID {
+		t.Fatalf("result.pos=%v, want TXID > %d", result.pos, oldPos.TXID)
+	}
+	if result.l0FileInfo == nil || result.l0FileInfo.MaxTXID <= oldL0.MaxTXID {
+		t.Fatalf("result.l0FileInfo=%v, want MaxTXID > %d", result.l0FileInfo, oldL0.MaxTXID)
+	}
+
+	if db.lastSyncedWALOffset != oldWALOffset {
+		t.Fatalf("lastSyncedWALOffset mutated early: got %d, want %d", db.lastSyncedWALOffset, oldWALOffset)
+	}
+	if db.syncedToWALEnd != oldSyncedToWALEnd {
+		t.Fatalf("syncedToWALEnd mutated early: got %t, want %t", db.syncedToWALEnd, oldSyncedToWALEnd)
+	}
+
+	db.pos.Lock()
+	gotPosBeforeApply := db.pos.value
+	db.pos.Unlock()
+	if gotPosBeforeApply == nil || gotPosBeforeApply.TXID != oldPos.TXID {
+		t.Fatalf("cached pos mutated early: got %v, want TXID=%d", gotPosBeforeApply, oldPos.TXID)
+	}
+
+	db.maxLTXFileInfos.Lock()
+	gotL0BeforeApply := db.maxLTXFileInfos.m[0]
+	db.maxLTXFileInfos.Unlock()
+	if gotL0BeforeApply == nil || gotL0BeforeApply.MaxTXID != oldL0.MaxTXID {
+		t.Fatalf("cached l0 file info mutated early: got %v, want MaxTXID=%d", gotL0BeforeApply, oldL0.MaxTXID)
+	}
+
+	db.applySyncResult(result)
+
+	if db.lastSyncedWALOffset != result.newWALSize {
+		t.Fatalf("lastSyncedWALOffset=%d, want %d", db.lastSyncedWALOffset, result.newWALSize)
+	}
+	if db.syncedToWALEnd != result.syncedToWALEnd {
+		t.Fatalf("syncedToWALEnd=%t, want %t", db.syncedToWALEnd, result.syncedToWALEnd)
+	}
+
+	db.pos.Lock()
+	gotPosAfterApply := db.pos.value
+	db.pos.Unlock()
+	if gotPosAfterApply == nil || gotPosAfterApply.TXID != result.pos.TXID {
+		t.Fatalf("cached pos=%v, want TXID=%d", gotPosAfterApply, result.pos.TXID)
+	}
+
+	db.maxLTXFileInfos.Lock()
+	gotL0AfterApply := db.maxLTXFileInfos.m[0]
+	db.maxLTXFileInfos.Unlock()
+	if gotL0AfterApply == nil || gotL0AfterApply.MaxTXID != result.l0FileInfo.MaxTXID {
+		t.Fatalf("cached l0 file info=%v, want MaxTXID=%d", gotL0AfterApply, result.l0FileInfo.MaxTXID)
+	}
+}


### PR DESCRIPTION
## Summary
- change `verifyAndSync()` to return a `syncResult` instead of relying on `sync()` to apply sync state as a side effect
- apply sync results explicitly in `Sync()` and `checkpoint()`
- add focused unit coverage for `applySyncResult()`

## Why
This is the first increment from #1221, following Ben's comment to start with `SyncResult` and keep the refactor very small.

The existing proof-of-concept work in #1222 and branch `issue-1221-proposal-incremental-extraction-of-sync-checkpoint-monitorin` was useful to validate the overall direction, but it is too broad to merge safely or review comfortably in one pass. The plan here is to keep that branch as reference material only, and land the extraction as small, reviewable steps instead.

## Scope
This PR intentionally stops at the `SyncResult` extraction. It does not include the wider checkpoint restructuring, sync-state split, restore extraction, or soak-test expansion from the proof-of-concept branch.

## Testing
- `pre-commit run --all-files`
- `go test ./...`
- `go test -race ./...`
- `go test . -run '^(TestApplySyncResult|TestDB_Sync_UpdatesMetrics|TestDB_Sync_InitErrorMetrics)$' -count=1`
- `go test . -run '^(TestDB_CheckpointDoesNotTriggerSnapshot|TestDB_CheckpointPageGapWithConcurrentWrites|TestDB_Sync_CompactionValidAfterGrowthAndCheckpoint)$' -count=1`
- `go test -count=1 -v -tags='integration,soak' -run '^(TestLTXBehavior|TestLTXBehavior_NoExcessiveSnapshots)$' -test.short -timeout=30m ./tests/integration`
