### PR TITLE
fix(restore): clean failed restore temp file

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -657,6 +657,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	// Output to temp file & atomically rename.
 	tmpOutputPath := opt.OutputPath + ".tmp"
 	r.Logger().Debug("compacting into database", "path", tmpOutputPath, "n", len(rdrs))
+	defer func() { _ = os.Remove(tmpOutputPath) }()
 
 	f, err := os.Create(tmpOutputPath)
 	if err != nil {

--- a/replica_test.go
+++ b/replica_test.go
@@ -857,6 +857,39 @@ func TestReplica_Restore_InvalidFileSize(t *testing.T) {
 	})
 }
 
+func TestReplica_Restore_RemovesTempFileOnFailure(t *testing.T) {
+	invalidLTX := bytes.Repeat([]byte{0xff}, ltx.HeaderSize)
+
+	var c mock.ReplicaClient
+	c.LTXFilesFunc = func(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error) {
+		if level == litestream.SnapshotLevel {
+			return ltx.NewFileInfoSliceIterator([]*ltx.FileInfo{{
+				Level:     litestream.SnapshotLevel,
+				MinTXID:   1,
+				MaxTXID:   1,
+				Size:      int64(len(invalidLTX)),
+				CreatedAt: time.Now(),
+			}}), nil
+		}
+		return ltx.NewFileInfoSliceIterator(nil), nil
+	}
+	c.OpenLTXFileFunc = func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(invalidLTX)), nil
+	}
+
+	r := litestream.NewReplicaWithClient(nil, &c)
+	outputPath := filepath.Join(t.TempDir(), "restored.db")
+
+	err := r.Restore(context.Background(), litestream.RestoreOptions{OutputPath: outputPath})
+	if err == nil {
+		t.Fatal("expected restore error")
+	}
+
+	if _, err := os.Stat(outputPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("expected temp restore file to be removed, err=%v", err)
+	}
+}
+
 func TestReplica_ContextCancellationNoLogs(t *testing.T) {
 	// This test verifies that context cancellation errors are not logged during shutdown.
 	// The fix for issue #235 ensures that context.Canceled and context.DeadlineExceeded


### PR DESCRIPTION
## Summary
Ensure failed LTX restore attempts remove the deterministic `<output>.tmp` restore file before returning.

## Problem
Issue #1274 reports stale restore temp files such as `/data/test.db.restored.tmp` consuming worker volume space after failed restores. The new regression reproduced this on `origin/main`: `TestReplica_Restore_RemovesTempFileOnFailure` failed with `expected temp restore file to be removed, err=<nil>`.

## Solution
Add cleanup for `opt.OutputPath + ".tmp"` in `Replica.Restore()` so failed compaction/decode/write paths do not leave the temporary database behind.

## Scope
**In scope:**
- Failed LTX restore temp-file cleanup
- Regression coverage for failed restore cleanup

**Not in scope:**
- Restore planning behavior
- Compaction behavior
- Storage backend changes

## Test Plan
```bash
go test ./... -run 'TestReplica_Restore_RemovesTempFileOnFailure|TestReplica_Restore_InvalidFileSize' -count=1
go build ./...
go test ./...
golangci-lint run --new-from-rev=origin/main
pre-commit run --all-files
```

Note: raw `golangci-lint run` still reports existing repo-wide errcheck findings unrelated to this PR.

## Related
Fixes #1274
Related to #1273
Reference: #1265 commit `51dda8e9301a324a27bad9ac27c332d46c7f790f`