### PR TITLE
fix(restore): retry initial ltx opens

### DIFF
--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -2,9 +2,11 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 
 	"github.com/superfly/ltx"
 )
@@ -62,13 +64,21 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 const resumableReaderMaxRetries = 3
 
 func (r *ResumableReader) Read(p []byte) (int, error) {
+	var lastErr error
 	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
 		// Reopen the stream from the current offset if the previous
 		// connection was closed (rc is nil after a retry).
 		if r.rc == nil {
 			rc, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
 			if err != nil {
-				return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				if errors.Is(err, os.ErrNotExist) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || r.ctx.Err() != nil {
+					return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				}
+				lastErr = fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				r.logger.Debug("reopen ltx file failed, retrying",
+					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
+					"offset", r.offset, "error", err, "attempt", attempt+1)
+				continue
 			}
 			r.rc = rc
 		}
@@ -88,7 +98,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 				r.logger.Debug("premature EOF on ltx file, reconnecting",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 					"offset", r.offset, "size", r.size, "attempt", attempt+1)
-				r.rc.Close()
+				_ = r.rc.Close()
 				r.rc = nil
 				if n > 0 {
 					// Return the bytes we did get. The caller (e.g. io.ReadFull)
@@ -105,7 +115,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		r.logger.Debug("read error on ltx file, reconnecting",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"error", err, "offset", r.offset, "attempt", attempt+1)
-		r.rc.Close()
+		_ = r.rc.Close()
 		r.rc = nil
 		if n > 0 {
 			return n, nil
@@ -113,6 +123,10 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		continue
 	}
 
+	if lastErr != nil {
+		return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d): %w",
+			r.level, r.minTXID, r.maxTXID, r.offset, lastErr)
+	}
 	return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d)",
 		r.level, r.minTXID, r.maxTXID, r.offset)
 }

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -139,6 +139,8 @@ func (r *ResumableReader) Close() error {
 }
 
 func (r *ResumableReader) close() {
+	// The stream is already being discarded after a read failure, so a close
+	// error should not stop recovery. Log it only to aid debugging.
 	if err := r.rc.Close(); err != nil {
 		r.logger.Debug("close ltx file",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -98,7 +98,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 				r.logger.Debug("premature EOF on ltx file, reconnecting",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 					"offset", r.offset, "size", r.size, "attempt", attempt+1)
-				_ = r.rc.Close()
+				r.closeAfterReadError("close ltx file after premature EOF")
 				r.rc = nil
 				if n > 0 {
 					// Return the bytes we did get. The caller (e.g. io.ReadFull)
@@ -115,7 +115,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		r.logger.Debug("read error on ltx file, reconnecting",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"error", err, "offset", r.offset, "attempt", attempt+1)
-		_ = r.rc.Close()
+		r.closeAfterReadError("close ltx file after read error")
 		r.rc = nil
 		if n > 0 {
 			return n, nil
@@ -136,4 +136,12 @@ func (r *ResumableReader) Close() error {
 		return r.rc.Close()
 	}
 	return nil
+}
+
+func (r *ResumableReader) closeAfterReadError(msg string) {
+	if err := r.rc.Close(); err != nil {
+		r.logger.Debug(msg,
+			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
+			"offset", r.offset, "error", err)
+	}
 }

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -98,7 +98,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 				r.logger.Debug("premature EOF on ltx file, reconnecting",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 					"offset", r.offset, "size", r.size, "attempt", attempt+1)
-				r.closeAfterReadError("close ltx file after premature EOF")
+				r.close()
 				r.rc = nil
 				if n > 0 {
 					// Return the bytes we did get. The caller (e.g. io.ReadFull)
@@ -115,7 +115,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		r.logger.Debug("read error on ltx file, reconnecting",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"error", err, "offset", r.offset, "attempt", attempt+1)
-		r.closeAfterReadError("close ltx file after read error")
+		r.close()
 		r.rc = nil
 		if n > 0 {
 			return n, nil
@@ -138,9 +138,9 @@ func (r *ResumableReader) Close() error {
 	return nil
 }
 
-func (r *ResumableReader) closeAfterReadError(msg string) {
+func (r *ResumableReader) close() {
 	if err := r.rc.Close(); err != nil {
-		r.logger.Debug(msg,
+		r.logger.Debug("close ltx file",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"offset", r.offset, "error", err)
 	}

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -67,6 +67,32 @@ func TestResumableReader(t *testing.T) {
 		}
 	})
 
+	t.Run("RetryInitialOpenError", func(t *testing.T) {
+		data := []byte("hello world")
+		callCount := 0
+		client := &testLTXFileOpener{
+			OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+				callCount++
+				if callCount <= 2 {
+					return nil, fmt.Errorf("net/http: TLS handshake timeout")
+				}
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			},
+		}
+
+		r := NewResumableReader(context.Background(), client, 0, 1, 1, int64(len(data)), nil, slog.Default())
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("got %q, want %q", got, data)
+		}
+		if got, want := callCount, 3; got != want {
+			t.Fatalf("OpenLTXFile() count=%d, want %d", got, want)
+		}
+	})
+
 	t.Run("ReconnectOnPrematureEOF", func(t *testing.T) {
 		// Simulate a server that closes the connection cleanly (returns io.EOF)
 		// before all bytes are transferred. The reader detects this by comparing

--- a/replica.go
+++ b/replica.go
@@ -633,12 +633,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 
 		r.Logger().Debug("opening ltx file for restore", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
 
-		// Add file to be compacted.
-		f, err := r.Client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
-		if err != nil {
-			return fmt.Errorf("open ltx file: %w", err)
-		}
-		rdrs = append(rdrs, internal.NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, r.Logger()))
+		rdrs = append(rdrs, internal.NewResumableReader(ctx, r.Client, info.Level, info.MinTXID, info.MaxTXID, info.Size, nil, r.Logger()))
 	}
 
 	if len(rdrs) == 0 {

--- a/replica_test.go
+++ b/replica_test.go
@@ -254,6 +254,43 @@ func TestReplica_RestoreAndReplicateAfterDataLoss(t *testing.T) {
 	t.Log("Test passed: New data after restore was successfully replicated")
 }
 
+func TestReplica_RestoreRetriesInitialLTXOpenError(t *testing.T) {
+	ctx := context.Background()
+
+	client := &transientOpenFailureClient{
+		ReplicaClient:     file.NewReplicaClient(t.TempDir()),
+		remainingFailures: 2,
+	}
+	createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
+
+	r := litestream.NewReplicaWithClient(nil, client)
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	if err := r.Restore(ctx, litestream.RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(restorePath); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := client.openCount, 3; got < want {
+		t.Fatalf("OpenLTXFile() count=%d, want at least %d", got, want)
+	}
+}
+
+type transientOpenFailureClient struct {
+	litestream.ReplicaClient
+	remainingFailures int
+	openCount         int
+}
+
+func (c *transientOpenFailureClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	c.openCount++
+	if offset == 0 && c.remainingFailures > 0 {
+		c.remainingFailures--
+		return nil, fmt.Errorf("net/http: TLS handshake timeout")
+	}
+	return c.ReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+}
+
 func TestReplica_CalcRestorePlan(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)


### PR DESCRIPTION
## Summary
Retry transient initial LTX file open failures during restore.

## Problem
Issue #1275 reports that initial LTX file opens can fail transiently against object storage. On the PR #1282 base, the new regressions reproduced the failure before the fix:
- `go test ./internal -run TestResumableReader/RetryInitialOpenError -count=1` failed with `reopen ltx file at offset 0: net/http: TLS handshake timeout`
- `go test . -run TestReplica_RestoreRetriesInitialLTXOpenError -count=1` failed with `open ltx file: net/http: TLS handshake timeout`

## Solution
Restore now gives `ResumableReader` ownership of opening LTX streams, including the first open. `ResumableReader` retries transient open failures and still returns immediately for missing files and canceled contexts.

## Scope
**In scope:**
- Lazy initial LTX stream open during restore
- Retry handling for transient `OpenLTXFile` failures in `ResumableReader`
- Restore and reader regression coverage

**Not in scope:**
- Sync/checkpoint executor changes
- Storage backend-specific retry policy changes
- Follow-mode apply retry behavior

## Test Plan
```bash
go test ./internal -run TestResumableReader/RetryInitialOpenError -count=1
go test . -run TestReplica_RestoreRetriesInitialLTXOpenError -count=1
go test ./internal -run TestResumableReader -count=1
go test ./... -run Restore -count=1
go build ./...
go test ./...
golangci-lint run --new-from-rev=origin/pr/1282 ./...
pre-commit run --all-files
```

Note: raw `golangci-lint run ./...` still reports existing repo-wide errcheck findings unrelated to this PR.

## Related
Fixes #1275
Related to #1273
Based on #1282 for now
Reference: #1265 commit `53a8f27c6242e746e17b89bb1f9696f1922bf9ae`