### PR TITLE
feat(cli): add restore dry run

### DIFF
--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -9,7 +9,10 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"text/tabwriter"
 	"time"
+
+	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/internal"
@@ -30,6 +33,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	ifDBNotExists := fs.Bool("if-db-not-exists", false, "")
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
+	dryRun := fs.Bool("dry-run", false, "print restore plan without writing")
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.BoolVar(&opt.Follow, "f", false, "follow mode")
 	fs.DurationVar(&opt.FollowInterval, "follow-interval", opt.FollowInterval, "polling interval for follow mode")
@@ -107,6 +111,25 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 	}
 
+	if *dryRun {
+		plan, err := c.dryRunPlan(ctx, fs.Arg(0), r, opt)
+		if errors.Is(err, litestream.ErrTxNotAvailable) {
+			return fmt.Errorf("no matching backup files available")
+		} else if err != nil {
+			return err
+		}
+		if *jsonOutput {
+			output, err := json.MarshalIndent(plan, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to format response: %w", err)
+			}
+			fmt.Println(string(output))
+			return nil
+		}
+		c.printDryRunPlan(plan)
+		return nil
+	}
+
 	txid := c.restoreTXID(ctx, r, opt)
 	start := time.Now()
 	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) {
@@ -134,12 +157,88 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	return nil
 }
 
+type RestorePlan struct {
+	Source     string            `json:"source"`
+	TargetPath string            `json:"target_path"`
+	Replica    string            `json:"replica"`
+	MinTXID    string            `json:"min_txid"`
+	MaxTXID    string            `json:"max_txid"`
+	Files      []RestorePlanFile `json:"files"`
+}
+
+type RestorePlanFile struct {
+	Level     int    `json:"level"`
+	Name      string `json:"name"`
+	MinTXID   string `json:"min_txid"`
+	MaxTXID   string `json:"max_txid"`
+	Size      int64  `json:"size"`
+	Timestamp string `json:"timestamp"`
+}
+
 type RestoreResult struct {
 	DBPath         string `json:"db_path"`
 	Replica        string `json:"replica"`
 	TXID           string `json:"txid"`
 	DurationMS     int64  `json:"duration_ms"`
 	IntegrityCheck string `json:"integrity_check"`
+}
+
+func (c *RestoreCommand) dryRunPlan(ctx context.Context, source string, r *litestream.Replica, opt litestream.RestoreOptions) (RestorePlan, error) {
+	if opt.Follow {
+		return RestorePlan{}, fmt.Errorf("cannot use -dry-run with -f")
+	}
+
+	infos, err := litestream.CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
+	if err != nil {
+		return RestorePlan{}, err
+	}
+	if len(infos) == 0 {
+		return RestorePlan{}, litestream.ErrTxNotAvailable
+	}
+
+	plan := RestorePlan{
+		Source:     source,
+		TargetPath: opt.OutputPath,
+		Replica:    r.Client.Type(),
+		MinTXID:    infos[0].MinTXID.String(),
+		MaxTXID:    infos[len(infos)-1].MaxTXID.String(),
+		Files:      make([]RestorePlanFile, 0, len(infos)),
+	}
+	for _, info := range infos {
+		plan.Files = append(plan.Files, RestorePlanFile{
+			Level:     info.Level,
+			Name:      ltx.FormatFilename(info.MinTXID, info.MaxTXID),
+			MinTXID:   info.MinTXID.String(),
+			MaxTXID:   info.MaxTXID.String(),
+			Size:      info.Size,
+			Timestamp: info.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	return plan, nil
+}
+
+func (c *RestoreCommand) printDryRunPlan(plan RestorePlan) {
+	fmt.Println("Restore plan:")
+	fmt.Printf("  source: %s\n", plan.Source)
+	fmt.Printf("  target: %s\n", plan.TargetPath)
+	fmt.Printf("  replica: %s\n", plan.Replica)
+	fmt.Printf("  txid range: %s - %s\n", plan.MinTXID, plan.MaxTXID)
+	fmt.Println()
+	fmt.Println("Files to fetch:")
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintln(w, "level\tfile\tmin_txid\tmax_txid\tsize\ttimestamp")
+	for _, file := range plan.Files {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%d\t%s\n",
+			file.Level,
+			file.Name,
+			file.MinTXID,
+			file.MaxTXID,
+			file.Size,
+			file.Timestamp,
+		)
+	}
 }
 
 func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica, opt litestream.RestoreOptions) string {
@@ -253,6 +352,9 @@ Arguments:
 	-if-replica-exists
 	    Returns exit code of 0 if no backups found.
 
+	-dry-run
+	    Print the restore plan and exit without writing a database.
+
 	-json
 	    Output raw JSON summary on successful restore.
 
@@ -289,6 +391,9 @@ Examples:
 
 	# Restore database from S3 replica URL.
 	$ litestream restore -o /tmp/db s3://mybucket/db
+
+	# Preview restore plan without writing a database.
+	$ litestream restore -dry-run -o /tmp/db s3://mybucket/db
 
 	# Continuously restore (follow) a database from a replica.
 	$ litestream restore -f -o /tmp/read-replica.db s3://mybucket/db

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -106,6 +106,86 @@ func TestRestoreCommand_RunSuggestedOutputArgs(t *testing.T) {
 
 func TestRestoreCommand_RunJSONOutput(t *testing.T) {
 	ctx := context.Background()
+	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &RestoreCommand{}
+		if err := cmd.Run(ctx, []string{"-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got RestoreResult
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.DBPath != restorePath {
+		t.Fatalf("unexpected db path: %s", got.DBPath)
+	}
+	if got.Replica != "file" {
+		t.Fatalf("unexpected replica: %s", got.Replica)
+	}
+	if got.TXID == "" {
+		t.Fatal("expected txid")
+	}
+	if got.DurationMS < 0 {
+		t.Fatalf("unexpected duration_ms: %d", got.DurationMS)
+	}
+	if got.IntegrityCheck != "none" {
+		t.Fatalf("unexpected integrity check: %s", got.IntegrityCheck)
+	}
+	if _, err := os.Stat(restorePath); err != nil {
+		t.Fatalf("expected restored database: %v", err)
+	}
+}
+
+func TestRestoreCommand_RunDryRunJSONOutput(t *testing.T) {
+	ctx := context.Background()
+	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &RestoreCommand{}
+		if err := cmd.Run(ctx, []string{"-dry-run", "-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got RestorePlan
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.Source != "file://"+replicaPath {
+		t.Fatalf("unexpected source: %s", got.Source)
+	}
+	if got.TargetPath != restorePath {
+		t.Fatalf("unexpected target path: %s", got.TargetPath)
+	}
+	if got.Replica != "file" {
+		t.Fatalf("unexpected replica: %s", got.Replica)
+	}
+	if got.MinTXID == "" {
+		t.Fatal("expected min txid")
+	}
+	if got.MaxTXID == "" {
+		t.Fatal("expected max txid")
+	}
+	if len(got.Files) == 0 {
+		t.Fatal("expected files")
+	}
+	if got.Files[0].Name == "" {
+		t.Fatal("expected file name")
+	}
+	if got.Files[0].Timestamp == "" {
+		t.Fatal("expected file timestamp")
+	}
+	if _, err := os.Stat(restorePath); !os.IsNotExist(err) {
+		t.Fatalf("expected no restored database, stat err=%v", err)
+	}
+}
+
+func createRestoreCommandTestData(t *testing.T, ctx context.Context) (string, string) {
+	t.Helper()
+
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db.sqlite")
 	replicaPath := filepath.Join(dir, "replica")
@@ -139,33 +219,5 @@ func TestRestoreCommand_RunJSONOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	output := captureLTXCommandStdout(t, func() {
-		cmd := &RestoreCommand{}
-		if err := cmd.Run(ctx, []string{"-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	var got RestoreResult
-	if err := json.Unmarshal([]byte(output), &got); err != nil {
-		t.Fatalf("failed to parse output: %v\n%s", err, output)
-	}
-	if got.DBPath != restorePath {
-		t.Fatalf("unexpected db path: %s", got.DBPath)
-	}
-	if got.Replica != "file" {
-		t.Fatalf("unexpected replica: %s", got.Replica)
-	}
-	if got.TXID == "" {
-		t.Fatal("expected txid")
-	}
-	if got.DurationMS < 0 {
-		t.Fatalf("unexpected duration_ms: %d", got.DurationMS)
-	}
-	if got.IntegrityCheck != "none" {
-		t.Fatalf("unexpected integrity check: %s", got.IntegrityCheck)
-	}
-	if _, err := os.Stat(restorePath); err != nil {
-		t.Fatalf("expected restored database: %v", err)
-	}
+	return replicaPath, restorePath
 }

--- a/docs/CLI_JSON_OUTPUT.md
+++ b/docs/CLI_JSON_OUTPUT.md
@@ -117,6 +117,44 @@ written to stderr so stdout remains parseable JSON.
 | `duration_ms` | number | Restore duration in milliseconds. |
 | `integrity_check` | string | Integrity check mode used for the restore: `none`, `quick`, or `full`. |
 
+When `-dry-run` is combined with `-json`, `restore` outputs the restore plan
+instead of the final restore summary.
+
+```json
+{
+  "source": "file:///backups/app.db",
+  "target_path": "/var/lib/app.db",
+  "replica": "file",
+  "min_txid": "0000000000000001",
+  "max_txid": "0000000000000004",
+  "files": [
+    {
+      "level": 9,
+      "name": "0000000000000001-0000000000000004.ltx",
+      "min_txid": "0000000000000001",
+      "max_txid": "0000000000000004",
+      "size": 8192,
+      "timestamp": "2026-04-24T12:00:00Z"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `source` | string | Database path or replica URL passed to `restore`. |
+| `target_path` | string | Database path that would be written by a restore. |
+| `replica` | string | Replica client type used to build the plan. |
+| `min_txid` | string | Minimum transaction ID included in the plan. |
+| `max_txid` | string | Maximum transaction ID included in the plan. |
+| `files` | array | LTX files that would be fetched. |
+| `files[].level` | number | LTX compaction level. |
+| `files[].name` | string | LTX file name. |
+| `files[].min_txid` | string | Minimum transaction ID in the file. |
+| `files[].max_txid` | string | Maximum transaction ID in the file. |
+| `files[].size` | number | File size in bytes. |
+| `files[].timestamp` | string | File creation time in RFC 3339 format. |
+
 ## `litestream status -json`
 
 Outputs replication status for configured databases.


### PR DESCRIPTION
## Summary
- add litestream restore -dry-run to print the planned source, target, TXID range, and LTX files without writing a database
- support -dry-run -json with a documented restore-plan schema
- add a regression test that parses the plan and verifies the target DB is not created

## Testing
- go test -run 'TestRestoreCommand_RunDryRunJSONOutput|TestRestoreCommand_RunJSONOutput|TestRestoreCommand_RunMissingOutputPathForReplicaURL|TestRestoreCommand_RunSuggestedOutputArgs' ./cmd/litestream
- go test ./...
- pre-commit run --all-files

Related to #1232
Stacked on #1250