### PR TITLE
docs(cli): add databases help examples

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -68,6 +68,12 @@ Arguments:
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
+Examples:
+
+	$ litestream databases
+	$ litestream databases -config /path/to/litestream.yml
+	$ litestream databases -no-expand-env -config /path/to/litestream.yml
+
 `[1:],
 		DefaultConfigPath(),
 	)

--- a/cmd/litestream/databases_test.go
+++ b/cmd/litestream/databases_test.go
@@ -1,0 +1,25 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+
+	main "github.com/benbjohnson/litestream/cmd/litestream"
+)
+
+func TestDatabasesCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.DatabasesCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream databases",
+		"$ litestream databases -config /path/to/litestream.yml",
+		"$ litestream databases -no-expand-env -config /path/to/litestream.yml",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `databases -help` examples for default config and explicit config usage
- add a focused usage regression test in a new test file

## Testing
- `go test -run 'TestDatabasesCommand_Usage' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1242