### PR TITLE
fix(compactor): close pipe on upload failure

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -154,29 +154,20 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	}
 
 	pr, pw := io.Pipe()
-	compactErrCh := make(chan error, 1)
 	go func() {
 		comp, err := ltx.NewCompactor(pw, rdrs)
 		if err != nil {
-			err = fmt.Errorf("new ltx compactor: %w", err)
-			_ = pw.CloseWithError(err)
-			compactErrCh <- err
+			_ = pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
 			return
 		}
 		comp.HeaderFlags = ltx.HeaderFlagNoChecksum
-		err = comp.Compact(ctx)
-		_ = pw.CloseWithError(err)
-		compactErrCh <- err
+		_ = pw.CloseWithError(comp.Compact(ctx))
 	}()
 
 	info, err := c.client.WriteLTXFile(ctx, dstLevel, minTXID, maxTXID, pr)
 	_ = pr.CloseWithError(err)
-	compactErr := <-compactErrCh
 	if err != nil {
 		return nil, fmt.Errorf("write ltx file: %w", err)
-	}
-	if compactErr != nil {
-		return nil, fmt.Errorf("compact ltx file: %w", compactErr)
 	}
 
 	if c.CacheSetter != nil {

--- a/compactor.go
+++ b/compactor.go
@@ -115,13 +115,19 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	defer itr.Close()
 
 	var rdrs []io.Reader
-	defer func() {
+	readersClosed := false
+	closeReaders := func() {
+		if readersClosed {
+			return
+		}
+		readersClosed = true
 		for _, rd := range rdrs {
 			if closer, ok := rd.(io.Closer); ok {
 				_ = closer.Close()
 			}
 		}
-	}()
+	}
+	defer closeReaders()
 
 	var minTXID, maxTXID ltx.TXID
 	for itr.Next() {
@@ -154,19 +160,29 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	}
 
 	pr, pw := io.Pipe()
+	compactErrCh := make(chan error, 1)
 	go func() {
 		comp, err := ltx.NewCompactor(pw, rdrs)
 		if err != nil {
-			pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
+			err = fmt.Errorf("new ltx compactor: %w", err)
+			_ = pw.CloseWithError(err)
+			compactErrCh <- err
 			return
 		}
 		comp.HeaderFlags = ltx.HeaderFlagNoChecksum
-		_ = pw.CloseWithError(comp.Compact(ctx))
+		err = comp.Compact(ctx)
+		_ = pw.CloseWithError(err)
+		compactErrCh <- err
 	}()
 
 	info, err := c.client.WriteLTXFile(ctx, dstLevel, minTXID, maxTXID, pr)
+	_ = pr.CloseWithError(err)
+	compactErr := <-compactErrCh
 	if err != nil {
 		return nil, fmt.Errorf("write ltx file: %w", err)
+	}
+	if compactErr != nil {
+		return nil, fmt.Errorf("compact ltx file: %w", compactErr)
 	}
 
 	if c.CacheSetter != nil {

--- a/compactor.go
+++ b/compactor.go
@@ -115,19 +115,13 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	defer itr.Close()
 
 	var rdrs []io.Reader
-	readersClosed := false
-	closeReaders := func() {
-		if readersClosed {
-			return
-		}
-		readersClosed = true
+	defer func() {
 		for _, rd := range rdrs {
 			if closer, ok := rd.(io.Closer); ok {
 				_ = closer.Close()
 			}
 		}
-	}
-	defer closeReaders()
+	}()
 
 	var minTXID, maxTXID ltx.TXID
 	for itr.Next() {

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -3,8 +3,11 @@ package litestream_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +86,59 @@ func TestCompactor_Compact(t *testing.T) {
 			t.Errorf("TXID range=%d-%d, want 1-3", info.MinTXID, info.MaxTXID)
 		}
 	})
+}
+
+func TestCompactor_CompactResumesRemoteReads(t *testing.T) {
+	client := newFlakyCompactionClient()
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
+
+	info, err := compactor.Compact(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Level != 1 {
+		t.Errorf("Level=%d, want 1", info.Level)
+	}
+	if info.MinTXID != 1 || info.MaxTXID != 2 {
+		t.Errorf("TXID range=%d-%d, want 1-2", info.MinTXID, info.MaxTXID)
+	}
+	if client.reopenCount == 0 {
+		t.Fatal("expected compaction to reopen at least one source LTX stream")
+	}
+}
+
+func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
+	client := newEarlyReturnCompactionClient()
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
+	client.failWrites = true
+
+	before := countCompactorPipeWriters()
+	if _, err := compactor.Compact(context.Background(), 1); err == nil {
+		t.Fatal("expected error")
+	} else if !strings.Contains(err.Error(), "write ltx file: early write failure") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := countCompactorPipeWriters(); got <= before {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("compactor goroutine leaked: got %d, want <= %d", countCompactorPipeWriters(), before)
+		case <-ticker.C:
+		}
+	}
 }
 
 func TestCompactor_MaxLTXFileInfo(t *testing.T) {
@@ -599,4 +655,128 @@ func createTestLTXFileWithTimestamp(t testing.TB, client litestream.ReplicaClien
 	if _, err := client.WriteLTXFile(context.Background(), level, minTXID, maxTXID, io.NopCloser(&buf)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+type flakyCompactionClient struct {
+	files       map[string][]byte
+	infos       []*ltx.FileInfo
+	failed      map[string]bool
+	reopenCount int
+}
+
+func newFlakyCompactionClient() *flakyCompactionClient {
+	return &flakyCompactionClient{
+		files:  make(map[string][]byte),
+		failed: make(map[string]bool),
+	}
+}
+
+func (c *flakyCompactionClient) Type() string { return "flaky" }
+
+func (c *flakyCompactionClient) Init(context.Context) error { return nil }
+
+func (c *flakyCompactionClient) SetLogger(*slog.Logger) {}
+
+func (c *flakyCompactionClient) LTXFiles(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {
+	var infos []*ltx.FileInfo
+	for _, info := range c.infos {
+		if info.Level == level && info.MaxTXID >= seek {
+			item := *info
+			infos = append(infos, &item)
+		}
+	}
+	return ltx.NewFileInfoSliceIterator(infos), nil
+}
+
+func (c *flakyCompactionClient) OpenLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	key := c.key(level, minTXID, maxTXID)
+	data, ok := c.files[key]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	if offset > int64(len(data)) {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+	data = data[offset:]
+	if size > 0 && size < int64(len(data)) {
+		data = data[:size]
+	}
+	if offset == 0 && !c.failed[key] {
+		c.failed[key] = true
+		n := ltx.HeaderSize / 2
+		if n > len(data) {
+			n = len(data)
+		}
+		return io.NopCloser(&shortReadCloser{data: data[:n]}), nil
+	}
+	if offset > 0 {
+		c.reopenCount++
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (c *flakyCompactionClient) WriteLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	hdr, _, err := ltx.PeekHeader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	info := &ltx.FileInfo{
+		Level:     level,
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Size:      int64(len(data)),
+		CreatedAt: time.UnixMilli(hdr.Timestamp).UTC(),
+	}
+	c.files[c.key(level, minTXID, maxTXID)] = data
+	c.infos = append(c.infos, info)
+	return info, nil
+}
+
+func (c *flakyCompactionClient) DeleteLTXFiles(context.Context, []*ltx.FileInfo) error { return nil }
+
+func (c *flakyCompactionClient) DeleteAll(context.Context) error { return nil }
+
+func (c *flakyCompactionClient) key(level int, minTXID, maxTXID ltx.TXID) string {
+	return fmt.Sprintf("%d/%s", level, ltx.FormatFilename(minTXID, maxTXID))
+}
+
+type shortReadCloser struct {
+	data []byte
+	done bool
+}
+
+func (r *shortReadCloser) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	return copy(p, r.data), io.EOF
+}
+
+func (r *shortReadCloser) Close() error { return nil }
+
+type earlyReturnCompactionClient struct {
+	*flakyCompactionClient
+	failWrites bool
+}
+
+func newEarlyReturnCompactionClient() *earlyReturnCompactionClient {
+	return &earlyReturnCompactionClient{flakyCompactionClient: newFlakyCompactionClient()}
+}
+
+func (c *earlyReturnCompactionClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if c.failWrites {
+		return nil, fmt.Errorf("early write failure")
+	}
+	return c.flakyCompactionClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+func countCompactorPipeWriters() int {
+	buf := make([]byte, 2<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "github.com/benbjohnson/litestream.(*Compactor).Compact.func")
 }

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -88,30 +88,8 @@ func TestCompactor_Compact(t *testing.T) {
 	})
 }
 
-func TestCompactor_CompactResumesRemoteReads(t *testing.T) {
-	client := newFlakyCompactionClient()
-	compactor := litestream.NewCompactor(client, slog.Default())
-
-	createTestLTXFile(t, client, 0, 1, 1)
-	createTestLTXFile(t, client, 0, 2, 2)
-
-	info, err := compactor.Compact(context.Background(), 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Level != 1 {
-		t.Errorf("Level=%d, want 1", info.Level)
-	}
-	if info.MinTXID != 1 || info.MaxTXID != 2 {
-		t.Errorf("TXID range=%d-%d, want 1-2", info.MinTXID, info.MaxTXID)
-	}
-	if client.reopenCount == 0 {
-		t.Fatal("expected compaction to reopen at least one source LTX stream")
-	}
-}
-
 func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
-	client := newEarlyReturnCompactionClient()
+	client := newEarlyReturnCompactionClient(t.TempDir())
 	compactor := litestream.NewCompactor(client, slog.Default())
 
 	createTestLTXFile(t, client, 0, 1, 1)
@@ -657,122 +635,20 @@ func createTestLTXFileWithTimestamp(t testing.TB, client litestream.ReplicaClien
 	}
 }
 
-type flakyCompactionClient struct {
-	files       map[string][]byte
-	infos       []*ltx.FileInfo
-	failed      map[string]bool
-	reopenCount int
-}
-
-func newFlakyCompactionClient() *flakyCompactionClient {
-	return &flakyCompactionClient{
-		files:  make(map[string][]byte),
-		failed: make(map[string]bool),
-	}
-}
-
-func (c *flakyCompactionClient) Type() string { return "flaky" }
-
-func (c *flakyCompactionClient) Init(context.Context) error { return nil }
-
-func (c *flakyCompactionClient) SetLogger(*slog.Logger) {}
-
-func (c *flakyCompactionClient) LTXFiles(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {
-	var infos []*ltx.FileInfo
-	for _, info := range c.infos {
-		if info.Level == level && info.MaxTXID >= seek {
-			item := *info
-			infos = append(infos, &item)
-		}
-	}
-	return ltx.NewFileInfoSliceIterator(infos), nil
-}
-
-func (c *flakyCompactionClient) OpenLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
-	key := c.key(level, minTXID, maxTXID)
-	data, ok := c.files[key]
-	if !ok {
-		return nil, fmt.Errorf("not found")
-	}
-	if offset > int64(len(data)) {
-		return io.NopCloser(bytes.NewReader(nil)), nil
-	}
-	data = data[offset:]
-	if size > 0 && size < int64(len(data)) {
-		data = data[:size]
-	}
-	if offset == 0 && !c.failed[key] {
-		c.failed[key] = true
-		n := ltx.HeaderSize / 2
-		if n > len(data) {
-			n = len(data)
-		}
-		return io.NopCloser(&shortReadCloser{data: data[:n]}), nil
-	}
-	if offset > 0 {
-		c.reopenCount++
-	}
-	return io.NopCloser(bytes.NewReader(data)), nil
-}
-
-func (c *flakyCompactionClient) WriteLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-	hdr, _, err := ltx.PeekHeader(bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-	info := &ltx.FileInfo{
-		Level:     level,
-		MinTXID:   minTXID,
-		MaxTXID:   maxTXID,
-		Size:      int64(len(data)),
-		CreatedAt: time.UnixMilli(hdr.Timestamp).UTC(),
-	}
-	c.files[c.key(level, minTXID, maxTXID)] = data
-	c.infos = append(c.infos, info)
-	return info, nil
-}
-
-func (c *flakyCompactionClient) DeleteLTXFiles(context.Context, []*ltx.FileInfo) error { return nil }
-
-func (c *flakyCompactionClient) DeleteAll(context.Context) error { return nil }
-
-func (c *flakyCompactionClient) key(level int, minTXID, maxTXID ltx.TXID) string {
-	return fmt.Sprintf("%d/%s", level, ltx.FormatFilename(minTXID, maxTXID))
-}
-
-type shortReadCloser struct {
-	data []byte
-	done bool
-}
-
-func (r *shortReadCloser) Read(p []byte) (int, error) {
-	if r.done {
-		return 0, io.EOF
-	}
-	r.done = true
-	return copy(p, r.data), io.EOF
-}
-
-func (r *shortReadCloser) Close() error { return nil }
-
 type earlyReturnCompactionClient struct {
-	*flakyCompactionClient
+	litestream.ReplicaClient
 	failWrites bool
 }
 
-func newEarlyReturnCompactionClient() *earlyReturnCompactionClient {
-	return &earlyReturnCompactionClient{flakyCompactionClient: newFlakyCompactionClient()}
+func newEarlyReturnCompactionClient(path string) *earlyReturnCompactionClient {
+	return &earlyReturnCompactionClient{ReplicaClient: file.NewReplicaClient(path)}
 }
 
 func (c *earlyReturnCompactionClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
 	if c.failWrites {
 		return nil, fmt.Errorf("early write failure")
 	}
-	return c.flakyCompactionClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
 }
 
 func countCompactorPipeWriters() int {


### PR DESCRIPTION
## Description
Close the compaction pipe reader when `WriteLTXFile` returns an upload/write error, then wait for the compactor goroutine to exit before returning. This prevents the producer side from remaining blocked on a pipe after an early upload failure.

## Motivation and Context
The soak split found a provider-agnostic compactor cleanup path that can leak a blocked producer goroutine when the destination upload fails before consuming the compacted LTX stream. This is extracted from #1265 as an isolated compactor fix.

Fixes #1277
Related: #1273, #1265

## How Has This Been Tested?
- `go test . -run TestCompactor_CompactClosesPipeOnWriteError -count=1`
- `go test ./... -run Compactor -count=1`
- `git diff --check`
- `go test ./... -count=1`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
