### PR TITLE
feat(cli): add start stop success payload

### DIFF
--- a/cmd/litestream/start.go
+++ b/cmd/litestream/start.go
@@ -23,6 +23,7 @@ func (c *StartCommand) Run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("litestream-start", flag.ContinueOnError)
 	timeout := fs.Int("timeout", 30, "timeout in seconds")
 	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -86,11 +87,40 @@ Run 'litestream start -h' for usage details.
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format response: %w", err)
+	confirmation := StartStopResult{
+		DBPath: result.Path,
+		State:  "running",
+		TXID:   result.TXID,
+		Socket: *socketPath,
 	}
-	fmt.Println(string(output))
+	if err := printStartStopResult(confirmation, *jsonOutput); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type StartStopResult struct {
+	DBPath string `json:"db_path"`
+	State  string `json:"state"`
+	TXID   uint64 `json:"txid"`
+	Socket string `json:"socket"`
+}
+
+func printStartStopResult(result StartStopResult, jsonOutput bool) error {
+	if jsonOutput {
+		output, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	fmt.Printf("db_path: %s\n", result.DBPath)
+	fmt.Printf("state: %s\n", result.State)
+	fmt.Printf("txid: %d\n", result.TXID)
+	fmt.Printf("socket: %s\n", result.Socket)
 
 	return nil
 }
@@ -109,9 +139,15 @@ Options:
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
 
+  -json
+      Output raw JSON instead of human-readable text.
+
 Examples:
   # Start replication for a database on the running daemon.
   $ litestream start /path/to/db
+
+  # Start replication and emit a JSON confirmation.
+  $ litestream start -json /path/to/db
 
   # Start replication using a non-default control socket.
   $ litestream start -socket /tmp/litestream.sock /path/to/db

--- a/cmd/litestream/start_stop_test.go
+++ b/cmd/litestream/start_stop_test.go
@@ -1,0 +1,124 @@
+package main_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/benbjohnson/litestream"
+	main "github.com/benbjohnson/litestream/cmd/litestream"
+	"github.com/benbjohnson/litestream/internal/testingutil"
+)
+
+func TestStartCommand_RunJSONOutput(t *testing.T) {
+	db, sqldb := newStartStopCommandDB(t)
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	defer store.Close(t.Context())
+
+	server := litestream.NewServer(store)
+	server.SocketPath = testSocketPath(t)
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	output := captureStdout(t, func() {
+		cmd := &main.StartCommand{}
+		if err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, db.Path()}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got main.StartStopResult
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.DBPath != db.Path() {
+		t.Fatalf("unexpected db path: %s", got.DBPath)
+	}
+	if got.State != "running" {
+		t.Fatalf("unexpected state: %s", got.State)
+	}
+	if got.TXID == 0 {
+		t.Fatal("expected non-zero txid")
+	}
+	if got.Socket != server.SocketPath {
+		t.Fatalf("unexpected socket: %s", got.Socket)
+	}
+}
+
+func TestStopCommand_RunJSONOutput(t *testing.T) {
+	db, _ := newStartStopCommandDB(t)
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	if err := store.Open(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close(t.Context())
+
+	server := litestream.NewServer(store)
+	server.SocketPath = testSocketPath(t)
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	output := captureStdout(t, func() {
+		cmd := &main.StopCommand{}
+		if err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, db.Path()}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got main.StartStopResult
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.DBPath != db.Path() {
+		t.Fatalf("unexpected db path: %s", got.DBPath)
+	}
+	if got.State != "stopped" {
+		t.Fatalf("unexpected state: %s", got.State)
+	}
+	if got.TXID == 0 {
+		t.Fatal("expected non-zero txid")
+	}
+	if got.Socket != server.SocketPath {
+		t.Fatalf("unexpected socket: %s", got.Socket)
+	}
+}
+
+func newStartStopCommandDB(t *testing.T) (*litestream.DB, *sql.DB) {
+	t.Helper()
+
+	db, sqldb := testingutil.MustOpenDBs(t)
+	t.Cleanup(func() {
+		_ = sqldb.Close()
+		_ = db.Close(context.Background())
+		_ = os.RemoveAll(filepath.Dir(db.Path()))
+	})
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	return db, sqldb
+}

--- a/cmd/litestream/stop.go
+++ b/cmd/litestream/stop.go
@@ -22,6 +22,7 @@ func (c *StopCommand) Run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("litestream-stop", flag.ContinueOnError)
 	timeout := fs.Int("timeout", 30, "timeout in seconds")
 	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -80,11 +81,15 @@ func (c *StopCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format response: %w", err)
+	confirmation := StartStopResult{
+		DBPath: result.Path,
+		State:  "stopped",
+		TXID:   result.TXID,
+		Socket: *socketPath,
 	}
-	fmt.Println(string(output))
+	if err := printStartStopResult(confirmation, *jsonOutput); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -104,9 +109,15 @@ Options:
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
 
+  -json
+      Output raw JSON instead of human-readable text.
+
 Examples:
   # Stop replication for a database.
   $ litestream stop /path/to/db
+
+  # Stop replication and emit a JSON confirmation.
+  $ litestream stop -json /path/to/db
 
   # Stop replication using a non-default control socket.
   $ litestream stop -socket /tmp/litestream.sock /path/to/db

--- a/server.go
+++ b/server.go
@@ -194,10 +194,16 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
+	txID, err := s.storeTXID(expandedPath)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, StartResponse{
 		Status: "started",
 		Path:   expandedPath,
+		TXID:   txID,
 	})
 }
 
@@ -230,11 +236,30 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
+	txID, err := s.storeTXID(expandedPath)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, StopResponse{
 		Status: "stopped",
 		Path:   expandedPath,
+		TXID:   txID,
 	})
+}
+
+func (s *Server) storeTXID(path string) (uint64, error) {
+	db := s.store.FindDB(path)
+	if db == nil {
+		return 0, fmt.Errorf("database not found: %s", path)
+	}
+
+	_, maxTXID, err := db.MaxLTX()
+	if err != nil {
+		return 0, fmt.Errorf("read txid: %w", err)
+	}
+	return uint64(maxTXID), nil
 }
 
 func (s *Server) handleTXID(w http.ResponseWriter, r *http.Request) {
@@ -321,6 +346,7 @@ type StartRequest struct {
 type StartResponse struct {
 	Status string `json:"status"`
 	Path   string `json:"path"`
+	TXID   uint64 `json:"txid"`
 }
 
 // StopRequest is the request body for the /stop endpoint.
@@ -333,6 +359,7 @@ type StopRequest struct {
 type StopResponse struct {
 	Status string `json:"status"`
 	Path   string `json:"path"`
+	TXID   uint64 `json:"txid"`
 }
 
 // ErrorResponse is returned when an error occurs.


### PR DESCRIPTION
## Description
Add explicit success confirmations for `litestream start` and `litestream stop`. Human output now reports `db_path`, `state`, `txid`, and `socket`; `-json` emits the same stable payload for chaining.

The daemon start/stop responses now include the last known local TXID so the CLI can report a real value instead of guessing.

## Motivation and Context
This addresses the `start` / `stop` success payload item in the CLI agent-friendly tracking issue.

Refs #1232

## How Has This Been Tested?
- `go test -run 'Test(Start|Stop)Command_(RunJSONOutput|Usage)$' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)