### PR TITLE
feat(cli): add unregister dry run

### DIFF
--- a/cmd/litestream/unregister.go
+++ b/cmd/litestream/unregister.go
@@ -20,6 +20,7 @@ func (c *UnregisterCommand) Run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("litestream-unregister", flag.ContinueOnError)
 	timeout := fs.Int("timeout", 30, "timeout in seconds")
 	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
+	dryRun := fs.Bool("dry-run", false, "print what would be unregistered without changing the daemon")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -36,6 +37,17 @@ func (c *UnregisterCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	dbPath := fs.Arg(0)
+
+	if *dryRun {
+		fmt.Println("Dry run: unregister request preview")
+		fmt.Printf("  database: %s\n", dbPath)
+		fmt.Printf("  socket: %s\n", *socketPath)
+		fmt.Printf("  replicas: daemon-managed replica for this database\n")
+		fmt.Printf("  final sync: daemon close will sync the database and replica before the command completes\n")
+		fmt.Printf("  timeout: %ds\n", *timeout)
+		fmt.Println("No unregister request was sent.")
+		return nil
+	}
 
 	// Create HTTP client that connects via Unix socket with timeout.
 	clientTimeout := time.Duration(*timeout) * time.Second
@@ -106,9 +118,15 @@ Options:
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
 
+  -dry-run
+      Preview what would be unregistered without changing the daemon.
+
 Examples:
   # Unregister a database from the running daemon.
   $ litestream unregister /path/to/db
+
+  # Preview an unregister request without changing the daemon.
+  $ litestream unregister -dry-run /path/to/db
 
   # Unregister a database using a non-default control socket.
   $ litestream unregister -socket /tmp/litestream.sock /path/to/db

--- a/cmd/litestream/unregister_test.go
+++ b/cmd/litestream/unregister_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
@@ -59,6 +60,29 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		err := cmd.Run(context.Background(), []string{"-socket", "/nonexistent/socket.sock", "/tmp/test.db"})
 		if err == nil {
 			t.Error("expected error for socket connection failure")
+		}
+	})
+
+	t.Run("DryRunDoesNotConnect", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			cmd := &main.UnregisterCommand{}
+			err := cmd.Run(context.Background(), []string{"-dry-run", "-socket", "/nonexistent/socket.sock", "/tmp/test.db"})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+
+		for _, substr := range []string{
+			"Dry run: unregister request preview",
+			"database: /tmp/test.db",
+			"socket: /nonexistent/socket.sock",
+			"replicas: daemon-managed replica for this database",
+			"final sync: daemon close will sync the database and replica before the command completes",
+			"No unregister request was sent.",
+		} {
+			if !strings.Contains(output, substr) {
+				t.Fatalf("output missing %q:\n%s", substr, output)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Summary
- add litestream unregister -dry-run to preview the daemon unregister request without connecting or sending the POST
- show the database path, control socket, daemon-managed replica teardown, final-sync behavior, and timeout
- add regression coverage that dry-run does not require a live socket

## Testing
- go test -run 'TestUnregisterCommand_Run|TestUnregisterCommand_Usage' ./cmd/litestream
- go test ./...
- pre-commit run --all-files

Related to #1232
Stacked on #1252