### PR TITLE
feat(cli): add sync success payload

### DIFF
--- a/cmd/litestream/sync.go
+++ b/cmd/litestream/sync.go
@@ -23,6 +23,7 @@ func (c *SyncCommand) Run(ctx context.Context, args []string) error {
 	timeout := fs.Int("timeout", 30, "timeout in seconds")
 	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
 	wait := fs.Bool("wait", false, "block until sync completes")
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -60,11 +61,13 @@ func (c *SyncCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
+	start := time.Now()
 	resp, err := client.Post("http://localhost/sync", "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("failed to connect to control socket: %w", err)
 	}
 	defer resp.Body.Close()
+	durationMS := time.Since(start).Milliseconds()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -84,11 +87,44 @@ func (c *SyncCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format response: %w", err)
+	confirmation := SyncResult{
+		DBPath:     result.Path,
+		TXID:       result.TXID,
+		DurationMS: durationMS,
 	}
-	fmt.Println(string(output))
+	if *wait {
+		confirmation.ReplicaTXID = &result.ReplicatedTXID
+	}
+	if err := printSyncResult(confirmation, *jsonOutput); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type SyncResult struct {
+	DBPath      string  `json:"db_path"`
+	TXID        uint64  `json:"txid"`
+	ReplicaTXID *uint64 `json:"replica_txid,omitempty"`
+	DurationMS  int64   `json:"duration_ms"`
+}
+
+func printSyncResult(result SyncResult, jsonOutput bool) error {
+	if jsonOutput {
+		output, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	fmt.Printf("db_path: %s\n", result.DBPath)
+	fmt.Printf("txid: %d\n", result.TXID)
+	if result.ReplicaTXID != nil {
+		fmt.Printf("replica_txid: %d\n", *result.ReplicaTXID)
+	}
+	fmt.Printf("duration_ms: %d\n", result.DurationMS)
 
 	return nil
 }
@@ -110,8 +146,12 @@ Options:
   -socket PATH
       Path to control socket (default: /var/run/litestream.sock).
 
+  -json
+      Output raw JSON instead of human-readable text.
+
 Examples:
   $ litestream sync /path/to/db
+  $ litestream sync -json /path/to/db
   $ litestream sync -wait /path/to/db
   $ litestream sync -wait -timeout 120 /path/to/db
 `[1:])

--- a/cmd/litestream/sync_test.go
+++ b/cmd/litestream/sync_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
@@ -108,6 +109,107 @@ func TestSyncCommand_Run(t *testing.T) {
 		err = cmd.Run(t.Context(), []string{"-socket", server.SocketPath, "-wait", db.Path()})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("JSONOutput", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		_, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close(t.Context())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer server.Close()
+
+		output := captureStdout(t, func() {
+			cmd := &main.SyncCommand{}
+			err = cmd.Run(t.Context(), []string{"-json", "-socket", server.SocketPath, db.Path()})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got main.SyncResult
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if got.DBPath != db.Path() {
+			t.Fatalf("unexpected db path: %s", got.DBPath)
+		}
+		if got.TXID == 0 {
+			t.Fatal("expected non-zero txid")
+		}
+		if got.ReplicaTXID != nil {
+			t.Fatalf("expected omitted replica txid without -wait, got %d", *got.ReplicaTXID)
+		}
+		if got.DurationMS < 0 {
+			t.Fatalf("unexpected duration: %d", got.DurationMS)
+		}
+	})
+
+	t.Run("JSONOutputWithWait", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		_, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close(t.Context())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer server.Close()
+
+		output := captureStdout(t, func() {
+			cmd := &main.SyncCommand{}
+			err = cmd.Run(t.Context(), []string{"-json", "-wait", "-socket", server.SocketPath, db.Path()})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got main.SyncResult
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if got.DBPath != db.Path() {
+			t.Fatalf("unexpected db path: %s", got.DBPath)
+		}
+		if got.TXID == 0 {
+			t.Fatal("expected non-zero txid")
+		}
+		if got.ReplicaTXID == nil {
+			t.Fatal("expected replica txid with -wait")
+		}
+		if *got.ReplicaTXID == 0 {
+			t.Fatal("expected non-zero replica txid")
+		}
+		if got.DurationMS < 0 {
+			t.Fatalf("unexpected duration: %d", got.DurationMS)
 		}
 	})
 }


### PR DESCRIPTION
## Description
Add explicit success output for `litestream sync`. Human output now reports `db_path`, `txid`, and `duration_ms`; `-wait` also includes `replica_txid`. `-json` emits the same payload for scripts and agents.

## Motivation and Context
This addresses the `sync` success payload item in the CLI agent-friendly tracking issue.

Refs #1232

## How Has This Been Tested?
- `go test -run 'TestSyncCommand_(Run|Usage)$' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)