### PR TITLE
docs(cli): add status help examples

### DIFF
--- a/cmd/litestream/status.go
+++ b/cmd/litestream/status.go
@@ -161,6 +161,12 @@ Output columns:
 Note: To see replica TXID and sync status, use the MCP tools or check logs
 while the replication daemon is running.
 
+Examples:
+
+	$ litestream status
+	$ litestream status /path/to/db
+	$ litestream status -json
+
 `[1:],
 		DefaultConfigPath(),
 	)

--- a/cmd/litestream/status_test.go
+++ b/cmd/litestream/status_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	main "github.com/benbjohnson/litestream/cmd/litestream"
@@ -119,4 +120,21 @@ func TestStatusCommand_Run(t *testing.T) {
 			t.Fatalf("unexpected wal size: %s", got[0].WALSize)
 		}
 	})
+}
+
+func TestStatusCommand_Usage(t *testing.T) {
+	output := captureStdout(t, func() {
+		(&main.StatusCommand{}).Usage()
+	})
+
+	for _, example := range []string{
+		"Examples:",
+		"$ litestream status",
+		"$ litestream status /path/to/db",
+		"$ litestream status -json",
+	} {
+		if !strings.Contains(output, example) {
+			t.Fatalf("usage output missing %q:\n%s", example, output)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add `status -help` examples for all databases, one database, and `-json`
- add a usage regression test for the documented examples

## Testing
- `go test -run 'TestStatusCommand_Run|TestStatusCommand_Usage' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1245