### PR TITLE
feat(cli): add unregister success payload

### DIFF
--- a/cmd/litestream/unregister.go
+++ b/cmd/litestream/unregister.go
@@ -21,6 +21,7 @@ func (c *UnregisterCommand) Run(ctx context.Context, args []string) error {
 	timeout := fs.Int("timeout", 30, "timeout in seconds")
 	socketPath := fs.String("socket", "/var/run/litestream.sock", "control socket path")
 	dryRun := fs.Bool("dry-run", false, "print what would be unregistered without changing the daemon")
+	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -93,11 +94,40 @@ func (c *UnregisterCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	output, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format response: %w", err)
+	confirmation := UnregisterResult{
+		Status:    result.Status,
+		DBPath:    result.Path,
+		FinalTXID: result.TXID,
+		Socket:    *socketPath,
 	}
-	fmt.Println(string(output))
+	if err := printUnregisterResult(confirmation, *jsonOutput); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type UnregisterResult struct {
+	Status    string `json:"status"`
+	DBPath    string `json:"db_path"`
+	FinalTXID uint64 `json:"final_txid"`
+	Socket    string `json:"socket"`
+}
+
+func printUnregisterResult(result UnregisterResult, jsonOutput bool) error {
+	if jsonOutput {
+		output, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to format response: %w", err)
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	fmt.Printf("status: %s\n", result.Status)
+	fmt.Printf("db_path: %s\n", result.DBPath)
+	fmt.Printf("final_txid: %d\n", result.FinalTXID)
+	fmt.Printf("socket: %s\n", result.Socket)
 
 	return nil
 }
@@ -121,9 +151,15 @@ Options:
   -dry-run
       Preview what would be unregistered without changing the daemon.
 
+  -json
+      Output raw JSON instead of human-readable text.
+
 Examples:
   # Unregister a database from the running daemon.
   $ litestream unregister /path/to/db
+
+  # Unregister a database and emit a JSON confirmation.
+  $ litestream unregister -json /path/to/db
 
   # Preview an unregister request without changing the daemon.
   $ litestream unregister -dry-run /path/to/db

--- a/cmd/litestream/unregister_test.go
+++ b/cmd/litestream/unregister_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -140,6 +141,62 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		}
 
 		// Verify database was unregistered from store.
+		if len(store.DBs()) != 0 {
+			t.Errorf("expected 0 databases in store, got %d", len(store.DBs()))
+		}
+	})
+
+	t.Run("JSONOutput", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+		dbPath := db.Path()
+
+		_, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close(context.Background())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer server.Close()
+
+		output := captureStdout(t, func() {
+			cmd := &main.UnregisterCommand{}
+			err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, dbPath})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got main.UnregisterResult
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if got.Status != "unregistered" {
+			t.Fatalf("unexpected status: %s", got.Status)
+		}
+		if got.DBPath != dbPath {
+			t.Fatalf("unexpected db path: %s", got.DBPath)
+		}
+		if got.FinalTXID == 0 {
+			t.Fatal("expected non-zero final txid")
+		}
+		if got.Socket != server.SocketPath {
+			t.Fatalf("unexpected socket: %s", got.Socket)
+		}
 		if len(store.DBs()) != 0 {
 			t.Errorf("expected 0 databases in store, got %d", len(store.DBs()))
 		}

--- a/server.go
+++ b/server.go
@@ -543,6 +543,7 @@ type UnregisterDatabaseRequest struct {
 type UnregisterDatabaseResponse struct {
 	Status string `json:"status"`
 	Path   string `json:"path"`
+	TXID   uint64 `json:"txid"`
 }
 
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
@@ -630,14 +631,26 @@ func (s *Server) handleUnregister(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
+	db := s.store.FindDB(expandedPath)
+
 	// Remove database from store (this also closes it).
 	if err := s.store.UnregisterDB(ctx, expandedPath); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, fmt.Sprintf("failed to unregister database: %v", err), nil)
 		return
 	}
+	var txID uint64
+	if db != nil {
+		_, maxTXID, err := db.MaxLTX()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, fmt.Sprintf("failed to read final txid: %v", err), nil)
+			return
+		}
+		txID = uint64(maxTXID)
+	}
 
 	writeJSON(w, http.StatusOK, UnregisterDatabaseResponse{
 		Status: "unregistered",
 		Path:   expandedPath,
+		TXID:   txID,
 	})
 }


### PR DESCRIPTION
## Description
Add explicit success output for `litestream unregister`. Human output now reports `status`, `db_path`, `final_txid`, and `socket`; `-json` emits the same stable payload.

The daemon unregister response now includes the final local TXID after the existing close/final-sync path completes.

## Motivation and Context
This addresses the `unregister` success payload item in the CLI agent-friendly tracking issue.

Refs #1232

## How Has This Been Tested?
- `go test -run 'TestUnregisterCommand_(Run|Usage)$' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality not to work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)