### PR TITLE
fix(cli): make start stop idempotent

### DIFF
--- a/cmd/litestream/start.go
+++ b/cmd/litestream/start.go
@@ -88,6 +88,7 @@ Run 'litestream start -h' for usage details.
 	}
 
 	confirmation := StartStopResult{
+		Status: result.Status,
 		DBPath: result.Path,
 		State:  "running",
 		TXID:   result.TXID,
@@ -101,6 +102,7 @@ Run 'litestream start -h' for usage details.
 }
 
 type StartStopResult struct {
+	Status string `json:"status"`
 	DBPath string `json:"db_path"`
 	State  string `json:"state"`
 	TXID   uint64 `json:"txid"`
@@ -117,6 +119,7 @@ func printStartStopResult(result StartStopResult, jsonOutput bool) error {
 		return nil
 	}
 
+	fmt.Printf("status: %s\n", result.Status)
 	fmt.Printf("db_path: %s\n", result.DBPath)
 	fmt.Printf("state: %s\n", result.State)
 	fmt.Printf("txid: %d\n", result.TXID)

--- a/cmd/litestream/start_stop_test.go
+++ b/cmd/litestream/start_stop_test.go
@@ -47,6 +47,9 @@ func TestStartCommand_RunJSONOutput(t *testing.T) {
 	if got.DBPath != db.Path() {
 		t.Fatalf("unexpected db path: %s", got.DBPath)
 	}
+	if got.Status != "started" {
+		t.Fatalf("unexpected status: %s", got.Status)
+	}
 	if got.State != "running" {
 		t.Fatalf("unexpected state: %s", got.State)
 	}
@@ -55,6 +58,45 @@ func TestStartCommand_RunJSONOutput(t *testing.T) {
 	}
 	if got.Socket != server.SocketPath {
 		t.Fatalf("unexpected socket: %s", got.Socket)
+	}
+}
+
+func TestStartCommand_RunAlreadyRunning(t *testing.T) {
+	db, _ := newStartStopCommandDB(t)
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	if err := store.Open(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close(t.Context())
+
+	server := litestream.NewServer(store)
+	server.SocketPath = testSocketPath(t)
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	output := captureStdout(t, func() {
+		cmd := &main.StartCommand{}
+		if err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, db.Path()}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got main.StartStopResult
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.Status != "already_running" {
+		t.Fatalf("unexpected status: %s", got.Status)
+	}
+	if got.State != "running" {
+		t.Fatalf("unexpected state: %s", got.State)
+	}
+	if got.TXID == 0 {
+		t.Fatal("expected non-zero txid")
 	}
 }
 
@@ -89,6 +131,9 @@ func TestStopCommand_RunJSONOutput(t *testing.T) {
 	if got.DBPath != db.Path() {
 		t.Fatalf("unexpected db path: %s", got.DBPath)
 	}
+	if got.Status != "stopped" {
+		t.Fatalf("unexpected status: %s", got.Status)
+	}
 	if got.State != "stopped" {
 		t.Fatalf("unexpected state: %s", got.State)
 	}
@@ -97,6 +142,48 @@ func TestStopCommand_RunJSONOutput(t *testing.T) {
 	}
 	if got.Socket != server.SocketPath {
 		t.Fatalf("unexpected socket: %s", got.Socket)
+	}
+}
+
+func TestStopCommand_RunAlreadyStopped(t *testing.T) {
+	db, sqldb := newStartStopCommandDB(t)
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	defer store.Close(t.Context())
+
+	server := litestream.NewServer(store)
+	server.SocketPath = testSocketPath(t)
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	output := captureStdout(t, func() {
+		cmd := &main.StopCommand{}
+		if err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, db.Path()}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var got main.StartStopResult
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.Status != "already_stopped" {
+		t.Fatalf("unexpected status: %s", got.Status)
+	}
+	if got.State != "stopped" {
+		t.Fatalf("unexpected state: %s", got.State)
+	}
+	if got.TXID == 0 {
+		t.Fatal("expected non-zero txid")
 	}
 }
 

--- a/cmd/litestream/stop.go
+++ b/cmd/litestream/stop.go
@@ -82,6 +82,7 @@ func (c *StopCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	confirmation := StartStopResult{
+		Status: result.Status,
 		DBPath: result.Path,
 		State:  "stopped",
 		TXID:   result.TXID,

--- a/server.go
+++ b/server.go
@@ -190,9 +190,20 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
-	if err := s.store.EnableDB(ctx, expandedPath); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
+	db := s.store.FindDB(expandedPath)
+	if db == nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Sprintf("database not found: %s", expandedPath), nil)
 		return
+	}
+
+	status := "started"
+	if db.IsOpen() {
+		status = "already_running"
+	} else {
+		if err := s.store.EnableDB(ctx, expandedPath); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
+			return
+		}
 	}
 	txID, err := s.storeTXID(expandedPath)
 	if err != nil {
@@ -201,7 +212,7 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, StartResponse{
-		Status: "started",
+		Status: status,
 		Path:   expandedPath,
 		TXID:   txID,
 	})
@@ -232,9 +243,20 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	if err := s.store.DisableDB(ctx, expandedPath); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
+	db := s.store.FindDB(expandedPath)
+	if db == nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Sprintf("database not found: %s", expandedPath), nil)
 		return
+	}
+
+	status := "stopped"
+	if !db.IsOpen() {
+		status = "already_stopped"
+	} else {
+		if err := s.store.DisableDB(ctx, expandedPath); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error(), nil)
+			return
+		}
 	}
 	txID, err := s.storeTXID(expandedPath)
 	if err != nil {
@@ -243,7 +265,7 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, StopResponse{
-		Status: "stopped",
+		Status: status,
 		Path:   expandedPath,
 		TXID:   txID,
 	})


### PR DESCRIPTION
## Description
Make `litestream start` and `litestream stop` idempotent through the control API. Calling `start` on an already running DB now exits 0 with `status: already_running`; calling `stop` on an already stopped DB exits 0 with `status: already_stopped`.

The CLI success payload includes status in both human and JSON output while preserving the existing state and TXID fields.

## Motivation and Context
This addresses the start/stop idempotency audit item in the CLI agent-friendly tracking issue.

Refs #1232

## How Has This Been Tested?
- `go test -run 'Test(Start|Stop)Command_(RunJSONOutput|RunAlreadyRunning|RunAlreadyStopped|Usage)$' ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality not to work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)