### PR TITLE
docs(cli): add list help examples

### DIFF
--- a/cmd/litestream/list.go
+++ b/cmd/litestream/list.go
@@ -108,5 +108,10 @@ Options:
 
   -timeout SECONDS
       Maximum time to wait in seconds (default: 10).
+
+Examples:
+  $ litestream list
+  $ litestream list -json
+  $ litestream list -socket /tmp/litestream.sock
 `[1:])
 }

--- a/cmd/litestream/list_test.go
+++ b/cmd/litestream/list_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
@@ -130,4 +131,21 @@ func TestListCommand_Run(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestListCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.ListCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream list",
+		"$ litestream list -json",
+		"$ litestream list -socket /tmp/litestream.sock",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add `list -help` examples for human-readable and `-json` output
- add a usage regression test for the documented examples

## Testing
- `go test -run 'TestListCommand_Run|TestListCommand_Usage' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1240