### PR TITLE
fix(restore): check for wal segment gaps in v3 restore

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -1170,6 +1170,8 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 	walPath := dbPath + "-wal"
 	var f *os.File
 	var err error
+	index := 0
+	offset := int64(0)
 
 	defer func() {
 		if f != nil {
@@ -1184,7 +1186,11 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 			return err
 		}
 		f = nil
-		return checkpointV3(dbPath)
+		if err = checkpointV3(dbPath); err != nil {
+			return err
+		}
+		r.Logger().Info(fmt.Sprintf("applied WAL index %d (%d bytes)", index, offset))
+		return nil
 	}
 
 	// Reconstruct each wal file, appending non-zero offsets, and apply them
@@ -1195,31 +1201,39 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 			if err = applyLastWalFile(); err != nil {
 				return err
 			}
+			if seg.Index != index+1 {
+				return fmt.Errorf("missing WAL index %d (got %d/%d)", index+1, seg.Index, seg.Offset)
+			}
+			index = seg.Index
+			offset = 0
 			// Open a new WAL file
-			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644); err != nil {
 				return err
 			}
+		} else if seg.Offset != offset {
+			return fmt.Errorf("missing WAL segment for index %d. Expected offset %d, got %d", seg.Index, offset, seg.Offset)
 		}
-		if err := r.appendWALSegmentV3(ctx, client, generation, seg, f); err != nil {
+		if n, err := r.appendWALSegmentV3(ctx, client, generation, seg, f); err != nil {
 			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)
+		} else {
+			offset += n
+			r.Logger().Debug("wrote WAL segment", "generation", generation, "index", seg.Index, "offset", seg.Offset, "bytes", n)
 		}
-		r.Logger().Debug("wrote WAL segment", "generation", generation, "index", seg.Index, "offset", seg.Offset)
 	}
 
 	return applyLastWalFile()
 }
 
 // appendWALSegmentV3 appends the specified segment to an open WAL file f.
-func (r *Replica) appendWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) error {
+func (r *Replica) appendWALSegmentV3(ctx context.Context, client ReplicaClientV3, generation string, seg WALSegmentInfoV3, f *os.File) (int64, error) {
 	// Download WAL segment.
 	rc, err := client.OpenWALSegmentV3(ctx, generation, seg.Index, seg.Offset)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { _ = rc.Close() }()
 
-	_, err = io.Copy(f, rc)
-	return err
+	return io.Copy(f, rc)
 }
 
 // checkpointV3 checkpoints the WAL file into the database.

--- a/replica.go
+++ b/replica.go
@@ -1071,7 +1071,7 @@ func (r *Replica) RestoreV3(ctx context.Context, opt RestoreOptions) error {
 	}
 
 	// Apply WAL segments.
-	if err := r.applyWALSegmentsV3(ctx, client, snapshot.Generation, segments, tmpPath); err != nil {
+	if err := r.applyWALSegmentsV3(ctx, client, snapshot.Generation, snapshot.Index, segments, tmpPath); err != nil {
 		return fmt.Errorf("apply WAL segments: %w", err)
 	}
 
@@ -1161,7 +1161,7 @@ func (r *Replica) downloadSnapshotV3(ctx context.Context, client ReplicaClientV3
 }
 
 // applyWALSegmentsV3 applies WAL segments to the database file.
-func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3, generation string, segments []WALSegmentInfoV3, dbPath string) error {
+func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3, generation string, snapshotIndex int, segments []WALSegmentInfoV3, dbPath string) error {
 	if len(segments) == 0 {
 		return nil
 	}
@@ -1170,7 +1170,7 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 	walPath := dbPath + "-wal"
 	var f *os.File
 	var err error
-	index := 0
+	expectedIndex := snapshotIndex
 	offset := int64(0)
 
 	defer func() {
@@ -1189,7 +1189,7 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 		if err = checkpointV3(dbPath); err != nil {
 			return err
 		}
-		r.Logger().Info(fmt.Sprintf("applied WAL index %d (%d bytes)", index, offset))
+		r.Logger().Debug("applied WAL index", "generation", generation, "index", expectedIndex-1, "bytes", offset)
 		return nil
 	}
 
@@ -1201,17 +1201,17 @@ func (r *Replica) applyWALSegmentsV3(ctx context.Context, client ReplicaClientV3
 			if err = applyLastWalFile(); err != nil {
 				return err
 			}
-			if seg.Index != index+1 {
-				return fmt.Errorf("missing WAL index %d (got %d/%d)", index+1, seg.Index, seg.Offset)
+			if seg.Index != expectedIndex {
+				return fmt.Errorf("missing WAL index: expected %d/0, got %d/%d", expectedIndex, seg.Index, seg.Offset)
 			}
-			index = seg.Index
 			offset = 0
 			// Open a new WAL file
 			if f, err = os.OpenFile(walPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644); err != nil {
 				return err
 			}
+			expectedIndex++
 		} else if seg.Offset != offset {
-			return fmt.Errorf("missing WAL segment for index %d. Expected offset %d, got %d", seg.Index, offset, seg.Offset)
+			return fmt.Errorf("missing WAL segment: expected %d/%d, got %d/%d", seg.Index, offset, seg.Index, seg.Offset)
 		}
 		if n, err := r.appendWALSegmentV3(ctx, client, generation, seg, f); err != nil {
 			return fmt.Errorf("write WAL segment %d/%d: %w", seg.Index, seg.Offset, err)

--- a/replica_test.go
+++ b/replica_test.go
@@ -1115,6 +1115,155 @@ func TestReplica_RestoreV3(t *testing.T) {
 		verifyRestoredDB(t, outputPath)
 	})
 
+	t.Run("MultipleWALIndices", func(t *testing.T) {
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		replicaDir := t.TempDir()
+
+		gen := "0123456789abcdef"
+		dbData := createTestSQLiteDB(t)
+		walData := createTestWALSequence(t, dbData, []string{"wal0"}, []string{"wal1"})
+
+		createV3Backup(t, replicaDir, gen, []v3SnapshotData{
+			{index: 0, data: dbData},
+		}, []v3WALSegmentData{
+			{index: 0, offset: 0, data: walData[0]},
+			{index: 1, offset: 0, data: walData[1]},
+		})
+
+		c := file.NewReplicaClient(replicaDir)
+		r := litestream.NewReplicaWithClient(nil, c)
+
+		outputPath := tmpDir + "/restored.db"
+		err := r.RestoreV3(ctx, litestream.RestoreOptions{
+			OutputPath: outputPath,
+		})
+		if err != nil {
+			t.Fatalf("RestoreV3 failed: %v", err)
+		}
+
+		verifyRestoredDB(t, outputPath)
+	})
+
+	t.Run("MissingWALIndex", func(t *testing.T) {
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		replicaDir := t.TempDir()
+
+		gen := "0123456789abcdef"
+		dbData := createTestSQLiteDB(t)
+		walData := createTestWALSequence(t, dbData, []string{"wal0"}, []string{"wal2"})
+
+		createV3Backup(t, replicaDir, gen, []v3SnapshotData{
+			{index: 0, data: dbData},
+		}, []v3WALSegmentData{
+			{index: 0, offset: 0, data: walData[0]},
+			{index: 2, offset: 0, data: walData[1]},
+		})
+
+		c := file.NewReplicaClient(replicaDir)
+		r := litestream.NewReplicaWithClient(nil, c)
+
+		outputPath := tmpDir + "/restored.db"
+		err := r.RestoreV3(ctx, litestream.RestoreOptions{
+			OutputPath: outputPath,
+		})
+		if err == nil || !strings.Contains(err.Error(), "missing WAL index") {
+			t.Fatalf("expected missing WAL index error, got %v", err)
+		}
+	})
+
+	t.Run("MissingWALOffset", func(t *testing.T) {
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		replicaDir := t.TempDir()
+
+		gen := "0123456789abcdef"
+		dbData := createTestSQLiteDB(t)
+		walData := createTestWALData(t, dbData)
+
+		createV3Backup(t, replicaDir, gen, []v3SnapshotData{
+			{index: 0, data: dbData},
+		}, []v3WALSegmentData{
+			{index: 0, offset: 0, data: walData},
+			{index: 0, offset: 999999, data: []byte("wal gap")},
+		})
+
+		c := file.NewReplicaClient(replicaDir)
+		r := litestream.NewReplicaWithClient(nil, c)
+
+		outputPath := tmpDir + "/restored.db"
+		err := r.RestoreV3(ctx, litestream.RestoreOptions{
+			OutputPath: outputPath,
+		})
+		if err == nil || !strings.Contains(err.Error(), "missing WAL segment") {
+			t.Fatalf("expected missing WAL segment error, got %v", err)
+		}
+	})
+
+	t.Run("SnapshotIndexNonZero", func(t *testing.T) {
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		replicaDir := t.TempDir()
+
+		gen := "0123456789abcdef"
+		dbData := createTestSQLiteDB(t)
+		walData := createTestWALSequence(t, dbData, []string{"wal5"}, []string{"wal6"})
+
+		createV3Backup(t, replicaDir, gen, []v3SnapshotData{
+			{index: 5, data: dbData},
+		}, []v3WALSegmentData{
+			{index: 5, offset: 0, data: walData[0]},
+			{index: 6, offset: 0, data: walData[1]},
+		})
+
+		c := file.NewReplicaClient(replicaDir)
+		r := litestream.NewReplicaWithClient(nil, c)
+
+		outputPath := tmpDir + "/restored.db"
+		err := r.RestoreV3(ctx, litestream.RestoreOptions{
+			OutputPath: outputPath,
+		})
+		if err != nil {
+			t.Fatalf("RestoreV3 failed: %v", err)
+		}
+
+		verifyRestoredDB(t, outputPath)
+	})
+
+	t.Run("WALTruncationBetweenIndices", func(t *testing.T) {
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+		replicaDir := t.TempDir()
+
+		gen := "0123456789abcdef"
+		dbData := createTestSQLiteDB(t)
+		walData := createTestWALSequence(t, dbData, []string{strings.Repeat("x", 128*1024)}, []string{"small"})
+		if len(walData[0]) <= len(walData[1]) {
+			t.Fatalf("expected first WAL to be larger than second WAL: %d <= %d", len(walData[0]), len(walData[1]))
+		}
+
+		createV3Backup(t, replicaDir, gen, []v3SnapshotData{
+			{index: 0, data: dbData},
+		}, []v3WALSegmentData{
+			{index: 0, offset: 0, data: walData[0]},
+			{index: 1, offset: 0, data: walData[1]},
+		})
+
+		c := file.NewReplicaClient(replicaDir)
+		r := litestream.NewReplicaWithClient(nil, c)
+
+		outputPath := tmpDir + "/restored.db"
+		err := r.RestoreV3(ctx, litestream.RestoreOptions{
+			OutputPath: outputPath,
+		})
+		if err != nil {
+			t.Fatalf("RestoreV3 failed: %v", err)
+		}
+
+		verifyRestoredDB(t, outputPath)
+	})
+
 	t.Run("TimestampRestore", func(t *testing.T) {
 		ctx := context.Background()
 		tmpDir := t.TempDir()
@@ -1671,7 +1820,7 @@ func writeV3WALSegment(t *testing.T, dir string, index int, offset int64, data [
 		t.Fatal(err)
 	}
 
-	filename := fmt.Sprintf("%08x-%016x.wal.lz4", index, offset)
+	filename := litestream.FormatWALSegmentFilenameV3(index, offset)
 	if err := os.WriteFile(filepath.Join(dir, filename), buf.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -1698,25 +1847,43 @@ func createTestSQLiteDB(t *testing.T) []byte {
 	return data
 }
 
-// createTestWALData creates minimal valid WAL data for testing.
-// For simplicity, returns an empty WAL header (32 bytes) which is valid.
 func createTestWALData(t *testing.T, dbData []byte) []byte {
 	t.Helper()
+	return createTestWALSequence(t, dbData, []string{"wal"})[0]
+}
 
-	// Create a minimal WAL header
-	// WAL header is 32 bytes:
-	// - magic number (4 bytes): 0x377f0683 (big-endian) or 0x377f0682 (little-endian)
-	// - file format version (4 bytes): 3007000
-	// - page size (4 bytes)
-	// - checkpoint sequence (4 bytes)
-	// - salt-1 (4 bytes)
-	// - salt-2 (4 bytes)
-	// - checksum-1 (4 bytes)
-	// - checksum-2 (4 bytes)
+func createTestWALSequence(t *testing.T, dbData []byte, valuesByIndex ...[]string) [][]byte {
+	t.Helper()
 
-	// For testing, we'll create an empty WAL that doesn't need frames applied
-	// This is sufficient for testing the restore mechanism
-	return make([]byte, 32) // Empty WAL header placeholder
+	tmpPath := t.TempDir() + "/test.db"
+	if err := os.WriteFile(tmpPath, dbData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb := testingutil.MustOpenSQLDB(t, tmpPath)
+	defer testingutil.MustCloseSQLDB(t, sqldb)
+
+	walData := make([][]byte, 0, len(valuesByIndex))
+	for _, values := range valuesByIndex {
+		for _, value := range values {
+			if _, err := sqldb.Exec(`INSERT INTO test (value) VALUES (?)`, value); err != nil {
+				t.Fatal(err)
+			}
+		}
+		data, err := os.ReadFile(tmpPath + "-wal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(data) == 0 {
+			t.Fatal("expected WAL data")
+		}
+		walData = append(walData, append([]byte(nil), data...))
+		if _, err := sqldb.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return walData
 }
 
 func TestWriteTXIDFile(t *testing.T) {


### PR DESCRIPTION
## Description

Adds checks for missing segments during v3 restore

## Motivation and Context

Early detection of corruption when there are missing wal segment files when restoring from a v3 backup

Addresses feedback in https://github.com/benbjohnson/litestream/pull/1229

## How Has This Been Tested?

Deleted wal segments from local backup folder and verified that the restore produces the expected errors.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
