### PR TITLE
feat(cli): add status json output

### DIFF
--- a/cmd/litestream/status.go
+++ b/cmd/litestream/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -19,6 +20,7 @@ type StatusCommand struct{}
 func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-status", flag.ContinueOnError)
 	configPath, noExpandEnv := registerConfigFlag(fs)
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -39,11 +41,7 @@ func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 		filterPath = fs.Arg(0)
 	}
 
-	// Print status for each database.
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	defer w.Flush()
-
-	fmt.Fprintln(w, "database\tstatus\tlocal txid\twal size")
+	var statuses []DBStatus
 
 	for _, dbConfig := range config.DBs {
 		db, err := NewDBFromConfig(dbConfig)
@@ -56,9 +54,25 @@ func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 			continue
 		}
 
-		status := c.getDBStatus(db)
+		statuses = append(statuses, c.getDBStatus(db))
+	}
+
+	if *jsonOutput {
+		output, err := json.MarshalIndent(statuses, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "database\tstatus\tlocal txid\twal size")
+	for _, status := range statuses {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-			db.Path(),
+			status.Database,
 			status.Status,
 			status.LocalTXID,
 			status.WALSize,
@@ -70,14 +84,16 @@ func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 
 // DBStatus holds the status information for a single database.
 type DBStatus struct {
-	Status    string
-	LocalTXID string
-	WALSize   string
+	Database  string `json:"database"`
+	Status    string `json:"status"`
+	LocalTXID string `json:"local_txid"`
+	WALSize   string `json:"wal_size"`
 }
 
 // getDBStatus gathers status information for a database.
 func (c *StatusCommand) getDBStatus(db *litestream.DB) DBStatus {
 	status := DBStatus{
+		Database:  db.Path(),
 		Status:    "unknown",
 		LocalTXID: "-",
 		WALSize:   "-",
@@ -126,6 +142,9 @@ Arguments:
 	-config PATH
 	    Specifies the configuration file.
 	    Defaults to %s
+
+	-json
+	    Output raw JSON instead of human-readable text.
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.

--- a/cmd/litestream/status_test.go
+++ b/cmd/litestream/status_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,6 +70,53 @@ func TestStatusCommand_Run(t *testing.T) {
 		err := cmd.Run(context.Background(), []string{"-config", configPath, dbPath})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("JSONOutput", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "missing.db")
+		configPath := filepath.Join(dir, "litestream.yml")
+
+		config := `dbs:
+  - path: ` + dbPath + `
+    replicas:
+      - url: file://` + filepath.Join(dir, "replica") + `
+`
+		if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		output := captureStdout(t, func() {
+			cmd := &main.StatusCommand{}
+			if err := cmd.Run(context.Background(), []string{"-config", configPath, "-json"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got []struct {
+			Database  string `json:"database"`
+			Status    string `json:"status"`
+			LocalTXID string `json:"local_txid"`
+			WALSize   string `json:"wal_size"`
+		}
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 status row, got %d", len(got))
+		}
+		if got[0].Database != dbPath {
+			t.Fatalf("unexpected database path: %s", got[0].Database)
+		}
+		if got[0].Status != "no database" {
+			t.Fatalf("unexpected status: %s", got[0].Status)
+		}
+		if got[0].LocalTXID != "-" {
+			t.Fatalf("unexpected local txid: %s", got[0].LocalTXID)
+		}
+		if got[0].WALSize != "-" {
+			t.Fatalf("unexpected wal size: %s", got[0].WALSize)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- add `-json` output to `litestream status`
- emit the `database`, `status`, `local_txid`, and `wal_size` fields from the issue
- add a focused stdout regression test for the JSON shape

## Testing
- `go test -run 'TestStatusCommand_Run' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1243