### PR TITLE
fix(gs): abort partial WriteLTXFile and use StartOffset for LTXFiles seek

### DIFF
--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -130,11 +130,18 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 
 	dir := litestream.LTXLevelDir(c.Path, level)
 	prefix := dir + "/"
+
+	// Use StartOffset (lexicographic >=) instead of extending the prefix with
+	// the seek TXID. LTX filenames are zero-padded fixed-width hex, so a
+	// lexicographic scan starting at the seek key returns every file whose
+	// MinTXID >= seek. Extending the prefix would only match objects whose
+	// key begins with that exact seek TXID string and silently skip the rest.
+	q := &storage.Query{Prefix: prefix}
 	if seek != 0 {
-		prefix += seek.String()
+		q.StartOffset = prefix + seek.String()
 	}
 
-	return newLTXFileIterator(c.bkt.Objects(ctx, &storage.Query{Prefix: prefix}), c, level), nil
+	return newLTXFileIterator(c.bkt.Objects(ctx, q), c, level), nil
 }
 
 // WriteLTXFile writes an LTX file from rd to a remote path.
@@ -159,8 +166,18 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	// Combine buffered data with rest of reader
 	fullReader := io.MultiReader(&buf, rd)
 
-	w := c.bkt.Object(key).NewWriter(ctx)
-	defer w.Close()
+	// Use a cancellable context so that a failed Copy can abort the upload
+	// rather than finalizing a partial object via the deferred Close.
+	writerCtx, cancelWriter := context.WithCancel(ctx)
+	w := c.bkt.Object(key).NewWriter(writerCtx)
+	closed := false
+	defer func() {
+		if !closed {
+			cancelWriter()
+			_ = w.Close()
+		}
+		cancelWriter()
+	}()
 
 	// Store timestamp in GCS metadata for accurate timestamp retrieval
 	w.Metadata = map[string]string{
@@ -170,7 +187,9 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	n, err := io.Copy(w, fullReader)
 	if err != nil {
 		return info, err
-	} else if err := w.Close(); err != nil {
+	}
+	closed = true
+	if err := w.Close(); err != nil {
 		return info, err
 	}
 


### PR DESCRIPTION
## Description

Two related fixes in `gs/replica_client.go` for the GCS replica client:

1. **`WriteLTXFile`** previously created the GCS writer on the parent `ctx` and used a single `defer w.Close()` to flush. The Go `cloud.google.com/go/storage` package documents that `Close()` finalizes the object even after a failed `io.Copy`, and that callers must cancel the writer's context to abort an upload without saving partial data. The fix derives a cancellable `writerCtx` from `ctx`, passes it to `NewWriter`, and cancels it on the error path (before the deferred best-effort Close runs) so a failed source read or compaction does not commit a partially written LTX object under the final key. This is the same risk the compactor path hits when the `io.Pipe` reader returns `CloseWithError`.

2. **`LTXFiles`** previously appended `seek.String()` to the GCS `Query.Prefix`. GCS prefix listing is a string-prefix match, so this only returned objects whose key literally started with the exact seek TXID, causing L1 compaction to advance one L0 file per pass once compaction fell behind the L0 head. The fix moves the seek key to `Query.StartOffset` (lexicographic `>=`), which is the documented way to start a list at a given key. LTX filenames are zero-padded fixed-width hex, so a lexicographic scan starting at `prefix + seek.String()` matches the intended `MinTXID >= seek` semantics.

## Motivation and Context

Fixes #1263
Fixes #1262

Both bugs are isolated to the GCS backend and were diagnosed by source inspection of the v0.5.11 / current `main` code. The S3 backend uses a different `s3.PutObject` API that finalizes only on successful `Send`, so the same partial-object risk does not apply there, and the file/SFTP backends rename on success rather than streaming directly, so this PR touches `gs/replica_client.go` only.

## How Has This Been Tested?

```bash
go build ./...
go vet ./gs/...
gofmt -l ./gs/        # no diff
go test -short -count=1 ./gs/...   # PASS (0.8s)
```

The `WriteLTXFile` fix matches the abort pattern documented at https://pkg.go.dev/cloud.google.com/go/storage#Writer.Close (cancel the writer context to stop writing without saving data). The `LTXFiles` fix is the GCS equivalent of the S3 `StartAfter` style listing already used elsewhere in the project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)

## AI-Assisted Contribution Disclosure

This PR was prepared with AI assistance (Claude). The investigation followed the two referenced issues' own source-inspection notes; the fixes were written, built, vetted, and tested locally against the existing `gs` package test suite before submission, per AI_PR_GUIDE.md.