### PR TITLE
fix(cli): add try hints for required flags

### DIFF
--- a/cmd/litestream/register.go
+++ b/cmd/litestream/register.go
@@ -33,7 +33,7 @@ func (c *RegisterCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("too many arguments")
 	}
 	if *replicaFlag == "" {
-		return fmt.Errorf("replica URL required (use -replica flag)")
+		return fmt.Errorf("-replica is required. Try: litestream register -replica s3://bucket/prefix /path/to/db")
 	}
 	if *timeout <= 0 {
 		return fmt.Errorf("timeout must be greater than 0")

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -2,15 +2,12 @@ package main_test
 
 import (
 	"context"
-	"net/url"
 	"path/filepath"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
 	main "github.com/benbjohnson/litestream/cmd/litestream"
-	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/internal/testingutil"
-	"github.com/benbjohnson/litestream/s3"
 )
 
 func TestRegisterCommand_Run(t *testing.T) {
@@ -135,13 +132,6 @@ func TestRegisterCommand_Run(t *testing.T) {
 	})
 
 	t.Run("SuggestedReplicaHintExample", func(t *testing.T) {
-		litestream.RegisterReplicaClientFactory("s3", func(string, string, string, url.Values, *url.Userinfo) (litestream.ReplicaClient, error) {
-			return file.NewReplicaClient(t.TempDir()), nil
-		})
-		t.Cleanup(func() {
-			litestream.RegisterReplicaClientFactory("s3", s3.NewReplicaClientFromURL)
-		})
-
 		store := litestream.NewStore(nil, litestream.CompactionLevels{{Level: 0}})
 		store.CompactionMonitorEnabled = false
 		if err := store.Open(context.Background()); err != nil {

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -2,12 +2,15 @@ package main_test
 
 import (
 	"context"
+	"net/url"
 	"path/filepath"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
 	main "github.com/benbjohnson/litestream/cmd/litestream"
+	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/internal/testingutil"
+	"github.com/benbjohnson/litestream/s3"
 )
 
 func TestRegisterCommand_Run(t *testing.T) {
@@ -128,6 +131,42 @@ func TestRegisterCommand_Run(t *testing.T) {
 		// Still only 1 database - didn't register a duplicate.
 		if len(store.DBs()) != 1 {
 			t.Errorf("expected 1 database in store, got %d", len(store.DBs()))
+		}
+	})
+
+	t.Run("SuggestedReplicaHintExample", func(t *testing.T) {
+		litestream.RegisterReplicaClientFactory("s3", func(string, string, string, url.Values, *url.Userinfo) (litestream.ReplicaClient, error) {
+			return file.NewReplicaClient(t.TempDir()), nil
+		})
+		t.Cleanup(func() {
+			litestream.RegisterReplicaClientFactory("s3", s3.NewReplicaClientFromURL)
+		})
+
+		store := litestream.NewStore(nil, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close(context.Background())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer server.Close()
+
+		db, sqldb := testingutil.MustOpenDBs(t)
+		testingutil.MustCloseDBs(t, db, sqldb)
+
+		cmd := &main.RegisterCommand{}
+		err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, "-replica", "s3://bucket/prefix", db.Path()})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(store.DBs()) != 1 {
+			t.Fatalf("expected 1 database in store, got %d", len(store.DBs()))
 		}
 	})
 }

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -28,7 +28,7 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for missing replica flag")
 		}
-		if err.Error() != "replica URL required (use -replica flag)" {
+		if err.Error() != "-replica is required. Try: litestream register -replica s3://bucket/prefix /path/to/db" {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -116,7 +116,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 // loadFromURL creates a replica & updates the restore options from a replica URL.
 func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	if opt.OutputPath == "" {
-		return nil, fmt.Errorf("output path required")
+		return nil, fmt.Errorf("-o is required when restoring from a replica URL. Try: litestream restore -o /path/to/db %s", replicaURL)
 	}
 
 	// Exit successfully if the output file already exists.

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"testing"
 	"time"
@@ -58,5 +59,16 @@ func TestRestoreCommand_FollowIntervalFlag(t *testing.T) {
 				t.Fatalf("FollowInterval=%v, want %v", opt.FollowInterval, tt.wantVal)
 			}
 		})
+	}
+}
+
+func TestRestoreCommand_RunMissingOutputPathForReplicaURL(t *testing.T) {
+	cmd := &RestoreCommand{}
+	err := cmd.Run(context.Background(), []string{"s3://bucket/prefix"})
+	if err == nil {
+		t.Fatal("expected error for missing output path")
+	}
+	if err.Error() != "-o is required when restoring from a replica URL. Try: litestream restore -o /path/to/db s3://bucket/prefix" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -69,6 +70,32 @@ func TestRestoreCommand_RunMissingOutputPathForReplicaURL(t *testing.T) {
 		t.Fatal("expected error for missing output path")
 	}
 	if err.Error() != "-o is required when restoring from a replica URL. Try: litestream restore -o /path/to/db s3://bucket/prefix" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewS3ReplicaClientFromConfig_SuggestedHintExample(t *testing.T) {
+	client, err := NewS3ReplicaClientFromConfig(&ReplicaConfig{URL: "s3://bucket/prefix"}, nil)
+	if err == nil {
+		if client.Bucket != "bucket" {
+			t.Fatalf("Bucket=%q, want %q", client.Bucket, "bucket")
+		}
+		if client.Path != "prefix" {
+			t.Fatalf("Path=%q, want %q", client.Path, "prefix")
+		}
+		return
+	}
+
+	t.Fatalf("unexpected error: %v", err)
+}
+
+func TestRestoreCommand_RunSuggestedOutputArgs(t *testing.T) {
+	cmd := &RestoreCommand{}
+	err := cmd.Run(context.Background(), []string{"-o", filepath.Join(t.TempDir(), "db.sqlite"), "file://" + t.TempDir()})
+	if err == nil {
+		t.Fatal("expected error for empty replica")
+	}
+	if err.Error() != "no matching backup files available" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Description
Add actionable `Try:` hints to CLI errors for missing required flags:

- `litestream register` now tells users how to supply `-replica`.
- `litestream restore REPLICA_URL` now tells users how to supply `-o`.

## Motivation and Context
This addresses the required-flag hint item from the CLI agent-friendly usability tracking issue.

Related to #1232

## How Has This Been Tested?
- `go test -run 'TestRegisterCommand_Run/MissingReplicaFlag|TestRestoreCommand_RunMissingOutputPathForReplicaURL' ./cmd/litestream`
- `go test ./cmd/litestream`
- `go build ./...`
- `go test ./...`
- `pre-commit run --all-files`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)