### PR TITLE
feat(cli): add reset dry run

### DIFF
--- a/cmd/litestream/reset.go
+++ b/cmd/litestream/reset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -17,6 +18,7 @@ type ResetCommand struct{}
 func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-reset", flag.ContinueOnError)
 	configPath, noExpandEnv := registerConfigFlag(fs)
+	dryRun := fs.Bool("dry-run", false, "print local state that would be removed without deleting")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -85,6 +87,27 @@ func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 		return nil
 	}
 
+	if *dryRun {
+		files, err := localLTXFiles(db.LTXDir())
+		if err != nil {
+			return fmt.Errorf("dry run failed: %w", err)
+		}
+
+		fmt.Printf("Dry run: local Litestream state would be reset for: %s\n", dbPath)
+		fmt.Printf("Would remove: %s\n", db.LTXDir())
+		if len(files) == 0 {
+			fmt.Println("No local LTX files would be removed.")
+			return nil
+		}
+
+		fmt.Println("Files that would be removed:")
+		for _, file := range files {
+			fmt.Printf("  %s\n", file)
+		}
+		fmt.Println("No files were removed.")
+		return nil
+	}
+
 	// Perform the reset
 	fmt.Printf("Resetting local Litestream state for: %s\n", dbPath)
 	fmt.Printf("Removing: %s\n", db.LTXDir())
@@ -95,6 +118,29 @@ func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 
 	fmt.Println("Reset complete. Next replication sync will create a fresh snapshot.")
 	return nil
+}
+
+func localLTXFiles(root string) ([]string, error) {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return files, nil
 }
 
 // Usage prints the help screen to STDOUT.
@@ -120,10 +166,16 @@ Arguments:
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
+	-dry-run
+	    Print the local LTX files that would be removed without deleting them.
+
 Examples:
 
 	# Reset local state for a specific database
 	litestream reset /path/to/database.db
+
+	# Preview local files that would be removed
+	litestream reset -dry-run /path/to/database.db
 
 	# Reset using a specific configuration file
 	litestream reset -config /etc/litestream.yml /path/to/database.db

--- a/cmd/litestream/reset_test.go
+++ b/cmd/litestream/reset_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/benbjohnson/litestream"
+)
+
+func TestResetCommand_RunDryRun(t *testing.T) {
+	dbPath, ltxPath := createResetCommandTestData(t)
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &ResetCommand{}
+		if err := cmd.Run(context.Background(), []string{"-dry-run", dbPath}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	for _, substr := range []string{
+		"Dry run: local Litestream state would be reset for:",
+		"Files that would be removed:",
+		ltxPath,
+		"No files were removed.",
+	} {
+		if !strings.Contains(output, substr) {
+			t.Fatalf("expected output to contain %q:\n%s", substr, output)
+		}
+	}
+	if _, err := os.Stat(ltxPath); err != nil {
+		t.Fatalf("expected dry run to keep LTX file: %v", err)
+	}
+}
+
+func TestResetCommand_Run(t *testing.T) {
+	dbPath, ltxPath := createResetCommandTestData(t)
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &ResetCommand{}
+		if err := cmd.Run(context.Background(), []string{dbPath}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Reset complete.") {
+		t.Fatalf("expected reset completion output:\n%s", output)
+	}
+	if _, err := os.Stat(ltxPath); !os.IsNotExist(err) {
+		t.Fatalf("expected LTX file to be removed, stat err=%v", err)
+	}
+}
+
+func createResetCommandTestData(t *testing.T) (string, string) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "db.sqlite")
+	if err := os.WriteFile(dbPath, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	db := litestream.NewDB(dbPath)
+	ltxDir := filepath.Join(db.LTXDir(), "0")
+	if err := os.MkdirAll(ltxDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	ltxPath := filepath.Join(ltxDir, "0000000000000001-0000000000000001.ltx")
+	if err := os.WriteFile(ltxPath, []byte("ltx"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	return dbPath, ltxPath
+}


### PR DESCRIPTION
## Summary
- add litestream reset -dry-run to show the local LTX directory and files that would be removed
- keep the dry-run path read-only and return before ResetLocalState
- add regression tests for dry-run preservation and the normal reset path

## Testing
- go test -run 'TestResetCommand_RunDryRun|TestResetCommand_Run' ./cmd/litestream
- go test ./...
- pre-commit run --all-files

Related to #1232
Stacked on #1251