### PR TITLE
fix(cli): exit 0 for explicit help

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -202,7 +202,10 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		fmt.Fprintln(os.Stderr, "Warning: 'wal' command is deprecated, please use 'ltx' instead")
 		return (&LTXCommand{}).Run(ctx, args)
 	default:
-		if cmd == "" || cmd == "help" || strings.HasPrefix(cmd, "-") {
+		if cmd == "help" || cmd == "-h" || cmd == "--help" {
+			m.Usage()
+			return nil
+		} else if cmd == "" || strings.HasPrefix(cmd, "-") {
 			m.Usage()
 			return flag.ErrHelp
 		}

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"flag"
 	"os"
 	"os/exec"
 	"os/user"
@@ -21,6 +22,43 @@ import (
 	"github.com/benbjohnson/litestream/s3"
 	"github.com/benbjohnson/litestream/sftp"
 )
+
+func TestMain_RunHelp(t *testing.T) {
+	t.Run("ExplicitShortHelp", func(t *testing.T) {
+		err := main.NewMain().Run(context.Background(), []string{"-h"})
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	})
+
+	t.Run("ExplicitLongHelp", func(t *testing.T) {
+		err := main.NewMain().Run(context.Background(), []string{"--help"})
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	})
+
+	t.Run("HelpCommand", func(t *testing.T) {
+		err := main.NewMain().Run(context.Background(), []string{"help"})
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	})
+
+	t.Run("NoCommand", func(t *testing.T) {
+		err := main.NewMain().Run(context.Background(), nil)
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("Run returned error %v, want %v", err, flag.ErrHelp)
+		}
+	})
+
+	t.Run("UnknownFlag", func(t *testing.T) {
+		err := main.NewMain().Run(context.Background(), []string{"-config", "litestream.yml"})
+		if !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("Run returned error %v, want %v", err, flag.ErrHelp)
+		}
+	})
+}
 
 func TestOpenConfigFile(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Return success for explicit top-level help requests: `litestream -h`, `litestream --help`, and `litestream help`.
- Preserve usage-error behavior for `litestream` with no command and unknown top-level flags.

## Problem
Issue #1232 tracks CLI agent-friendliness improvements, including the explicit help exit code checkbox. Before this change, top-level explicit help printed usage but returned `flag.ErrHelp`, so `main()` exited with status 1.

## Solution
Split explicit help handling from missing/flag-like command handling in the top-level dispatcher. Explicit help now returns nil; missing commands and unknown top-level flags still return `flag.ErrHelp`.

## Scope
**In scope:**
- Top-level `-h`, `--help`, and `help` dispatch behavior.
- Unit coverage for explicit help, no command, and unknown top-level flag cases.

**Not in scope:**
- Subcommand help behavior.
- Other CLI usability items in #1232.

## Test Plan
- `go test -run TestMain_RunHelp ./cmd/litestream`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `pre-commit run --all-files`
- `golangci-lint run --new-from-rev=HEAD ./cmd/litestream`
- `go run ./cmd/litestream -h >/dev/null`
- `go run ./cmd/litestream --help >/dev/null`
- `go run ./cmd/litestream >/dev/null` exits 1

## Related
- Related to #1232
