### PR TITLE
feat(cli): guard restore overwrites

### DIFF
--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -34,6 +34,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	ifReplicaExists := fs.Bool("if-replica-exists", false, "")
 	timestampStr := fs.String("timestamp", "", "timestamp")
 	dryRun := fs.Bool("dry-run", false, "print restore plan without writing")
+	force := fs.Bool("force", false, "overwrite existing output database")
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.BoolVar(&opt.Follow, "f", false, "follow mode")
 	fs.DurationVar(&opt.FollowInterval, "follow-interval", opt.FollowInterval, "polling interval for follow mode")
@@ -128,6 +129,12 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 		c.printDryRunPlan(plan)
 		return nil
+	}
+
+	if !opt.Follow {
+		if err := c.prepareOutputPath(opt.OutputPath, *force); err != nil {
+			return err
+		}
 	}
 
 	txid := c.restoreTXID(ctx, r, opt)
@@ -255,6 +262,37 @@ func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica,
 	return infos[len(infos)-1].MaxTXID.String()
 }
 
+func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("cannot access output path: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("cannot restore, output path is a directory: %s", path)
+	}
+
+	if info.Size() > 0 && !force {
+		return fmt.Errorf("cannot restore, output path already exists and is not empty: %s. Use -force to overwrite", path)
+	}
+
+	for _, sidecarPath := range []string{path + "-wal", path + "-shm"} {
+		if _, err := os.Stat(sidecarPath); err == nil && !force {
+			return fmt.Errorf("cannot restore, SQLite sidecar path already exists: %s. Use -force to overwrite", sidecarPath)
+		} else if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("cannot access SQLite sidecar path: %w", err)
+		}
+	}
+
+	for _, removePath := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(removePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove existing output path: %w", err)
+		}
+	}
+	return nil
+}
+
 // loadFromURL creates a replica & updates the restore options from a replica URL.
 func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	if opt.OutputPath == "" {
@@ -354,6 +392,9 @@ Arguments:
 
 	-dry-run
 	    Print the restore plan and exit without writing a database.
+
+	-force
+	    Overwrite an existing output database and SQLite sidecar files.
 
 	-json
 	    Output raw JSON summary on successful restore.

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -277,7 +277,7 @@ func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {
 		return fmt.Errorf("cannot restore, output path already exists and is not empty: %s. Use -force to overwrite", path)
 	}
 
-	for _, sidecarPath := range []string{path + "-wal", path + "-shm"} {
+	for _, sidecarPath := range []string{path + "-wal", path + "-shm", path + "-journal"} {
 		if _, err := os.Stat(sidecarPath); err == nil && !force {
 			return fmt.Errorf("cannot restore, SQLite sidecar path already exists: %s. Use -force to overwrite", sidecarPath)
 		} else if err != nil && !os.IsNotExist(err) {
@@ -285,7 +285,7 @@ func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {
 		}
 	}
 
-	for _, removePath := range []string{path, path + "-wal", path + "-shm"} {
+	for _, removePath := range []string{path, path + "-wal", path + "-shm", path + "-journal"} {
 		if err := os.Remove(removePath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove existing output path: %w", err)
 		}

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -183,6 +183,62 @@ func TestRestoreCommand_RunDryRunJSONOutput(t *testing.T) {
 	}
 }
 
+func TestRestoreCommand_RunRequiresForceForExistingOutput(t *testing.T) {
+	ctx := context.Background()
+	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
+	if err := os.WriteFile(restorePath, []byte("existing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &RestoreCommand{}
+	err := cmd.Run(ctx, []string{"-o", restorePath, "file://" + replicaPath})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	expected := "cannot restore, output path already exists and is not empty: " + restorePath + ". Use -force to overwrite"
+	if err.Error() != expected {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf, err := os.ReadFile(restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "existing" {
+		t.Fatalf("existing output was modified: %q", string(buf))
+	}
+}
+
+func TestRestoreCommand_RunForceOverwritesExistingOutput(t *testing.T) {
+	ctx := context.Background()
+	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
+	for _, path := range []string{restorePath, restorePath + "-wal", restorePath + "-shm"} {
+		if err := os.WriteFile(path, []byte("existing"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := &RestoreCommand{}
+	if err := cmd.Run(ctx, []string{"-force", "-o", restorePath, "file://" + replicaPath}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertRestoreCommandDB(t, restorePath)
+}
+
+func TestRestoreCommand_RunAllowsEmptyOutput(t *testing.T) {
+	ctx := context.Background()
+	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
+	if err := os.WriteFile(restorePath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &RestoreCommand{}
+	if err := cmd.Run(ctx, []string{"-o", restorePath, "file://" + replicaPath}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertRestoreCommandDB(t, restorePath)
+}
+
 func createRestoreCommandTestData(t *testing.T, ctx context.Context) (string, string) {
 	t.Helper()
 
@@ -220,4 +276,23 @@ func createRestoreCommandTestData(t *testing.T, ctx context.Context) (string, st
 	}
 
 	return replicaPath, restorePath
+}
+
+func assertRestoreCommandDB(t *testing.T, path string) {
+	t.Helper()
+
+	sqldb := testingutil.MustOpenSQLDB(t, path)
+	defer func() {
+		if err := sqldb.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	var count int
+	if err := sqldb.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM t`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("count=%d, want 1", count)
+	}
 }

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -212,7 +212,7 @@ func TestRestoreCommand_RunRequiresForceForExistingOutput(t *testing.T) {
 func TestRestoreCommand_RunForceOverwritesExistingOutput(t *testing.T) {
 	ctx := context.Background()
 	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
-	for _, path := range []string{restorePath, restorePath + "-wal", restorePath + "-shm"} {
+	for _, path := range []string{restorePath, restorePath + "-wal", restorePath + "-shm", restorePath + "-journal"} {
 		if err := os.WriteFile(path, []byte("existing"), 0600); err != nil {
 			t.Fatal(err)
 		}
@@ -223,6 +223,29 @@ func TestRestoreCommand_RunForceOverwritesExistingOutput(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertRestoreCommandDB(t, restorePath)
+}
+
+func TestRestoreCommand_RunRequiresForceForExistingJournal(t *testing.T) {
+	ctx := context.Background()
+	replicaPath, restorePath := createRestoreCommandTestData(t, ctx)
+	// Empty main file passes the size check; journal sidecar should still trip the guard.
+	if err := os.WriteFile(restorePath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	journalPath := restorePath + "-journal"
+	if err := os.WriteFile(journalPath, []byte("existing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &RestoreCommand{}
+	err := cmd.Run(ctx, []string{"-o", restorePath, "file://" + replicaPath})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	expected := "cannot restore, SQLite sidecar path already exists: " + journalPath + ". Use -force to overwrite"
+	if err.Error() != expected {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestRestoreCommand_RunAllowsEmptyOutput(t *testing.T) {


### PR DESCRIPTION
## Summary
- add -force to litestream restore for intentional overwrite of an existing output database
- require -force for non-empty output paths and existing SQLite sidecar files
- allow empty placeholder output files by removing them before the restore; keep follow mode and -if-db-not-exists behavior unchanged

## Testing
- go test -run 'TestRestoreCommand_RunRequiresForceForExistingOutput|TestRestoreCommand_RunForceOverwritesExistingOutput|TestRestoreCommand_RunAllowsEmptyOutput|TestRestoreCommand_RunJSONOutput|TestRestoreCommand_RunDryRunJSONOutput' ./cmd/litestream
- go test ./...
- pre-commit run --all-files

Related to #1232
Stacked on #1253