### PR TITLE
fix(build): bump Go toolchain to 1.25.9 for stdlib vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/benbjohnson/litestream
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Description

Bumps `toolchain go1.25.8` → `toolchain go1.25.9` in `go.mod`. Single-line change. No code, workflow, or Dockerfile edits needed:

- All `.github/workflows/*.yml` use `go-version-file: "go.mod"` — they pick up the new toolchain automatically.
- `Dockerfile` pins `golang:1.25` (unpinned minor) — picks up 1.25.9 automatically.

## Motivation and Context

The PR build metrics bot on #1233 flagged four reachable Go stdlib vulnerabilities fixed in Go 1.25.9:

- **GO-2026-4947** — Unexpected work during chain building in `crypto/x509`
- **GO-2026-4946** — Inefficient policy validation in `crypto/x509`
- **GO-2026-4870** — Unauthenticated TLS 1.3 KeyUpdate DoS in `crypto/tls` (reachable via NATS replica client, HTTP server TLS handshake, resumable reader, heartbeat client)
- **GO-2026-4865** — JsBraceDepth context tracking bugs (XSS) in `html/template`

Scope is deliberately narrow — has nothing to do with the CLI work on #1233 and ships as its own PR.

Fixes #1234

## How Has This Been Tested?

Locally, on macOS darwin/arm64, against the pinned toolchain via `GOTOOLCHAIN=go1.25.9`:

- `go build -o bin/litestream ./cmd/litestream` — clean build (53M binary).
- `go test -race ./...` — all packages `ok`, 0 failures.
- `GOTOOLCHAIN=go1.25.9 govulncheck ./...` — `No vulnerabilities found.` The 4 stdlib findings are cleared. (1 out-of-scope finding in an imported package remains, not called by Litestream code — expected per the issue.)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed) — no docs affected