### PR TITLE
feat(cli): add databases json output

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -15,6 +16,7 @@ type DatabasesCommand struct{}
 func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-databases", flag.ContinueOnError)
 	configPath, noExpandEnv := registerConfigFlag(fs)
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -31,23 +33,42 @@ func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 		return err
 	}
 
-	// List all databases.
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	defer w.Flush()
-
-	fmt.Fprintln(w, "path\treplica")
+	var databases []DatabaseInfo
 	for _, dbConfig := range config.DBs {
 		db, err := NewDBFromConfig(dbConfig)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(w, "%s\t%s\n",
-			db.Path(),
-			db.Replica.Client.Type())
+		databases = append(databases, DatabaseInfo{
+			Path:    db.Path(),
+			Replica: db.Replica.Client.Type(),
+		})
+	}
+
+	if *jsonOutput {
+		output, err := json.MarshalIndent(databases, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "path\treplica")
+	for _, db := range databases {
+		fmt.Fprintf(w, "%s\t%s\n", db.Path, db.Replica)
 	}
 
 	return nil
+}
+
+type DatabaseInfo struct {
+	Path    string `json:"path"`
+	Replica string `json:"replica"`
 }
 
 // Usage prints the help screen to STDOUT.
@@ -64,6 +85,9 @@ Arguments:
 	-config PATH
 	    Specifies the configuration file.
 	    Defaults to %s
+
+	-json
+	    Output raw JSON instead of human-readable text.
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.

--- a/cmd/litestream/databases_test.go
+++ b/cmd/litestream/databases_test.go
@@ -1,11 +1,71 @@
 package main_test
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	main "github.com/benbjohnson/litestream/cmd/litestream"
 )
+
+func TestDatabasesCommand_Run(t *testing.T) {
+	t.Run("TooManyArguments", func(t *testing.T) {
+		cmd := &main.DatabasesCommand{}
+		err := cmd.Run(context.Background(), []string{"extra-arg"})
+		if err == nil {
+			t.Fatal("expected error for too many arguments")
+		}
+		if err.Error() != "too many arguments" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("JSONOutput", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+		configPath := filepath.Join(dir, "litestream.yml")
+
+		if err := os.WriteFile(dbPath, []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		config := `dbs:
+  - path: ` + dbPath + `
+    replicas:
+      - url: file://` + filepath.Join(dir, "replica") + `
+`
+		if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		output := captureStdout(t, func() {
+			cmd := &main.DatabasesCommand{}
+			if err := cmd.Run(context.Background(), []string{"-config", configPath, "-json"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got []struct {
+			Path    string `json:"path"`
+			Replica string `json:"replica"`
+		}
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 database row, got %d", len(got))
+		}
+		if got[0].Path != dbPath {
+			t.Fatalf("unexpected database path: %s", got[0].Path)
+		}
+		if got[0].Replica != "file" {
+			t.Fatalf("unexpected replica type: %s", got[0].Replica)
+		}
+	})
+}
 
 func TestDatabasesCommand_Usage(t *testing.T) {
 	output := captureStdout(t, func() {


### PR DESCRIPTION
## Summary
- add `-json` output to `litestream databases`
- emit configured database entries as JSON objects with `path` and `replica`
- add focused command tests for JSON output and argument validation

## Testing
- `go test -run 'TestDatabasesCommand_Run|TestDatabasesCommand_Usage' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

Related to #1232
Stacked on #1246