### PR TITLE
feat(cli): add ltx json output

### DIFF
--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -19,6 +20,7 @@ type LTXCommand struct{}
 func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-ltx", flag.ContinueOnError)
 	configPath, noExpandEnv := registerConfigFlag(fs)
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	var level levelVar
 	fs.Var(&level, "level", "compaction level (0-9 or \"all\")")
 	fs.Usage = c.Usage
@@ -69,12 +71,6 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		r = db.Replica
 	}
 
-	// List LTX files.
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	defer w.Flush()
-
-	fmt.Fprintln(w, "level\tmin_txid\tmax_txid\tsize\tcreated")
-
 	// Determine which levels to iterate.
 	var levels []int
 	if int(level) == levelAll {
@@ -85,6 +81,7 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		levels = []int{int(level)}
 	}
 
+	var files []LTXFileInfo
 	for _, lvl := range levels {
 		itr, err := r.Client.LTXFiles(ctx, lvl, 0, false)
 		if err != nil {
@@ -92,19 +89,50 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 		for itr.Next() {
 			info := itr.Item()
-			fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\n",
-				lvl,
-				info.MinTXID,
-				info.MaxTXID,
-				info.Size,
-				info.CreatedAt.Format(time.RFC3339),
-			)
+			files = append(files, LTXFileInfo{
+				Level:     lvl,
+				MinTXID:   info.MinTXID.String(),
+				MaxTXID:   info.MaxTXID.String(),
+				Size:      info.Size,
+				Timestamp: info.CreatedAt.Format(time.RFC3339),
+			})
 		}
 		if err := itr.Close(); err != nil {
 			return err
 		}
 	}
+
+	if *jsonOutput {
+		output, err := json.MarshalIndent(files, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "level\tmin_txid\tmax_txid\tsize\tcreated")
+	for _, file := range files {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\n",
+			file.Level,
+			file.MinTXID,
+			file.MaxTXID,
+			file.Size,
+			file.Timestamp,
+		)
+	}
 	return nil
+}
+
+type LTXFileInfo struct {
+	Level     int    `json:"level"`
+	MinTXID   string `json:"min_txid"`
+	MaxTXID   string `json:"max_txid"`
+	Size      int64  `json:"size"`
+	Timestamp string `json:"timestamp"`
 }
 
 // Usage prints the help screen to STDOUT.
@@ -133,6 +161,9 @@ Arguments:
 	-level LEVEL
 	    Compaction level to list (0-9 or "all").
 	    Defaults to 0.
+
+	-json
+	    Output raw JSON instead of human-readable text.
 
 Examples:
 

--- a/cmd/litestream/ltx_test.go
+++ b/cmd/litestream/ltx_test.go
@@ -1,12 +1,65 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
 )
+
+func TestLTXCommand_Run_JSONOutput(t *testing.T) {
+	replicaDir := filepath.Join(t.TempDir(), "replica")
+	replicaURL := "file://" + replicaDir
+	r, err := NewReplicaFromConfig(&ReplicaConfig{URL: replicaURL}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timestamp := time.Date(2026, 4, 24, 12, 30, 0, 0, time.UTC)
+	data := createLTXCommandTestData(ltx.TXID(2), ltx.TXID(3), timestamp, []byte("payload"))
+	info, err := r.Client.WriteLTXFile(context.Background(), 0, ltx.TXID(2), ltx.TXID(3), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &LTXCommand{}
+		if err := cmd.Run(context.Background(), []string{"-json", replicaURL}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got []LTXFileInfo
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 LTX file, got %d", len(got))
+	}
+	if got[0].Level != 0 {
+		t.Fatalf("unexpected level: %d", got[0].Level)
+	}
+	if got[0].MinTXID != "0000000000000002" {
+		t.Fatalf("unexpected min txid: %s", got[0].MinTXID)
+	}
+	if got[0].MaxTXID != "0000000000000003" {
+		t.Fatalf("unexpected max txid: %s", got[0].MaxTXID)
+	}
+	if got[0].Size != info.Size {
+		t.Fatalf("unexpected size: %d", got[0].Size)
+	}
+	if got[0].Timestamp != timestamp.Format(time.RFC3339) {
+		t.Fatalf("unexpected timestamp: %s", got[0].Timestamp)
+	}
+}
 
 func TestTXIDVarParsing(t *testing.T) {
 	tests := []struct {
@@ -69,6 +122,53 @@ func TestTXIDVarParsing(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createLTXCommandTestData(minTXID, maxTXID ltx.TXID, timestamp time.Time, data []byte) []byte {
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		PageSize:  4096,
+		Commit:    1,
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Timestamp: timestamp.UnixMilli(),
+	}
+	if minTXID == 1 {
+		hdr.PreApplyChecksum = 0
+	} else {
+		hdr.PreApplyChecksum = ltx.ChecksumFlag
+	}
+
+	header, _ := hdr.MarshalBinary()
+	return append(header, data...)
+}
+
+func captureLTXCommandStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = orig
+	})
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
 }
 
 func TestTXIDVarString(t *testing.T) {


### PR DESCRIPTION
## Description
Add `-json` output to `litestream ltx` while preserving the existing table output.

## Motivation and Context
This handles one structured-output item from #1232. It gives scripts and agents a stable JSON array for LTX file metadata without scraping columns.

Related to #1232
Stacked on #1247

## How Has This Been Tested?
- `go test -run 'TestLTXCommand_Run_JSONOutput|TestTXIDVar|TestLevelVar' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)