### PR TITLE
test(db): retry SQLITE_BUSY in checkpoint page-gap test

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -1896,29 +1896,21 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	case err := <-writerDone:
 		t.Fatalf("writer exited before starting: %v", err)
 	}
-	// Retry SQLITE_BUSY on the checkpoint just as the writer does — wal_checkpoint(TRUNCATE)
-	// can legitimately return BUSY while a writer is actively committing on a slow runner,
-	// and a BUSY return means no checkpoint happened so there is nothing to verify.
-	checkpointDeadline := time.Now().Add(30 * time.Second)
-	var checkpointErr error
-	for {
-		checkpointErr = db.Checkpoint(ctx, CheckpointModeTruncate)
-		if checkpointErr == nil {
-			break
-		}
-		if !strings.Contains(checkpointErr.Error(), "database is locked") &&
-			!strings.Contains(checkpointErr.Error(), "SQLITE_BUSY") {
-			break
-		}
-		if time.Now().After(checkpointDeadline) {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-	if checkpointErr != nil {
+	// Run the checkpoint exactly once. wal_checkpoint(TRUNCATE) can legitimately
+	// return SQLITE_BUSY while a writer is actively committing on a slow runner.
+	// Retrying db.Checkpoint() would re-run its internal pre-checkpoint sync and
+	// upload additional L0 files, which would widen the page coverage across
+	// attempts and could mask the very TOCTOU page-gap bug this test is meant
+	// to detect. On BUSY, skip this iteration instead — no checkpoint occurred,
+	// so there is nothing to verify.
+	if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
 		cancelWriter()
 		<-writerDone
-		t.Fatal(checkpointErr)
+		if strings.Contains(err.Error(), "database is locked") ||
+			strings.Contains(err.Error(), "SQLITE_BUSY") {
+			t.Skipf("checkpoint returned BUSY under concurrent writer; no checkpoint occurred so the page-gap invariant cannot be validated this run: %v", err)
+		}
+		t.Fatal(err)
 	}
 	cancelWriter()
 	if err := <-writerDone; err != nil {

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -1896,10 +1896,29 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	case err := <-writerDone:
 		t.Fatalf("writer exited before starting: %v", err)
 	}
-	if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
+	// Retry SQLITE_BUSY on the checkpoint just as the writer does — wal_checkpoint(TRUNCATE)
+	// can legitimately return BUSY while a writer is actively committing on a slow runner,
+	// and a BUSY return means no checkpoint happened so there is nothing to verify.
+	checkpointDeadline := time.Now().Add(30 * time.Second)
+	var checkpointErr error
+	for {
+		checkpointErr = db.Checkpoint(ctx, CheckpointModeTruncate)
+		if checkpointErr == nil {
+			break
+		}
+		if !strings.Contains(checkpointErr.Error(), "database is locked") &&
+			!strings.Contains(checkpointErr.Error(), "SQLITE_BUSY") {
+			break
+		}
+		if time.Now().After(checkpointDeadline) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if checkpointErr != nil {
 		cancelWriter()
 		<-writerDone
-		t.Fatal(err)
+		t.Fatal(checkpointErr)
 	}
 	cancelWriter()
 	if err := <-writerDone; err != nil {


### PR DESCRIPTION
## Description
Replace the `db.Checkpoint` call in `TestDB_CheckpointPageGapWithConcurrentWrites` with a single attempt that `t.Skip`s on `SQLITE_BUSY` instead of failing.

## Motivation and Context
The test runs `db.Checkpoint(ctx, CheckpointModeTruncate)` concurrently with a writer goroutine. `wal_checkpoint(TRUNCATE)` can legitimately return `SQLITE_BUSY` while a writer is actively committing — on a slow CI runner this caused the test to fail with `database is locked (5) (SQLITE_BUSY)` even though no actual page loss occurred.

An earlier revision of this PR retried `db.Checkpoint` on BUSY. Code review flagged that `db.Checkpoint` is not just the raw `wal_checkpoint` pragma — it also runs an internal `verifyAndSync` before each checkpoint, which uploads L0 files. Retrying therefore widens page coverage across attempts and could mask the very TOCTOU page-gap bug this test is designed to detect. Skipping on BUSY is the honest response: no checkpoint occurred, so the invariant cannot be validated this iteration.

Observed flake: [run 24842765150](https://github.com/benbjohnson/litestream/actions/runs/24842765150) — `TestDB_CheckpointPageGapWithConcurrentWrites` failed at `db_internal_test.go:1902` with `SQLITE_BUSY` on a post-merge main build, after the same code passed in the PR's own CI.

## How Has This Been Tested?
- `go test -run TestDB_CheckpointPageGapWithConcurrentWrites -count=20 -race ./.` — all 20 iterations pass.
- `go vet ./...` clean.
- Only `SQLITE_BUSY` / `database is locked` triggers `t.Skip`; any other error still fails the test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)