### PR TITLE
feat(cli): add register success payload

### DIFF
--- a/cmd/litestream/register.go
+++ b/cmd/litestream/register.go
@@ -21,6 +21,7 @@ func (c *RegisterCommand) Run(ctx context.Context, args []string) error {
 	timeout := fs.Int("timeout", 30, "timeout in seconds")
 	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
 	replicaFlag := fs.String("replica", "", "replica URL (e.g., s3://bucket/prefix, file:///backup/path)")
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -86,13 +87,34 @@ func (c *RegisterCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format response: %w", err)
+	confirmation := RegisterResult{
+		Status:  result.Status,
+		DBPath:  result.Path,
+		Replica: replicaURL,
+		Socket:  *socketPath,
 	}
-	fmt.Println(string(output))
+	if *jsonOutput {
+		output, err := json.MarshalIndent(confirmation, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	fmt.Printf("status: %s\n", confirmation.Status)
+	fmt.Printf("db_path: %s\n", confirmation.DBPath)
+	fmt.Printf("replica: %s\n", confirmation.Replica)
+	fmt.Printf("socket: %s\n", confirmation.Socket)
 
 	return nil
+}
+
+type RegisterResult struct {
+	Status  string `json:"status"`
+	DBPath  string `json:"db_path"`
+	Replica string `json:"replica"`
+	Socket  string `json:"socket"`
 }
 
 func (c *RegisterCommand) Usage() {
@@ -115,6 +137,9 @@ Options:
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
 
+  -json
+      Output raw JSON instead of human-readable text.
+
 Examples:
   # Register a database with an S3 replica.
   $ litestream register -replica s3://mybucket/db /path/to/db
@@ -124,5 +149,8 @@ Examples:
 
   # Register using a non-default control socket.
   $ litestream register -socket /tmp/litestream.sock -replica s3://mybucket/db /path/to/db
+
+  # Register and emit a JSON confirmation.
+  $ litestream register -json -replica s3://mybucket/db /path/to/db
 `[1:])
 }

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -128,6 +129,52 @@ func TestRegisterCommand_Run(t *testing.T) {
 		// Still only 1 database - didn't register a duplicate.
 		if len(store.DBs()) != 1 {
 			t.Errorf("expected 1 database in store, got %d", len(store.DBs()))
+		}
+	})
+
+	t.Run("JSONOutput", func(t *testing.T) {
+		store := litestream.NewStore(nil, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close(context.Background())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer server.Close()
+
+		db, sqldb := testingutil.MustOpenDBs(t)
+		testingutil.MustCloseDBs(t, db, sqldb)
+		backupDir := filepath.Join(t.TempDir(), "backup")
+		replicaURL := "file://" + backupDir
+
+		output := captureStdout(t, func() {
+			cmd := &main.RegisterCommand{}
+			err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, "-replica", replicaURL, db.Path()})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got main.RegisterResult
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if got.Status != "registered" {
+			t.Fatalf("unexpected status: %s", got.Status)
+		}
+		if got.DBPath != db.Path() {
+			t.Fatalf("unexpected db path: %s", got.DBPath)
+		}
+		if got.Replica != replicaURL {
+			t.Fatalf("unexpected replica: %s", got.Replica)
+		}
+		if got.Socket != server.SocketPath {
+			t.Fatalf("unexpected socket: %s", got.Socket)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- add a register confirmation payload with status, db_path, replica, and socket
- add -json for the chainable register result while using labeled text by default
- cover the JSON payload and updated help example in tests

## Testing
- go test -run 'TestRegisterCommand_Run|TestRegisterCommand_Usage' ./cmd/litestream
- go test ./...
- pre-commit run --all-files

Related to #1232
Stacked on #1254