### PR TITLE
docs(cli): add sync help examples

### DIFF
--- a/cmd/litestream/sync.go
+++ b/cmd/litestream/sync.go
@@ -109,5 +109,10 @@ Options:
 
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
+
+Examples:
+  $ litestream sync /path/to/db
+  $ litestream sync -wait /path/to/db
+  $ litestream sync -wait -timeout 120 /path/to/db
 `[1:])
 }

--- a/cmd/litestream/sync_test.go
+++ b/cmd/litestream/sync_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
@@ -110,4 +111,21 @@ func TestSyncCommand_Run(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestSyncCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.SyncCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream sync /path/to/db",
+		"$ litestream sync -wait /path/to/db",
+		"$ litestream sync -wait -timeout 120 /path/to/db",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add `sync -help` examples for non-blocking, blocking, and timeout usage
- add a usage regression test for the documented examples

## Testing
- `go test -run 'TestSyncCommand_Run|TestSyncCommand_Usage' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1239