### PR TITLE
docs(cli): add info help examples

### DIFF
--- a/cmd/litestream/info.go
+++ b/cmd/litestream/info.go
@@ -103,5 +103,10 @@ Options:
 
   -timeout SECONDS
       Maximum time to wait in seconds (default: 10).
+
+Examples:
+  $ litestream info
+  $ litestream info -json
+  $ litestream info -socket /tmp/litestream.sock
 `[1:])
 }

--- a/cmd/litestream/info_test.go
+++ b/cmd/litestream/info_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -123,4 +124,21 @@ func TestInfoCommand_Run(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestInfoCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.InfoCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream info",
+		"$ litestream info -json",
+		"$ litestream info -socket /tmp/litestream.sock",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add `info -help` examples for human-readable and `-json` output
- add a usage regression test for the documented examples

## Testing
- `go test -run 'TestInfoCommand_Run|TestInfoCommand_Usage' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1241