### PR TITLE
integration: soak-stabilization reference branch

### DIFF
--- a/cmd/litestream-test/README.md
+++ b/cmd/litestream-test/README.md
@@ -112,6 +112,7 @@ litestream-test validate [options]
   - `integrity` - SQLite PRAGMA integrity_check
   - `checksum` - Full database checksum comparison
   - `full` - All validation types
+- `-txid` - Restore target transaction ID
 - `-ltx-continuity` - Check LTX file continuity (default: false)
 - `-config` - Litestream config file path (alternative to replica-url)
 

--- a/cmd/litestream-test/validate.go
+++ b/cmd/litestream-test/validate.go
@@ -23,6 +23,7 @@ type ValidateCommand struct {
 	ReplicaURL    string
 	RestoredDB    string
 	CheckType     string
+	TXID          string
 	LTXContinuity bool
 	ConfigPath    string
 }
@@ -41,6 +42,7 @@ func (c *ValidateCommand) Run(ctx context.Context, args []string) error {
 	fs.StringVar(&c.ReplicaURL, "replica-url", "", "Replica URL to validate")
 	fs.StringVar(&c.RestoredDB, "restored-db", "", "Path for restored database")
 	fs.StringVar(&c.CheckType, "check-type", "quick", "Type of check (quick, integrity, checksum, full)")
+	fs.StringVar(&c.TXID, "txid", "", "Restore target transaction ID")
 	fs.BoolVar(&c.LTXContinuity, "ltx-continuity", false, "Check LTX file continuity")
 	fs.StringVar(&c.ConfigPath, "config", "", "Litestream config file path")
 	fs.Usage = c.Usage
@@ -64,6 +66,7 @@ func (c *ValidateCommand) Run(ctx context.Context, args []string) error {
 		"source_db", c.SourceDB,
 		"replica_url", c.ReplicaURL,
 		"check_type", c.CheckType,
+		"txid", c.TXID,
 		"ltx_continuity", c.LTXContinuity,
 	)
 
@@ -107,20 +110,22 @@ func (c *ValidateCommand) performRestore(ctx context.Context) ValidationResult {
 		slog.Warn("Could not remove existing restored database", "error", err)
 	}
 
-	var cmd *exec.Cmd
+	args := []string{"restore"}
 	if c.ConfigPath != "" {
-		cmd = exec.CommandContext(ctx, "litestream", "restore",
-			"-config", c.ConfigPath,
-			"-o", c.RestoredDB,
-			c.SourceDB,
-		)
+		args = append(args, "-config", c.ConfigPath)
 	} else {
-		cmd = exec.CommandContext(ctx, "litestream", "restore",
-			"-o", c.RestoredDB,
-			c.ReplicaURL,
-		)
+		args = append(args, "-o", c.RestoredDB)
+	}
+	if c.TXID != "" {
+		args = append(args, "-txid", c.TXID)
+	}
+	if c.ConfigPath != "" {
+		args = append(args, "-o", c.RestoredDB, c.SourceDB)
+	} else {
+		args = append(args, c.ReplicaURL)
 	}
 
+	cmd := exec.CommandContext(ctx, "litestream", args...)
 	output, err := cmd.CombinedOutput()
 	result.Duration = time.Since(startTime)
 
@@ -482,6 +487,9 @@ Options:
 	-check-type TYPE
 	    Type of check: quick, integrity, checksum, full
 	    Default: quick
+
+	-txid TXID
+	    Restore target transaction ID
 
 	-ltx-continuity
 	    Check LTX file continuity

--- a/cmd/litestream-test/validate_test.go
+++ b/cmd/litestream-test/validate_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidatePerformRestorePassesTXID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fake binary requires Unix")
+	}
+
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	writeFakeLitestream(t, dir, `
+if [ "$1" = "restore" ]; then
+  shift
+fi
+printf '%s\n' "$@" > "$LITESTREAM_ARGS"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+: > "$out"
+`)
+	t.Setenv("LITESTREAM_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := &ValidateCommand{
+		SourceDB:   filepath.Join(dir, "test.db"),
+		ConfigPath: filepath.Join(dir, "litestream.yml"),
+		RestoredDB: filepath.Join(dir, "test.db.restored"),
+		TXID:       "00000000000224b6",
+	}
+	result := cmd.performRestore(context.Background())
+	if !result.Passed {
+		t.Fatalf("restore failed: %s", result.ErrorMessage)
+	}
+
+	args := readLines(t, argsPath)
+	assertContains(t, args, "-config")
+	assertContains(t, args, cmd.ConfigPath)
+	assertContains(t, args, "-txid")
+	assertContains(t, args, cmd.TXID)
+	assertContains(t, args, "-o")
+	assertContains(t, args, cmd.RestoredDB)
+	assertContains(t, args, cmd.SourceDB)
+}
+
+func writeFakeLitestream(t *testing.T, dir, body string) {
+	t.Helper()
+
+	path := filepath.Join(dir, "litestream")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := strings.TrimSpace(string(body))
+	if text == "" {
+		return nil
+	}
+	return strings.Split(text, "\n")
+}
+
+func assertContains(t *testing.T, values []string, want string) {
+	t.Helper()
+
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("values=%v want %q", values, want)
+}

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1468,6 +1468,10 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 	if isCloudflareR2 {
 		client.Concurrency = s3.DefaultR2Concurrency
 	}
+	if isTigris {
+		client.Concurrency = s3.DefaultTigrisConcurrency
+		client.PartSize = s3.DefaultTigrisPartSize
+	}
 
 	// Apply upload configuration if specified.
 	if c.PartSize != nil {

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -325,6 +325,42 @@ func (c *Config) propagateGlobalSettings() {
 	}
 }
 
+func (c *Config) applyDBSnapshotConfig(globalIntervalSet, globalRetentionSet bool) error {
+	var interval *time.Duration
+	var intervalDB string
+	var retention *time.Duration
+	var retentionDB string
+
+	for _, db := range c.DBs {
+		dbID := db.Path
+		if dbID == "" {
+			dbID = db.Dir
+		}
+		if db.Snapshot.Interval != nil {
+			if interval != nil && *interval != *db.Snapshot.Interval {
+				return fmt.Errorf("conflicting database snapshot intervals: %s has %v, %s has %v", intervalDB, *interval, dbID, *db.Snapshot.Interval)
+			}
+			interval = db.Snapshot.Interval
+			intervalDB = dbID
+		}
+		if db.Snapshot.Retention != nil {
+			if retention != nil && *retention != *db.Snapshot.Retention {
+				return fmt.Errorf("conflicting database snapshot retentions: %s has %v, %s has %v", retentionDB, *retention, dbID, *db.Snapshot.Retention)
+			}
+			retention = db.Snapshot.Retention
+			retentionDB = dbID
+		}
+	}
+
+	if !globalIntervalSet && interval != nil {
+		c.Snapshot.Interval = interval
+	}
+	if !globalRetentionSet && retention != nil {
+		c.Snapshot.Retention = retention
+	}
+	return nil
+}
+
 // DefaultConfig returns a new instance of Config with defaults set.
 func DefaultConfig() Config {
 	defaultSnapshotInterval := 24 * time.Hour
@@ -448,6 +484,21 @@ func (c *Config) Validate() error {
 			dbIdentifier = db.Dir
 		}
 
+		if db.Snapshot.Interval != nil && *db.Snapshot.Interval <= 0 {
+			return &ConfigValidationError{
+				Err:   ErrInvalidSnapshotInterval,
+				Field: fmt.Sprintf("dbs[%s].snapshot.interval", dbIdentifier),
+				Value: *db.Snapshot.Interval,
+			}
+		}
+		if db.Snapshot.Retention != nil && *db.Snapshot.Retention <= 0 {
+			return &ConfigValidationError{
+				Err:   ErrInvalidSnapshotRetention,
+				Field: fmt.Sprintf("dbs[%s].snapshot.retention", dbIdentifier),
+				Value: *db.Snapshot.Retention,
+			}
+		}
+
 		// Validate sync intervals for replicas
 		if db.Replica != nil && db.Replica.SyncInterval != nil && *db.Replica.SyncInterval <= 0 {
 			return &ConfigValidationError{
@@ -549,6 +600,15 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 		}))
 	}
 
+	var raw struct {
+		Snapshot *SnapshotConfig `yaml:"snapshot"`
+	}
+	if err := yaml.Unmarshal(buf, &raw); err != nil {
+		return config, err
+	}
+	globalSnapshotIntervalSet := raw.Snapshot != nil && raw.Snapshot.Interval != nil
+	globalSnapshotRetentionSet := raw.Snapshot != nil && raw.Snapshot.Retention != nil
+
 	// Save defaults before unmarshaling
 	defaultSnapshotInterval := config.Snapshot.Interval
 	defaultSnapshotRetention := config.Snapshot.Retention
@@ -571,6 +631,9 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	}
 	if config.L0RetentionCheckInterval == nil {
 		config.L0RetentionCheckInterval = defaultL0RetentionCheckInterval
+	}
+	if err := config.applyDBSnapshotConfig(globalSnapshotIntervalSet, globalSnapshotRetentionSet); err != nil {
+		return config, err
 	}
 
 	// Normalize paths.
@@ -616,6 +679,7 @@ type DBConfig struct {
 	Pattern            string         `yaml:"pattern"`   // File pattern to match (e.g., "*.db", "*.sqlite")
 	Recursive          bool           `yaml:"recursive"` // Scan subdirectories recursively
 	Watch              bool           `yaml:"watch"`     // Enable directory monitoring for changes
+	Snapshot           SnapshotConfig `yaml:"snapshot"`
 	MetaPath           *string        `yaml:"meta-path"`
 	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
 	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -441,6 +441,57 @@ snapshot:
 		}
 	})
 
+	t.Run("DBLevelCompatibility", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/test.db
+    snapshot:
+      interval: 10m
+      retention: 2h
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if config.DBs[0].Snapshot.Interval == nil || *config.DBs[0].Snapshot.Interval != 10*time.Minute {
+			t.Fatalf("expected db snapshot interval of 10m, got %v", config.DBs[0].Snapshot.Interval)
+		}
+		if config.DBs[0].Snapshot.Retention == nil || *config.DBs[0].Snapshot.Retention != 2*time.Hour {
+			t.Fatalf("expected db snapshot retention of 2h, got %v", config.DBs[0].Snapshot.Retention)
+		}
+		if config.Snapshot.Interval == nil || *config.Snapshot.Interval != 10*time.Minute {
+			t.Fatalf("expected promoted snapshot interval of 10m, got %v", config.Snapshot.Interval)
+		}
+		if config.Snapshot.Retention == nil || *config.Snapshot.Retention != 2*time.Hour {
+			t.Fatalf("expected promoted snapshot retention of 2h, got %v", config.Snapshot.Retention)
+		}
+	})
+
+	t.Run("GlobalSnapshotTakesPrecedence", func(t *testing.T) {
+		yaml := `
+snapshot:
+  interval: 1h
+  retention: 24h
+dbs:
+  - path: /tmp/test.db
+    snapshot:
+      interval: 10m
+      retention: 2h
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if config.Snapshot.Interval == nil || *config.Snapshot.Interval != time.Hour {
+			t.Fatalf("expected global snapshot interval of 1h, got %v", config.Snapshot.Interval)
+		}
+		if config.Snapshot.Retention == nil || *config.Snapshot.Retention != 24*time.Hour {
+			t.Fatalf("expected global snapshot retention of 24h, got %v", config.Snapshot.Retention)
+		}
+	})
+
 	t.Run("ZeroInterval", func(t *testing.T) {
 		yaml := `
 snapshot:
@@ -483,6 +534,41 @@ snapshot:
 		}
 		if !errors.Is(err, main.ErrInvalidSnapshotInterval) {
 			t.Errorf("expected ErrInvalidSnapshotInterval, got %v", err)
+		}
+	})
+
+	t.Run("DBLevelZeroInterval", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/test.db
+    snapshot:
+      interval: 0s
+`
+		_, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err == nil {
+			t.Fatal("expected error for zero database snapshot interval")
+		}
+		if !errors.Is(err, main.ErrInvalidSnapshotInterval) {
+			t.Errorf("expected ErrInvalidSnapshotInterval, got %v", err)
+		}
+	})
+
+	t.Run("DBLevelConflictingIntervals", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/a.db
+    snapshot:
+      interval: 10m
+  - path: /tmp/b.db
+    snapshot:
+      interval: 20m
+`
+		_, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err == nil {
+			t.Fatal("expected error for conflicting database snapshot intervals")
+		}
+		if !strings.Contains(err.Error(), "conflicting database snapshot intervals") {
+			t.Errorf("expected conflicting interval error, got %v", err)
 		}
 	})
 

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -2519,6 +2519,12 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		if client.RequireContentMD5 {
 			t.Error("expected RequireContentMD5 to be false for Tigris")
 		}
+		if client.Concurrency != s3.DefaultTigrisConcurrency {
+			t.Errorf("expected Tigris concurrency %d, got %d", s3.DefaultTigrisConcurrency, client.Concurrency)
+		}
+		if client.PartSize != s3.DefaultTigrisPartSize {
+			t.Errorf("expected Tigris part size %d, got %d", s3.DefaultTigrisPartSize, client.PartSize)
+		}
 	})
 
 	t.Run("TigrisConfigEndpoint", func(t *testing.T) {
@@ -2540,6 +2546,12 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		}
 		if client.RequireContentMD5 {
 			t.Error("expected RequireContentMD5 to be false for config-based Tigris endpoint")
+		}
+		if client.Concurrency != s3.DefaultTigrisConcurrency {
+			t.Errorf("expected config-based Tigris concurrency %d, got %d", s3.DefaultTigrisConcurrency, client.Concurrency)
+		}
+		if client.PartSize != s3.DefaultTigrisPartSize {
+			t.Errorf("expected config-based Tigris part size %d, got %d", s3.DefaultTigrisPartSize, client.PartSize)
 		}
 	})
 

--- a/compactor.go
+++ b/compactor.go
@@ -117,13 +117,19 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	defer itr.Close()
 
 	var rdrs []io.Reader
-	defer func() {
+	readersClosed := false
+	closeReaders := func() {
+		if readersClosed {
+			return
+		}
+		readersClosed = true
 		for _, rd := range rdrs {
 			if closer, ok := rd.(io.Closer); ok {
 				_ = closer.Close()
 			}
 		}
-	}()
+	}
+	defer closeReaders()
 
 	var minTXID, maxTXID ltx.TXID
 	for itr.Next() {
@@ -156,19 +162,29 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	}
 
 	pr, pw := io.Pipe()
+	compactErrCh := make(chan error, 1)
 	go func() {
 		comp, err := ltx.NewCompactor(pw, rdrs)
 		if err != nil {
-			pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
+			err = fmt.Errorf("new ltx compactor: %w", err)
+			_ = pw.CloseWithError(err)
+			compactErrCh <- err
 			return
 		}
 		comp.HeaderFlags = ltx.HeaderFlagNoChecksum
-		_ = pw.CloseWithError(comp.Compact(ctx))
+		err = comp.Compact(ctx)
+		_ = pw.CloseWithError(err)
+		compactErrCh <- err
 	}()
 
 	info, err := c.client.WriteLTXFile(ctx, dstLevel, minTXID, maxTXID, pr)
+	_ = pr.CloseWithError(err)
+	compactErr := <-compactErrCh
 	if err != nil {
 		return nil, fmt.Errorf("write ltx file: %w", err)
+	}
+	if compactErr != nil {
+		return nil, fmt.Errorf("compact ltx file: %w", compactErr)
 	}
 
 	if c.CacheSetter != nil {

--- a/compactor.go
+++ b/compactor.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // Compactor handles compaction and retention for LTX files.
@@ -147,7 +149,7 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		if err != nil {
 			return nil, fmt.Errorf("open ltx file: %w", err)
 		}
-		rdrs = append(rdrs, f)
+		rdrs = append(rdrs, internal.NewResumableReader(ctx, c.client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, c.logger))
 	}
 	if len(rdrs) == 0 {
 		return nil, ErrNoCompaction

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -3,6 +3,7 @@ package litestream_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -83,6 +84,28 @@ func TestCompactor_Compact(t *testing.T) {
 			t.Errorf("TXID range=%d-%d, want 1-3", info.MinTXID, info.MaxTXID)
 		}
 	})
+}
+
+func TestCompactor_CompactResumesRemoteReads(t *testing.T) {
+	client := newFlakyCompactionClient()
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
+
+	info, err := compactor.Compact(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Level != 1 {
+		t.Errorf("Level=%d, want 1", info.Level)
+	}
+	if info.MinTXID != 1 || info.MaxTXID != 2 {
+		t.Errorf("TXID range=%d-%d, want 1-2", info.MinTXID, info.MaxTXID)
+	}
+	if client.reopenCount == 0 {
+		t.Fatal("expected compaction to reopen at least one source LTX stream")
+	}
 }
 
 func TestCompactor_MaxLTXFileInfo(t *testing.T) {
@@ -600,3 +623,105 @@ func createTestLTXFileWithTimestamp(t testing.TB, client litestream.ReplicaClien
 		t.Fatal(err)
 	}
 }
+
+type flakyCompactionClient struct {
+	files       map[string][]byte
+	infos       []*ltx.FileInfo
+	failed      map[string]bool
+	reopenCount int
+}
+
+func newFlakyCompactionClient() *flakyCompactionClient {
+	return &flakyCompactionClient{
+		files:  make(map[string][]byte),
+		failed: make(map[string]bool),
+	}
+}
+
+func (c *flakyCompactionClient) Type() string { return "flaky" }
+
+func (c *flakyCompactionClient) Init(context.Context) error { return nil }
+
+func (c *flakyCompactionClient) SetLogger(*slog.Logger) {}
+
+func (c *flakyCompactionClient) LTXFiles(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {
+	var infos []*ltx.FileInfo
+	for _, info := range c.infos {
+		if info.Level == level && info.MaxTXID >= seek {
+			item := *info
+			infos = append(infos, &item)
+		}
+	}
+	return ltx.NewFileInfoSliceIterator(infos), nil
+}
+
+func (c *flakyCompactionClient) OpenLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	key := c.key(level, minTXID, maxTXID)
+	data, ok := c.files[key]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	if offset > int64(len(data)) {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+	data = data[offset:]
+	if size > 0 && size < int64(len(data)) {
+		data = data[:size]
+	}
+	if offset == 0 && !c.failed[key] {
+		c.failed[key] = true
+		n := ltx.HeaderSize / 2
+		if n > len(data) {
+			n = len(data)
+		}
+		return io.NopCloser(&shortReadCloser{data: data[:n]}), nil
+	}
+	if offset > 0 {
+		c.reopenCount++
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (c *flakyCompactionClient) WriteLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	hdr, _, err := ltx.PeekHeader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	info := &ltx.FileInfo{
+		Level:     level,
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Size:      int64(len(data)),
+		CreatedAt: time.UnixMilli(hdr.Timestamp).UTC(),
+	}
+	c.files[c.key(level, minTXID, maxTXID)] = data
+	c.infos = append(c.infos, info)
+	return info, nil
+}
+
+func (c *flakyCompactionClient) DeleteLTXFiles(context.Context, []*ltx.FileInfo) error { return nil }
+
+func (c *flakyCompactionClient) DeleteAll(context.Context) error { return nil }
+
+func (c *flakyCompactionClient) key(level int, minTXID, maxTXID ltx.TXID) string {
+	return fmt.Sprintf("%d/%s", level, ltx.FormatFilename(minTXID, maxTXID))
+}
+
+type shortReadCloser struct {
+	data []byte
+	done bool
+}
+
+func (r *shortReadCloser) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	return copy(p, r.data), io.EOF
+}
+
+func (r *shortReadCloser) Close() error { return nil }

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,6 +107,37 @@ func TestCompactor_CompactResumesRemoteReads(t *testing.T) {
 	}
 	if client.reopenCount == 0 {
 		t.Fatal("expected compaction to reopen at least one source LTX stream")
+	}
+}
+
+func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
+	client := newEarlyReturnCompactionClient()
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
+	client.failWrites = true
+
+	before := countCompactorPipeWriters()
+	if _, err := compactor.Compact(context.Background(), 1); err == nil {
+		t.Fatal("expected error")
+	} else if !strings.Contains(err.Error(), "write ltx file: early write failure") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := countCompactorPipeWriters(); got <= before {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("compactor goroutine leaked: got %d, want <= %d", countCompactorPipeWriters(), before)
+		case <-ticker.C:
+		}
 	}
 }
 
@@ -725,3 +758,25 @@ func (r *shortReadCloser) Read(p []byte) (int, error) {
 }
 
 func (r *shortReadCloser) Close() error { return nil }
+
+type earlyReturnCompactionClient struct {
+	*flakyCompactionClient
+	failWrites bool
+}
+
+func newEarlyReturnCompactionClient() *earlyReturnCompactionClient {
+	return &earlyReturnCompactionClient{flakyCompactionClient: newFlakyCompactionClient()}
+}
+
+func (c *earlyReturnCompactionClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if c.failWrites {
+		return nil, fmt.Errorf("early write failure")
+	}
+	return c.flakyCompactionClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+func countCompactorPipeWriters() int {
+	buf := make([]byte, 2<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "github.com/benbjohnson/litestream.(*Compactor).Compact.func")
+}

--- a/db.go
+++ b/db.go
@@ -63,6 +63,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
+	execMu    sync.Mutex
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -200,6 +201,13 @@ type syncState struct {
 	// a checkpoint. This prevents issue #997 where PASSIVE checkpoints
 	// trigger a feedback loop because stale file size exceeds threshold.
 	lastSyncedWALOffset int64
+}
+
+type syncExecutor struct {
+	state      syncState
+	pos        ltx.Pos
+	l0FileInfo *ltx.FileInfo
+	synced     bool
 }
 
 // NewDB returns a new instance of DB for a given path.
@@ -608,9 +616,12 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
-		if e := db.Sync(ctx); e != nil {
+		if e := db.syncLocked(ctx); e != nil {
 			err = e
 		}
 	}
@@ -632,24 +643,26 @@ func (db *DB) Close(ctx context.Context) (err error) {
 		}
 	}
 
-	if db.db != nil {
-		if e := db.db.Close(); e != nil && err == nil {
-			err = e
-		}
-		db.db = nil
-	}
-
-	if db.f != nil {
-		if e := db.f.Close(); e != nil && err == nil {
-			err = e
-		}
-		db.f = nil
-	}
-
 	db.mu.Lock()
+	sqlDB := db.db
+	f := db.f
+	db.db = nil
+	db.f = nil
 	db.opened = false
 	db.rtx = nil
 	db.mu.Unlock()
+
+	if sqlDB != nil {
+		if e := sqlDB.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
+
+	if f != nil {
+		if e := f.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
 
 	return err
 }
@@ -998,9 +1011,13 @@ func (db *DB) releaseReadLock() error {
 
 // Sync copies pending data from the WAL to the shadow WAL.
 func (db *DB) Sync(ctx context.Context) (err error) {
-	db.mu.Lock()
-	defer db.mu.Unlock()
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
 
+	return db.syncLocked(ctx)
+}
+
+func (db *DB) syncLocked(ctx context.Context) (err error) {
 	// Track total sync metrics.
 	t := time.Now()
 	defer func() {
@@ -1011,61 +1028,64 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		db.syncSecondsCounter.Add(float64(time.Since(t).Seconds()))
 	}()
 
-	// Initialize database, if necessary. Exit if no DB exists.
-	if err := db.init(ctx); err != nil {
+	exec, err := db.newSyncExecutor(ctx)
+	if err != nil {
 		return err
-	} else if db.db == nil {
+	} else if exec == nil {
 		db.Logger.Debug("sync: no database found")
 		return nil
 	}
+	defer db.applySyncExecutor(exec, true)
 
 	// Ensure WAL has at least one frame in it.
 	if err := db.ensureWALExists(ctx); err != nil {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	result, err := db.verifyAndSync(ctx, false, &db.syncState)
+	result, err := db.verifyAndSyncWithExecutor(ctx, false, exec)
 	if err != nil {
 		return err
 	}
-	db.applySyncResult(&db.syncState, result)
+	exec.applySyncResult(result)
 
 	// Track that data was synced for time-based checkpoint decisions.
 	if result.synced {
-		db.syncState.syncedSinceCheckpoint = true
+		exec.state.syncedSinceCheckpoint = true
 	}
 
-	if err := db.checkpointIfNeeded(ctx, &db.syncState, result.origWALSize, result.newWALSize); err != nil {
+	if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
 
 	// Compute current index and total shadow WAL size.
-	pos, err := db.Pos()
-	if err != nil {
-		return fmt.Errorf("pos: %w", err)
-	}
-	db.txIDGauge.Set(float64(pos.TXID))
+	db.txIDGauge.Set(float64(exec.pos.TXID))
 
 	// Update file size metrics.
 	if fi, err := os.Stat(db.path); err == nil {
 		db.dbSizeGauge.Set(float64(fi.Size()))
 	}
-	db.walSizeGauge.Set(float64(result.newWALSize))
-
-	// Notify replicas of WAL changes.
-	// if changed {
-	close(db.notify)
-	db.notify = make(chan struct{})
-	// }
+	db.walSizeGauge.Set(float64(exec.state.lastSyncedWALOffset))
 
 	return nil
 }
 
 func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *syncState) (syncResult, error) {
+	pos, err := db.Pos()
+	if err != nil {
+		return syncResult{}, fmt.Errorf("pos: %w", err)
+	}
+
+	return db.verifyAndSyncWithExecutor(ctx, checkpointing, &syncExecutor{
+		state: *state,
+		pos:   pos,
+	})
+}
+
+func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor) (syncResult, error) {
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
 	// This avoids using file size which may include stale frames with old salt
 	// values after a checkpoint. See issue #997.
-	origWALSize := state.lastSyncedWALOffset
+	origWALSize := exec.state.lastSyncedWALOffset
 	if origWALSize == 0 {
 		// First sync - use file size as fallback
 		var err error
@@ -1078,12 +1098,12 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *sync
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that the last sync position of the real WAL hasn't
 	// been overwritten by another process.
-	info, err := db.verify(ctx, state)
+	info, err := db.verifyWithExecutor(ctx, exec)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
-	result, err := db.sync(ctx, checkpointing, state, info)
+	result, err := db.sync(ctx, checkpointing, exec, info)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
 	}
@@ -1101,7 +1121,7 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *sync
 // that data has been synced since the last checkpoint. This prevents creating unnecessary
 // LTX files when the only WAL data is from internal bookkeeping (like _litestream_seq
 // updates from previous checkpoints). See issue #896.
-func (db *DB) checkpointIfNeeded(ctx context.Context, state *syncState, origWALSize, newWALSize int64) error {
+func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWALSize, newWALSize int64) error {
 	if db.pageSize == 0 {
 		return nil
 	}
@@ -1112,12 +1132,12 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, state *syncState, origWALS
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
 			"threshold", calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)))
-		return db.checkpoint(ctx, CheckpointModeTruncate, state)
+		return db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
 	}
 
 	// Priority 2: Regular checkpoint at min threshold (PASSIVE mode, non-blocking)
 	if newWALSize >= calcWALSize(uint32(db.pageSize), uint32(db.MinCheckpointPageN)) {
-		if err := db.checkpoint(ctx, CheckpointModePassive, state); err != nil {
+		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
 			// PASSIVE checkpoints can fail with SQLITE_BUSY when database is locked.
 			// This is expected behavior and not an error - just log and continue.
 			if isSQLiteBusyError(err) {
@@ -1133,7 +1153,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, state *syncState, origWALS
 	// Only trigger if there have been actual changes synced since the last
 	// checkpoint. This prevents creating unnecessary LTX files when the only
 	// WAL data is from internal bookkeeping (like _litestream_seq updates).
-	if db.CheckpointInterval > 0 && state.syncedSinceCheckpoint {
+	if db.CheckpointInterval > 0 && exec.state.syncedSinceCheckpoint {
 		// Get database file modification time
 		fi, err := db.f.Stat()
 		if err != nil {
@@ -1142,7 +1162,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, state *syncState, origWALS
 
 		// Only checkpoint if enough time has passed and WAL has data
 		if time.Since(fi.ModTime()) > db.CheckpointInterval && newWALSize > calcWALSize(uint32(db.pageSize), 1) {
-			if err := db.checkpoint(ctx, CheckpointModePassive, state); err != nil {
+			if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
 				// PASSIVE checkpoints can fail with SQLITE_BUSY when database is locked.
 				// This is expected behavior and not an error - just log and continue.
 				if isSQLiteBusyError(err) {
@@ -1299,29 +1319,38 @@ func (db *DB) checkDatabaseBehindReplica(ctx context.Context) error {
 // verify ensures the current LTX state matches where it left off from
 // the real WAL. Check info.ok if verification was successful.
 func (db *DB) verify(ctx context.Context, state *syncState) (info syncInfo, err error) {
-	frameSize := int64(db.pageSize + WALFrameHeaderSize)
-	info.snapshotting = true
-
 	pos, err := db.Pos()
 	if err != nil {
 		return info, fmt.Errorf("pos: %w", err)
-	} else if pos.TXID == 0 {
+	}
+
+	return db.verifyWithExecutor(ctx, &syncExecutor{
+		state: *state,
+		pos:   pos,
+	})
+}
+
+func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info syncInfo, err error) {
+	frameSize := int64(db.pageSize + WALFrameHeaderSize)
+	info.snapshotting = true
+
+	if exec.pos.TXID == 0 {
 		info.offset = WALHeaderSize
 		return info, nil // first sync
 	}
 
 	// Determine last WAL offset we save from.
-	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	ltxPath := db.LTXPath(0, exec.pos.TXID, exec.pos.TXID)
 	ltxFile, err := os.Open(ltxPath)
 	if err != nil {
-		return info, NewLTXError("open", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), err)
+		return info, NewLTXError("open", ltxPath, 0, uint64(exec.pos.TXID), uint64(exec.pos.TXID), err)
 	}
 	defer func() { _ = ltxFile.Close() }()
 
 	dec := ltx.NewDecoder(ltxFile)
 	if err := dec.DecodeHeader(); err != nil {
 		// Decode failure indicates corruption
-		ltxErr := NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+		ltxErr := NewLTXError("decode", ltxPath, 0, uint64(exec.pos.TXID), uint64(exec.pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
 		return info, ltxErr
 	}
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
@@ -1335,9 +1364,7 @@ func (db *DB) verify(ctx context.Context, state *syncState) (info syncInfo, err 
 		// If we previously synced to the exact end of the WAL, this truncation
 		// is expected (normal checkpoint behavior). Reset position and continue
 		// incrementally rather than triggering a full snapshot. See issue #927.
-		if state.syncedToWALEnd {
-			state.syncedToWALEnd = false // Clear flag
-
+		if exec.state.syncedToWALEnd {
 			// Read new WAL header to get current salt values
 			hdr, err := readWALHeader(db.WALPath())
 			if err != nil {
@@ -1349,6 +1376,7 @@ func (db *DB) verify(ctx context.Context, state *syncState) (info syncInfo, err 
 			info.salt2 = binary.BigEndian.Uint32(hdr[20:])
 			info.snapshotting = false
 			info.reason = ""
+			info.clearSyncedToWALEnd = true
 
 			db.Logger.Log(ctx, internal.LevelTrace, "wal truncated after sync to end (expected checkpoint)",
 				"new_salt1", info.salt1,
@@ -1510,11 +1538,12 @@ func (db *DB) detectFullCheckpoint(ctx context.Context, knownSalts [][2]uint32) 
 }
 
 type syncInfo struct {
-	offset       int64 // end of the previous LTX read
-	salt1        uint32
-	salt2        uint32
-	snapshotting bool   // if true, a full snapshot is required
-	reason       string // reason for snapshot
+	offset              int64 // end of the previous LTX read
+	salt1               uint32
+	salt2               uint32
+	snapshotting        bool   // if true, a full snapshot is required
+	reason              string // reason for snapshot
+	clearSyncedToWALEnd bool
 }
 
 type syncResult struct {
@@ -1541,18 +1570,77 @@ func (db *DB) applySyncResult(state *syncState, result syncResult) {
 	}
 }
 
-// sync copies pending bytes from the real WAL to LTX.
-// Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
-func (db *DB) sync(ctx context.Context, checkpointing bool, state *syncState, info syncInfo) (result syncResult, err error) {
-	result.newWALSize = state.lastSyncedWALOffset
-	result.syncedToWALEnd = state.syncedToWALEnd
+func (db *DB) newSyncExecutor(ctx context.Context) (*syncExecutor, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 
-	// Determine the next sequential transaction ID.
+	if err := db.init(ctx); err != nil {
+		return nil, err
+	} else if db.db == nil {
+		return nil, nil
+	}
+
 	pos, err := db.Pos()
 	if err != nil {
-		return result, fmt.Errorf("pos: %w", err)
+		return nil, fmt.Errorf("pos: %w", err)
 	}
-	txID := pos.TXID + 1
+
+	return &syncExecutor{
+		state: db.syncState,
+		pos:   pos,
+	}, nil
+}
+
+func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
+	if exec == nil {
+		return
+	}
+
+	db.mu.Lock()
+	db.syncState = exec.state
+	if notify && exec.synced {
+		close(db.notify)
+		db.notify = make(chan struct{})
+	}
+	db.mu.Unlock()
+
+	db.pos.Lock()
+	pos := exec.pos
+	db.pos.value = &pos
+	db.pos.Unlock()
+
+	if exec.l0FileInfo != nil {
+		db.maxLTXFileInfos.Lock()
+		info := *exec.l0FileInfo
+		db.maxLTXFileInfos.m[0] = &info
+		db.maxLTXFileInfos.Unlock()
+	}
+}
+
+func (exec *syncExecutor) applySyncResult(result syncResult) {
+	exec.state.lastSyncedWALOffset = result.newWALSize
+	exec.state.syncedToWALEnd = result.syncedToWALEnd
+	if result.pos != nil {
+		exec.pos = *result.pos
+	}
+	if result.l0FileInfo != nil {
+		info := *result.l0FileInfo
+		exec.l0FileInfo = &info
+	}
+	exec.synced = exec.synced || result.synced
+}
+
+// sync copies pending bytes from the real WAL to LTX.
+// Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
+func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo) (result syncResult, err error) {
+	result.newWALSize = exec.state.lastSyncedWALOffset
+	result.syncedToWALEnd = exec.state.syncedToWALEnd
+	if info.clearSyncedToWALEnd {
+		result.syncedToWALEnd = false
+	}
+
+	// Determine the next sequential transaction ID.
+	txID := exec.pos.TXID + 1
 
 	filename := db.LTXPath(0, txID, txID)
 
@@ -1825,14 +1913,51 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 // Checkpoint performs a checkpoint on the WAL file.
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	return db.checkpoint(ctx, mode, &db.syncState)
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	exec, err := db.newSyncExecutor(ctx)
+	if err != nil {
+		return err
+	} else if exec == nil {
+		return nil
+	}
+	defer db.applySyncExecutor(exec, true)
+
+	return db.checkpointWithExecutor(ctx, mode, exec)
 }
 
 // checkpoint performs a checkpoint on the WAL file and initializes a
 // new shadow WAL file.
 func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) error {
+	pos, err := db.Pos()
+	if err != nil {
+		return fmt.Errorf("pos: %w", err)
+	}
+
+	exec := &syncExecutor{
+		state: *state,
+		pos:   pos,
+	}
+	if err := db.checkpointWithExecutor(ctx, mode, exec); err != nil {
+		return err
+	}
+
+	*state = exec.state
+	db.pos.Lock()
+	pos = exec.pos
+	db.pos.value = &pos
+	db.pos.Unlock()
+	if exec.l0FileInfo != nil {
+		db.maxLTXFileInfos.Lock()
+		info := *exec.l0FileInfo
+		db.maxLTXFileInfos.m[0] = &info
+		db.maxLTXFileInfos.Unlock()
+	}
+	return nil
+}
+
+func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syncExecutor) error {
 	// Try getting a checkpoint lock, will fail during snapshots.
 	if !db.chkMu.TryLock() {
 		return nil
@@ -1846,11 +1971,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
-	result, err := db.verifyAndSync(ctx, true, state)
+	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
-	db.applySyncResult(state, result)
+	exec.applySyncResult(result)
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
@@ -1864,7 +1989,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 	if other, err := readWALHeader(db.WALPath()); err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
-		state.syncedSinceCheckpoint = false
+		exec.state.syncedSinceCheckpoint = false
 		return nil
 	}
 
@@ -1884,11 +2009,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
-	result, err = db.verifyAndSync(ctx, true, state)
+	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 	}
-	db.applySyncResult(state, result)
+	exec.applySyncResult(result)
 
 	// Release write lock before exiting.
 	// Use rollback() helper for consistency with releaseReadLock() and the
@@ -1897,7 +2022,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 		return fmt.Errorf("rollback post-checkpoint tx: %w", err)
 	}
 
-	state.syncedSinceCheckpoint = false
+	exec.state.syncedSinceCheckpoint = false
 	return nil
 }
 
@@ -1949,12 +2074,15 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	if db.PageSize() == 0 {
+	db.execMu.Lock()
+	pageSize := db.PageSize()
+	pos, err := db.Pos()
+	db.execMu.Unlock()
+
+	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
 		return ltx.Pos{}, nil, &DBNotReadyError{Reason: "page size not initialized"}
 	}
-
-	pos, err := db.Pos()
 	if err != nil {
 		return pos, nil, fmt.Errorf("pos: %w", err)
 	}
@@ -1971,7 +2099,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 	if err != nil {
 		return pos, nil, err
 	}
-	commit := uint32(fi.Size() / int64(db.pageSize))
+	commit := uint32(fi.Size() / int64(pageSize))
 
 	// Execute encoding in a separate goroutine so the caller can initialize before reading.
 	pr, pw := io.Pipe()
@@ -2020,7 +2148,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 		if err := enc.EncodeHeader(ltx.Header{
 			Version:   ltx.Version,
 			Flags:     ltx.HeaderFlagNoChecksum,
-			PageSize:  uint32(db.pageSize),
+			PageSize:  uint32(pageSize),
 			Commit:    commit,
 			MinTXID:   1,
 			MaxTXID:   pos.TXID,
@@ -2356,35 +2484,30 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	db.mu.Lock()
-	defer db.mu.Unlock()
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
 
-	if err := db.init(ctx); err != nil {
+	exec, err := db.newSyncExecutor(ctx)
+	if err != nil {
 		return 0, ltx.Pos{}, err
-	} else if db.db == nil {
+	} else if exec == nil {
 		return 0, ltx.Pos{}, os.ErrNotExist
 	}
+	defer db.applySyncExecutor(exec, true)
 
 	// Force a RESTART checkpoint to ensure the database is at the start of the WAL.
-	if err := db.checkpoint(ctx, CheckpointModeRestart, &db.syncState); err != nil {
+	if err := db.checkpointWithExecutor(ctx, CheckpointModeRestart, exec); err != nil {
 		return 0, ltx.Pos{}, err
-	}
-
-	// Obtain current position. Clear the offset since we are only reading the
-	// DB and not applying the current WAL.
-	pos, err := db.Pos()
-	if err != nil {
-		return 0, pos, err
 	}
 
 	// Seek to the beginning of the db file descriptor and checksum whole file.
 	h := crc64.New(crc64.MakeTable(crc64.ISO))
 	if _, err := db.f.Seek(0, io.SeekStart); err != nil {
-		return 0, pos, err
+		return 0, exec.pos, err
 	} else if _, err := io.Copy(h, db.f); err != nil {
-		return 0, pos, err
+		return 0, exec.pos, err
 	}
-	return h.Sum64(), pos, nil
+	return h.Sum64(), exec.pos, nil
 }
 
 // MaxLTXFileInfo returns the metadata for the last LTX file in a level.

--- a/db.go
+++ b/db.go
@@ -1372,6 +1372,7 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
 	info.salt1 = dec.Header().WALSalt1
 	info.salt2 = dec.Header().WALSalt2
+	info.prevCommit = dec.Header().Commit
 
 	// If LTX WAL offset is larger than real WAL then the WAL has been truncated.
 	if fi, err := os.Stat(db.WALPath()); err != nil {
@@ -1557,6 +1558,7 @@ type syncInfo struct {
 	offset              int64 // end of the previous LTX read
 	salt1               uint32
 	salt2               uint32
+	prevCommit          uint32
 	snapshotting        bool   // if true, a full snapshot is required
 	reason              string // reason for snapshot
 	clearSyncedToWALEnd bool
@@ -1791,7 +1793,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
-		if err := db.writeLTXFromWAL(ctx, enc, walFile, pageMap); err != nil {
+		if err := db.writeLTXFromWAL(ctx, enc, walFile, info.prevCommit, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
@@ -1898,28 +1900,45 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 	return nil
 }
 
-func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, pageMap map[uint32]int64) error {
+func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
 	}
+	lockPgno := ltx.LockPgno(uint32(db.pageSize))
+	if commit > prevCommit {
+		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if pgno == lockPgno {
+				continue
+			}
+			if _, ok := pageMap[pgno]; ok {
+				continue
+			}
+			pgnos = append(pgnos, pgno)
+		}
+	}
 	slices.Sort(pgnos)
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
-		offset := pageMap[pgno]
+		if offset, ok := pageMap[pgno]; ok {
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+			} else if n != len(data) {
+				return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			}
+		} else {
+			offset := int64(pgno-1) * int64(db.pageSize)
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
 
-		// Read source page using page map.
-		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-		} else if n != len(data) {
-			return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			if _, err := db.f.ReadAt(data, offset); err != nil {
+				return fmt.Errorf("read database page %d: %w", pgno, err)
+			}
 		}
 
-		// Write page to LTX encoder.
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {
 			return fmt.Errorf("encode ltx frame (pgno=%d): %w", pgno, err)
 		}

--- a/db.go
+++ b/db.go
@@ -2026,15 +2026,13 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	if barrierTx != nil {
-		if _, err = barrierTx.ExecContext(ctx, checkpointSeqSQL); err != nil {
-			return err
-		} else if _, err = barrierTx.ExecContext(ctx, `DELETE FROM _litestream_lock`); err != nil {
-			return err
-		} else if err = barrierTx.Commit(); err != nil {
-			return err
+		if err = rollback(barrierTx); err != nil {
+			return fmt.Errorf("rollback passive checkpoint barrier: %w", err)
 		}
 		barrierTx = nil
-	} else if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
+	}
+
+	if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
 		return err
 	}
 

--- a/db.go
+++ b/db.go
@@ -1011,10 +1011,32 @@ func (db *DB) releaseReadLock() error {
 
 // Sync copies pending data from the WAL to the shadow WAL.
 func (db *DB) Sync(ctx context.Context) (err error) {
-	db.execMu.Lock()
+	if err := db.lockExec(ctx); err != nil {
+		return err
+	}
 	defer db.execMu.Unlock()
 
 	return db.syncLocked(ctx)
+}
+
+func (db *DB) lockExec(ctx context.Context) error {
+	if db.execMu.TryLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if db.execMu.TryLock() {
+				return nil
+			}
+		}
+	}
 }
 
 func (db *DB) syncLocked(ctx context.Context) (err error) {
@@ -1948,7 +1970,9 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 // Checkpoint performs a checkpoint on the WAL file.
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
-	db.execMu.Lock()
+	if err := db.lockExec(ctx); err != nil {
+		return err
+	}
 	defer db.execMu.Unlock()
 
 	exec, err := db.newSyncExecutor(ctx)
@@ -2174,7 +2198,9 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	db.execMu.Lock()
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, nil, err
+	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
 	db.execMu.Unlock()

--- a/db.go
+++ b/db.go
@@ -1923,6 +1923,18 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 }
 
 func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
+	checkContext := func() error {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
+			return nil
+		}
+	}
+	if err := checkContext(); err != nil {
+		return err
+	}
+
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
@@ -1931,6 +1943,9 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	lockPgno := ltx.LockPgno(uint32(db.pageSize))
 	if commit > prevCommit {
 		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if err := checkContext(); err != nil {
+				return err
+			}
 			if pgno == lockPgno {
 				continue
 			}
@@ -1944,6 +1959,9 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
+		if err := checkContext(); err != nil {
+			return err
+		}
 		if offset, ok := pageMap[pgno]; ok {
 			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 

--- a/db.go
+++ b/db.go
@@ -1596,14 +1596,6 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 		return
 	}
 
-	db.mu.Lock()
-	db.syncState = exec.state
-	if notify && exec.synced {
-		close(db.notify)
-		db.notify = make(chan struct{})
-	}
-	db.mu.Unlock()
-
 	db.pos.Lock()
 	pos := exec.pos
 	db.pos.value = &pos
@@ -1615,6 +1607,14 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 		db.maxLTXFileInfos.m[0] = &info
 		db.maxLTXFileInfos.Unlock()
 	}
+
+	db.mu.Lock()
+	db.syncState = exec.state
+	if notify && exec.synced {
+		close(db.notify)
+		db.notify = make(chan struct{})
+	}
+	db.mu.Unlock()
 }
 
 func (exec *syncExecutor) applySyncResult(result syncResult) {
@@ -1985,8 +1985,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		return err
 	}
 
-	// If WAL hasn't been restarted, exit.
-	if other, err := readWALHeader(db.WALPath()); err != nil {
+	other, err := readWALHeader(db.WALPath())
+	if err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
 		exec.state.syncedSinceCheckpoint = false
@@ -2009,9 +2009,16 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
-	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+	snapshotInfo := syncInfo{
+		offset:       WALHeaderSize,
+		salt1:        binary.BigEndian.Uint32(other[16:]),
+		salt2:        binary.BigEndian.Uint32(other[20:]),
+		snapshotting: true,
+		reason:       "checkpoint boundary snapshot",
+	}
+	result, err = db.sync(ctx, true, exec, snapshotInfo)
 	if err != nil {
-		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+		return fmt.Errorf("cannot snapshot after checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 

--- a/db.go
+++ b/db.go
@@ -62,38 +62,17 @@ const (
 // with indefinite write blocking (issue #724). All checkpoints now use either
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
-	mu       sync.RWMutex
-	path     string        // part to database
-	metaPath string        // Path to the database metadata.
-	db       *sql.DB       // target database
-	f        *os.File      // long-running db file descriptor
-	rtx      *sql.Tx       // long running read transaction
-	pageSize int           // page size, in bytes
-	notify   chan struct{} // closes on WAL change
-	chkMu    sync.RWMutex  // checkpoint lock
-	opened   bool          // true if Open() was called and Close() not yet called
-
-	// syncedSinceCheckpoint tracks whether any data has been synced since
-	// the last checkpoint. Used to prevent time-based checkpoints from
-	// triggering when there are no actual database changes, which would
-	// otherwise create unnecessary LTX files. See issue #896.
-	syncedSinceCheckpoint bool
-
-	// syncedToWALEnd tracks whether the last successful sync reached the
-	// exact end of the WAL file. When true, a subsequent WAL truncation
-	// (from checkpoint) is expected and should NOT trigger a full snapshot.
-	// This prevents issue #927 where every checkpoint triggers unnecessary
-	// full snapshots because verify() sees the old LTX position exceeds
-	// the new (truncated) WAL size.
-	syncedToWALEnd bool
-
-	// lastSyncedWALOffset tracks the logical end of the WAL content after
-	// the last successful sync. This is the WALOffset + WALSize from the
-	// last LTX file. Used for checkpoint threshold decisions instead of
-	// file size, which may include stale frames with old salt values after
-	// a checkpoint. This prevents issue #997 where PASSIVE checkpoints
-	// trigger a feedback loop because stale file size exceeds threshold.
-	lastSyncedWALOffset int64
+	mu        sync.RWMutex
+	path      string        // part to database
+	metaPath  string        // Path to the database metadata.
+	db        *sql.DB       // target database
+	f         *os.File      // long-running db file descriptor
+	rtx       *sql.Tx       // long running read transaction
+	pageSize  int           // page size, in bytes
+	notify    chan struct{} // closes on WAL change
+	chkMu     sync.RWMutex  // checkpoint lock
+	opened    bool          // true if Open() was called and Close() not yet called
+	syncState syncState
 
 	// last file info for each level
 	maxLTXFileInfos struct {
@@ -195,6 +174,32 @@ type DB struct {
 
 	// Where to send log messages, defaults to global slog with database epath.
 	Logger *slog.Logger
+}
+
+// syncState holds mutable sync-tracking fields extracted from DB.
+// These fields are threaded through sync/checkpoint methods via pointer.
+type syncState struct {
+	// syncedSinceCheckpoint tracks whether any data has been synced since
+	// the last checkpoint. Used to prevent time-based checkpoints from
+	// triggering when there are no actual database changes, which would
+	// otherwise create unnecessary LTX files. See issue #896.
+	syncedSinceCheckpoint bool
+
+	// syncedToWALEnd tracks whether the last successful sync reached the
+	// exact end of the WAL file. When true, a subsequent WAL truncation
+	// (from checkpoint) is expected and should NOT trigger a full snapshot.
+	// This prevents issue #927 where every checkpoint triggers unnecessary
+	// full snapshots because verify() sees the old LTX position exceeds
+	// the new (truncated) WAL size.
+	syncedToWALEnd bool
+
+	// lastSyncedWALOffset tracks the logical end of the WAL content after
+	// the last successful sync. This is the WALOffset + WALSize from the
+	// last LTX file. Used for checkpoint threshold decisions instead of
+	// file size, which may include stale frames with old salt values after
+	// a checkpoint. This prevents issue #997 where PASSIVE checkpoints
+	// trigger a feedback loop because stale file size exceeds threshold.
+	lastSyncedWALOffset int64
 }
 
 // NewDB returns a new instance of DB for a given path.
@@ -1019,18 +1024,18 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	result, err := db.verifyAndSync(ctx, false)
+	result, err := db.verifyAndSync(ctx, false, &db.syncState)
 	if err != nil {
 		return err
 	}
-	db.applySyncResult(result)
+	db.applySyncResult(&db.syncState, result)
 
 	// Track that data was synced for time-based checkpoint decisions.
 	if result.synced {
-		db.syncedSinceCheckpoint = true
+		db.syncState.syncedSinceCheckpoint = true
 	}
 
-	if err := db.checkpointIfNeeded(ctx, result.origWALSize, result.newWALSize); err != nil {
+	if err := db.checkpointIfNeeded(ctx, &db.syncState, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
 
@@ -1056,11 +1061,11 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	return nil
 }
 
-func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult, error) {
+func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *syncState) (syncResult, error) {
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
 	// This avoids using file size which may include stale frames with old salt
 	// values after a checkpoint. See issue #997.
-	origWALSize := db.lastSyncedWALOffset
+	origWALSize := state.lastSyncedWALOffset
 	if origWALSize == 0 {
 		// First sync - use file size as fallback
 		var err error
@@ -1073,12 +1078,12 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that the last sync position of the real WAL hasn't
 	// been overwritten by another process.
-	info, err := db.verify(ctx)
+	info, err := db.verify(ctx, state)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
-	result, err := db.sync(ctx, checkpointing, info)
+	result, err := db.sync(ctx, checkpointing, state, info)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
 	}
@@ -1092,11 +1097,11 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult
 //
 // TruncatePageN uses TRUNCATE mode (blocking), others use PASSIVE mode (non-blocking).
 //
-// Time-based checkpoints only trigger if db.syncedSinceCheckpoint is true, indicating
+// Time-based checkpoints only trigger if state.syncedSinceCheckpoint is true, indicating
 // that data has been synced since the last checkpoint. This prevents creating unnecessary
 // LTX files when the only WAL data is from internal bookkeeping (like _litestream_seq
 // updates from previous checkpoints). See issue #896.
-func (db *DB) checkpointIfNeeded(ctx context.Context, origWALSize, newWALSize int64) error {
+func (db *DB) checkpointIfNeeded(ctx context.Context, state *syncState, origWALSize, newWALSize int64) error {
 	if db.pageSize == 0 {
 		return nil
 	}
@@ -1107,12 +1112,12 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, origWALSize, newWALSize in
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
 			"threshold", calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)))
-		return db.checkpoint(ctx, CheckpointModeTruncate)
+		return db.checkpoint(ctx, CheckpointModeTruncate, state)
 	}
 
 	// Priority 2: Regular checkpoint at min threshold (PASSIVE mode, non-blocking)
 	if newWALSize >= calcWALSize(uint32(db.pageSize), uint32(db.MinCheckpointPageN)) {
-		if err := db.checkpoint(ctx, CheckpointModePassive); err != nil {
+		if err := db.checkpoint(ctx, CheckpointModePassive, state); err != nil {
 			// PASSIVE checkpoints can fail with SQLITE_BUSY when database is locked.
 			// This is expected behavior and not an error - just log and continue.
 			if isSQLiteBusyError(err) {
@@ -1128,7 +1133,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, origWALSize, newWALSize in
 	// Only trigger if there have been actual changes synced since the last
 	// checkpoint. This prevents creating unnecessary LTX files when the only
 	// WAL data is from internal bookkeeping (like _litestream_seq updates).
-	if db.CheckpointInterval > 0 && db.syncedSinceCheckpoint {
+	if db.CheckpointInterval > 0 && state.syncedSinceCheckpoint {
 		// Get database file modification time
 		fi, err := db.f.Stat()
 		if err != nil {
@@ -1137,7 +1142,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, origWALSize, newWALSize in
 
 		// Only checkpoint if enough time has passed and WAL has data
 		if time.Since(fi.ModTime()) > db.CheckpointInterval && newWALSize > calcWALSize(uint32(db.pageSize), 1) {
-			if err := db.checkpoint(ctx, CheckpointModePassive); err != nil {
+			if err := db.checkpoint(ctx, CheckpointModePassive, state); err != nil {
 				// PASSIVE checkpoints can fail with SQLITE_BUSY when database is locked.
 				// This is expected behavior and not an error - just log and continue.
 				if isSQLiteBusyError(err) {
@@ -1293,7 +1298,7 @@ func (db *DB) checkDatabaseBehindReplica(ctx context.Context) error {
 
 // verify ensures the current LTX state matches where it left off from
 // the real WAL. Check info.ok if verification was successful.
-func (db *DB) verify(ctx context.Context) (info syncInfo, err error) {
+func (db *DB) verify(ctx context.Context, state *syncState) (info syncInfo, err error) {
 	frameSize := int64(db.pageSize + WALFrameHeaderSize)
 	info.snapshotting = true
 
@@ -1330,8 +1335,8 @@ func (db *DB) verify(ctx context.Context) (info syncInfo, err error) {
 		// If we previously synced to the exact end of the WAL, this truncation
 		// is expected (normal checkpoint behavior). Reset position and continue
 		// incrementally rather than triggering a full snapshot. See issue #927.
-		if db.syncedToWALEnd {
-			db.syncedToWALEnd = false // Clear flag
+		if state.syncedToWALEnd {
+			state.syncedToWALEnd = false // Clear flag
 
 			// Read new WAL header to get current salt values
 			hdr, err := readWALHeader(db.WALPath())
@@ -1521,9 +1526,9 @@ type syncResult struct {
 	l0FileInfo     *ltx.FileInfo
 }
 
-func (db *DB) applySyncResult(result syncResult) {
-	db.lastSyncedWALOffset = result.newWALSize
-	db.syncedToWALEnd = result.syncedToWALEnd
+func (db *DB) applySyncResult(state *syncState, result syncResult) {
+	state.lastSyncedWALOffset = result.newWALSize
+	state.syncedToWALEnd = result.syncedToWALEnd
 	if result.pos != nil {
 		db.pos.Lock()
 		db.pos.value = result.pos
@@ -1538,9 +1543,9 @@ func (db *DB) applySyncResult(result syncResult) {
 
 // sync copies pending bytes from the real WAL to LTX.
 // Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
-func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (result syncResult, err error) {
-	result.newWALSize = db.lastSyncedWALOffset
-	result.syncedToWALEnd = db.syncedToWALEnd
+func (db *DB) sync(ctx context.Context, checkpointing bool, state *syncState, info syncInfo) (result syncResult, err error) {
+	result.newWALSize = state.lastSyncedWALOffset
+	result.syncedToWALEnd = state.syncedToWALEnd
 
 	// Determine the next sequential transaction ID.
 	pos, err := db.Pos()
@@ -1822,12 +1827,12 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	return db.checkpoint(ctx, mode)
+	return db.checkpoint(ctx, mode, &db.syncState)
 }
 
 // checkpoint performs a checkpoint on the WAL file and initializes a
 // new shadow WAL file.
-func (db *DB) checkpoint(ctx context.Context, mode string) error {
+func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) error {
 	// Try getting a checkpoint lock, will fail during snapshots.
 	if !db.chkMu.TryLock() {
 		return nil
@@ -1841,11 +1846,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
-	result, err := db.verifyAndSync(ctx, true)
+	result, err := db.verifyAndSync(ctx, true, state)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
-	db.applySyncResult(result)
+	db.applySyncResult(state, result)
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
@@ -1859,7 +1864,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	if other, err := readWALHeader(db.WALPath()); err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
-		db.syncedSinceCheckpoint = false
+		state.syncedSinceCheckpoint = false
 		return nil
 	}
 
@@ -1879,11 +1884,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
-	result, err = db.verifyAndSync(ctx, true)
+	result, err = db.verifyAndSync(ctx, true, state)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 	}
-	db.applySyncResult(result)
+	db.applySyncResult(state, result)
 
 	// Release write lock before exiting.
 	// Use rollback() helper for consistency with releaseReadLock() and the
@@ -1892,7 +1897,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 		return fmt.Errorf("rollback post-checkpoint tx: %w", err)
 	}
 
-	db.syncedSinceCheckpoint = false
+	state.syncedSinceCheckpoint = false
 	return nil
 }
 
@@ -2361,7 +2366,7 @@ func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
 	}
 
 	// Force a RESTART checkpoint to ensure the database is at the start of the WAL.
-	if err := db.checkpoint(ctx, CheckpointModeRestart); err != nil {
+	if err := db.checkpoint(ctx, CheckpointModeRestart, &db.syncState); err != nil {
 		return 0, ltx.Pos{}, err
 	}
 

--- a/db.go
+++ b/db.go
@@ -1129,9 +1129,19 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	// Priority 1: Emergency truncate checkpoint (TRUNCATE mode, blocking)
 	// This prevents unbounded WAL growth from long-lived read transactions.
 	if db.TruncatePageN > 0 && origWALSize >= calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)) {
+		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
-			"threshold", calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)))
+			"threshold", truncateThreshold)
+
+		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+			if !isSQLiteBusyError(err) {
+				return err
+			}
+		} else if exec.state.lastSyncedWALOffset < truncateThreshold {
+			return nil
+		}
+
 		return db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
 	}
 
@@ -1964,6 +1974,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	defer db.chkMu.Unlock()
 
+	const checkpointSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
+
 	// Read WAL header before checkpoint to check if it has been restarted.
 	hdr, err := readWALHeader(db.WALPath())
 	if err != nil {
@@ -1977,11 +1989,52 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	exec.applySyncResult(result)
 
+	var barrierTx *sql.Tx
+	if mode == CheckpointModePassive {
+		barrierTx, err = db.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin passive checkpoint barrier: %w", err)
+		}
+		defer func() {
+			if barrierTx != nil {
+				_ = rollback(barrierTx)
+			}
+		}()
+
+		if _, err := barrierTx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+			return fmt.Errorf("_litestream_lock: %w", err)
+		}
+
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+		if err != nil {
+			return fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
+	}
+
+	frameSize := int64(db.pageSize + WALFrameHeaderSize)
+	preCheckpointFrameN := 0
+	if exec.state.lastSyncedWALOffset > WALHeaderSize {
+		preCheckpointFrameN = int((exec.state.lastSyncedWALOffset - WALHeaderSize) / frameSize)
+	}
+
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
-	if err := db.execCheckpoint(ctx, mode); err != nil {
+	checkpointRow, err := db.execCheckpoint(ctx, mode)
+	if err != nil {
 		return err
-	} else if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
+	}
+
+	if barrierTx != nil {
+		if _, err = barrierTx.ExecContext(ctx, checkpointSeqSQL); err != nil {
+			return err
+		} else if _, err = barrierTx.ExecContext(ctx, `DELETE FROM _litestream_lock`); err != nil {
+			return err
+		} else if err = barrierTx.Commit(); err != nil {
+			return err
+		}
+		barrierTx = nil
+	} else if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
 		return err
 	}
 
@@ -1989,6 +2042,26 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	if err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
+		exec.state.syncedSinceCheckpoint = false
+		return nil
+	}
+
+	if mode == CheckpointModePassive {
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+		if err != nil {
+			return fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
+		exec.state.syncedSinceCheckpoint = false
+		return nil
+	}
+
+	if checkpointRow[1] <= preCheckpointFrameN {
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+		if err != nil {
+			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
 		exec.state.syncedSinceCheckpoint = false
 		return nil
 	}
@@ -2033,10 +2106,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	return nil
 }
 
-func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
+func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err error) {
 	// Ignore if there is no underlying database.
 	if db.db == nil {
-		return nil
+		return row, nil
 	}
 
 	// Track checkpoint metrics.
@@ -2053,7 +2126,7 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// Ensure the read lock has been removed before issuing a checkpoint.
 	// We defer the re-acquire to ensure it occurs even on an early return.
 	if err := db.releaseReadLock(); err != nil {
-		return fmt.Errorf("release read lock: %w", err)
+		return row, fmt.Errorf("release read lock: %w", err)
 	}
 	defer func() { _ = db.acquireReadLock(ctx) }()
 
@@ -2065,18 +2138,17 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// See: https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
 	rawsql := `PRAGMA wal_checkpoint(` + mode + `);`
 
-	var row [3]int
 	if err := db.db.QueryRowContext(ctx, rawsql).Scan(&row[0], &row[1], &row[2]); err != nil {
-		return err
+		return row, err
 	}
 	db.Logger.Debug("checkpoint", "mode", mode, "result", fmt.Sprintf("%d,%d,%d", row[0], row[1], row[2]))
 
 	// Reacquire the read lock immediately after the checkpoint.
 	if err := db.acquireReadLock(ctx); err != nil {
-		return fmt.Errorf("reacquire read lock: %w", err)
+		return row, fmt.Errorf("reacquire read lock: %w", err)
 	}
 
-	return nil
+	return row, nil
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.

--- a/db.go
+++ b/db.go
@@ -1229,6 +1229,13 @@ func calcWALSize(pageSize uint32, pageN uint32) int64 {
 	return int64(WALHeaderSize) + (int64(WALFrameHeaderSize+pageSize) * int64(pageN))
 }
 
+const bumpLitestreamSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
+
+func (db *DB) bumpLitestreamSeq(ctx context.Context) error {
+	_, err := db.db.ExecContext(ctx, bumpLitestreamSeqSQL)
+	return err
+}
+
 // ensureWALExists checks that the real WAL exists and has a header.
 func (db *DB) ensureWALExists(ctx context.Context) (err error) {
 	// Exit early if WAL header exists.
@@ -1237,8 +1244,7 @@ func (db *DB) ensureWALExists(ctx context.Context) (err error) {
 	}
 
 	// Otherwise create transaction that updates the internal litestream table.
-	_, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`)
-	return err
+	return db.bumpLitestreamSeq(ctx)
 }
 
 // checkDatabaseBehindReplica detects when a database has been restored to an
@@ -1974,8 +1980,6 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	defer db.chkMu.Unlock()
 
-	const checkpointSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
-
 	// Read WAL header before checkpoint to check if it has been restarted.
 	hdr, err := readWALHeader(db.WALPath())
 	if err != nil {
@@ -2032,8 +2036,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		barrierTx = nil
 	}
 
-	if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
-		return err
+	if err = db.bumpLitestreamSeq(ctx); err != nil {
+		return fmt.Errorf("bump litestream seq: %w", err)
 	}
 
 	other, err := readWALHeader(db.WALPath())

--- a/db.go
+++ b/db.go
@@ -33,6 +33,7 @@ const (
 	DefaultBusyTimeout          = 1 * time.Second
 	DefaultMinCheckpointPageN   = 1000
 	DefaultTruncatePageN        = 121359 // ~500MB with 4KB page size
+	DefaultMaxSyncWALBytes      = 64 << 20
 	DefaultShutdownSyncTimeout  = 30 * time.Second
 	DefaultShutdownSyncInterval = 500 * time.Millisecond
 
@@ -138,6 +139,10 @@ type DB struct {
 
 	// Frequency at which to perform db sync.
 	MonitorInterval time.Duration
+
+	// Maximum WAL bytes to process in a single sync executor run.
+	// Set to zero to process all committed WAL frames in one run.
+	MaxSyncWALBytes int64
 
 	// The timeout to wait for EBUSY from SQLite.
 	BusyTimeout time.Duration
@@ -258,6 +263,7 @@ func NewDB(path string) *DB {
 		TruncatePageN:        DefaultTruncatePageN,
 		CheckpointInterval:   DefaultCheckpointInterval,
 		MonitorInterval:      DefaultMonitorInterval,
+		MaxSyncWALBytes:      DefaultMaxSyncWALBytes,
 		BusyTimeout:          DefaultBusyTimeout,
 		L0Retention:          DefaultL0Retention,
 		RetentionEnabled:     true,
@@ -764,7 +770,7 @@ func (db *DB) Close(ctx context.Context) (err error) {
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
-		if e := db.syncLocked(ctx); e != nil {
+		if _, e := db.syncLocked(ctx, 0); e != nil {
 			err = e
 		}
 	}
@@ -1153,13 +1159,28 @@ func (db *DB) releaseReadLock() error {
 }
 
 // Sync copies pending data from the WAL to the shadow WAL.
-func (db *DB) Sync(ctx context.Context) (err error) {
+func (db *DB) Sync(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
+
+		result, err := db.syncOnce(ctx, db.MaxSyncWALBytes)
+		if err != nil {
+			return err
+		} else if !result.synced || !result.limited || result.syncedToWALEnd {
+			return nil
+		}
+	}
+}
+
+func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, error) {
 	if err := db.lockExec(ctx); err != nil {
-		return err
+		return syncResult{}, err
 	}
 	defer db.execMu.Unlock()
 
-	return db.syncLocked(ctx)
+	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
@@ -1186,7 +1207,7 @@ func (db *DB) lockExec(ctx context.Context) error {
 	}
 }
 
-func (db *DB) syncLocked(ctx context.Context) (err error) {
+func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {
 	db.beginSyncDiagnostic("sync")
 	defer func() { db.finishSyncDiagnostic(err) }()
 
@@ -1202,23 +1223,23 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {
-		return err
+		return result, err
 	} else if exec == nil {
 		db.Logger.Debug("sync: no database found")
-		return nil
+		return result, nil
 	}
 	defer db.applySyncExecutor(exec, true)
 	db.setSyncDiagnosticPhase("ensure_wal", syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 
 	// Ensure WAL has at least one frame in it.
 	if err := db.ensureWALExists(ctx); err != nil {
-		return fmt.Errorf("ensure wal exists: %w", err)
+		return result, fmt.Errorf("ensure wal exists: %w", err)
 	}
 
 	db.setSyncDiagnosticPhase("verify_and_sync", syncDiagnosticTXID(exec.pos.TXID+1))
-	result, err := db.verifyAndSyncWithExecutor(ctx, false, exec)
+	result, err = db.verifyAndSyncWithExecutor(ctx, false, exec, maxSyncWALBytes)
 	if err != nil {
-		return err
+		return result, err
 	}
 	exec.applySyncResult(result)
 
@@ -1227,11 +1248,13 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		exec.state.syncedSinceCheckpoint = true
 	}
 
-	db.setSyncDiagnosticPhase("checkpoint_if_needed",
-		syncDiagnosticTXID(exec.pos.TXID),
-		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
-	if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
-		return fmt.Errorf("checkpoint: %w", err)
+	if !result.limited || result.syncedToWALEnd {
+		db.setSyncDiagnosticPhase("checkpoint_if_needed",
+			syncDiagnosticTXID(exec.pos.TXID),
+			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
+		if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
+			return result, fmt.Errorf("checkpoint: %w", err)
+		}
 	}
 
 	db.setSyncDiagnosticPhase("update_metrics",
@@ -1247,7 +1270,7 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 	}
 	db.walSizeGauge.Set(float64(exec.state.lastSyncedWALOffset))
 
-	return nil
+	return result, nil
 }
 
 func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *syncState) (syncResult, error) {
@@ -1259,10 +1282,10 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *sync
 	return db.verifyAndSyncWithExecutor(ctx, checkpointing, &syncExecutor{
 		state: *state,
 		pos:   pos,
-	})
+	}, 0)
 }
 
-func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor) (syncResult, error) {
+func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor, maxSyncWALBytes int64) (syncResult, error) {
 	db.setSyncDiagnosticPhase("stat_wal", syncDiagnosticTXID(exec.pos.TXID+1), syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
@@ -1292,7 +1315,7 @@ func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool,
 		syncDiagnosticSnapshotting(info.snapshotting),
 		syncDiagnosticReason(info.reason),
 		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
-	result, err := db.sync(ctx, checkpointing, exec, info)
+	result, err := db.sync(ctx, checkpointing, exec, info, maxSyncWALBytes)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
 	}
@@ -1757,6 +1780,7 @@ type syncResult struct {
 	origWALSize    int64
 	newWALSize     int64
 	synced         bool
+	limited        bool
 	syncedToWALEnd bool
 	pos            *ltx.Pos
 	l0FileInfo     *ltx.FileInfo
@@ -1839,7 +1863,7 @@ func (exec *syncExecutor) applySyncResult(result syncResult) {
 
 // sync copies pending bytes from the real WAL to LTX.
 // Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
-func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo) (result syncResult, err error) {
+func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo, maxSyncWALBytes int64) (result syncResult, err error) {
 	result.newWALSize = exec.state.lastSyncedWALOffset
 	result.syncedToWALEnd = exec.state.syncedToWALEnd
 	if info.clearSyncedToWALEnd {
@@ -1915,10 +1939,14 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		syncDiagnosticTXID(txID),
 		syncDiagnosticSnapshotting(info.snapshotting),
 		syncDiagnosticReason(info.reason))
-	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
+	if info.snapshotting {
+		maxSyncWALBytes = 0
+	}
+	pageMap, maxOffset, walCommit, limited, err := rd.pageMap(ctx, maxSyncWALBytes)
 	if err != nil {
 		return result, fmt.Errorf("page map: %w", err)
 	}
+	result.limited = limited
 	if walCommit > 0 {
 		commit = walCommit
 	}
@@ -2263,7 +2291,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		syncDiagnosticTXID(exec.pos.TXID),
 		syncDiagnosticCheckpointMode(mode),
 		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
-	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec)
+	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
@@ -2293,7 +2321,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			syncDiagnosticTXID(exec.pos.TXID),
 			syncDiagnosticCheckpointMode(mode),
 			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
-		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
 			return fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
 		}
@@ -2349,7 +2377,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			syncDiagnosticTXID(exec.pos.TXID),
 			syncDiagnosticCheckpointMode(mode),
 			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
-		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
 			return fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
 		}
@@ -2363,7 +2391,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			syncDiagnosticTXID(exec.pos.TXID),
 			syncDiagnosticCheckpointMode(mode),
 			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
-		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
 			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 		}
@@ -2403,7 +2431,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		snapshotting: true,
 		reason:       "checkpoint boundary snapshot",
 	}
-	result, err = db.sync(ctx, true, exec, snapshotInfo)
+	result, err = db.sync(ctx, true, exec, snapshotInfo, 0)
 	if err != nil {
 		return fmt.Errorf("cannot snapshot after checkpoint: %w", err)
 	}
@@ -2830,7 +2858,7 @@ func (db *DB) monitor() {
 		}
 
 		// Sync the database to the shadow WAL.
-		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if _, err := db.syncOnce(db.ctx, db.MaxSyncWALBytes); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max

--- a/db.go
+++ b/db.go
@@ -64,7 +64,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execMu    sync.Mutex
+	execMu    contextMutex
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -181,6 +181,58 @@ type DB struct {
 
 	// Where to send log messages, defaults to global slog with database epath.
 	Logger *slog.Logger
+}
+
+type contextMutex struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+func (m *contextMutex) init() {
+	m.once.Do(func() {
+		m.ch = make(chan struct{}, 1)
+	})
+}
+
+func (m *contextMutex) Lock() {
+	m.init()
+	m.ch <- struct{}{}
+}
+
+func (m *contextMutex) LockContext(ctx context.Context) error {
+	m.init()
+
+	select {
+	case m.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		err := context.Cause(ctx)
+		if err == nil {
+			err = ctx.Err()
+		}
+		return err
+	}
+}
+
+func (m *contextMutex) TryLock() bool {
+	m.init()
+
+	select {
+	case m.ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *contextMutex) Unlock() {
+	m.init()
+
+	select {
+	case <-m.ch:
+	default:
+		panic("unlock of unlocked contextMutex")
+	}
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -1222,23 +1274,10 @@ func (db *DB) lockExec(ctx context.Context) error {
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if err == nil {
-				err = ctx.Err()
-			}
-			return fmt.Errorf("wait for db sync executor: %w", err)
-		case <-ticker.C:
-			if db.execMu.TryLock() {
-				return nil
-			}
-		}
+	if err := db.execMu.LockContext(ctx); err != nil {
+		return fmt.Errorf("wait for db sync executor: %w", err)
 	}
+	return nil
 }
 
 func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {

--- a/db.go
+++ b/db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 	"modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -64,7 +65,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execMu    contextMutex
+	execGate  syncGate
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -183,56 +184,36 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type contextMutex struct {
+type syncGate struct {
 	once sync.Once
-	ch   chan struct{}
+	sem  *semaphore.Weighted
 }
 
-func (m *contextMutex) init() {
-	m.once.Do(func() {
-		m.ch = make(chan struct{}, 1)
+func (g *syncGate) init() {
+	g.once.Do(func() {
+		g.sem = semaphore.NewWeighted(1)
 	})
 }
 
-func (m *contextMutex) Lock() {
-	m.init()
-	m.ch <- struct{}{}
-}
-
-func (m *contextMutex) LockContext(ctx context.Context) error {
-	m.init()
-
-	select {
-	case m.ch <- struct{}{}:
-		return nil
-	case <-ctx.Done():
-		err := context.Cause(ctx)
-		if err == nil {
-			err = ctx.Err()
+func (g *syncGate) Acquire(ctx context.Context) error {
+	g.init()
+	if err := g.sem.Acquire(ctx, 1); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return cause
 		}
 		return err
 	}
+	return nil
 }
 
-func (m *contextMutex) TryLock() bool {
-	m.init()
-
-	select {
-	case m.ch <- struct{}{}:
-		return true
-	default:
-		return false
-	}
+func (g *syncGate) TryAcquire() bool {
+	g.init()
+	return g.sem.TryAcquire(1)
 }
 
-func (m *contextMutex) Unlock() {
-	m.init()
-
-	select {
-	case <-m.ch:
-	default:
-		panic("unlock of unlocked contextMutex")
-	}
+func (g *syncGate) Release() {
+	g.init()
+	g.sem.Release(1)
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -849,8 +830,10 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.execGate.Acquire(ctx); err != nil {
+		return err
+	}
+	defer db.execGate.Release()
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -1262,19 +1245,19 @@ func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, 
 	if err := db.lockExec(ctx); err != nil {
 		return syncResult{}, err
 	}
-	defer db.execMu.Unlock()
+	defer db.execGate.Release()
 
 	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
-	if db.execMu.TryLock() {
+	if db.execGate.TryAcquire() {
 		return nil
 	}
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	if err := db.execMu.LockContext(ctx); err != nil {
+	if err := db.execGate.Acquire(ctx); err != nil {
 		return fmt.Errorf("wait for db sync executor: %w", err)
 	}
 	return nil
@@ -2300,7 +2283,7 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	if err := db.lockExec(ctx); err != nil {
 		return err
 	}
-	defer db.execMu.Unlock()
+	defer db.execGate.Release()
 	db.beginSyncDiagnostic("checkpoint")
 	defer func() { db.finishSyncDiagnostic(err) }()
 
@@ -2581,7 +2564,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execMu.Unlock()
+	db.execGate.Release()
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
@@ -2988,8 +2971,10 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.execGate.Acquire(ctx); err != nil {
+		return 0, ltx.Pos{}, err
+	}
+	defer db.execGate.Release()
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -74,6 +74,7 @@ type DB struct {
 	chkMu     sync.RWMutex  // checkpoint lock
 	opened    bool          // true if Open() was called and Close() not yet called
 	syncState syncState
+	syncDiag  syncDiagnosticState
 
 	// last file info for each level
 	maxLTXFileInfos struct {
@@ -210,6 +211,40 @@ type syncExecutor struct {
 	synced     bool
 }
 
+type syncDiagnosticState struct {
+	sync.RWMutex
+	active              bool
+	operation           string
+	phase               string
+	startedAt           time.Time
+	updatedAt           time.Time
+	txID                ltx.TXID
+	walSize             int64
+	lastSyncedWALOffset int64
+	snapshotting        bool
+	checkpointMode      string
+	reason              string
+	err                 string
+}
+
+// SyncDiagnostic reports the latest DB sync/checkpoint activity.
+type SyncDiagnostic struct {
+	Path                string     `json:"path"`
+	Active              bool       `json:"active"`
+	Operation           string     `json:"operation,omitempty"`
+	Phase               string     `json:"phase,omitempty"`
+	StartedAt           *time.Time `json:"started_at,omitempty"`
+	UpdatedAt           *time.Time `json:"updated_at,omitempty"`
+	ElapsedSeconds      float64    `json:"elapsed_seconds,omitempty"`
+	TXID                uint64     `json:"txid,omitempty"`
+	WALSize             int64      `json:"wal_size,omitempty"`
+	LastSyncedWALOffset int64      `json:"last_synced_wal_offset,omitempty"`
+	Snapshotting        bool       `json:"snapshotting,omitempty"`
+	CheckpointMode      string     `json:"checkpoint_mode,omitempty"`
+	Reason              string     `json:"reason,omitempty"`
+	Error               string     `json:"error,omitempty"`
+}
+
 // NewDB returns a new instance of DB for a given path.
 func NewDB(path string) *DB {
 	dir, file := filepath.Split(path)
@@ -294,6 +329,114 @@ func (db *DB) IsOpen() bool {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 	return db.opened
+}
+
+// SyncDiagnostic returns the latest sync/checkpoint diagnostic snapshot.
+func (db *DB) SyncDiagnostic() SyncDiagnostic {
+	db.syncDiag.RLock()
+	defer db.syncDiag.RUnlock()
+
+	diag := SyncDiagnostic{
+		Path:                db.path,
+		Active:              db.syncDiag.active,
+		Operation:           db.syncDiag.operation,
+		Phase:               db.syncDiag.phase,
+		TXID:                uint64(db.syncDiag.txID),
+		WALSize:             db.syncDiag.walSize,
+		LastSyncedWALOffset: db.syncDiag.lastSyncedWALOffset,
+		Snapshotting:        db.syncDiag.snapshotting,
+		CheckpointMode:      db.syncDiag.checkpointMode,
+		Reason:              db.syncDiag.reason,
+		Error:               db.syncDiag.err,
+	}
+	if !db.syncDiag.startedAt.IsZero() {
+		startedAt := db.syncDiag.startedAt
+		diag.StartedAt = &startedAt
+	}
+	if !db.syncDiag.updatedAt.IsZero() {
+		updatedAt := db.syncDiag.updatedAt
+		diag.UpdatedAt = &updatedAt
+	}
+	if !db.syncDiag.startedAt.IsZero() {
+		end := db.syncDiag.updatedAt
+		if db.syncDiag.active || end.IsZero() {
+			end = time.Now()
+		}
+		diag.ElapsedSeconds = end.Sub(db.syncDiag.startedAt).Seconds()
+	}
+	return diag
+}
+
+type syncDiagnosticOption func(*syncDiagnosticState)
+
+func syncDiagnosticTXID(txID ltx.TXID) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.txID = txID }
+}
+
+func syncDiagnosticWALSize(n int64) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.walSize = n }
+}
+
+func syncDiagnosticLastSyncedWALOffset(n int64) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.lastSyncedWALOffset = n }
+}
+
+func syncDiagnosticSnapshotting(v bool) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.snapshotting = v }
+}
+
+func syncDiagnosticCheckpointMode(mode string) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.checkpointMode = mode }
+}
+
+func syncDiagnosticReason(reason string) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.reason = reason }
+}
+
+func (db *DB) beginSyncDiagnostic(operation string) {
+	now := time.Now()
+	walSize, _ := db.walFileSize()
+
+	db.syncDiag.Lock()
+	db.syncDiag.active = true
+	db.syncDiag.operation = operation
+	db.syncDiag.phase = "starting"
+	db.syncDiag.startedAt = now
+	db.syncDiag.updatedAt = now
+	db.syncDiag.txID = 0
+	db.syncDiag.walSize = walSize
+	db.syncDiag.lastSyncedWALOffset = db.syncState.lastSyncedWALOffset
+	db.syncDiag.snapshotting = false
+	db.syncDiag.checkpointMode = ""
+	db.syncDiag.reason = ""
+	db.syncDiag.err = ""
+	db.syncDiag.Unlock()
+}
+
+func (db *DB) setSyncDiagnosticPhase(phase string, opts ...syncDiagnosticOption) {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if !db.syncDiag.active {
+		return
+	}
+	db.syncDiag.phase = phase
+	db.syncDiag.updatedAt = time.Now()
+	for _, opt := range opts {
+		opt(&db.syncDiag)
+	}
+}
+
+func (db *DB) finishSyncDiagnostic(err error) {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if !db.syncDiag.active {
+		return
+	}
+	db.syncDiag.active = false
+	db.syncDiag.updatedAt = time.Now()
+	if err != nil {
+		db.syncDiag.err = err.Error()
+	}
 }
 
 // WALPath returns the path to the database's WAL file.
@@ -1030,7 +1173,11 @@ func (db *DB) lockExec(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			err := context.Cause(ctx)
+			if err == nil {
+				err = ctx.Err()
+			}
+			return fmt.Errorf("wait for db sync executor: %w", err)
 		case <-ticker.C:
 			if db.execMu.TryLock() {
 				return nil
@@ -1040,6 +1187,9 @@ func (db *DB) lockExec(ctx context.Context) error {
 }
 
 func (db *DB) syncLocked(ctx context.Context) (err error) {
+	db.beginSyncDiagnostic("sync")
+	defer func() { db.finishSyncDiagnostic(err) }()
+
 	// Track total sync metrics.
 	t := time.Now()
 	defer func() {
@@ -1058,12 +1208,14 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		return nil
 	}
 	defer db.applySyncExecutor(exec, true)
+	db.setSyncDiagnosticPhase("ensure_wal", syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 
 	// Ensure WAL has at least one frame in it.
 	if err := db.ensureWALExists(ctx); err != nil {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
+	db.setSyncDiagnosticPhase("verify_and_sync", syncDiagnosticTXID(exec.pos.TXID+1))
 	result, err := db.verifyAndSyncWithExecutor(ctx, false, exec)
 	if err != nil {
 		return err
@@ -1075,9 +1227,16 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		exec.state.syncedSinceCheckpoint = true
 	}
 
+	db.setSyncDiagnosticPhase("checkpoint_if_needed",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
+
+	db.setSyncDiagnosticPhase("update_metrics",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 
 	// Compute current index and total shadow WAL size.
 	db.txIDGauge.Set(float64(exec.pos.TXID))
@@ -1104,6 +1263,8 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *sync
 }
 
 func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor) (syncResult, error) {
+	db.setSyncDiagnosticPhase("stat_wal", syncDiagnosticTXID(exec.pos.TXID+1), syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
+
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
 	// This avoids using file size which may include stale frames with old salt
 	// values after a checkpoint. See issue #997.
@@ -1120,11 +1281,17 @@ func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool,
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that the last sync position of the real WAL hasn't
 	// been overwritten by another process.
+	db.setSyncDiagnosticPhase("verify_wal", syncDiagnosticTXID(exec.pos.TXID+1), syncDiagnosticWALSize(origWALSize))
 	info, err := db.verifyWithExecutor(ctx, exec)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
+	db.setSyncDiagnosticPhase("sync_ltx",
+		syncDiagnosticTXID(exec.pos.TXID+1),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	result, err := db.sync(ctx, checkpointing, exec, info)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
@@ -1681,6 +1848,11 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 
 	// Determine the next sequential transaction ID.
 	txID := exec.pos.TXID + 1
+	db.setSyncDiagnosticPhase("sync_open_wal",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 
 	filename := db.LTXPath(0, txID, txID)
 
@@ -1739,6 +1911,10 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 
 	// Build a mapping of changed page numbers and their latest content.
+	db.setSyncDiagnosticPhase("sync_page_map",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
 	if err != nil {
 		return result, fmt.Errorf("page map: %w", err)
@@ -1752,6 +1928,11 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		sz = maxOffset - info.offset
 	}
 	assert(sz >= 0, fmt.Sprintf("wal size must be positive: sz=%d, maxOffset=%d, info.offset=%d", sz, maxOffset, info.offset))
+	db.setSyncDiagnosticPhase("sync_prepare_ltx",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticWALSize(sz),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 
 	// Track total WAL bytes synced.
 	if sz > 0 {
@@ -1811,21 +1992,33 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	// If we need a full snapshot, then copy from the database & WAL.
 	// Otherwise, just copy incrementally from the WAL.
 	if info.snapshotting {
+		db.setSyncDiagnosticPhase("write_ltx_from_db",
+			syncDiagnosticTXID(txID),
+			syncDiagnosticWALSize(sz),
+			syncDiagnosticSnapshotting(true),
+			syncDiagnosticReason(info.reason))
 		if err := db.writeLTXFromDB(ctx, enc, walFile, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
+		db.setSyncDiagnosticPhase("write_ltx_from_wal",
+			syncDiagnosticTXID(txID),
+			syncDiagnosticWALSize(sz),
+			syncDiagnosticSnapshotting(false),
+			syncDiagnosticReason(info.reason))
 		if err := db.writeLTXFromWAL(ctx, enc, walFile, info.prevCommit, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
 
 	// Encode final trailer to the end of the LTX file.
+	db.setSyncDiagnosticPhase("close_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
 	if err := enc.Close(); err != nil {
 		return result, fmt.Errorf("close ltx encoder: %w", err)
 	}
 
 	// Sync & close LTX file.
+	db.setSyncDiagnosticPhase("fsync_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
 	if err := ltxFile.Sync(); err != nil {
 		return result, fmt.Errorf("sync ltx file: %w", err)
 	}
@@ -1834,6 +2027,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 
 	// Atomically rename file to final path.
+	db.setSyncDiagnosticPhase("rename_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
 	if err := os.Rename(tmpFilename, filename); err != nil {
 		db.maxLTXFileInfos.Lock()
 		delete(db.maxLTXFileInfos.m, 0) // clear cache if in unknown state
@@ -1869,6 +2063,12 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	} else {
 		result.syncedToWALEnd = false
 	}
+	db.setSyncDiagnosticPhase("sync_complete",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticWALSize(sz),
+		syncDiagnosticLastSyncedWALOffset(finalOffset),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 
 	db.Logger.Debug("db sync", "status", "ok")
 
@@ -1992,6 +2192,8 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 		return err
 	}
 	defer db.execMu.Unlock()
+	db.beginSyncDiagnostic("checkpoint")
+	defer func() { db.finishSyncDiagnostic(err) }()
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {
@@ -2035,6 +2237,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 }
 
 func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syncExecutor) error {
+	db.setSyncDiagnosticPhase("checkpoint_lock",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
+
 	// Try getting a checkpoint lock, will fail during snapshots.
 	if !db.chkMu.TryLock() {
 		return nil
@@ -2042,12 +2249,20 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	defer db.chkMu.Unlock()
 
 	// Read WAL header before checkpoint to check if it has been restarted.
+	db.setSyncDiagnosticPhase("checkpoint_read_wal_header",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	hdr, err := readWALHeader(db.WALPath())
 	if err != nil {
 		return err
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
+	db.setSyncDiagnosticPhase("checkpoint_copy_before",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
@@ -2056,6 +2271,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 
 	var barrierTx *sql.Tx
 	if mode == CheckpointModePassive {
+		db.setSyncDiagnosticPhase("checkpoint_passive_barrier",
+			syncDiagnosticTXID(exec.pos.TXID),
+			syncDiagnosticCheckpointMode(mode),
+			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 		barrierTx, err = db.db.BeginTx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("begin passive checkpoint barrier: %w", err)
@@ -2070,6 +2289,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			return fmt.Errorf("_litestream_lock: %w", err)
 		}
 
+		db.setSyncDiagnosticPhase("checkpoint_seal_wal",
+			syncDiagnosticTXID(exec.pos.TXID),
+			syncDiagnosticCheckpointMode(mode),
+			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
 		if err != nil {
 			return fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
@@ -2085,12 +2308,20 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
+	db.setSyncDiagnosticPhase("checkpoint_exec",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	checkpointRow, err := db.execCheckpoint(ctx, mode)
 	if err != nil {
 		return err
 	}
 
 	if barrierTx != nil {
+		db.setSyncDiagnosticPhase("checkpoint_release_barrier",
+			syncDiagnosticTXID(exec.pos.TXID),
+			syncDiagnosticCheckpointMode(mode),
+			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 		if err = rollback(barrierTx); err != nil {
 			return fmt.Errorf("rollback passive checkpoint barrier: %w", err)
 		}
@@ -2101,6 +2332,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		return fmt.Errorf("bump litestream seq: %w", err)
 	}
 
+	db.setSyncDiagnosticPhase("checkpoint_verify_restart",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	other, err := readWALHeader(db.WALPath())
 	if err != nil {
 		return err
@@ -2110,6 +2345,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	if mode == CheckpointModePassive {
+		db.setSyncDiagnosticPhase("checkpoint_copy_after_passive",
+			syncDiagnosticTXID(exec.pos.TXID),
+			syncDiagnosticCheckpointMode(mode),
+			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
 		if err != nil {
 			return fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
@@ -2120,6 +2359,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	if checkpointRow[1] <= preCheckpointFrameN {
+		db.setSyncDiagnosticPhase("checkpoint_copy_after",
+			syncDiagnosticTXID(exec.pos.TXID),
+			syncDiagnosticCheckpointMode(mode),
+			syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
 		if err != nil {
 			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
@@ -2130,6 +2373,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	// Start a transaction. This will be promoted immediately after.
+	db.setSyncDiagnosticPhase("checkpoint_snapshot_boundary_lock",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	tx, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
@@ -2145,6 +2392,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
+	db.setSyncDiagnosticPhase("checkpoint_snapshot_boundary",
+		syncDiagnosticTXID(exec.pos.TXID),
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(exec.state.lastSyncedWALOffset))
 	snapshotInfo := syncInfo{
 		offset:       WALHeaderSize,
 		salt1:        binary.BigEndian.Uint32(other[16:]),

--- a/db.go
+++ b/db.go
@@ -2553,21 +2553,36 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	if err := db.lockExec(ctx); err != nil {
-		return ltx.Pos{}, nil, err
+	pos, pageSize, err := db.snapshotPosition(ctx)
+	if err != nil {
+		return pos, nil, err
 	}
+
+	r, err := db.snapshotReader(ctx, pos, pageSize)
+	return pos, r, err
+}
+
+func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, 0, err
+	}
+	defer db.execSem.Release(1)
+
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execSem.Release(1)
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
-		return ltx.Pos{}, nil, &DBNotReadyError{Reason: "page size not initialized"}
+		return ltx.Pos{}, 0, &DBNotReadyError{Reason: "page size not initialized"}
 	}
 	if err != nil {
-		return pos, nil, fmt.Errorf("pos: %w", err)
+		return pos, pageSize, fmt.Errorf("pos: %w", err)
 	}
 
+	return pos, pageSize, nil
+}
+
+func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io.Reader, error) {
 	db.Logger.Debug("snapshot", "txid", pos.TXID.String())
 
 	// Prevent internal checkpoints during sync.
@@ -2578,7 +2593,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 
 	fi, err := db.f.Stat()
 	if err != nil {
-		return pos, nil, err
+		return nil, err
 	}
 	commit := uint32(fi.Size() / int64(pageSize))
 
@@ -2655,7 +2670,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 		_ = pw.Close()
 	}()
 
-	return pos, pr, nil
+	return pr, nil
 }
 
 // Compact performs a compaction of the LTX file at the previous level into dstLevel.
@@ -2680,12 +2695,24 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 	return info, nil
 }
 
-// SnapshotDB writes a snapshot to the replica for the current position of the database.
+// Snapshot writes a snapshot to the replica for the current database position.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, r, err := db.SnapshotReader(ctx)
+	pos, pageSize, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
 	}
+	if info, ok, err := db.existingSnapshotInfo(ctx, pos.TXID); err != nil {
+		return nil, err
+	} else if ok {
+		db.Logger.Debug("snapshot already exists", "txid", pos.TXID.String(), "snapshot", info.MaxTXID.String())
+		return info, nil
+	}
+
+	r, err := db.snapshotReader(ctx, pos, pageSize)
+	if err != nil {
+		return nil, err
+	}
+
 	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
 	if err != nil {
 		return info, err
@@ -2696,6 +2723,17 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	db.maxLTXFileInfos.Unlock()
 
 	return info, nil
+}
+
+func (db *DB) existingSnapshotInfo(ctx context.Context, txID ltx.TXID) (*ltx.FileInfo, bool, error) {
+	info, err := db.MaxLTXFileInfo(ctx, SnapshotLevel)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.MaxTXID == 0 || info.MaxTXID < txID {
+		return nil, false, nil
+	}
+	return &info, true, nil
 }
 
 // EnforceSnapshotRetention enforces retention of the snapshot level in the database by timestamp.

--- a/db.go
+++ b/db.go
@@ -65,7 +65,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execGate  syncGate
+	execSem   *semaphore.Weighted
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -184,38 +184,6 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type syncGate struct {
-	once sync.Once
-	sem  *semaphore.Weighted
-}
-
-func (g *syncGate) init() {
-	g.once.Do(func() {
-		g.sem = semaphore.NewWeighted(1)
-	})
-}
-
-func (g *syncGate) Acquire(ctx context.Context) error {
-	g.init()
-	if err := g.sem.Acquire(ctx, 1); err != nil {
-		if cause := context.Cause(ctx); cause != nil {
-			return cause
-		}
-		return err
-	}
-	return nil
-}
-
-func (g *syncGate) TryAcquire() bool {
-	g.init()
-	return g.sem.TryAcquire(1)
-}
-
-func (g *syncGate) Release() {
-	g.init()
-	g.sem.Release(1)
-}
-
 // syncState holds mutable sync-tracking fields extracted from DB.
 // These fields are threaded through sync/checkpoint methods via pointer.
 type syncState struct {
@@ -288,6 +256,13 @@ type SyncDiagnostic struct {
 	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
 }
 
+func contextCause(ctx context.Context, err error) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return err
+}
+
 // NewDB returns a new instance of DB for a given path.
 func NewDB(path string) *DB {
 	dir, file := filepath.Split(path)
@@ -295,6 +270,7 @@ func NewDB(path string) *DB {
 	db := &DB{
 		path:     path,
 		metaPath: filepath.Join(dir, "."+file+MetaDirSuffix),
+		execSem:  semaphore.NewWeighted(1),
 		notify:   make(chan struct{}),
 
 		MinCheckpointPageN:   DefaultMinCheckpointPageN,
@@ -830,10 +806,10 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return err
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return contextCause(ctx, err)
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -1245,20 +1221,20 @@ func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, 
 	if err := db.lockExec(ctx); err != nil {
 		return syncResult{}, err
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
-	if db.execGate.TryAcquire() {
+	if db.execSem.TryAcquire(1) {
 		return nil
 	}
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return fmt.Errorf("wait for db sync executor: %w", err)
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("wait for db sync executor: %w", contextCause(ctx, err))
 	}
 	return nil
 }
@@ -2283,7 +2259,7 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	if err := db.lockExec(ctx); err != nil {
 		return err
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 	db.beginSyncDiagnostic("checkpoint")
 	defer func() { db.finishSyncDiagnostic(err) }()
 
@@ -2564,7 +2540,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execGate.Release()
+	db.execSem.Release(1)
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
@@ -2971,10 +2947,10 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return 0, ltx.Pos{}, err
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return 0, ltx.Pos{}, contextCause(ctx, err)
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -230,6 +230,8 @@ type syncDiagnosticState struct {
 	checkpointMode      string
 	reason              string
 	err                 string
+	executorWaiterCount int
+	executorWaitStarted time.Time
 }
 
 // SyncDiagnostic reports the latest DB sync/checkpoint activity.
@@ -248,6 +250,9 @@ type SyncDiagnostic struct {
 	CheckpointMode      string     `json:"checkpoint_mode,omitempty"`
 	Reason              string     `json:"reason,omitempty"`
 	Error               string     `json:"error,omitempty"`
+	ExecutorWaiterCount int        `json:"executor_waiter_count,omitempty"`
+	ExecutorWaitStarted *time.Time `json:"executor_wait_started_at,omitempty"`
+	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
 }
 
 // NewDB returns a new instance of DB for a given path.
@@ -354,6 +359,12 @@ func (db *DB) SyncDiagnostic() SyncDiagnostic {
 		CheckpointMode:      db.syncDiag.checkpointMode,
 		Reason:              db.syncDiag.reason,
 		Error:               db.syncDiag.err,
+		ExecutorWaiterCount: db.syncDiag.executorWaiterCount,
+	}
+	if !db.syncDiag.executorWaitStarted.IsZero() {
+		startedAt := db.syncDiag.executorWaitStarted
+		diag.ExecutorWaitStarted = &startedAt
+		diag.ExecutorWaitSeconds = time.Since(db.syncDiag.executorWaitStarted).Seconds()
 	}
 	if !db.syncDiag.startedAt.IsZero() {
 		startedAt := db.syncDiag.startedAt
@@ -442,6 +453,27 @@ func (db *DB) finishSyncDiagnostic(err error) {
 	db.syncDiag.updatedAt = time.Now()
 	if err != nil {
 		db.syncDiag.err = err.Error()
+	}
+}
+
+func (db *DB) beginSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Now()
+	}
+	db.syncDiag.executorWaiterCount++
+}
+
+func (db *DB) finishSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		return
+	}
+	db.syncDiag.executorWaiterCount--
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Time{}
 	}
 }
 
@@ -1187,6 +1219,8 @@ func (db *DB) lockExec(ctx context.Context) error {
 	if db.execMu.TryLock() {
 		return nil
 	}
+	db.beginSyncExecutorWait()
+	defer db.finishSyncExecutorWait()
 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()

--- a/db.go
+++ b/db.go
@@ -2023,6 +2023,17 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	if walCommit > 0 {
 		commit = walCommit
 	}
+	if !info.snapshotting {
+		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
+			info.snapshotting = true
+			info.reason = fmt.Sprintf("missing WAL growth page %d, full LTX", pgno)
+			db.Logger.Info("missing WAL growth page, writing full LTX",
+				"txid", txID.String(),
+				"pgno", pgno,
+				"prev_commit", info.prevCommit,
+				"commit", commit)
+		}
+	}
 
 	var sz int64
 	if maxOffset > 0 {
@@ -2235,26 +2246,14 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	if err := checkContext(); err != nil {
 		return err
 	}
+	if pgno, ok := missingGrowthPage(prevCommit, commit, uint32(db.pageSize), pageMap); ok {
+		return fmt.Errorf("missing WAL growth page %d between previous commit %d and commit %d", pgno, prevCommit, commit)
+	}
 
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
-	}
-	lockPgno := ltx.LockPgno(uint32(db.pageSize))
-	if commit > prevCommit {
-		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
-			if err := checkContext(); err != nil {
-				return err
-			}
-			if pgno == lockPgno {
-				continue
-			}
-			if _, ok := pageMap[pgno]; ok {
-				continue
-			}
-			pgnos = append(pgnos, pgno)
-		}
 	}
 	slices.Sort(pgnos)
 
@@ -2263,21 +2262,13 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		if err := checkContext(); err != nil {
 			return err
 		}
-		if offset, ok := pageMap[pgno]; ok {
-			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+		offset := pageMap[pgno]
+		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-			} else if n != len(data) {
-				return fmt.Errorf("short read page %d @ %d", pgno, offset)
-			}
-		} else {
-			offset := int64(pgno-1) * int64(db.pageSize)
-			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
-
-			if _, err := db.f.ReadAt(data, offset); err != nil {
-				return fmt.Errorf("read database page %d: %w", pgno, err)
-			}
+		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+		} else if n != len(data) {
+			return fmt.Errorf("short read page %d @ %d", pgno, offset)
 		}
 
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {
@@ -2285,6 +2276,23 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		}
 	}
 	return nil
+}
+
+func missingGrowthPage(prevCommit, commit, pageSize uint32, pageMap map[uint32]int64) (uint32, bool) {
+	if commit <= prevCommit {
+		return 0, false
+	}
+
+	lockPgno := ltx.LockPgno(pageSize)
+	for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+		if pgno == lockPgno {
+			continue
+		}
+		if _, ok := pageMap[pgno]; !ok {
+			return pgno, true
+		}
+	}
+	return 0, false
 }
 
 // Checkpoint performs a checkpoint on the WAL file.

--- a/db.go
+++ b/db.go
@@ -1984,9 +1984,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 	if !info.snapshotting {
 		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-			info.snapshotting = true
-			info.reason = fmt.Sprintf("missing WAL growth page %d, full LTX", pgno)
-			db.Logger.Info("missing WAL growth page, writing full LTX",
+			db.Logger.Info("missing WAL growth page, reading from database",
 				"txid", txID.String(),
 				"pgno", pgno,
 				"prev_commit", info.prevCommit,
@@ -2205,14 +2203,26 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	if err := checkContext(); err != nil {
 		return err
 	}
-	if pgno, ok := missingGrowthPage(prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-		return fmt.Errorf("missing WAL growth page %d between previous commit %d and commit %d", pgno, prevCommit, commit)
-	}
 
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
+	}
+	lockPgno := ltx.LockPgno(uint32(db.pageSize))
+	if commit > prevCommit {
+		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if err := checkContext(); err != nil {
+				return err
+			}
+			if pgno == lockPgno {
+				continue
+			}
+			if _, ok := pageMap[pgno]; ok {
+				continue
+			}
+			pgnos = append(pgnos, pgno)
+		}
 	}
 	slices.Sort(pgnos)
 
@@ -2221,13 +2231,21 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		if err := checkContext(); err != nil {
 			return err
 		}
-		offset := pageMap[pgno]
-		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+		if offset, ok := pageMap[pgno]; ok {
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-		} else if n != len(data) {
-			return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+			} else if n != len(data) {
+				return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			}
+		} else {
+			offset := int64(pgno-1) * int64(db.pageSize)
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
+
+			if _, err := db.f.ReadAt(data, offset); err != nil {
+				return fmt.Errorf("read database page %d: %w", pgno, err)
+			}
 		}
 
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {

--- a/db.go
+++ b/db.go
@@ -2551,20 +2551,38 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 	return row, nil
 }
 
-// SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
-func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	pos, pageSize, err := db.snapshotPosition(ctx)
-	if err != nil {
-		return pos, nil, err
-	}
-
-	r, err := db.snapshotReader(ctx, pos, pageSize)
-	return pos, r, err
+type snapshotReadPosition struct {
+	pos          ltx.Pos
+	pageSize     int
+	walEndOffset int64
+	db           *DB
 }
 
-func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
+func (p *snapshotReadPosition) close() {
+	if p.db != nil {
+		p.db.chkMu.RUnlock()
+		p.db = nil
+	}
+}
+
+// SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
+func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
+	pos, err := db.snapshotPosition(ctx)
+	if err != nil {
+		return ltx.Pos{}, nil, err
+	}
+
+	r, err := db.snapshotReader(ctx, pos)
+	if err != nil {
+		pos.close()
+		return pos.pos, nil, err
+	}
+	return pos.pos, r, nil
+}
+
+func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, error) {
 	if err := db.lockExec(ctx); err != nil {
-		return ltx.Pos{}, 0, err
+		return nil, err
 	}
 	defer db.execSem.Release(1)
 
@@ -2573,21 +2591,53 @@ func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
-		return ltx.Pos{}, 0, &DBNotReadyError{Reason: "page size not initialized"}
+		return nil, &DBNotReadyError{Reason: "page size not initialized"}
 	}
 	if err != nil {
-		return pos, pageSize, fmt.Errorf("pos: %w", err)
+		return nil, fmt.Errorf("pos: %w", err)
 	}
 
-	return pos, pageSize, nil
+	walEndOffset, err := db.snapshotWALEndOffset(ctx, pos)
+	if err != nil {
+		return nil, err
+	}
+	if walEndOffset < WALHeaderSize {
+		walEndOffset = WALHeaderSize
+	}
+
+	db.chkMu.RLock()
+	return &snapshotReadPosition{
+		pos:          pos,
+		pageSize:     pageSize,
+		walEndOffset: walEndOffset,
+		db:           db,
+	}, nil
 }
 
-func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io.Reader, error) {
-	db.Logger.Debug("snapshot", "txid", pos.TXID.String())
+func (db *DB) snapshotWALEndOffset(ctx context.Context, pos ltx.Pos) (int64, error) {
+	if db.syncState.lastSyncedWALOffset > 0 {
+		return db.syncState.lastSyncedWALOffset, nil
+	}
+	if pos.TXID == 0 {
+		return WALHeaderSize, nil
+	}
 
-	// Prevent internal checkpoints during sync.
-	db.chkMu.RLock()
-	defer db.chkMu.RUnlock()
+	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	f, err := os.Open(ltxPath)
+	if err != nil {
+		return 0, NewLTXError("open", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), err)
+	}
+	defer func() { _ = f.Close() }()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.DecodeHeader(); err != nil {
+		return 0, NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+	}
+	return dec.Header().WALOffset + dec.Header().WALSize, nil
+}
+
+func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io.Reader, error) {
+	db.Logger.Debug("snapshot", "txid", pos.pos.TXID.String(), "walEndOffset", pos.walEndOffset)
 
 	// TODO(ltx): Read database size from database header.
 
@@ -2595,11 +2645,13 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 	if err != nil {
 		return nil, err
 	}
-	commit := uint32(fi.Size() / int64(pageSize))
+	commit := uint32(fi.Size() / int64(pos.pageSize))
 
 	// Execute encoding in a separate goroutine so the caller can initialize before reading.
 	pr, pw := io.Pipe()
 	go func() {
+		defer pos.close()
+
 		walFile, err := os.Open(db.WALPath())
 		if err != nil {
 			pw.CloseWithError(err)
@@ -2614,25 +2666,33 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 		}
 
 		// Build a mapping of changed page numbers and their latest content.
-		pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("page map: %w", err))
-			return
+		maxBytes := pos.walEndOffset - WALHeaderSize
+		pageMap := make(map[uint32]int64)
+		var maxOffset int64
+		var walCommit uint32
+		if maxBytes > 0 {
+			pageMap, maxOffset, walCommit, _, err = rd.pageMap(ctx, maxBytes)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("page map: %w", err))
+				return
+			}
 		}
 		if walCommit > 0 {
 			commit = walCommit
 		}
 
-		var sz int64
-		if maxOffset > 0 {
-			sz = maxOffset - rd.Offset()
+		walOffset, walSize := snapshotHeaderWALRange(pos.walEndOffset, maxOffset, int64(WALFrameHeaderSize+pos.pageSize))
+		if maxOffset > pos.walEndOffset {
+			pw.CloseWithError(fmt.Errorf("snapshot wal read exceeded bound: max offset %d > end offset %d", maxOffset, pos.walEndOffset))
+			return
 		}
 
 		db.Logger.Debug("encode snapshot header",
-			"txid", pos.TXID.String(),
+			"txid", pos.pos.TXID.String(),
 			"commit", commit,
-			"walOffset", rd.Offset(),
-			"walSize", sz,
+			"walOffset", walOffset,
+			"walSize", walSize,
+			"walEndOffset", pos.walEndOffset,
 			"salt1", rd.salt1,
 			"salt2", rd.salt2)
 
@@ -2644,13 +2704,13 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 		if err := enc.EncodeHeader(ltx.Header{
 			Version:   ltx.Version,
 			Flags:     ltx.HeaderFlagNoChecksum,
-			PageSize:  uint32(pageSize),
+			PageSize:  uint32(pos.pageSize),
 			Commit:    commit,
 			MinTXID:   1,
-			MaxTXID:   pos.TXID,
+			MaxTXID:   pos.pos.TXID,
 			Timestamp: time.Now().UnixMilli(),
-			WALOffset: rd.Offset(),
-			WALSize:   sz,
+			WALOffset: walOffset,
+			WALSize:   walSize,
 			WALSalt1:  rd.salt1,
 			WALSalt2:  rd.salt2,
 		}); err != nil {
@@ -2671,6 +2731,20 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 	}()
 
 	return pr, nil
+}
+
+func snapshotHeaderWALRange(walEndOffset, maxOffset, frameSize int64) (offset, size int64) {
+	if maxOffset <= WALHeaderSize || frameSize <= 0 {
+		return WALHeaderSize, 0
+	}
+	offset = maxOffset - frameSize
+	if offset < WALHeaderSize {
+		offset = WALHeaderSize
+	}
+	if maxOffset > walEndOffset {
+		maxOffset = walEndOffset
+	}
+	return offset, maxOffset - offset
 }
 
 // Compact performs a compaction of the LTX file at the previous level into dstLevel.
@@ -2697,24 +2771,30 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 
 // Snapshot writes a snapshot to the replica for the current database position.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, pageSize, err := db.snapshotPosition(ctx)
+	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if info, ok, err := db.existingSnapshotInfo(ctx, pos.TXID); err != nil {
+	if info, ok, err := db.existingSnapshotInfo(ctx, pos.pos.TXID); err != nil {
+		pos.close()
 		return nil, err
 	} else if ok {
-		db.Logger.Debug("snapshot already exists", "txid", pos.TXID.String(), "snapshot", info.MaxTXID.String())
+		pos.close()
+		db.Logger.Debug("snapshot already exists", "txid", pos.pos.TXID.String(), "snapshot", info.MaxTXID.String())
 		return info, nil
 	}
 
-	r, err := db.snapshotReader(ctx, pos, pageSize)
+	r, err := db.snapshotReader(ctx, pos)
 	if err != nil {
+		pos.close()
 		return nil, err
 	}
 
-	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
+	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.pos.TXID, r)
 	if err != nil {
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
 		return info, err
 	}
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -1766,13 +1766,47 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 	// Verify a snapshot L0 was created during checkpoint.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
 	newL0Count := 0
+	newCoverageCount := 0
 	for _, entry := range l0AfterEntries {
 		if !l0BeforeNames[entry.Name()] {
 			newL0Count++
+
+			f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			dec := ltx.NewDecoder(f)
+			if err := dec.DecodeHeader(); err != nil {
+				_ = f.Close()
+				t.Fatal(err)
+			}
+			hdr := dec.Header()
+			buf := make([]byte, hdr.PageSize)
+			pageCount := 0
+			for {
+				var pageHdr ltx.PageHeader
+				if err := dec.DecodePage(&pageHdr, buf); err == io.EOF {
+					break
+				} else if err != nil {
+					_ = f.Close()
+					t.Fatal(err)
+				}
+				pageCount++
+			}
+			if pageCount > 1 {
+				newCoverageCount++
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
+	}
+	if newCoverageCount == 0 {
+		t.Fatal("expected checkpoint to create an L0 file with more than one page")
 	}
 }
 
@@ -1896,10 +1930,18 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	case err := <-writerDone:
 		t.Fatalf("writer exited before starting: %v", err)
 	}
-	if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
-		cancelWriter()
-		<-writerDone
-		t.Fatal(err)
+	checkpointDeadline := time.Now().Add(5 * time.Second)
+	for {
+		err := db.Checkpoint(ctx, CheckpointModeTruncate)
+		if err == nil {
+			break
+		}
+		if !isSQLiteBusyError(err) || time.Now().After(checkpointDeadline) {
+			cancelWriter()
+			<-writerDone
+			t.Fatal(err)
+		}
+		time.Sleep(time.Millisecond)
 	}
 	cancelWriter()
 	if err := <-writerDone; err != nil {
@@ -2018,6 +2060,55 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	}
 
 	t.Logf("all %d pages present across L0 files (commit=%d)", len(allPages), maxCommit)
+
+	replicaDir := t.TempDir()
+	replicaL0Dir := filepath.Join(replicaDir, "l0")
+	if err := os.Mkdir(replicaL0Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l0Entries, err := os.ReadDir(db.LTXLevelDir(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range l0Entries {
+		srcPath := filepath.Join(db.LTXLevelDir(0), entry.Name())
+		dstPath := filepath.Join(replicaL0Dir, entry.Name())
+
+		src, err := os.Open(srcPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			_ = src.Close()
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			_ = src.Close()
+			_ = dst.Close()
+			t.Fatal(err)
+		}
+		if err := src.Close(); err != nil {
+			_ = dst.Close()
+			t.Fatal(err)
+		}
+		if err := dst.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	restorePath := filepath.Join(dir, "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreReplica := NewReplica(restoreDB)
+	restoreReplica.Client = &testReplicaClient{dir: replicaDir}
+
+	restoreOpt := NewRestoreOptions()
+	restoreOpt.OutputPath = restorePath
+	restoreOpt.IntegrityCheck = IntegrityCheckFull
+
+	if err := restoreReplica.Restore(ctx, restoreOpt); err != nil {
+		t.Fatalf("restore from local ltx chain: %v", err)
+	}
 }
 
 // TestDB_Sync_InitErrorMetrics verifies that sync error counter is incremented

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2317,3 +2317,75 @@ func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
 		t.Fatalf("cached l0 file info=%v, want MaxTXID=%d", gotL0AfterApply, result.l0FileInfo.MaxTXID)
 	}
 }
+
+func TestVerifyAndSync_DelaysExpectedTruncationStateMutationUntilApply(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = db.Close(context.Background())
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO t VALUES (1, 'before')`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if !db.syncState.syncedToWALEnd {
+		t.Fatal("syncedToWALEnd=false, want true after sync")
+	}
+	oldSyncedToWALEnd := db.syncState.syncedToWALEnd
+
+	if err := os.Truncate(db.WALPath(), WALHeaderSize); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := db.verifyAndSync(ctx, false, &db.syncState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.synced {
+		t.Fatal("verifyAndSync reported a sync, want no sync after truncation without new writes")
+	}
+	if result.syncedToWALEnd {
+		t.Fatal("result.syncedToWALEnd=true, want false")
+	}
+	if db.syncState.syncedToWALEnd != oldSyncedToWALEnd {
+		t.Fatalf("syncedToWALEnd mutated early: got %t, want %t", db.syncState.syncedToWALEnd, oldSyncedToWALEnd)
+	}
+
+	db.applySyncResult(&db.syncState, result)
+
+	if db.syncState.syncedToWALEnd {
+		t.Fatal("syncedToWALEnd=true after apply, want false")
+	}
+}

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1576,6 +1577,145 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 		last := missing[len(missing)-1]
 		t.Errorf("pages missing from incremental LTX: %d total (first=%d, last=%d, prevCommit=%d, newCommit=%d)",
 			len(missing), first, last, prevCommit, newCommit)
+	}
+}
+
+func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	walPath := filepath.Join(dir, "db-wal")
+
+	const pageSize = 1024
+
+	dbFile, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbFile.Close()
+
+	for pgno := 1; pgno <= 5; pgno++ {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if _, err := dbFile.WriteAt(page, int64(pgno-1)*pageSize); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	walFile, err := os.OpenFile(walPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer walFile.Close()
+
+	frameSize := int64(WALFrameHeaderSize + pageSize)
+	pageMap := map[uint32]int64{
+		3: 0,
+		5: frameSize,
+	}
+	for _, pgno := range []uint32{3, 5} {
+		offset := pageMap[pgno] + WALFrameHeaderSize
+		page := bytes.Repeat([]byte{byte(pgno + 10)}, pageSize)
+		if _, err := walFile.WriteAt(page, offset); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	db := NewDB(dbPath)
+	db.pageSize = pageSize
+	db.f = dbFile
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    5,
+		MinTXID:   2,
+		MaxTXID:   2,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pgnos []uint32
+	got := make(map[uint32][]byte)
+	pageBuf := make([]byte, pageSize)
+	for {
+		var phdr ltx.PageHeader
+		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		pgnos = append(pgnos, phdr.Pgno)
+		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
+	}
+
+	if !reflect.DeepEqual([]uint32{3, 4, 5}, pgnos) {
+		t.Fatalf("page numbers mismatch: got=%v", pgnos)
+	}
+	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
+		t.Fatal("expected page 3 to come from WAL")
+	}
+	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
+		t.Fatal("expected page 4 to come from database")
+	}
+	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
+		t.Fatal("expected page 5 to come from WAL")
+	}
+
+	snapshot := new(bytes.Buffer)
+	snapshotEnc, err := ltx.NewEncoder(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotEnc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, pgno := range []uint32{1, 2} {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := snapshotEnc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := new(bytes.Buffer)
+	c, err := ltx.NewCompactor(compacted, []io.Reader{
+		bytes.NewReader(snapshot.Bytes()),
+		bytes.NewReader(buf.Bytes()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	if err := c.Compact(context.Background()); err != nil {
+		t.Fatalf("compaction failed: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -488,7 +488,7 @@ func TestDB_Checkpoint_ErrorMetrics(t *testing.T) {
 
 	db.db.Close()
 
-	if err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
+	if _, err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
 		t.Fatal("expected error from checkpoint with closed db")
 	}
 
@@ -1766,47 +1766,13 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 	// Verify a snapshot L0 was created during checkpoint.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
 	newL0Count := 0
-	newCoverageCount := 0
 	for _, entry := range l0AfterEntries {
 		if !l0BeforeNames[entry.Name()] {
 			newL0Count++
-
-			f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			dec := ltx.NewDecoder(f)
-			if err := dec.DecodeHeader(); err != nil {
-				_ = f.Close()
-				t.Fatal(err)
-			}
-			hdr := dec.Header()
-			buf := make([]byte, hdr.PageSize)
-			pageCount := 0
-			for {
-				var pageHdr ltx.PageHeader
-				if err := dec.DecodePage(&pageHdr, buf); err == io.EOF {
-					break
-				} else if err != nil {
-					_ = f.Close()
-					t.Fatal(err)
-				}
-				pageCount++
-			}
-			if pageCount > 1 {
-				newCoverageCount++
-			}
-			if err := f.Close(); err != nil {
-				t.Fatal(err)
-			}
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
-	}
-	if newCoverageCount == 0 {
-		t.Fatal("expected checkpoint to create an L0 file with more than one page")
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -665,7 +665,7 @@ func TestDB_Verify_WALOffsetAtHeader(t *testing.T) {
 
 	// Now call verify - before the fix, this would fail with:
 	// "prev WAL offset is less than the header size: -4088"
-	info, err := db.verify(context.Background())
+	info, err := db.verify(context.Background(), &db.syncState)
 	if err != nil {
 		t.Fatalf("verify() returned error: %v", err)
 	}
@@ -787,7 +787,7 @@ func TestDB_Verify_WALOffsetAtHeader_SaltMismatch(t *testing.T) {
 	db.invalidatePosCache()
 
 	// Call verify - should succeed but indicate snapshotting due to salt mismatch
-	info, err := db.verify(context.Background())
+	info, err := db.verify(context.Background(), &db.syncState)
 	if err != nil {
 		t.Fatalf("verify() returned error: %v", err)
 	}
@@ -944,7 +944,7 @@ func testCheckpointSnapshot(t *testing.T, mode string) {
 	t.Logf("After pre-checkpoint sync: TXID=%d", pos2.TXID)
 
 	// Call verify() BEFORE checkpoint to confirm snapshotting=false
-	info1, err := db.verify(ctx)
+	info1, err := db.verify(ctx, &db.syncState)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -968,7 +968,7 @@ func testCheckpointSnapshot(t *testing.T, mode string) {
 	// - Old LTX has WALOffset+WALSize pointing to old (larger) WAL
 	// - New WAL is truncated (smaller)
 	// - Line 973: info.offset > fi.Size() → "wal truncated" → snapshotting=true
-	info2, err := db.verify(ctx)
+	info2, err := db.verify(ctx, &db.syncState)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1036,7 +1036,7 @@ func TestDB_MultipleCheckpointsWithWrites(t *testing.T) {
 		}
 
 		// Check if this was a snapshot
-		info, err := db.verify(ctx)
+		info, err := db.verify(ctx, &db.syncState)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1759,7 +1759,7 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 
 	// TRUNCATE checkpoint should create a full snapshot L0 to ensure
 	// complete page coverage across the checkpoint boundary.
-	if err := db.checkpoint(ctx, CheckpointModeTruncate); err != nil {
+	if err := db.checkpoint(ctx, CheckpointModeTruncate, &db.syncState); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2133,11 +2133,11 @@ func TestApplySyncResult(t *testing.T) {
 		db.mu.Lock()
 		defer db.mu.Unlock()
 
-		db.applySyncResult(syncResult{newWALSize: 12345, syncedToWALEnd: true})
-		if got := db.lastSyncedWALOffset; got != 12345 {
+		db.applySyncResult(&db.syncState, syncResult{newWALSize: 12345, syncedToWALEnd: true})
+		if got := db.syncState.lastSyncedWALOffset; got != 12345 {
 			t.Fatalf("lastSyncedWALOffset=%d, want 12345", got)
 		}
-		if !db.syncedToWALEnd {
+		if !db.syncState.syncedToWALEnd {
 			t.Fatal("syncedToWALEnd=false, want true")
 		}
 	})
@@ -2147,7 +2147,7 @@ func TestApplySyncResult(t *testing.T) {
 		defer db.mu.Unlock()
 
 		pos := ltx.Pos{TXID: 42}
-		db.applySyncResult(syncResult{pos: &pos})
+		db.applySyncResult(&db.syncState, syncResult{pos: &pos})
 
 		db.pos.Lock()
 		got := db.pos.value
@@ -2166,7 +2166,7 @@ func TestApplySyncResult(t *testing.T) {
 		db.pos.value = &existing
 		db.pos.Unlock()
 
-		db.applySyncResult(syncResult{})
+		db.applySyncResult(&db.syncState, syncResult{})
 
 		db.pos.Lock()
 		got := db.pos.value
@@ -2181,7 +2181,7 @@ func TestApplySyncResult(t *testing.T) {
 		defer db.mu.Unlock()
 
 		info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
-		db.applySyncResult(syncResult{l0FileInfo: info})
+		db.applySyncResult(&db.syncState, syncResult{l0FileInfo: info})
 
 		db.maxLTXFileInfos.Lock()
 		got := db.maxLTXFileInfos.m[0]
@@ -2238,8 +2238,8 @@ func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	oldWALOffset := db.lastSyncedWALOffset
-	oldSyncedToWALEnd := db.syncedToWALEnd
+	oldWALOffset := db.syncState.lastSyncedWALOffset
+	oldSyncedToWALEnd := db.syncState.syncedToWALEnd
 
 	db.pos.Lock()
 	if db.pos.value == nil {
@@ -2256,7 +2256,7 @@ func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
 		t.Fatal("cached l0 file info is nil after initial sync")
 	}
 
-	result, err := db.verifyAndSync(ctx, false)
+	result, err := db.verifyAndSync(ctx, false, &db.syncState)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2273,11 +2273,11 @@ func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
 		t.Fatalf("result.l0FileInfo=%v, want MaxTXID > %d", result.l0FileInfo, oldL0.MaxTXID)
 	}
 
-	if db.lastSyncedWALOffset != oldWALOffset {
-		t.Fatalf("lastSyncedWALOffset mutated early: got %d, want %d", db.lastSyncedWALOffset, oldWALOffset)
+	if db.syncState.lastSyncedWALOffset != oldWALOffset {
+		t.Fatalf("lastSyncedWALOffset mutated early: got %d, want %d", db.syncState.lastSyncedWALOffset, oldWALOffset)
 	}
-	if db.syncedToWALEnd != oldSyncedToWALEnd {
-		t.Fatalf("syncedToWALEnd mutated early: got %t, want %t", db.syncedToWALEnd, oldSyncedToWALEnd)
+	if db.syncState.syncedToWALEnd != oldSyncedToWALEnd {
+		t.Fatalf("syncedToWALEnd mutated early: got %t, want %t", db.syncState.syncedToWALEnd, oldSyncedToWALEnd)
 	}
 
 	db.pos.Lock()
@@ -2294,13 +2294,13 @@ func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
 		t.Fatalf("cached l0 file info mutated early: got %v, want MaxTXID=%d", gotL0BeforeApply, oldL0.MaxTXID)
 	}
 
-	db.applySyncResult(result)
+	db.applySyncResult(&db.syncState, result)
 
-	if db.lastSyncedWALOffset != result.newWALSize {
-		t.Fatalf("lastSyncedWALOffset=%d, want %d", db.lastSyncedWALOffset, result.newWALSize)
+	if db.syncState.lastSyncedWALOffset != result.newWALSize {
+		t.Fatalf("lastSyncedWALOffset=%d, want %d", db.syncState.lastSyncedWALOffset, result.newWALSize)
 	}
-	if db.syncedToWALEnd != result.syncedToWALEnd {
-		t.Fatalf("syncedToWALEnd=%t, want %t", db.syncedToWALEnd, result.syncedToWALEnd)
+	if db.syncState.syncedToWALEnd != result.syncedToWALEnd {
+		t.Fatalf("syncedToWALEnd=%t, want %t", db.syncState.syncedToWALEnd, result.syncedToWALEnd)
 	}
 
 	db.pos.Lock()

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -120,6 +120,46 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	}
 }
 
+func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	walPath := filepath.Join(dir, "db-wal")
+
+	walFile, err := os.OpenFile(walPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer walFile.Close()
+
+	db := NewDB(dbPath)
+	db.pageSize = 1024
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:  ltx.Version,
+		Flags:    ltx.HeaderFlagNoChecksum,
+		PageSize: 1024,
+		Commit:   1,
+		MinTXID:  1,
+		MaxTXID:  1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = db.writeLTXFromWAL(ctx, enc, walFile, 0, 1, map[uint32]int64{1: 0})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+}
+
 // TestCalcWALSize ensures calcWALSize doesn't overflow with large page sizes.
 // Regression test for uint32 overflow bug where large page sizes (>=16KB)
 // caused incorrect WAL size calculations, triggering checkpoints too early.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -106,6 +106,20 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	err := db.Sync(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v, want context deadline exceeded", err)
+	}
+}
+
 // TestCalcWALSize ensures calcWALSize doesn't overflow with large page sizes.
 // Regression test for uint32 overflow bug where large page sizes (>=16KB)
 // caused incorrect WAL size calculations, triggering checkpoints too early.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 	_ "modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -105,16 +106,16 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
-func mustAcquireGate(g *syncGate) {
-	if err := g.Acquire(context.Background()); err != nil {
+func mustAcquireSemaphore(s *semaphore.Weighted) {
+	if err := s.Acquire(context.Background(), 1); err != nil {
 		panic(err)
 	}
 }
 
 func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
-	defer db.execGate.Release()
+	mustAcquireSemaphore(db.execSem)
+	defer db.execSem.Release(1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -130,8 +131,8 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 
 func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
-	defer db.execGate.Release()
+	mustAcquireSemaphore(db.execSem)
+	defer db.execSem.Release(1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -177,7 +178,7 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 
 func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
+	mustAcquireSemaphore(db.execSem)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -186,7 +187,7 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := db.lockExec(ctx)
 		if err == nil {
-			db.execGate.Release()
+			db.execSem.Release(1)
 		}
 		done <- err
 	}()
@@ -214,16 +215,16 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		mustAcquireGate(&db.execGate)
+		mustAcquireSemaphore(db.execSem)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		db.execGate.Release()
+		db.execSem.Release(1)
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	db.execGate.Release()
+	db.execSem.Release(1)
 
 	select {
 	case err := <-done:
@@ -244,7 +245,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
 
-	mustAcquireGate(&r.syncGate)
+	mustAcquireSemaphore(r.syncSem)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
@@ -253,7 +254,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("err=%v, want context deadline exceeded", err)
 		}
@@ -261,7 +262,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 			t.Fatalf("err=%q, want replica sync context", err)
 		}
 	case <-time.After(100 * time.Millisecond):
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		select {
 		case <-done:
 		case <-time.After(time.Second):
@@ -274,7 +275,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
-	mustAcquireGate(&r.syncGate)
+	mustAcquireSemaphore(r.syncSem)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -283,7 +284,7 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := r.lockSync(ctx)
 		if err == nil {
-			r.syncGate.Release()
+			r.syncSem.Release(1)
 		}
 		done <- err
 	}()
@@ -295,16 +296,16 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		mustAcquireGate(&r.syncGate)
+		mustAcquireSemaphore(r.syncSem)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	r.syncGate.Release()
+	r.syncSem.Release(1)
 
 	select {
 	case err := <-done:

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -170,6 +170,71 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	}
 }
 
+func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		err := db.lockExec(ctx)
+		if err == nil {
+			db.execMu.Unlock()
+		}
+		done <- err
+	}()
+
+	deadline := time.After(100 * time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if db.SyncDiagnostic().ExecutorWaiterCount == 1 {
+			break
+		}
+
+		select {
+		case err := <-done:
+			t.Fatalf("lockExec returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("lockExec did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+
+	hogReady := make(chan struct{})
+	hogAcquired := make(chan struct{})
+	hogDone := make(chan struct{})
+	go func() {
+		close(hogReady)
+		db.execMu.Lock()
+		close(hogAcquired)
+		time.Sleep(150 * time.Millisecond)
+		db.execMu.Unlock()
+		close(hogDone)
+	}()
+	<-hogReady
+	time.Sleep(5 * time.Millisecond)
+
+	db.execMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lockExec returned error: %v", err)
+		}
+	case <-hogAcquired:
+		<-hogDone
+		err := <-done
+		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+	case <-ctx.Done():
+		err := <-done
+		t.Fatalf("lockExec timed out waiting behind later lock attempt: %v", err)
+	}
+}
+
 func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -217,6 +217,99 @@ func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {
 	}
 }
 
+func TestDB_SyncChunksWALAtCommitBoundary(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.MaxSyncWALBytes = int64(WALFrameHeaderSize + 4096)
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := db.syncOnce(context.Background(), db.MaxSyncWALBytes)
+	if err != nil {
+		t.Fatal(err)
+	} else if !result.synced {
+		t.Fatal("expected sync to create an LTX file")
+	} else if !result.limited {
+		t.Fatal("expected sync to stop at WAL byte limit")
+	} else if result.syncedToWALEnd {
+		t.Fatal("expected first bounded sync to leave pending WAL frames")
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	syncedToWALEnd := db.syncState.syncedToWALEnd
+	db.mu.RUnlock()
+	if !syncedToWALEnd {
+		t.Fatal("expected public Sync to finish remaining WAL chunks")
+	}
+}
+
+func TestWALReaderPageMapLimitStopsAtCommittedFrame(t *testing.T) {
+	b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewWALReader(bytes.NewReader(b), slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pageMap, maxOffset, commit, limited, err := r.pageMap(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !limited {
+		t.Fatal("expected page map to stop at limit")
+	}
+	if got, want := maxOffset, int64(8272); got != want {
+		t.Fatalf("maxOffset=%d, want %d", got, want)
+	}
+	if got, want := commit, uint32(2); got != want {
+		t.Fatalf("commit=%d, want %d", got, want)
+	}
+	if got, want := len(pageMap), 2; got != want {
+		t.Fatalf("len(pageMap)=%d, want %d", got, want)
+	}
+}
+
 // TestCalcWALSize ensures calcWALSize doesn't overflow with large page sizes.
 // Regression test for uint32 overflow bug where large page sizes (>=16KB)
 // caused incorrect WAL size calculations, triggering checkpoints too early.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2063,7 +2062,7 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 	}
 }
 
-func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
+func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 	walPath := filepath.Join(dir, "db-wal")
@@ -2123,82 +2122,12 @@ func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
-		t.Fatal(err)
+	err = db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap)
+	if err == nil {
+		t.Fatal("expected missing growth page error")
 	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
-	if err := dec.DecodeHeader(); err != nil {
-		t.Fatal(err)
-	}
-
-	var pgnos []uint32
-	got := make(map[uint32][]byte)
-	pageBuf := make([]byte, pageSize)
-	for {
-		var phdr ltx.PageHeader
-		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
-			break
-		} else if err != nil {
-			t.Fatal(err)
-		}
-		pgnos = append(pgnos, phdr.Pgno)
-		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
-	}
-
-	if !reflect.DeepEqual([]uint32{3, 4, 5}, pgnos) {
-		t.Fatalf("page numbers mismatch: got=%v", pgnos)
-	}
-	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
-		t.Fatal("expected page 3 to come from WAL")
-	}
-	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
-		t.Fatal("expected page 4 to come from database")
-	}
-	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
-		t.Fatal("expected page 5 to come from WAL")
-	}
-
-	snapshot := new(bytes.Buffer)
-	snapshotEnc, err := ltx.NewEncoder(snapshot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := snapshotEnc.EncodeHeader(ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    2,
-		MinTXID:   1,
-		MaxTXID:   1,
-		Timestamp: time.Now().UnixMilli(),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	for _, pgno := range []uint32{1, 2} {
-		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
-		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := snapshotEnc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	compacted := new(bytes.Buffer)
-	c, err := ltx.NewCompactor(compacted, []io.Reader{
-		bytes.NewReader(snapshot.Bytes()),
-		bytes.NewReader(buf.Bytes()),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.HeaderFlags = ltx.HeaderFlagNoChecksum
-	if err := c.Compact(context.Background()); err != nil {
-		t.Fatalf("compaction failed: %v", err)
+	if !strings.Contains(err.Error(), "missing WAL growth page 4") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -118,6 +118,63 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want context deadline exceeded", err)
 	}
+	if !strings.Contains(err.Error(), "wait for db sync executor") {
+		t.Fatalf("err=%q, want sync executor context", err)
+	}
+}
+
+func TestDB_SyncDiagnostic(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+
+	db.beginSyncDiagnostic("sync")
+	db.setSyncDiagnosticPhase("write_ltx_from_wal",
+		syncDiagnosticTXID(ltx.TXID(7)),
+		syncDiagnosticWALSize(1024),
+		syncDiagnosticLastSyncedWALOffset(2048),
+		syncDiagnosticSnapshotting(false),
+		syncDiagnosticReason("test reason"),
+	)
+
+	diag := db.SyncDiagnostic()
+	if !diag.Active {
+		t.Fatal("expected active diagnostic")
+	}
+	if diag.Path != db.Path() {
+		t.Fatalf("path=%q, want %q", diag.Path, db.Path())
+	}
+	if diag.Operation != "sync" {
+		t.Fatalf("operation=%q, want sync", diag.Operation)
+	}
+	if diag.Phase != "write_ltx_from_wal" {
+		t.Fatalf("phase=%q, want write_ltx_from_wal", diag.Phase)
+	}
+	if diag.TXID != 7 {
+		t.Fatalf("txid=%d, want 7", diag.TXID)
+	}
+	if diag.WALSize != 1024 {
+		t.Fatalf("wal_size=%d, want 1024", diag.WALSize)
+	}
+	if diag.LastSyncedWALOffset != 2048 {
+		t.Fatalf("last_synced_wal_offset=%d, want 2048", diag.LastSyncedWALOffset)
+	}
+	if diag.Reason != "test reason" {
+		t.Fatalf("reason=%q, want test reason", diag.Reason)
+	}
+	if diag.StartedAt == nil || diag.UpdatedAt == nil {
+		t.Fatalf("started_at=%v updated_at=%v, want both set", diag.StartedAt, diag.UpdatedAt)
+	}
+
+	db.finishSyncDiagnostic(errors.New("boom"))
+	diag = db.SyncDiagnostic()
+	if diag.Active {
+		t.Fatal("expected inactive diagnostic")
+	}
+	if diag.Phase != "write_ltx_from_wal" {
+		t.Fatalf("phase=%q, want last phase retained", diag.Phase)
+	}
+	if diag.Error != "boom" {
+		t.Fatalf("error=%q, want boom", diag.Error)
+	}
 }
 
 func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -266,6 +266,56 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	}
 }
 
+func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+	r.syncMu.Lock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		err := r.lockSync(ctx)
+		if err == nil {
+			r.syncMu.Unlock()
+		}
+		done <- err
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	hogReady := make(chan struct{})
+	hogAcquired := make(chan struct{})
+	hogDone := make(chan struct{})
+	go func() {
+		close(hogReady)
+		r.syncMu.Lock()
+		close(hogAcquired)
+		time.Sleep(150 * time.Millisecond)
+		r.syncMu.Unlock()
+		close(hogDone)
+	}()
+	<-hogReady
+	time.Sleep(5 * time.Millisecond)
+
+	r.syncMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lockSync returned error: %v", err)
+		}
+	case <-hogAcquired:
+		<-hogDone
+		err := <-done
+		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+	case <-ctx.Done():
+		err := <-done
+		t.Fatalf("lockSync timed out waiting behind later lock attempt: %v", err)
+	}
+}
+
 func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2069,7 +2069,7 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 	}
 }
 
-func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
+func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 	walPath := filepath.Join(dir, "db-wal")
@@ -2129,12 +2129,88 @@ func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	err = db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap)
-	if err == nil {
-		t.Fatal("expected missing growth page error")
+	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "missing WAL growth page 4") {
-		t.Fatalf("unexpected error: %v", err)
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pgnos []uint32
+	got := make(map[uint32][]byte)
+	pageBuf := make([]byte, pageSize)
+	for {
+		var phdr ltx.PageHeader
+		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		pgnos = append(pgnos, phdr.Pgno)
+		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
+	}
+
+	wantPgnos := []uint32{3, 4, 5}
+	if len(pgnos) != len(wantPgnos) {
+		t.Fatalf("page numbers mismatch: got=%v want=%v", pgnos, wantPgnos)
+	}
+	for i := range wantPgnos {
+		if pgnos[i] != wantPgnos[i] {
+			t.Fatalf("page numbers mismatch: got=%v want=%v", pgnos, wantPgnos)
+		}
+	}
+	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
+		t.Fatal("expected page 3 to come from WAL")
+	}
+	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
+		t.Fatal("expected page 4 to come from database")
+	}
+	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
+		t.Fatal("expected page 5 to come from WAL")
+	}
+
+	snapshot := new(bytes.Buffer)
+	snapshotEnc, err := ltx.NewEncoder(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotEnc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, pgno := range []uint32{1, 2} {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := snapshotEnc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := new(bytes.Buffer)
+	c, err := ltx.NewCompactor(compacted, []io.Reader{
+		bytes.NewReader(snapshot.Bytes()),
+		bytes.NewReader(buf.Bytes()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	if err := c.Compact(context.Background()); err != nil {
+		t.Fatalf("compaction failed: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -123,6 +123,170 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	}
 }
 
+func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- db.Sync(ctx) }()
+
+	deadline := time.After(100 * time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	var diag SyncDiagnostic
+	for {
+		diag = db.SyncDiagnostic()
+		if diag.ExecutorWaiterCount == 1 {
+			break
+		}
+
+		select {
+		case err := <-done:
+			t.Fatalf("sync returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("sync diagnostic did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+
+	if diag.ExecutorWaitStarted == nil {
+		t.Fatal("expected executor wait start time")
+	}
+	if diag.ExecutorWaitSeconds <= 0 {
+		t.Fatalf("executor_wait_seconds=%f, want positive", diag.ExecutorWaitSeconds)
+	}
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+	if got := db.SyncDiagnostic().ExecutorWaiterCount; got != 0 {
+		t.Fatalf("executor_waiter_count=%d, want 0", got)
+	}
+}
+
+func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+
+	r.syncMu.Lock()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Sync(ctx) }()
+
+	select {
+	case err := <-done:
+		r.syncMu.Unlock()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err=%v, want context deadline exceeded", err)
+		}
+		if !strings.Contains(err.Error(), "wait for replica sync") {
+			t.Fatalf("err=%q, want replica sync context", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		r.syncMu.Unlock()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("replica sync did not return after lock release")
+		}
+		t.Fatal("replica sync did not honor context while waiting for sync lock")
+	}
+}
+
+func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	client := &testReplicaClient{dir: t.TempDir()}
+	r := NewReplicaWithClient(db, client)
+	r.MonitorEnabled = false
+	db.Replica = r
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t DEFAULT VALUES;`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dpos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dpos.TXID < 2 {
+		t.Fatalf("db txid=%s, want at least 2", dpos.TXID)
+	}
+	r.SetPos(ltx.Pos{TXID: dpos.TXID - 2})
+
+	result, err := r.syncOnce(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("expected limited replica sync to upload one file")
+	}
+	if !result.limited {
+		t.Fatal("expected limited replica sync to stop before catching up")
+	}
+	if got, want := r.Pos().TXID, dpos.TXID-1; got != want {
+		t.Fatalf("replica txid=%s, want %s", got, want)
+	}
+	if !db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("limited replica sync should not record full sync success")
+	}
+
+	result, err = r.syncOnce(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("expected final replica sync to upload remaining files")
+	}
+	if result.limited {
+		t.Fatal("expected final replica sync to catch up")
+	}
+	if got, want := r.Pos().TXID, dpos.TXID; got != want {
+		t.Fatalf("replica txid=%s, want %s", got, want)
+	}
+	if db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("full replica sync should record sync success")
+	}
+}
+
 func TestDB_SyncDiagnostic(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -105,10 +105,16 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func mustAcquireGate(g *syncGate) {
+	if err := g.Acquire(context.Background()); err != nil {
+		panic(err)
+	}
+}
+
 func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	mustAcquireGate(&db.execGate)
+	defer db.execGate.Release()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -124,8 +130,8 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 
 func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	mustAcquireGate(&db.execGate)
+	defer db.execGate.Release()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -171,7 +177,7 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 
 func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
+	mustAcquireGate(&db.execGate)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -180,7 +186,7 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := db.lockExec(ctx)
 		if err == nil {
-			db.execMu.Unlock()
+			db.execGate.Release()
 		}
 		done <- err
 	}()
@@ -208,16 +214,16 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		db.execMu.Lock()
+		mustAcquireGate(&db.execGate)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		db.execMu.Unlock()
+		db.execGate.Release()
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	db.execMu.Unlock()
+	db.execGate.Release()
 
 	select {
 	case err := <-done:
@@ -238,7 +244,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
 
-	r.syncMu.Lock()
+	mustAcquireGate(&r.syncGate)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
@@ -247,7 +253,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("err=%v, want context deadline exceeded", err)
 		}
@@ -255,7 +261,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 			t.Fatalf("err=%q, want replica sync context", err)
 		}
 	case <-time.After(100 * time.Millisecond):
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		select {
 		case <-done:
 		case <-time.After(time.Second):
@@ -268,7 +274,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
-	r.syncMu.Lock()
+	mustAcquireGate(&r.syncGate)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -277,7 +283,7 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := r.lockSync(ctx)
 		if err == nil {
-			r.syncMu.Unlock()
+			r.syncGate.Release()
 		}
 		done <- err
 	}()
@@ -289,16 +295,16 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		r.syncMu.Lock()
+		mustAcquireGate(&r.syncGate)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	r.syncMu.Unlock()
+	r.syncGate.Release()
 
 	select {
 	case err := <-done:

--- a/db_test.go
+++ b/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/crc64"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,27 @@ import (
 	"github.com/benbjohnson/litestream/internal/testingutil"
 	"github.com/benbjohnson/litestream/mock"
 )
+
+type snapshotCountingClient struct {
+	litestream.ReplicaClient
+	mu sync.Mutex
+	n  int
+}
+
+func (c *snapshotCountingClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if level == litestream.SnapshotLevel {
+		c.mu.Lock()
+		c.n++
+		c.mu.Unlock()
+	}
+	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+func (c *snapshotCountingClient) writeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
 
 func TestDB_Path(t *testing.T) {
 	db := testingutil.NewDB(t, "/tmp/db")
@@ -547,6 +569,42 @@ func TestDB_Snapshot(t *testing.T) {
 		t.Fatal(err)
 	} else if got, want := h.Sum64(), chksum0; got != want {
 		t.Fatal("snapshot checksum mismatch")
+	}
+}
+
+func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	client := &snapshotCountingClient{ReplicaClient: db.Replica.Client}
+	db.Replica.Client = client
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+		t.Fatal(err)
+	} else if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+		t.Fatal(err)
+	} else if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	info0, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	info1, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := ltx.FormatFilename(info1.MinTXID, info1.MaxTXID), ltx.FormatFilename(info0.MinTXID, info0.MaxTXID); got != want {
+		t.Fatalf("Filename=%s, want %s", got, want)
+	}
+	if got, want := client.writeCount(), 1; got != want {
+		t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
 	}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -572,6 +572,67 @@ func TestDB_Snapshot(t *testing.T) {
 	}
 }
 
+func TestDB_SnapshotExcludesUnsyncedWALFrames(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (1);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (2);`); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.MaxTXID != pos.TXID {
+		t.Fatalf("snapshot txid=%s, want %s", info.MaxTXID, pos.TXID)
+	}
+
+	rc, err := db.Replica.Client.OpenLTXFile(t.Context(), litestream.SnapshotLevel, 1, pos.TXID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	restorePath := filepath.Join(t.TempDir(), "snapshot.db")
+	f, err := os.Create(restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ltx.NewDecoder(rc).DecodeDatabaseTo(f); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := testingutil.MustOpenSQLDB(t, restorePath)
+	defer testingutil.MustCloseSQLDB(t, restored)
+
+	var count int
+	if err := restored.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM t;`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("restored row count=%d, want 1", count)
+	}
+}
+
 func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)

--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -319,8 +319,8 @@ Parameters with an alias accept both camelCase and hyphenated forms
 | `skipVerify` | `skip-verify` | Skip TLS verification | `false` |
 | `signPayload` | `sign-payload` | Sign request payloads | `true` |
 | `requireContentMD5` | `require-content-md5` | Require Content-MD5 header | `true` |
-| `concurrency` | | Multipart upload concurrency | `5` |
-| `partSize` | `part-size` | Multipart upload part size | `5MB` |
+| `concurrency` | | Multipart upload concurrency | `5` (`2` for R2/Tigris) |
+| `partSize` | `part-size` | Multipart upload part size | `5MB` (`16MiB` for Tigris) |
 | `sseCustomerAlgorithm` | `sse-customer-algorithm` | SSE-C encryption algorithm | None |
 | `sseCustomerKey` | `sse-customer-key` | SSE-C encryption key | None |
 | `sseCustomerKeyMD5` | `sse-customer-key-md5` | SSE-C key MD5 checksum | None |
@@ -338,7 +338,7 @@ Litestream automatically detects certain providers and applies appropriate defau
 | DigitalOcean | `*.digitaloceanspaces.com` | `sign-payload=true` |
 | Scaleway | `*.scw.cloud` | `sign-payload=true` |
 | Filebase | `s3.filebase.com` | `sign-payload=true`, `force-path-style=true` |
-| Tigris | `*.tigris.dev` | `sign-payload=true`, `require-content-md5=false` |
+| Tigris | `*.tigris.dev` | `sign-payload=true`, `require-content-md5=false`, `concurrency=2`, `part-size=16MiB` |
 | MinIO | host with port (not cloud provider) | `sign-payload=true`, `force-path-style=true` |
 | Supabase | `*.supabase.co` | `sign-payload=true`, `force-path-style=true` |
 

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -2,9 +2,11 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 
 	"github.com/superfly/ltx"
 )
@@ -62,13 +64,21 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 const resumableReaderMaxRetries = 3
 
 func (r *ResumableReader) Read(p []byte) (int, error) {
+	var lastErr error
 	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
 		// Reopen the stream from the current offset if the previous
 		// connection was closed (rc is nil after a retry).
 		if r.rc == nil {
 			rc, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
 			if err != nil {
-				return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				if errors.Is(err, os.ErrNotExist) {
+					return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				}
+				lastErr = fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				r.logger.Debug("reopen ltx file failed, retrying",
+					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
+					"offset", r.offset, "error", err, "attempt", attempt+1)
+				continue
 			}
 			r.rc = rc
 		}
@@ -113,6 +123,10 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		continue
 	}
 
+	if lastErr != nil {
+		return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d): %w",
+			r.level, r.minTXID, r.maxTXID, r.offset, lastErr)
+	}
 	return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d)",
 		r.level, r.minTXID, r.maxTXID, r.offset)
 }

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -186,6 +186,33 @@ func TestResumableReader(t *testing.T) {
 		}
 	})
 
+	t.Run("TransientReopenFailure", func(t *testing.T) {
+		data := []byte("hello world")
+		callCount := 0
+		client := &testLTXFileOpener{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				switch callCount {
+				case 1:
+					return io.NopCloser(&errorAfterN{data: data, n: 5, err: fmt.Errorf("connection reset")}), nil
+				case 2, 3:
+					return nil, fmt.Errorf("request canceled")
+				default:
+					return io.NopCloser(bytes.NewReader(data[offset:])), nil
+				}
+			},
+		}
+
+		r := newTestResumableReader(client, int64(len(data)), data)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got %q, want %q", got, data)
+		}
+	})
+
 	t.Run("UnknownSize", func(t *testing.T) {
 		// When file size is unknown (size=0), premature EOF cannot be detected,
 		// so a clean EOF from a truncated stream is treated as legitimate.

--- a/replica.go
+++ b/replica.go
@@ -24,6 +24,8 @@ const (
 	DefaultSyncInterval = 1 * time.Second
 )
 
+var errReplicaWaitForData = errors.New("no position, waiting for data")
+
 // Replica connects a database to a replication destination via a ReplicaClient.
 // The replica manages periodic synchronization and maintaining the current
 // replica position.
@@ -156,7 +158,7 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("cannot determine current position: %w", err)
 	} else if dpos.IsZero() {
-		return fmt.Errorf("no position, waiting for data")
+		return errReplicaWaitForData
 	}
 
 	r.Logger().Info("replica sync",
@@ -327,10 +329,7 @@ func (r *Replica) monitor(ctx context.Context) {
 	ticker := time.NewTicker(r.SyncInterval)
 	defer ticker.Stop()
 
-	// Continuously check for new data to replicate.
-	ch := make(chan struct{})
-	close(ch)
-	var notify <-chan struct{} = ch
+	notify := r.db.Notify()
 
 	var backoff time.Duration
 	var lastLogTime time.Time
@@ -355,11 +354,17 @@ func (r *Replica) monitor(ctx context.Context) {
 			}
 		}
 
-		// Wait for changes to the database.
+		waitCh := notify
+		if pos, err := r.db.Pos(); err == nil && pos.TXID > r.Pos().TXID {
+			ch := make(chan struct{})
+			close(ch)
+			waitCh = ch
+		}
+
 		select {
 		case <-ctx.Done():
 			return
-		case <-notify:
+		case <-waitCh:
 		}
 
 		// Fetch new notify channel before replicating data.
@@ -367,6 +372,10 @@ func (r *Replica) monitor(ctx context.Context) {
 
 		// Synchronize the shadow wal into the replication directory.
 		if err := r.Sync(ctx); err != nil {
+			if errors.Is(err, errReplicaWaitForData) {
+				continue
+			}
+
 			// Don't log context cancellation errors during shutdown
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				consecutiveErrs++

--- a/replica.go
+++ b/replica.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/benbjohnson/litestream/internal"
 )
@@ -36,7 +37,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncGate syncGate
+	syncSem *semaphore.Weighted
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -67,8 +68,9 @@ type Replica struct {
 
 func NewReplica(db *DB) *Replica {
 	r := &Replica{
-		db:     db,
-		cancel: func() {},
+		db:      db,
+		syncSem: semaphore.NewWeighted(1),
+		cancel:  func() {},
 
 		SyncInterval:    DefaultSyncInterval,
 		MaxSyncLTXFiles: DefaultMaxSyncLTXFiles,
@@ -151,7 +153,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	if err := r.lockSync(ctx); err != nil {
 		return result, err
 	}
-	defer r.syncGate.Release()
+	defer r.syncSem.Release(1)
 
 	// Clear last position if if an error occurs during sync.
 	defer func() {
@@ -213,11 +215,11 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 }
 
 func (r *Replica) lockSync(ctx context.Context) error {
-	if r.syncGate.TryAcquire() {
+	if r.syncSem.TryAcquire(1) {
 		return nil
 	}
-	if err := r.syncGate.Acquire(ctx); err != nil {
-		return fmt.Errorf("wait for replica sync: %w", err)
+	if err := r.syncSem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("wait for replica sync: %w", contextCause(ctx, err))
 	}
 	return nil
 }

--- a/replica.go
+++ b/replica.go
@@ -36,7 +36,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncMu contextMutex // protects Sync() from concurrent calls
+	syncGate syncGate
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -151,7 +151,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	if err := r.lockSync(ctx); err != nil {
 		return result, err
 	}
-	defer r.syncMu.Unlock()
+	defer r.syncGate.Release()
 
 	// Clear last position if if an error occurs during sync.
 	defer func() {
@@ -213,10 +213,10 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 }
 
 func (r *Replica) lockSync(ctx context.Context) error {
-	if r.syncMu.TryLock() {
+	if r.syncGate.TryAcquire() {
 		return nil
 	}
-	if err := r.syncMu.LockContext(ctx); err != nil {
+	if err := r.syncGate.Acquire(ctx); err != nil {
 		return fmt.Errorf("wait for replica sync: %w", err)
 	}
 	return nil

--- a/replica.go
+++ b/replica.go
@@ -685,12 +685,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 
 		r.Logger().Debug("opening ltx file for restore", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
 
-		// Add file to be compacted.
-		f, err := r.Client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
-		if err != nil {
-			return fmt.Errorf("open ltx file: %w", err)
-		}
-		rdrs = append(rdrs, internal.NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, r.Logger()))
+		rdrs = append(rdrs, internal.NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, nil, r.Logger()))
 	}
 
 	if len(rdrs) == 0 {

--- a/replica.go
+++ b/replica.go
@@ -704,6 +704,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Output to temp file & atomically rename.
 	tmpOutputPath := opt.OutputPath + ".tmp"
 	r.Logger().Debug("compacting into database", "path", tmpOutputPath, "n", len(rdrs))
+	defer func() { _ = os.Remove(tmpOutputPath) }()
 
 	f, err := os.Create(tmpOutputPath)
 	if err != nil {

--- a/replica.go
+++ b/replica.go
@@ -21,7 +21,8 @@ import (
 
 // Default replica settings.
 const (
-	DefaultSyncInterval = 1 * time.Second
+	DefaultSyncInterval    = 1 * time.Second
+	DefaultMaxSyncLTXFiles = 256
 )
 
 var errReplicaWaitForData = errors.New("no position, waiting for data")
@@ -49,6 +50,10 @@ type Replica struct {
 	// Time between syncs with the shadow WAL.
 	SyncInterval time.Duration
 
+	// Maximum L0 files to upload in a single monitor sync run.
+	// Set to zero to process all pending L0 files in one run.
+	MaxSyncLTXFiles int
+
 	// If true, replica monitors database for changes automatically.
 	// Set to false if replica is being used synchronously (such as in tests).
 	MonitorEnabled bool
@@ -65,8 +70,9 @@ func NewReplica(db *DB) *Replica {
 		db:     db,
 		cancel: func() {},
 
-		SyncInterval:   DefaultSyncInterval,
-		MonitorEnabled: true,
+		SyncInterval:    DefaultSyncInterval,
+		MaxSyncLTXFiles: DefaultMaxSyncLTXFiles,
+		MonitorEnabled:  true,
 	}
 
 	return r
@@ -132,7 +138,19 @@ func (r *Replica) Stop(hard bool) (err error) {
 // Sync copies new WAL frames from the shadow WAL to the replica client.
 // Only one Sync can run at a time to prevent concurrent uploads of the same file.
 func (r *Replica) Sync(ctx context.Context) (err error) {
-	r.syncMu.Lock()
+	_, err = r.syncOnce(ctx, 0)
+	return err
+}
+
+type replicaSyncResult struct {
+	synced  bool
+	limited bool
+}
+
+func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result replicaSyncResult, err error) {
+	if err := r.lockSync(ctx); err != nil {
+		return result, err
+	}
 	defer r.syncMu.Unlock()
 
 	// Clear last position if if an error occurs during sync.
@@ -144,11 +162,15 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		}
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return result, context.Cause(ctx)
+	}
+
 	// Calculate current replica position, if unknown.
 	if r.Pos().IsZero() {
 		pos, err := r.calcPos(ctx)
 		if err != nil {
-			return fmt.Errorf("calc pos: %w", err)
+			return result, fmt.Errorf("calc pos: %w", err)
 		}
 		r.SetPos(pos)
 	}
@@ -156,9 +178,9 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 	// Find current position of database.
 	dpos, err := r.db.Pos()
 	if err != nil {
-		return fmt.Errorf("cannot determine current position: %w", err)
+		return result, fmt.Errorf("cannot determine current position: %w", err)
 	} else if dpos.IsZero() {
-		return errReplicaWaitForData
+		return result, errReplicaWaitForData
 	}
 
 	r.Logger().Info("replica sync",
@@ -168,17 +190,50 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		))
 
 	// Replicate all L0 LTX files since last replica position.
-	for txID := r.Pos().TXID + 1; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+	for txID, syncedFileN := r.Pos().TXID+1, 0; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+		if maxSyncLTXFiles > 0 && syncedFileN >= maxSyncLTXFiles {
+			result.limited = true
+			return result, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return result, context.Cause(ctx)
+		}
 		if err := r.uploadLTXFile(ctx, 0, txID, txID); err != nil {
-			return err
+			return result, err
 		}
 		r.SetPos(ltx.Pos{TXID: txID})
+		result.synced = true
+		syncedFileN++
 	}
 
 	// Record successful sync for heartbeat monitoring.
 	r.db.RecordSuccessfulSync()
 
-	return nil
+	return result, nil
+}
+
+func (r *Replica) lockSync(ctx context.Context) error {
+	if r.syncMu.TryLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			err := context.Cause(ctx)
+			if err == nil {
+				err = ctx.Err()
+			}
+			return fmt.Errorf("wait for replica sync: %w", err)
+		case <-ticker.C:
+			if r.syncMu.TryLock() {
+				return nil
+			}
+		}
+	}
 }
 
 func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {
@@ -371,7 +426,7 @@ func (r *Replica) monitor(ctx context.Context) {
 		notify = r.db.Notify()
 
 		// Synchronize the shadow wal into the replication directory.
-		if err := r.Sync(ctx); err != nil {
+		if _, err := r.syncOnce(ctx, r.MaxSyncLTXFiles); err != nil {
 			if errors.Is(err, errReplicaWaitForData) {
 				continue
 			}

--- a/replica.go
+++ b/replica.go
@@ -36,7 +36,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncMu sync.Mutex // protects Sync() from concurrent calls
+	syncMu contextMutex // protects Sync() from concurrent calls
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -216,24 +216,10 @@ func (r *Replica) lockSync(ctx context.Context) error {
 	if r.syncMu.TryLock() {
 		return nil
 	}
-
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if err == nil {
-				err = ctx.Err()
-			}
-			return fmt.Errorf("wait for replica sync: %w", err)
-		case <-ticker.C:
-			if r.syncMu.TryLock() {
-				return nil
-			}
-		}
+	if err := r.syncMu.LockContext(ctx); err != nil {
+		return fmt.Errorf("wait for replica sync: %w", err)
 	}
+	return nil
 }
 
 func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {

--- a/replica_test.go
+++ b/replica_test.go
@@ -897,6 +897,39 @@ func TestReplica_Restore_InvalidFileSize(t *testing.T) {
 	})
 }
 
+func TestReplica_Restore_RemovesTempFileOnFailure(t *testing.T) {
+	invalidLTX := bytes.Repeat([]byte{0xff}, ltx.HeaderSize)
+
+	var c mock.ReplicaClient
+	c.LTXFilesFunc = func(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error) {
+		if level == litestream.SnapshotLevel {
+			return ltx.NewFileInfoSliceIterator([]*ltx.FileInfo{{
+				Level:     litestream.SnapshotLevel,
+				MinTXID:   1,
+				MaxTXID:   1,
+				Size:      int64(len(invalidLTX)),
+				CreatedAt: time.Now(),
+			}}), nil
+		}
+		return ltx.NewFileInfoSliceIterator(nil), nil
+	}
+	c.OpenLTXFileFunc = func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(invalidLTX)), nil
+	}
+
+	r := litestream.NewReplicaWithClient(nil, &c)
+	outputPath := filepath.Join(t.TempDir(), "restored.db")
+
+	err := r.Restore(context.Background(), litestream.RestoreOptions{OutputPath: outputPath})
+	if err == nil {
+		t.Fatal("expected restore error")
+	}
+
+	if _, err := os.Stat(outputPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("expected temp restore file to be removed, err=%v", err)
+	}
+}
+
 func TestReplica_ContextCancellationNoLogs(t *testing.T) {
 	// This test verifies that context cancellation errors are not logged during shutdown.
 	// The fix for issue #235 ensures that context.Canceled and context.DeadlineExceeded

--- a/replica_test.go
+++ b/replica_test.go
@@ -254,6 +254,31 @@ func TestReplica_RestoreAndReplicateAfterDataLoss(t *testing.T) {
 	t.Log("Test passed: New data after restore was successfully replicated")
 }
 
+func TestReplica_RestoreRetriesInitialLTXOpenError(t *testing.T) {
+	ctx := context.Background()
+
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	client := &transientOpenFailureClient{
+		flakyCompactionClient: newFlakyCompactionClient(),
+		remainingFailures:     2,
+	}
+	createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
+
+	r := litestream.NewReplicaWithClient(db, client)
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	if err := r.Restore(ctx, litestream.RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(restorePath); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := client.openCount, 3; got < want {
+		t.Fatalf("OpenLTXFile() count=%d, want at least %d", got, want)
+	}
+}
+
 func TestReplica_CalcRestorePlan(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)
@@ -528,6 +553,21 @@ func TestReplica_CalcRestorePlan(t *testing.T) {
 			t.Fatalf("expected ErrTxNotAvailable, got %v", err)
 		}
 	})
+}
+
+type transientOpenFailureClient struct {
+	*flakyCompactionClient
+	remainingFailures int
+	openCount         int
+}
+
+func (c *transientOpenFailureClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	c.openCount++
+	if offset == 0 && c.remainingFailures > 0 {
+		c.remainingFailures--
+		return nil, fmt.Errorf("net/http: TLS handshake timeout")
+	}
+	return c.flakyCompactionClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
 }
 
 func TestReplica_TimeBounds(t *testing.T) {

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -68,6 +68,10 @@ const DefaultMetadataConcurrency = 50
 // parts for Cloudflare R2, which has strict concurrent upload limits.
 const DefaultR2Concurrency = 2
 
+const DefaultTigrisConcurrency = 2
+
+const DefaultTigrisPartSize = 16 * 1024 * 1024
+
 const s3MaxRetryAttempts = 10
 
 const s3RequestCanceledErrorCode = "RequestCanceled"
@@ -252,6 +256,12 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 		}
 		if !requireMD5Set {
 			requireMD5, requireMD5Set = false, true
+		}
+		if !concurrencySet {
+			client.Concurrency = DefaultTigrisConcurrency
+		}
+		if partSize == 0 {
+			client.PartSize = DefaultTigrisPartSize
 		}
 	}
 	if isHetzner || isDigitalOcean || isBackblaze || isFilebase || isScaleway || isCloudflareR2 || isMinIO || isSupabase {

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -66,6 +67,10 @@ const DefaultMetadataConcurrency = 50
 // DefaultR2Concurrency is the default number of concurrent multipart upload
 // parts for Cloudflare R2, which has strict concurrent upload limits.
 const DefaultR2Concurrency = 2
+
+const s3MaxRetryAttempts = 10
+
+const s3RequestCanceledErrorCode = "RequestCanceled"
 
 // contentMD5StackKey is used to pass the precomputed Content-MD5 checksum
 // through the middleware stack from Serialize to Finalize phase.
@@ -382,10 +387,7 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// Build configuration options
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithRegion(region),
-		// Use adaptive retry mode for better resilience with 24 hour timeout
-		// This matches Azure's approach for long-running operations
-		config.WithRetryMode(aws.RetryModeAdaptive),
-		config.WithRetryMaxAttempts(10), // Increase retry attempts for resilience
+		config.WithRetryer(newS3Retryer),
 	}
 
 	// Add HTTP client with proper timeout
@@ -474,6 +476,22 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	c.uploader = manager.NewUploader(c.s3, uploaderOpts...)
 
 	return nil
+}
+
+func newS3Retryer() aws.Retryer {
+	return retry.AddWithErrorCodes(
+		retry.NewAdaptiveMode(func(o *retry.AdaptiveModeOptions) {
+			o.StandardOptions = append(o.StandardOptions, func(so *retry.StandardOptions) {
+				so.MaxAttempts = s3MaxRetryAttempts
+				so.Retryables = append(so.Retryables, retry.RetryableHTTPStatusCode{
+					Codes: map[int]struct{}{
+						http.StatusRequestTimeout: {},
+					},
+				})
+			})
+		}),
+		s3RequestCanceledErrorCode,
+	)
 }
 
 // configureEndpoint adds custom endpoint configuration to S3 client options if needed.

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -1880,19 +1880,31 @@ func TestReplicaClient_NoSSE_Headers(t *testing.T) {
 	}
 }
 
-// TestReplicaClient_R2ConcurrencyDefault tests that Cloudflare R2 endpoints get
-// Concurrency=2 by default to avoid their strict concurrent upload limits.
-// This is a regression test for issue #948.
-func TestReplicaClient_R2ConcurrencyDefault(t *testing.T) {
+// TestReplicaClient_ProviderUploadDefaults verifies provider-specific upload
+// defaults for S3-compatible endpoints with known concurrency limits.
+func TestReplicaClient_ProviderUploadDefaults(t *testing.T) {
 	tests := []struct {
 		name            string
 		url             string
 		wantConcurrency int
+		wantPartSize    int64
 	}{
 		{
 			name:            "R2_DefaultConcurrency",
 			url:             "s3://mybucket/path?endpoint=https://account123.r2.cloudflarestorage.com",
 			wantConcurrency: 2,
+		},
+		{
+			name:            "Tigris_DefaultUploadShape",
+			url:             "s3://mybucket/path?endpoint=https://fly.storage.tigris.dev",
+			wantConcurrency: DefaultTigrisConcurrency,
+			wantPartSize:    DefaultTigrisPartSize,
+		},
+		{
+			name:            "Tigris_ExplicitUploadShape",
+			url:             "s3://mybucket/path?endpoint=https://fly.storage.tigris.dev&concurrency=4&part-size=33554432",
+			wantConcurrency: 4,
+			wantPartSize:    33554432,
 		},
 		{
 			name:            "AWS_NoConcurrencyOverride",
@@ -1916,6 +1928,9 @@ func TestReplicaClient_R2ConcurrencyDefault(t *testing.T) {
 
 			if c.Concurrency != tt.wantConcurrency {
 				t.Errorf("Concurrency = %d, want %d", c.Concurrency, tt.wantConcurrency)
+			}
+			if c.PartSize != tt.wantPartSize {
+				t.Errorf("PartSize = %d, want %d", c.PartSize, tt.wantPartSize)
 			}
 		})
 	}

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -97,6 +98,96 @@ func TestReplicaClient_DefaultSignPayload(t *testing.T) {
 	}
 	if !client.RequireContentMD5 {
 		t.Error("expected default RequireContentMD5 to be true for AWS S3 compatibility")
+	}
+}
+
+func TestNewS3Retryer(t *testing.T) {
+	retryer := newS3Retryer()
+	if got, want := retryer.MaxAttempts(), s3MaxRetryAttempts; got != want {
+		t.Fatalf("MaxAttempts() = %d, want %d", got, want)
+	}
+	if !retryer.IsErrorRetryable(&mockAPIError{code: s3RequestCanceledErrorCode, message: "Request is canceled."}) {
+		t.Fatal("expected RequestCanceled API error to be retryable")
+	}
+	if retryer.IsErrorRetryable(&aws.RequestCanceledError{Err: context.Canceled}) {
+		t.Fatal("expected client-side context cancellation to remain non-retryable")
+	}
+}
+
+func TestReplicaClientLTXFiles_RetriesRequestCanceledList(t *testing.T) {
+	var listCalls atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("list-type"); got != "2" {
+			t.Errorf("list-type = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("prefix"); got != "replica/0000/" {
+			t.Errorf("prefix = %q, want replica/0000/", got)
+		}
+
+		call := listCalls.Add(1)
+		w.Header().Set("Content-Type", "application/xml")
+		if call == 1 {
+			w.WriteHeader(http.StatusRequestTimeout)
+			fmt.Fprint(w, `<Error><Code>RequestCanceled</Code><Message>Request is canceled.</Message><RequestId>test-request-id</RequestId></Error>`)
+			return
+		}
+
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>test-bucket</Name>
+  <Prefix>replica/0000/</Prefix>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>replica/0000/0000000000000001-0000000000000001.ltx</Key>
+    <LastModified>2026-04-26T19:00:00.000Z</LastModified>
+    <Size>208</Size>
+  </Contents>
+</ListBucketResult>`)
+	}))
+	defer server.Close()
+
+	client := NewReplicaClient()
+	client.Bucket = "test-bucket"
+	client.Path = "replica"
+	client.Region = "us-east-1"
+	client.Endpoint = server.URL
+	client.ForcePathStyle = true
+	client.AccessKeyID = "test-access-key"
+	client.SecretAccessKey = "test-secret-key"
+
+	itr, err := client.LTXFiles(context.Background(), 0, 0, false)
+	if err != nil {
+		t.Fatalf("LTXFiles() error: %v", err)
+	}
+	defer itr.Close()
+
+	if !itr.Next() {
+		t.Fatalf("Next() = false, err=%v", itr.Err())
+	}
+	info := itr.Item()
+	if got, want := info.MinTXID, ltx.TXID(1); got != want {
+		t.Fatalf("MinTXID = %s, want %s", got, want)
+	}
+	if got, want := info.MaxTXID, ltx.TXID(1); got != want {
+		t.Fatalf("MaxTXID = %s, want %s", got, want)
+	}
+	if got, want := info.Size, int64(208); got != want {
+		t.Fatalf("Size = %d, want %d", got, want)
+	}
+	if itr.Next() {
+		t.Fatal("expected one LTX file")
+	}
+	if err := itr.Err(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if got, want := int(listCalls.Load()), 2; got != want {
+		t.Fatalf("list calls = %d, want %d", got, want)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -80,6 +80,7 @@ func NewServer(store *Store) *Server {
 	mux.HandleFunc("POST /sync", s.handleSync)
 	mux.HandleFunc("GET /list", s.handleList)
 	mux.HandleFunc("GET /info", s.handleInfo)
+	mux.HandleFunc("GET /debug/sync-status", s.handleSyncStatus)
 
 	// pprof endpoints
 	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
@@ -266,6 +267,35 @@ func (s *Server) handleTXID(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleSyncStatus(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if path != "" {
+		expandedPath, err := s.expandPath(path)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err), nil)
+			return
+		}
+
+		db := s.store.FindDB(expandedPath)
+		if db == nil {
+			writeJSONError(w, http.StatusNotFound, "database not found", nil)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, SyncDiagnosticsResponse{
+			Databases: []SyncDiagnostic{db.SyncDiagnostic()},
+		})
+		return
+	}
+
+	dbs := s.store.DBs()
+	diagnostics := make([]SyncDiagnostic, 0, len(dbs))
+	for _, db := range dbs {
+		diagnostics = append(diagnostics, db.SyncDiagnostic())
+	}
+	writeJSON(w, http.StatusOK, SyncDiagnosticsResponse{Databases: diagnostics})
+}
+
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -314,6 +344,11 @@ type ErrorResponse struct {
 // TXIDResponse is the response body for the /txid endpoint.
 type TXIDResponse struct {
 	TXID uint64 `json:"txid"`
+}
+
+// SyncDiagnosticsResponse is the response body for /debug/sync-status.
+type SyncDiagnosticsResponse struct {
+	Databases []SyncDiagnostic `json:"databases"`
 }
 
 func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -656,6 +656,55 @@ func TestServer_HandleSync(t *testing.T) {
 	})
 }
 
+func TestServer_HandleSyncStatus(t *testing.T) {
+	t.Run("AllDatabases", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		require.NoError(t, store.Open(t.Context()))
+		defer store.Close(t.Context())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		require.NoError(t, server.Start())
+		defer server.Close()
+
+		client := newSocketClient(t, server.SocketPath)
+		resp, err := client.Get("http://localhost/debug/sync-status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result litestream.SyncDiagnosticsResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		require.Len(t, result.Databases, 1)
+		require.Equal(t, db.Path(), result.Databases[0].Path)
+		require.False(t, result.Databases[0].Active)
+	})
+
+	t.Run("DatabaseNotFound", func(t *testing.T) {
+		store := litestream.NewStore(nil, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		require.NoError(t, store.Open(t.Context()))
+		defer store.Close(t.Context())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		require.NoError(t, server.Start())
+		defer server.Close()
+
+		client := newSocketClient(t, server.SocketPath)
+		resp, err := client.Get("http://localhost/debug/sync-status?path=/nonexistent/db")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
 func newSocketClient(t *testing.T, socketPath string) *http.Client {
 	t.Helper()
 	return &http.Client{

--- a/store.go
+++ b/store.go
@@ -405,7 +405,6 @@ type SyncDBResult struct {
 // SyncDB forces an immediate sync for a database. If wait is true, blocks
 // until both WAL-to-LTX and LTX-to-remote sync complete. If wait is false,
 // only performs the WAL-to-LTX sync and lets the replica monitor handle upload.
-// The timeout is best-effort as internal lock acquisition is not context-aware.
 func (s *Store) SyncDB(ctx context.Context, path string, wait bool) (SyncDBResult, error) {
 	db := s.FindDB(path)
 	if db == nil {

--- a/store.go
+++ b/store.go
@@ -760,6 +760,14 @@ func (s *Store) CompactDB(ctx context.Context, db *DB, lvl *CompactionLevel) (*l
 
 	// Shortcut if this is a snapshot since we are not pulling from a previous level.
 	if dstLevel == SnapshotLevel {
+		pos, err := db.Pos()
+		if err != nil {
+			return nil, fmt.Errorf("fetch db position: %w", err)
+		}
+		if dstInfo.MaxTXID != 0 && dstInfo.MaxTXID >= pos.TXID {
+			return nil, ErrNoCompaction
+		}
+
 		info, err := db.Snapshot(ctx)
 		if err != nil {
 			return info, err

--- a/store_test.go
+++ b/store_test.go
@@ -102,6 +102,43 @@ func TestStore_CompactDB(t *testing.T) {
 		}
 	})
 
+	t.Run("SnapshotNoProgress", func(t *testing.T) {
+		db0, sqldb0 := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db0, sqldb0)
+
+		client := &snapshotCountingClient{ReplicaClient: db0.Replica.Client}
+		db0.Replica.Client = client
+
+		s := litestream.NewStore([]*litestream.DB{db0}, litestream.CompactionLevels{{Level: 0}})
+		s.SnapshotInterval = time.Nanosecond
+		s.CompactionMonitorEnabled = false
+		if err := s.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close(t.Context())
+
+		if _, err := sqldb0.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrNoCompaction) {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got, want := client.writeCount(), 1; got != want {
+			t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
+		}
+	})
+
 	// Regression test for GitHub issue #877: level 9 compaction fails with
 	// "page size not initialized yet" error when attempted before DB initialization.
 	t.Run("DBNotReady", func(t *testing.T) {

--- a/wal_reader.go
+++ b/wal_reader.go
@@ -134,7 +134,13 @@ func (r *WALReader) ReadFrame(ctx context.Context, data []byte) (pgno, commit ui
 	return r.readFrame(ctx, data, true)
 }
 
-func (r *WALReader) readFrame(_ context.Context, data []byte, verifyChecksum bool) (pgno, commit uint32, err error) {
+func (r *WALReader) readFrame(ctx context.Context, data []byte, verifyChecksum bool) (pgno, commit uint32, err error) {
+	select {
+	case <-ctx.Done():
+		return 0, 0, context.Cause(ctx)
+	default:
+	}
+
 	if len(data) != int(r.pageSize) {
 		return 0, 0, fmt.Errorf("WALReader.ReadFrame(): buffer size (%d) must match page size (%d)", len(data), r.pageSize)
 	}
@@ -190,15 +196,22 @@ func (r *WALReader) readFrame(_ context.Context, data []byte, verifyChecksum boo
 // map of pgno to offset of the latest version of each page. Also returns the
 // max offset of the wal segment read, and the final database size, in pages.
 func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset int64, commit uint32, err error) {
+	m, maxOffset, commit, _, err = r.pageMap(ctx, 0)
+	return m, maxOffset, commit, err
+}
+
+func (r *WALReader) pageMap(ctx context.Context, maxBytes int64) (m map[uint32]int64, maxOffset int64, commit uint32, limited bool, err error) {
 	m = make(map[uint32]int64)
 	txMap := make(map[uint32]int64)
 	data := make([]byte, r.pageSize)
-	for i := 0; ; i++ {
+	frameSize := int64(WALFrameHeaderSize + r.pageSize)
+	startOffset := WALHeaderSize + int64(r.frameN)*frameSize
+	for {
 		pgno, fcommit, err := r.ReadFrame(ctx, data)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
-			return nil, 0, 0, err
+			return nil, 0, 0, false, err
 		}
 
 		// Update latest offset for the page for this transaction.
@@ -211,7 +224,13 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 			for pgno, offset := range txMap {
 				m[pgno] = offset
 			}
+			txMap = make(map[uint32]int64)
 			commit = fcommit
+
+			if maxBytes > 0 && r.Offset()+frameSize-startOffset >= maxBytes {
+				limited = true
+				break
+			}
 		}
 	}
 
@@ -225,7 +244,7 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 
 	// If full transactions available, return the original offset.
 	if len(m) == 0 {
-		return m, 0, 0, nil
+		return m, 0, 0, limited, nil
 	}
 
 	// Compute the highest page offsets.
@@ -240,7 +259,7 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 	end += WALFrameHeaderSize + int64(r.pageSize)
 
 	r.logger.Log(ctx, internal.LevelTrace, "page map complete", "n", len(m), "end", end, "commit", commit)
-	return m, end, commit, nil
+	return m, end, commit, limited, nil
 }
 
 // FrameSaltsUntil returns a set of all unique frame salts in the WAL file.

--- a/wal_reader_test.go
+++ b/wal_reader_test.go
@@ -244,6 +244,24 @@ func TestWALReader(t *testing.T) {
 			t.Fatalf("unexpected error: %#v", err)
 		}
 	})
+
+	t.Run("ErrContextCanceled", func(t *testing.T) {
+		b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r, err := litestream.NewWALReader(bytes.NewReader(b), slog.Default())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, _, err := r.ReadFrame(ctx, make([]byte, 4096)); !errors.Is(err, context.Canceled) {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	})
 }
 
 func TestWALReader_FrameSaltsUntil(t *testing.T) {


### PR DESCRIPTION
## Status

This PR is now a draft integration/reference branch, not the final reviewable merge PR.

The branch captures the full soak-stabilization stack that was validated together. The work is being split into smaller PRs tracked by #1273 so each production change can be reviewed and merged independently.

## Current Soak Evidence

- Validated head: `51dda8e9301a324a27bad9ac27c332d46c7f790f`
- Live control-plane check on 2026-05-15 showed PR-1265 workers running for roughly 27 hours.
- No active failure clusters were reported by `/api/diagnosis`.
- PR-1265 incident windows showed zero recent failed verifications across the checked workers.
- CI for this PR head is green.

## Split Tracking

Parent issue: #1273

Focused child issues:

- #1274
- #1275
- #1276
- #1277
- #1278
- #1279
- #1280
- #1281

## How To Use This PR

Use this PR as reference material and soak evidence only. New implementation PRs should start from `origin/main`, not from this branch, and should re-author only the scoped change needed for the corresponding issue.

Do not replay the investigation history one commit at a time. Intermediate experiments and rollbacks should be folded into coherent final changes or dropped.

## Original Problem Summary

The soak system exposed several recurring failure families while exercising the prior stabilization work:

- Foreground `/sync` calls could time out behind DB sync/checkpoint executor work.
- Restore/integrity failures appeared around WAL/checkpoint boundary handling and page-growth coverage.
- S3-compatible storage showed request-canceled list failures and Tigris upload-default issues.
- A failed restore could leave `/data/test.db.restored.tmp`, consuming worker disk and causing subsequent checkpoint/sync failures.

## Local Validation Run On This Branch

```bash
go test ./... -run 'TestReplica_Restore_RemovesTempFileOnFailure|TestReplica_Restore_InvalidFileSize' -count=1
go test ./... -count=1
pre-commit run --all-files
```

Additional targeted validation previously run on this branch:

```bash
go test . -run 'TestDB_Snapshot(ExcludesUnsyncedWALFrames|SkipsExistingTXID)?$' -count=1
go test -race . -run TestDB_SnapshotExcludesUnsyncedWALFrames -count=1
```
