### PR TITLE
fix(restore-follow): skip SHARED-byte-range exclusive lock on apply to avoid deadlock with persistent WAL readers

### DIFF
--- a/internal/lock_unix.go
+++ b/internal/lock_unix.go
@@ -14,15 +14,21 @@ const (
 	sqliteSharedSize  = 510
 )
 
+// LockFileExclusive takes the PENDING-byte writer mutex on the database
+// file. We deliberately do NOT acquire the SHARED-byte-range exclusive
+// lock here: WAL-mode reader connections in the consuming application
+// can hold SHARED on that range for the lifetime of their connection
+// (e.g. via a long-lived per-worker connection pool), in which case the
+// blocking F_SETLKW on the SHARED range would deadlock applyLTXFile
+// indefinitely. The PENDING lock alone is sufficient to serialize
+// writers; readers do not consult the main-DB lock-byte page in WAL
+// mode and observe no torn reads as long as page writes are atomic at
+// the filesystem level (true for SQLite page sizes ≥ filesystem block
+// size on modern Unix filesystems).
 func LockFileExclusive(f *os.File) error {
 	fd := int(f.Fd())
 
 	if err := setFcntlLock(fd, unix.F_WRLCK, sqlitePendingByte, 1); err != nil {
-		return err
-	}
-
-	if err := setFcntlLock(fd, unix.F_WRLCK, sqliteSharedFirst, sqliteSharedSize); err != nil {
-		_ = setFcntlLock(fd, unix.F_UNLCK, sqlitePendingByte, 1)
 		return err
 	}
 
@@ -31,12 +37,7 @@ func LockFileExclusive(f *os.File) error {
 
 func UnlockFile(f *os.File) error {
 	fd := int(f.Fd())
-	err1 := setFcntlLock(fd, unix.F_UNLCK, sqliteSharedFirst, sqliteSharedSize)
-	err2 := setFcntlLock(fd, unix.F_UNLCK, sqlitePendingByte, 1)
-	if err1 != nil {
-		return err1
-	}
-	return err2
+	return setFcntlLock(fd, unix.F_UNLCK, sqlitePendingByte, 1)
 }
 
 func setFcntlLock(fd int, lockType int16, start int64, length int64) error {


### PR DESCRIPTION
## Summary

`internal.LockFileExclusive` (called by `applyLTXFile` on the consumer side) takes the legacy SQLite SHARED-byte-range exclusive with `F_SETLKW`. If the consuming application maintains a long-lived SQLite connection pool against the restored database in WAL mode, that blocking acquisition deadlocks indefinitely — applies stop, the consumer falls behind, and only restarting the application releases the lock. This PR makes `LockFileExclusive` take only the PENDING byte and skip the SHARED-range exclusive.

## Problem

We deploy litestream to replicate a per-region SIP-subscriber SQLite database from a single writer (`litestream replicate` on the writer side) to per-region consumer hosts running the application binary continuously (`litestream restore -f`). The application, kamailio 6.0.6, opens ~90 long-lived SQLite reader connections via its `db_sqlite` connection pool — one per worker process — and each holds a SHARED lock at bytes `1073741826–1073742335` of the main DB for its connection lifetime (this is SQLite's WAL transition guard). Litestream is configured normally; this is an unmodified `litestream restore -f` against an S3 replica.

After ~60 minutes of normal operation we'd see the consumer fall arbitrarily far behind:

```
$ /proc/locks (filtered to registrations.sqlite inode)
... 91 lines: POSIX  ADVISORY  READ <kamailio-worker-pid>  ...:5722502  1073741826  1073742335
275: POSIX  ADVISORY  WRITE  563250 (litestream)  ...:5722502  1073741824  1073741824
376: -> POSIX  ADVISORY  WRITE  563250 (litestream)  ...:5722502  1073741826  1073742335
```

The `->` prefix is the kernel's "blocked, waiting" marker. Litestream had successfully taken PENDING (byte `1073741824`) but was wedged waiting to upgrade to the SHARED-range exclusive against 91 incompatible reader locks. Thread state on the litestream apply goroutine was `S (sleeping)` with `wchan=fcntl_setlk` for ~37 minutes by the time we caught it. Zero S3 connections from the litestream process during the wait — confirming the block was at lock acquisition, not network.

`litestream wal s3://...` from the same host returned the latest writer txid fine, ruling out S3-side issues. Stopping the application released the SHARED locks immediately and litestream caught up to the writer in seconds. Restarting the application restored the deadlock pattern within ~30s as workers re-established their pool. We reproduced the exact pattern with the same litestream binary in an isolated test using a writer + reader pair against a fresh S3 prefix on the same host:

| Test | File replica follow | S3 follow no stale state | S3 follow with stale-but-snapshot-fresh sidecar | Apply against persistent SQLite reader |
|---|---|---|---|---|
| Result | works | works | catches up after delay | **wedges indefinitely** |

The first three rows ruled out follow-loop logic, transport, and snapshot recovery as causes. Only the last row reproduced the production wedge — and it does so deterministically.

## Root cause

`internal/lock_unix.go:LockFileExclusive` takes both the PENDING byte (1 byte) and the SHARED range (510 bytes) using `F_SETLKW`. The latter conflicts with any SQLite WAL reader's per-connection SHARED hold at the same range. With persistent reader pools — which are normal for any application that doesn't open/close per query — there is no moment during which all readers are simultaneously absent, so `F_SETLKW` never completes.

PENDING alone is sufficient to serialize multiple litestream writers against the same file. The SHARED-range exclusive was guarding against torn page reads by readers that consult the main DB lock-byte page directly — a path WAL readers don't take during their transaction snapshot. Page writes via `f.WriteAt` in `applyLTXFile` are atomic at the OS level when the SQLite page size is ≥ filesystem block size (default 4 KiB pages on ext4/xfs).

## Solution

Drop the SHARED-range exclusive acquisition in `LockFileExclusive`. Keep PENDING (the writer mutex) so concurrent litestream writers still serialize. `UnlockFile` mirror-cleaned to release only the PENDING byte.

```diff
 func LockFileExclusive(f *os.File) error {
     fd := int(f.Fd())
     if err := setFcntlLock(fd, unix.F_WRLCK, sqlitePendingByte, 1); err != nil {
         return err
     }
-
-    if err := setFcntlLock(fd, unix.F_WRLCK, sqliteSharedFirst, sqliteSharedSize); err != nil {
-        _ = setFcntlLock(fd, unix.F_UNLCK, sqlitePendingByte, 1)
-        return err
-    }
-
     return nil
 }

 func UnlockFile(f *os.File) error {
     fd := int(f.Fd())
-    err1 := setFcntlLock(fd, unix.F_UNLCK, sqliteSharedFirst, sqliteSharedSize)
-    err2 := setFcntlLock(fd, unix.F_UNLCK, sqlitePendingByte, 1)
-    if err1 != nil { return err1 }
-    return err2
+    return setFcntlLock(fd, unix.F_UNLCK, sqlitePendingByte, 1)
 }
```

If maintainers prefer a more conservative shape (e.g. switch the SHARED-range acquisition from `F_SETLKW` to `F_SETLK` and fall through with a debug log when it fails), happy to iterate — that variant preserves the lock as a best-effort safeguard for non-WAL consumers while still avoiding the deadlock. Submitting the simpler variant first because that's the one we have empirical evidence for.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Apply with no readers / cooperative readers | Takes PENDING + SHARED-range exclusive | Takes PENDING only |
| Apply with persistent WAL reader pool | Wedges on `F_SETLKW` indefinitely | Proceeds, writes pages, releases PENDING |
| Multiple concurrent litestream writers against same file | Serialized via PENDING | Serialized via PENDING |
| Reader observes mid-apply state | Blocked from reading until apply releases | Reads via -wal/-shm at its snapshot; doesn't observe direct main-DB page writes |

## Scope

**In scope:**
- `internal/lock_unix.go`: skip SHARED-range exclusive in `LockFileExclusive` / `UnlockFile`.

**Not in scope:**
- `internal/lock_windows.go`: same logical issue exists on Windows, but I have no way to test there. Happy to mirror the change in this PR or a follow-up at maintainer's preference.
- `cmd/litestream-vfs` and the VFS write path: separate code, not affected by this change.
- Recovery / snapshot logic.

## Test plan

```bash
# Existing tests should still pass
go test -race -v ./internal/...
go test -race -v ./...

# Manual reproduction of the deadlock + verification of the fix
# (requires a Linux host with two SQLite consumers sharing a WAL DB)
#
# Setup:
#   1. writer: litestream replicate (any backend)
#   2. consumer A: litestream restore -f  (the patched binary)
#   3. consumer B: any application keeping ~50+ persistent SQLite reader
#      connections against the consumer's local DB file in WAL mode
#
# Verify:
#   - /proc/locks for the consumer DB inode shows persistent SHARED locks
#     from consumer B, but no stuck '-> WRITE' from consumer A
#   - consumer A's <db>-txid sidecar advances in step with the writer
#   - 'follow: applied updates' log entries appear at the configured interval
```

Empirical verification on the affected production-stg host after deploying the patched binary:

```
04:23:51 follow: applied updates from_txid=0x201 to_txid=0x203
04:24:06 follow: applied updates from_txid=0x203 to_txid=0x204
04:24:12 follow: applied updates from_txid=0x204 to_txid=0x205
04:24:17 follow: applied updates from_txid=0x205 to_txid=0x206
04:24:51 follow: applied updates from_txid=0x206 to_txid=0x207
```

Consumer continuously matches writer txid; lock count for the file stays at the application's reader-pool size; no `-> WRITE` blocked entries; litestream process CPU ~1.8% (idle polling). Sustained over hours.

## Related

- Litestream version under test: v0.5.11 (commit 016c368).
- Go runtime: 1.25.
- Filed as a fix rather than a feature; happy to split into smaller commits or restructure if requested.