### PR TITLE
fix(config): honor database snapshot settings

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -328,6 +328,42 @@ func (c *Config) propagateGlobalSettings() {
 	}
 }
 
+func (c *Config) applyDBSnapshotConfig(globalIntervalSet, globalRetentionSet bool) error {
+	var interval *time.Duration
+	var intervalDB string
+	var retention *time.Duration
+	var retentionDB string
+
+	for _, db := range c.DBs {
+		dbID := db.Path
+		if dbID == "" {
+			dbID = db.Dir
+		}
+		if db.Snapshot.Interval != nil {
+			if interval != nil && *interval != *db.Snapshot.Interval {
+				return fmt.Errorf("conflicting database snapshot intervals: %s has %v, %s has %v", intervalDB, *interval, dbID, *db.Snapshot.Interval)
+			}
+			interval = db.Snapshot.Interval
+			intervalDB = dbID
+		}
+		if db.Snapshot.Retention != nil {
+			if retention != nil && *retention != *db.Snapshot.Retention {
+				return fmt.Errorf("conflicting database snapshot retentions: %s has %v, %s has %v", retentionDB, *retention, dbID, *db.Snapshot.Retention)
+			}
+			retention = db.Snapshot.Retention
+			retentionDB = dbID
+		}
+	}
+
+	if !globalIntervalSet && interval != nil {
+		c.Snapshot.Interval = interval
+	}
+	if !globalRetentionSet && retention != nil {
+		c.Snapshot.Retention = retention
+	}
+	return nil
+}
+
 // DefaultConfig returns a new instance of Config with defaults set.
 func DefaultConfig() Config {
 	defaultSnapshotInterval := 24 * time.Hour
@@ -451,6 +487,21 @@ func (c *Config) Validate() error {
 			dbIdentifier = db.Dir
 		}
 
+		if db.Snapshot.Interval != nil && *db.Snapshot.Interval <= 0 {
+			return &ConfigValidationError{
+				Err:   ErrInvalidSnapshotInterval,
+				Field: fmt.Sprintf("dbs[%s].snapshot.interval", dbIdentifier),
+				Value: *db.Snapshot.Interval,
+			}
+		}
+		if db.Snapshot.Retention != nil && *db.Snapshot.Retention <= 0 {
+			return &ConfigValidationError{
+				Err:   ErrInvalidSnapshotRetention,
+				Field: fmt.Sprintf("dbs[%s].snapshot.retention", dbIdentifier),
+				Value: *db.Snapshot.Retention,
+			}
+		}
+
 		// Validate sync intervals for replicas
 		if db.Replica != nil && db.Replica.SyncInterval != nil && *db.Replica.SyncInterval <= 0 {
 			return &ConfigValidationError{
@@ -552,6 +603,15 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 		}))
 	}
 
+	var raw struct {
+		Snapshot *SnapshotConfig `yaml:"snapshot"`
+	}
+	if err := yaml.Unmarshal(buf, &raw); err != nil {
+		return config, err
+	}
+	globalSnapshotIntervalSet := raw.Snapshot != nil && raw.Snapshot.Interval != nil
+	globalSnapshotRetentionSet := raw.Snapshot != nil && raw.Snapshot.Retention != nil
+
 	// Save defaults before unmarshaling
 	defaultSnapshotInterval := config.Snapshot.Interval
 	defaultSnapshotRetention := config.Snapshot.Retention
@@ -574,6 +634,9 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	}
 	if config.L0RetentionCheckInterval == nil {
 		config.L0RetentionCheckInterval = defaultL0RetentionCheckInterval
+	}
+	if err := config.applyDBSnapshotConfig(globalSnapshotIntervalSet, globalSnapshotRetentionSet); err != nil {
+		return config, err
 	}
 
 	// Normalize paths.
@@ -619,6 +682,7 @@ type DBConfig struct {
 	Pattern            string         `yaml:"pattern"`   // File pattern to match (e.g., "*.db", "*.sqlite")
 	Recursive          bool           `yaml:"recursive"` // Scan subdirectories recursively
 	Watch              bool           `yaml:"watch"`     // Enable directory monitoring for changes
+	Snapshot           SnapshotConfig `yaml:"snapshot"`
 	MetaPath           *string        `yaml:"meta-path"`
 	MonitorInterval    *time.Duration `yaml:"monitor-interval"`
 	CheckpointInterval *time.Duration `yaml:"checkpoint-interval"`

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -479,6 +479,57 @@ snapshot:
 		}
 	})
 
+	t.Run("DBLevelCompatibility", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/test.db
+    snapshot:
+      interval: 10m
+      retention: 2h
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if config.DBs[0].Snapshot.Interval == nil || *config.DBs[0].Snapshot.Interval != 10*time.Minute {
+			t.Fatalf("expected db snapshot interval of 10m, got %v", config.DBs[0].Snapshot.Interval)
+		}
+		if config.DBs[0].Snapshot.Retention == nil || *config.DBs[0].Snapshot.Retention != 2*time.Hour {
+			t.Fatalf("expected db snapshot retention of 2h, got %v", config.DBs[0].Snapshot.Retention)
+		}
+		if config.Snapshot.Interval == nil || *config.Snapshot.Interval != 10*time.Minute {
+			t.Fatalf("expected promoted snapshot interval of 10m, got %v", config.Snapshot.Interval)
+		}
+		if config.Snapshot.Retention == nil || *config.Snapshot.Retention != 2*time.Hour {
+			t.Fatalf("expected promoted snapshot retention of 2h, got %v", config.Snapshot.Retention)
+		}
+	})
+
+	t.Run("GlobalSnapshotTakesPrecedence", func(t *testing.T) {
+		yaml := `
+snapshot:
+  interval: 1h
+  retention: 24h
+dbs:
+  - path: /tmp/test.db
+    snapshot:
+      interval: 10m
+      retention: 2h
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if config.Snapshot.Interval == nil || *config.Snapshot.Interval != time.Hour {
+			t.Fatalf("expected global snapshot interval of 1h, got %v", config.Snapshot.Interval)
+		}
+		if config.Snapshot.Retention == nil || *config.Snapshot.Retention != 24*time.Hour {
+			t.Fatalf("expected global snapshot retention of 24h, got %v", config.Snapshot.Retention)
+		}
+	})
+
 	t.Run("ZeroInterval", func(t *testing.T) {
 		yaml := `
 snapshot:
@@ -521,6 +572,41 @@ snapshot:
 		}
 		if !errors.Is(err, main.ErrInvalidSnapshotInterval) {
 			t.Errorf("expected ErrInvalidSnapshotInterval, got %v", err)
+		}
+	})
+
+	t.Run("DBLevelZeroInterval", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/test.db
+    snapshot:
+      interval: 0s
+`
+		_, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err == nil {
+			t.Fatal("expected error for zero database snapshot interval")
+		}
+		if !errors.Is(err, main.ErrInvalidSnapshotInterval) {
+			t.Errorf("expected ErrInvalidSnapshotInterval, got %v", err)
+		}
+	})
+
+	t.Run("DBLevelConflictingIntervals", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/a.db
+    snapshot:
+      interval: 10m
+  - path: /tmp/b.db
+    snapshot:
+      interval: 20m
+`
+		_, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err == nil {
+			t.Fatal("expected error for conflicting database snapshot intervals")
+		}
+		if !strings.Contains(err.Error(), "conflicting database snapshot intervals") {
+			t.Errorf("expected conflicting interval error, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Description
Honor database-level `snapshot` settings during config loading by preserving `dbs[].snapshot`, promoting unambiguous DB-level interval/retention values when top-level snapshot values are not explicitly set, and rejecting zero or conflicting DB-level snapshot values.

## Motivation and Context
This preserves compatibility for configs that set snapshot interval or retention under a database instead of only under the top-level `snapshot` block. It is extracted from #1265 so it can be reviewed independently from soak/runtime changes.

Fixes #1276
Related: #1273, #1265

## How Has This Been Tested?
- `go test ./cmd/litestream -run 'Snapshot|ParseConfig|Config' -count=1`
- `go test ./cmd/litestream -count=1`
- `git diff --check`
- `go test ./... -count=1`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
