### PR TITLE
fix(restore): fix v3 restore

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -1177,7 +1177,7 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 		}
 	}()
 
-	applyLastWalSegment := func() error {
+	applyLastWalFile := func() error {
 		if f == nil {
 			return nil
 		} else if err = f.Close(); err != nil {
@@ -1191,11 +1191,11 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 	// to the db.
 	for _, seg := range segments {
 		if seg.Offset == 0 {
-			// Apply the last WAL segment, if any
-			if err = applyLastWalSegment(); err != nil {
+			// Apply the last WAL file, if any
+			if err = applyLastWalFile(); err != nil {
 				return err
 			}
-			// Open a new WAL segment
+			// Open a new WAL file
 			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY, 0644); err != nil {
 				return err
 			}
@@ -1206,7 +1206,7 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 		r.Logger().Debug("wrote WAL segment", "index", seg.Index, "offset", seg.Offset)
 	}
 
-	return applyLastWalSegment()
+	return applyLastWalFile()
 }
 
 // writeWALSegmentV3 writes a single WAL segment to the WAL file.

--- a/replica.go
+++ b/replica.go
@@ -1168,18 +1168,49 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 
 	// Write all WAL segments to the WAL file.
 	walPath := dbPath + "-wal"
-	for _, seg := range segments {
-		if err := r.writeWALSegmentV3(ctx, client, generation, seg, walPath); err != nil {
-			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)
+	var f *os.File
+	var err error
+
+	defer func() {
+		if f != nil {
+			_ = f.Close()
 		}
+	}()
+
+	applyLastWalSegment := func() error {
+		if f == nil {
+			return nil
+		} else if err = f.Close(); err != nil {
+			return err
+		}
+		f = nil
+		return checkpointV3(dbPath)
 	}
 
-	// Checkpoint to apply WAL to database.
-	return checkpointV3(dbPath)
+	// Reconstruct each wal file, appending non-zero offsets, and apply them
+	// to the db.
+	for _, seg := range segments {
+		if seg.Offset == 0 {
+			// Apply the last WAL segment, if any
+			if err = applyLastWalSegment(); err != nil {
+				return err
+			}
+			// Open a new WAL segment
+			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+				return err
+			}
+		}
+		if err := r.writeWALSegmentV3(ctx, client, generation, seg, f); err != nil {
+			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)
+		}
+		r.Logger().Debug("wrote WAL segment", "index", seg.Index, "offset", seg.Offset)
+	}
+
+	return applyLastWalSegment()
 }
 
 // writeWALSegmentV3 writes a single WAL segment to the WAL file.
-func (r *Replica) writeWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, walPath string) error {
+func (r *Replica) writeWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) error {
 	// Download WAL segment.
 	rc, err := client.OpenWALSegmentV3(ctx, generation, seg.Index, seg.Offset)
 	if err != nil {
@@ -1187,21 +1218,8 @@ func (r *Replica) writeWALSegmentV3(ctx context.Context, client ReplicaClientV3,
 	}
 	defer func() { _ = rc.Close() }()
 
-	// Open WAL file for writing.
-	f, err := os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-
-	// Seek to offset and write.
-	if _, err := f.Seek(seg.Offset, io.SeekStart); err != nil {
-		return err
-	}
-	if _, err := io.Copy(f, rc); err != nil {
-		return err
-	}
-	return f.Sync()
+	_, err = io.Copy(f, rc)
+	return err
 }
 
 // checkpointV3 checkpoints the WAL file into the database.

--- a/replica.go
+++ b/replica.go
@@ -1200,17 +1200,17 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 				return err
 			}
 		}
-		if err := r.writeWALSegmentV3(ctx, client, generation, seg, f); err != nil {
+		if err := r.appendWALSegmentV3(ctx, client, generation, seg, f); err != nil {
 			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)
 		}
-		r.Logger().Debug("wrote WAL segment", "index", seg.Index, "offset", seg.Offset)
+		r.Logger().Debug("wrote WAL segment", "generation", generation, "index", seg.Index, "offset", seg.Offset)
 	}
 
 	return applyLastWalFile()
 }
 
-// writeWALSegmentV3 writes a single WAL segment to the WAL file.
-func (r *Replica) writeWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) error {
+// appendWALSegmentV3 appends the specified segment to an open WAL file f.
+func (r *Replica) appendWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) error {
 	// Download WAL segment.
 	rc, err := client.OpenWALSegmentV3(ctx, generation, seg.Index, seg.Offset)
 	if err != nil {


### PR DESCRIPTION
## Description

Fix logic that restores from wal segments to follow the logic in litestream v0.3.x restores:
* append all segments for a given index into a single file
* apply each index to the db in order ([ref](https://github.com/benbjohnson/litestream/blob/ad0a123938631cb081e090f15d01f10af72884e8/replica.go#L1203))

The previous restore-from-v3 logic was using a single tmp wal file, overwriting the previous one with each segment, and only applying the last one.

## Motivation and Context

Fixes v3 restore from wal files

## How Has This Been Tested?

Tested on multiple previously failing generations.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
