### PR TITLE
fix(cli): clarify register idempotency

### DIFF
--- a/cmd/litestream/register.go
+++ b/cmd/litestream/register.go
@@ -102,7 +102,7 @@ func (c *RegisterCommand) Run(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("status: %s\n", confirmation.Status)
+	fmt.Printf("status: %s\n", registerDisplayStatus(confirmation.Status))
 	fmt.Printf("db_path: %s\n", confirmation.DBPath)
 	fmt.Printf("replica: %s\n", confirmation.Replica)
 	fmt.Printf("socket: %s\n", confirmation.Socket)
@@ -115,6 +115,13 @@ type RegisterResult struct {
 	DBPath  string `json:"db_path"`
 	Replica string `json:"replica"`
 	Socket  string `json:"socket"`
+}
+
+func registerDisplayStatus(status string) string {
+	if status == "already_exists" {
+		return "already registered"
+	}
+	return status
 }
 
 func (c *RegisterCommand) Usage() {

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/benbjohnson/litestream"
@@ -121,9 +122,14 @@ func TestRegisterCommand_Run(t *testing.T) {
 		backupDir := filepath.Join(t.TempDir(), "backup")
 
 		cmd := &main.RegisterCommand{}
-		err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, "-replica", "file://" + backupDir, db.Path()})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		output := captureStdout(t, func() {
+			err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, "-replica", "file://" + backupDir, db.Path()})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+		if !strings.Contains(output, "status: already registered") {
+			t.Fatalf("expected already registered status, got:\n%s", output)
 		}
 
 		// Still only 1 database - didn't register a duplicate.


### PR DESCRIPTION
## Description
Clarify the human output for idempotent `litestream register` calls. Re-registering an already registered database still exits 0, and now prints `status: already registered` instead of the internal `already_exists` value.

The JSON payload remains unchanged so scripts can continue to match the stable daemon status.

## Motivation and Context
This addresses the register idempotency audit item in the CLI agent-friendly tracking issue.

Refs #1232

## How Has This Been Tested?
- `go test -run 'TestRegisterCommand_(Run|Usage)$' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality not to work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)