### PR TITLE
docs(cli): add start stop help examples

### DIFF
--- a/cmd/litestream/start.go
+++ b/cmd/litestream/start.go
@@ -108,5 +108,15 @@ Options:
 
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
+
+Examples:
+  # Start replication for a database on the running daemon.
+  $ litestream start /path/to/db
+
+  # Start replication using a non-default control socket.
+  $ litestream start -socket /tmp/litestream.sock /path/to/db
+
+  # Start replication and wait up to 10 seconds for the daemon response.
+  $ litestream start -timeout 10 /path/to/db
 `[1:])
 }

--- a/cmd/litestream/start_stop_test.go
+++ b/cmd/litestream/start_stop_test.go
@@ -1,0 +1,42 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+
+	main "github.com/benbjohnson/litestream/cmd/litestream"
+)
+
+func TestStartCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.StartCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream start /path/to/db",
+		"$ litestream start -socket /tmp/litestream.sock /path/to/db",
+		"$ litestream start -timeout 10 /path/to/db",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
+}
+
+func TestStopCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.StopCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream stop /path/to/db",
+		"$ litestream stop -socket /tmp/litestream.sock /path/to/db",
+		"$ litestream stop -timeout 10 /path/to/db",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
+}

--- a/cmd/litestream/stop.go
+++ b/cmd/litestream/stop.go
@@ -103,5 +103,15 @@ Options:
 
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
+
+Examples:
+  # Stop replication for a database.
+  $ litestream stop /path/to/db
+
+  # Stop replication using a non-default control socket.
+  $ litestream stop -socket /tmp/litestream.sock /path/to/db
+
+  # Stop replication and wait up to 10 seconds for final sync and shutdown.
+  $ litestream stop -timeout 10 /path/to/db
 `[1:])
 }


### PR DESCRIPTION
## Description
This stacked draft PR adds `Examples:` sections to `litestream start -help` and `litestream stop -help`, and adds regression tests that lock those examples into the usage output.

This PR is intentionally scoped to the combined `start` / `stop` checkbox only.

## Motivation and Context
Issue #1232 tracks agent-friendly CLI improvements, including runnable help examples for command discovery.

Related to #1232
Base branch: #1238 (`feat/1232-unregister-help-examples`)

## How Has This Been Tested?
- `go test -run 'TestStartCommand_Usage|TestStopCommand_Usage' ./cmd/litestream`
- `go test ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
