### PR TITLE
fix(cli): clarify unregister idempotency

### DIFF
--- a/cmd/litestream/unregister_test.go
+++ b/cmd/litestream/unregister_test.go
@@ -102,11 +102,19 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		}
 		defer server.Close()
 
-		cmd := &main.UnregisterCommand{}
-		// Should not error even though database doesn't exist.
-		err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, "/nonexistent/db"})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		output := captureStdout(t, func() {
+			cmd := &main.UnregisterCommand{}
+			// Should not error even though database doesn't exist.
+			err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, "/nonexistent/db"})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+		if !strings.Contains(output, "status: not_registered") {
+			t.Fatalf("expected not_registered status, got:\n%s", output)
+		}
+		if !strings.Contains(output, "final_txid: 0") {
+			t.Fatalf("expected zero final txid, got:\n%s", output)
 		}
 	})
 

--- a/server.go
+++ b/server.go
@@ -661,6 +661,7 @@ func (s *Server) handleUnregister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var txID uint64
+	status := "not_registered"
 	if db != nil {
 		_, maxTXID, err := db.MaxLTX()
 		if err != nil {
@@ -668,10 +669,11 @@ func (s *Server) handleUnregister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		txID = uint64(maxTXID)
+		status = "unregistered"
 	}
 
 	writeJSON(w, http.StatusOK, UnregisterDatabaseResponse{
-		Status: "unregistered",
+		Status: status,
 		Path:   expandedPath,
 		TXID:   txID,
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -462,7 +462,8 @@ func TestServer_HandleUnregister(t *testing.T) {
 
 		var result litestream.UnregisterDatabaseResponse
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
-		require.Equal(t, "unregistered", result.Status)
+		require.Equal(t, "not_registered", result.Status)
+		require.Zero(t, result.TXID)
 	})
 
 	t.Run("Success", func(t *testing.T) {


### PR DESCRIPTION
## Description
Clarify the idempotent unregister no-op case. Unregistering a database that is not registered still exits 0, but now returns `status: not_registered` with `final_txid: 0` instead of reporting it as `unregistered`.

## Motivation and Context
This addresses the unregister idempotency audit item in the CLI agent-friendly tracking issue.

Refs #1232

## How Has This Been Tested?
- `go test -run 'TestServer_HandleUnregister|TestUnregisterCommand_(Run|Usage)$' . ./cmd/litestream`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality not to work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)