### PR TITLE
feat(cli): add restore json output

### DIFF
--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -29,6 +30,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.BoolVar(&opt.Follow, "f", false, "follow mode")
 	fs.DurationVar(&opt.FollowInterval, "follow-interval", opt.FollowInterval, "polling interval for follow mode")
 	integrityCheck := fs.String("integrity-check", "none", "post-restore integrity check: none, quick, or full")
@@ -41,7 +43,11 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		return fmt.Errorf("too many arguments")
 	}
 
-	internal.InitLog(os.Stdout, "INFO", "text", false)
+	logOutput := os.Stdout
+	if *jsonOutput {
+		logOutput = os.Stderr
+	}
+	internal.InitLog(logOutput, "INFO", "text", false)
 
 	// When follow mode is enabled, set up signal handling so Ctrl+C stops
 	// the follow loop cleanly.
@@ -101,6 +107,8 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 	}
 
+	txid := c.restoreTXID(ctx, r, opt)
+	start := time.Now()
 	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) {
 		if *ifReplicaExists {
 			slog.Info("no matching backups found")
@@ -110,7 +118,42 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	} else if err != nil {
 		return err
 	}
+	if *jsonOutput {
+		output, err := json.MarshalIndent(RestoreResult{
+			DBPath:         opt.OutputPath,
+			Replica:        r.Client.Type(),
+			TXID:           txid,
+			DurationMS:     time.Since(start).Milliseconds(),
+			IntegrityCheck: *integrityCheck,
+		}, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+	}
 	return nil
+}
+
+type RestoreResult struct {
+	DBPath         string `json:"db_path"`
+	Replica        string `json:"replica"`
+	TXID           string `json:"txid"`
+	DurationMS     int64  `json:"duration_ms"`
+	IntegrityCheck string `json:"integrity_check"`
+}
+
+func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica, opt litestream.RestoreOptions) string {
+	if opt.TXID != 0 {
+		return opt.TXID.String()
+	}
+	if opt.Follow {
+		return ""
+	}
+	infos, err := litestream.CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
+	if err != nil || len(infos) == 0 {
+		return ""
+	}
+	return infos[len(infos)-1].MaxTXID.String()
 }
 
 // loadFromURL creates a replica & updates the restore options from a replica URL.
@@ -209,6 +252,9 @@ Arguments:
 
 	-if-replica-exists
 	    Returns exit code of 0 if no backups found.
+
+	-json
+	    Output raw JSON summary on successful restore.
 
 	-f
 	    Follow mode. After restoring, continuously poll for and apply

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	litestream "github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/file"
+	"github.com/benbjohnson/litestream/internal/testingutil"
 )
 
 func TestRestoreCommand_FollowIntervalFlag(t *testing.T) {
@@ -97,5 +101,71 @@ func TestRestoreCommand_RunSuggestedOutputArgs(t *testing.T) {
 	}
 	if err.Error() != "no matching backup files available" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRestoreCommand_RunJSONOutput(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db.sqlite")
+	replicaPath := filepath.Join(dir, "replica")
+	restorePath := filepath.Join(dir, "restored.sqlite")
+
+	db := testingutil.NewDB(t, dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	client := file.NewReplicaClient(replicaPath)
+	replica := litestream.NewReplicaWithClient(db, client)
+	replica.MonitorEnabled = false
+	db.Replica = replica
+
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	sqldb := testingutil.MustOpenSQLDB(t, dbPath)
+	if _, err := sqldb.ExecContext(ctx, `CREATE TABLE t (id INT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(ctx, `INSERT INTO t (id) VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SyncAndWait(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &RestoreCommand{}
+		if err := cmd.Run(ctx, []string{"-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got RestoreResult
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.DBPath != restorePath {
+		t.Fatalf("unexpected db path: %s", got.DBPath)
+	}
+	if got.Replica != "file" {
+		t.Fatalf("unexpected replica: %s", got.Replica)
+	}
+	if got.TXID == "" {
+		t.Fatal("expected txid")
+	}
+	if got.DurationMS < 0 {
+		t.Fatalf("unexpected duration_ms: %d", got.DurationMS)
+	}
+	if got.IntegrityCheck != "none" {
+		t.Fatalf("unexpected integrity check: %s", got.IntegrityCheck)
+	}
+	if _, err := os.Stat(restorePath); err != nil {
+		t.Fatalf("expected restored database: %v", err)
 	}
 }


### PR DESCRIPTION
## Description
Add `-json` output to `litestream restore` for a final machine-readable success summary.

## Motivation and Context
This handles the restore structured-output item from #1232. The summary includes `db_path`, `replica`, `txid`, `duration_ms`, and `integrity_check`, and routes restore logs to stderr when JSON output is requested.

Related to #1232
Stacked on #1248

## How Has This Been Tested?
- `go test -run 'TestRestoreCommand_RunJSONOutput|TestRestoreCommand_RunMissingOutputPathForReplicaURL|TestRestoreCommand_RunSuggestedOutputArgs' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)