### PR TITLE
feat(db): expose sync diagnostics

### DIFF
--- a/db.go
+++ b/db.go
@@ -198,11 +198,45 @@ type DB struct {
 	Logger *slog.Logger
 }
 
+type syncDiagnosticOperation string
+
+const (
+	syncDiagnosticOperationSync       syncDiagnosticOperation = "sync"
+	syncDiagnosticOperationCheckpoint syncDiagnosticOperation = "checkpoint"
+)
+
+type syncDiagnosticPhase string
+
+const (
+	syncDiagnosticPhaseStarting                       syncDiagnosticPhase = "starting"
+	syncDiagnosticPhaseEnsureWAL                      syncDiagnosticPhase = "ensure_wal"
+	syncDiagnosticPhaseVerifyAndSync                  syncDiagnosticPhase = "verify_and_sync"
+	syncDiagnosticPhaseCheckpointIfNeeded             syncDiagnosticPhase = "checkpoint_if_needed"
+	syncDiagnosticPhaseUpdateMetrics                  syncDiagnosticPhase = "update_metrics"
+	syncDiagnosticPhaseVerify                         syncDiagnosticPhase = "verify"
+	syncDiagnosticPhaseSyncOpenLTX                    syncDiagnosticPhase = "sync_open_ltx"
+	syncDiagnosticPhaseSyncPageMap                    syncDiagnosticPhase = "sync_page_map"
+	syncDiagnosticPhaseSyncPrepareLTX                 syncDiagnosticPhase = "sync_prepare_ltx"
+	syncDiagnosticPhaseWriteLTXFromDB                 syncDiagnosticPhase = "write_ltx_from_db"
+	syncDiagnosticPhaseWriteLTXFromWAL                syncDiagnosticPhase = "write_ltx_from_wal"
+	syncDiagnosticPhaseCloseLTX                       syncDiagnosticPhase = "close_ltx"
+	syncDiagnosticPhaseFsyncLTX                       syncDiagnosticPhase = "fsync_ltx"
+	syncDiagnosticPhaseRenameLTX                      syncDiagnosticPhase = "rename_ltx"
+	syncDiagnosticPhaseSyncComplete                   syncDiagnosticPhase = "sync_complete"
+	syncDiagnosticPhaseCheckpointLock                 syncDiagnosticPhase = "checkpoint_lock"
+	syncDiagnosticPhaseCheckpointReadWALHeader        syncDiagnosticPhase = "checkpoint_read_wal_header"
+	syncDiagnosticPhaseCheckpointCopyBefore           syncDiagnosticPhase = "checkpoint_copy_before"
+	syncDiagnosticPhaseCheckpointExec                 syncDiagnosticPhase = "checkpoint_exec"
+	syncDiagnosticPhaseCheckpointVerifyRestart        syncDiagnosticPhase = "checkpoint_verify_restart"
+	syncDiagnosticPhaseCheckpointSnapshotBoundaryLock syncDiagnosticPhase = "checkpoint_snapshot_boundary_lock"
+	syncDiagnosticPhaseCheckpointSnapshotBoundary     syncDiagnosticPhase = "checkpoint_snapshot_boundary"
+)
+
 type syncDiagnosticState struct {
 	sync.RWMutex
 	active              bool
-	operation           string
-	phase               string
+	operation           syncDiagnosticOperation
+	phase               syncDiagnosticPhase
 	startedAt           time.Time
 	updatedAt           time.Time
 	txID                ltx.TXID
@@ -319,8 +353,8 @@ func (db *DB) SyncDiagnostic() SyncDiagnostic {
 	diag := SyncDiagnostic{
 		Path:                db.path,
 		Active:              db.syncDiag.active,
-		Operation:           db.syncDiag.operation,
-		Phase:               db.syncDiag.phase,
+		Operation:           string(db.syncDiag.operation),
+		Phase:               string(db.syncDiag.phase),
 		TXID:                uint64(db.syncDiag.txID),
 		WALSize:             db.syncDiag.walSize,
 		LastSyncedWALOffset: db.syncDiag.lastSyncedWALOffset,
@@ -347,40 +381,14 @@ func (db *DB) SyncDiagnostic() SyncDiagnostic {
 	return diag
 }
 
-type syncDiagnosticOption func(*syncDiagnosticState)
-
-func syncDiagnosticTXID(txID ltx.TXID) syncDiagnosticOption {
-	return func(s *syncDiagnosticState) { s.txID = txID }
-}
-
-func syncDiagnosticWALSize(n int64) syncDiagnosticOption {
-	return func(s *syncDiagnosticState) { s.walSize = n }
-}
-
-func syncDiagnosticLastSyncedWALOffset(n int64) syncDiagnosticOption {
-	return func(s *syncDiagnosticState) { s.lastSyncedWALOffset = n }
-}
-
-func syncDiagnosticSnapshotting(v bool) syncDiagnosticOption {
-	return func(s *syncDiagnosticState) { s.snapshotting = v }
-}
-
-func syncDiagnosticCheckpointMode(mode string) syncDiagnosticOption {
-	return func(s *syncDiagnosticState) { s.checkpointMode = mode }
-}
-
-func syncDiagnosticReason(reason string) syncDiagnosticOption {
-	return func(s *syncDiagnosticState) { s.reason = reason }
-}
-
-func (db *DB) beginSyncDiagnostic(operation string) {
+func (db *DB) beginSyncDiagnostic(operation syncDiagnosticOperation) {
 	now := time.Now()
 	walSize, _ := db.walFileSize()
 
 	db.syncDiag.Lock()
 	db.syncDiag.active = true
 	db.syncDiag.operation = operation
-	db.syncDiag.phase = "starting"
+	db.syncDiag.phase = syncDiagnosticPhaseStarting
 	db.syncDiag.startedAt = now
 	db.syncDiag.updatedAt = now
 	db.syncDiag.txID = 0
@@ -393,7 +401,7 @@ func (db *DB) beginSyncDiagnostic(operation string) {
 	db.syncDiag.Unlock()
 }
 
-func (db *DB) setSyncDiagnosticPhase(phase string, opts ...syncDiagnosticOption) {
+func (db *DB) setSyncDiagnosticPhase(phase syncDiagnosticPhase, updates ...func(*syncDiagnosticState)) {
 	db.syncDiag.Lock()
 	defer db.syncDiag.Unlock()
 	if !db.syncDiag.active {
@@ -401,8 +409,8 @@ func (db *DB) setSyncDiagnosticPhase(phase string, opts ...syncDiagnosticOption)
 	}
 	db.syncDiag.phase = phase
 	db.syncDiag.updatedAt = time.Now()
-	for _, opt := range opts {
-		opt(&db.syncDiag)
+	for _, update := range updates {
+		update(&db.syncDiag)
 	}
 }
 
@@ -1138,7 +1146,7 @@ func (db *DB) releaseReadLock() error {
 func (db *DB) Sync(ctx context.Context) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	db.beginSyncDiagnostic("sync")
+	db.beginSyncDiagnostic(syncDiagnosticOperationSync)
 	defer func() { db.finishSyncDiagnostic(err) }()
 
 	// Track total sync metrics.
@@ -1160,12 +1168,14 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	}
 
 	// Ensure WAL has at least one frame in it.
-	db.setSyncDiagnosticPhase("ensure_wal", syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseEnsureWAL, func(s *syncDiagnosticState) {
+		s.lastSyncedWALOffset = db.lastSyncedWALOffset
+	})
 	if err := db.ensureWALExists(ctx); err != nil {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	db.setSyncDiagnosticPhase("verify_and_sync")
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseVerifyAndSync)
 	result, err := db.verifyAndSync(ctx, false)
 	if err != nil {
 		return err
@@ -1177,12 +1187,16 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		db.syncedSinceCheckpoint = true
 	}
 
-	db.setSyncDiagnosticPhase("checkpoint_if_needed", syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointIfNeeded, func(s *syncDiagnosticState) {
+		s.lastSyncedWALOffset = db.lastSyncedWALOffset
+	})
 	if err := db.checkpointIfNeeded(ctx, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
 
-	db.setSyncDiagnosticPhase("update_metrics", syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseUpdateMetrics, func(s *syncDiagnosticState) {
+		s.lastSyncedWALOffset = db.lastSyncedWALOffset
+	})
 
 	// Compute current index and total shadow WAL size.
 	pos, err := db.Pos()
@@ -1223,7 +1237,7 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that the last sync position of the real WAL hasn't
 	// been overwritten by another process.
-	db.setSyncDiagnosticPhase("verify")
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseVerify)
 	info, err := db.verify(ctx)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
@@ -1699,10 +1713,12 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 		return result, fmt.Errorf("pos: %w", err)
 	}
 	txID := pos.TXID + 1
-	db.setSyncDiagnosticPhase("sync_open_ltx",
-		syncDiagnosticTXID(txID),
-		syncDiagnosticSnapshotting(info.snapshotting),
-		syncDiagnosticReason(info.reason))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncOpenLTX,
+		func(s *syncDiagnosticState) {
+			s.txID = txID
+			s.snapshotting = info.snapshotting
+			s.reason = info.reason
+		})
 
 	filename := db.LTXPath(0, txID, txID)
 
@@ -1761,10 +1777,12 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Build a mapping of changed page numbers and their latest content.
-	db.setSyncDiagnosticPhase("sync_page_map",
-		syncDiagnosticTXID(txID),
-		syncDiagnosticSnapshotting(info.snapshotting),
-		syncDiagnosticReason(info.reason))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncPageMap,
+		func(s *syncDiagnosticState) {
+			s.txID = txID
+			s.snapshotting = info.snapshotting
+			s.reason = info.reason
+		})
 	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
 	if err != nil {
 		return result, fmt.Errorf("page map: %w", err)
@@ -1778,11 +1796,13 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 		sz = maxOffset - info.offset
 	}
 	assert(sz >= 0, fmt.Sprintf("wal size must be positive: sz=%d, maxOffset=%d, info.offset=%d", sz, maxOffset, info.offset))
-	db.setSyncDiagnosticPhase("sync_prepare_ltx",
-		syncDiagnosticTXID(txID),
-		syncDiagnosticWALSize(sz),
-		syncDiagnosticSnapshotting(info.snapshotting),
-		syncDiagnosticReason(info.reason))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncPrepareLTX,
+		func(s *syncDiagnosticState) {
+			s.txID = txID
+			s.walSize = sz
+			s.snapshotting = info.snapshotting
+			s.reason = info.reason
+		})
 
 	// Track total WAL bytes synced.
 	if sz > 0 {
@@ -1842,33 +1862,43 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	// If we need a full snapshot, then copy from the database & WAL.
 	// Otherwise, just copy incrementally from the WAL.
 	if info.snapshotting {
-		db.setSyncDiagnosticPhase("write_ltx_from_db",
-			syncDiagnosticTXID(txID),
-			syncDiagnosticWALSize(sz),
-			syncDiagnosticSnapshotting(true),
-			syncDiagnosticReason(info.reason))
+		db.setSyncDiagnosticPhase(syncDiagnosticPhaseWriteLTXFromDB,
+			func(s *syncDiagnosticState) {
+				s.txID = txID
+				s.walSize = sz
+				s.snapshotting = true
+				s.reason = info.reason
+			})
 		if err := db.writeLTXFromDB(ctx, enc, walFile, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
-		db.setSyncDiagnosticPhase("write_ltx_from_wal",
-			syncDiagnosticTXID(txID),
-			syncDiagnosticWALSize(sz),
-			syncDiagnosticSnapshotting(false),
-			syncDiagnosticReason(info.reason))
+		db.setSyncDiagnosticPhase(syncDiagnosticPhaseWriteLTXFromWAL,
+			func(s *syncDiagnosticState) {
+				s.txID = txID
+				s.walSize = sz
+				s.snapshotting = false
+				s.reason = info.reason
+			})
 		if err := db.writeLTXFromWAL(ctx, enc, walFile, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
 
 	// Encode final trailer to the end of the LTX file.
-	db.setSyncDiagnosticPhase("close_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCloseLTX, func(s *syncDiagnosticState) {
+		s.txID = txID
+		s.walSize = sz
+	})
 	if err := enc.Close(); err != nil {
 		return result, fmt.Errorf("close ltx encoder: %w", err)
 	}
 
 	// Sync & close LTX file.
-	db.setSyncDiagnosticPhase("fsync_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseFsyncLTX, func(s *syncDiagnosticState) {
+		s.txID = txID
+		s.walSize = sz
+	})
 	if err := ltxFile.Sync(); err != nil {
 		return result, fmt.Errorf("sync ltx file: %w", err)
 	}
@@ -1877,7 +1907,10 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Atomically rename file to final path.
-	db.setSyncDiagnosticPhase("rename_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseRenameLTX, func(s *syncDiagnosticState) {
+		s.txID = txID
+		s.walSize = sz
+	})
 	if err := os.Rename(tmpFilename, filename); err != nil {
 		db.maxLTXFileInfos.Lock()
 		delete(db.maxLTXFileInfos.m, 0) // clear cache if in unknown state
@@ -1913,12 +1946,14 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	} else {
 		result.syncedToWALEnd = false
 	}
-	db.setSyncDiagnosticPhase("sync_complete",
-		syncDiagnosticTXID(txID),
-		syncDiagnosticWALSize(sz),
-		syncDiagnosticLastSyncedWALOffset(finalOffset),
-		syncDiagnosticSnapshotting(info.snapshotting),
-		syncDiagnosticReason(info.reason))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncComplete,
+		func(s *syncDiagnosticState) {
+			s.txID = txID
+			s.walSize = sz
+			s.lastSyncedWALOffset = finalOffset
+			s.snapshotting = info.snapshotting
+			s.reason = info.reason
+		})
 
 	db.Logger.Debug("db sync", "status", "ok")
 
@@ -2005,7 +2040,7 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	db.beginSyncDiagnostic("checkpoint")
+	db.beginSyncDiagnostic(syncDiagnosticOperationCheckpoint)
 	defer func() { db.finishSyncDiagnostic(err) }()
 	return db.checkpoint(ctx, mode)
 }
@@ -2013,9 +2048,11 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 // checkpoint performs a checkpoint on the WAL file and initializes a
 // new shadow WAL file.
 func (db *DB) checkpoint(ctx context.Context, mode string) error {
-	db.setSyncDiagnosticPhase("checkpoint_lock",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointLock,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 
 	// Try getting a checkpoint lock, will fail during snapshots.
 	if !db.chkMu.TryLock() {
@@ -2024,18 +2061,22 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	defer db.chkMu.Unlock()
 
 	// Read WAL header before checkpoint to check if it has been restarted.
-	db.setSyncDiagnosticPhase("checkpoint_read_wal_header",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointReadWALHeader,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 	hdr, err := readWALHeader(db.WALPath())
 	if err != nil {
 		return err
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
-	db.setSyncDiagnosticPhase("checkpoint_copy_before",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointCopyBefore,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 	result, err := db.verifyAndSync(ctx, true)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
@@ -2044,9 +2085,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
-	db.setSyncDiagnosticPhase("checkpoint_exec",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointExec,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 	if err := db.execCheckpoint(ctx, mode); err != nil {
 		return err
 	} else if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
@@ -2054,9 +2097,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// If WAL hasn't been restarted, exit.
-	db.setSyncDiagnosticPhase("checkpoint_verify_restart",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointVerifyRestart,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 	if other, err := readWALHeader(db.WALPath()); err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
@@ -2065,9 +2110,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Start a transaction. This will be promoted immediately after.
-	db.setSyncDiagnosticPhase("checkpoint_snapshot_boundary_lock",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointSnapshotBoundaryLock,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 	tx, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
@@ -2083,9 +2130,11 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
-	db.setSyncDiagnosticPhase("checkpoint_snapshot_boundary",
-		syncDiagnosticCheckpointMode(mode),
-		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointSnapshotBoundary,
+		func(s *syncDiagnosticState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = db.lastSyncedWALOffset
+		})
 	result, err = db.verifyAndSync(ctx, true)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)

--- a/db.go
+++ b/db.go
@@ -72,6 +72,7 @@ type DB struct {
 	notify   chan struct{} // closes on WAL change
 	chkMu    sync.RWMutex  // checkpoint lock
 	opened   bool          // true if Open() was called and Close() not yet called
+	syncDiag syncDiagnosticState
 
 	// syncedSinceCheckpoint tracks whether any data has been synced since
 	// the last checkpoint. Used to prevent time-based checkpoints from
@@ -197,6 +198,40 @@ type DB struct {
 	Logger *slog.Logger
 }
 
+type syncDiagnosticState struct {
+	sync.RWMutex
+	active              bool
+	operation           string
+	phase               string
+	startedAt           time.Time
+	updatedAt           time.Time
+	txID                ltx.TXID
+	walSize             int64
+	lastSyncedWALOffset int64
+	snapshotting        bool
+	checkpointMode      string
+	reason              string
+	err                 string
+}
+
+// SyncDiagnostic reports the latest DB sync/checkpoint activity.
+type SyncDiagnostic struct {
+	Path                string     `json:"path"`
+	Active              bool       `json:"active"`
+	Operation           string     `json:"operation,omitempty"`
+	Phase               string     `json:"phase,omitempty"`
+	StartedAt           *time.Time `json:"started_at,omitempty"`
+	UpdatedAt           *time.Time `json:"updated_at,omitempty"`
+	ElapsedSeconds      float64    `json:"elapsed_seconds,omitempty"`
+	TXID                uint64     `json:"txid,omitempty"`
+	WALSize             int64      `json:"wal_size,omitempty"`
+	LastSyncedWALOffset int64      `json:"last_synced_wal_offset,omitempty"`
+	Snapshotting        bool       `json:"snapshotting,omitempty"`
+	CheckpointMode      string     `json:"checkpoint_mode,omitempty"`
+	Reason              string     `json:"reason,omitempty"`
+	Error               string     `json:"error,omitempty"`
+}
+
 // NewDB returns a new instance of DB for a given path.
 func NewDB(path string) *DB {
 	dir, file := filepath.Split(path)
@@ -274,6 +309,114 @@ func (db *DB) SQLDB() *sql.DB {
 // Path returns the path to the database.
 func (db *DB) Path() string {
 	return db.path
+}
+
+// SyncDiagnostic returns the latest sync/checkpoint diagnostic snapshot.
+func (db *DB) SyncDiagnostic() SyncDiagnostic {
+	db.syncDiag.RLock()
+	defer db.syncDiag.RUnlock()
+
+	diag := SyncDiagnostic{
+		Path:                db.path,
+		Active:              db.syncDiag.active,
+		Operation:           db.syncDiag.operation,
+		Phase:               db.syncDiag.phase,
+		TXID:                uint64(db.syncDiag.txID),
+		WALSize:             db.syncDiag.walSize,
+		LastSyncedWALOffset: db.syncDiag.lastSyncedWALOffset,
+		Snapshotting:        db.syncDiag.snapshotting,
+		CheckpointMode:      db.syncDiag.checkpointMode,
+		Reason:              db.syncDiag.reason,
+		Error:               db.syncDiag.err,
+	}
+	if !db.syncDiag.startedAt.IsZero() {
+		startedAt := db.syncDiag.startedAt
+		diag.StartedAt = &startedAt
+	}
+	if !db.syncDiag.updatedAt.IsZero() {
+		updatedAt := db.syncDiag.updatedAt
+		diag.UpdatedAt = &updatedAt
+	}
+	if !db.syncDiag.startedAt.IsZero() {
+		end := db.syncDiag.updatedAt
+		if db.syncDiag.active || end.IsZero() {
+			end = time.Now()
+		}
+		diag.ElapsedSeconds = end.Sub(db.syncDiag.startedAt).Seconds()
+	}
+	return diag
+}
+
+type syncDiagnosticOption func(*syncDiagnosticState)
+
+func syncDiagnosticTXID(txID ltx.TXID) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.txID = txID }
+}
+
+func syncDiagnosticWALSize(n int64) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.walSize = n }
+}
+
+func syncDiagnosticLastSyncedWALOffset(n int64) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.lastSyncedWALOffset = n }
+}
+
+func syncDiagnosticSnapshotting(v bool) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.snapshotting = v }
+}
+
+func syncDiagnosticCheckpointMode(mode string) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.checkpointMode = mode }
+}
+
+func syncDiagnosticReason(reason string) syncDiagnosticOption {
+	return func(s *syncDiagnosticState) { s.reason = reason }
+}
+
+func (db *DB) beginSyncDiagnostic(operation string) {
+	now := time.Now()
+	walSize, _ := db.walFileSize()
+
+	db.syncDiag.Lock()
+	db.syncDiag.active = true
+	db.syncDiag.operation = operation
+	db.syncDiag.phase = "starting"
+	db.syncDiag.startedAt = now
+	db.syncDiag.updatedAt = now
+	db.syncDiag.txID = 0
+	db.syncDiag.walSize = walSize
+	db.syncDiag.lastSyncedWALOffset = db.lastSyncedWALOffset
+	db.syncDiag.snapshotting = false
+	db.syncDiag.checkpointMode = ""
+	db.syncDiag.reason = ""
+	db.syncDiag.err = ""
+	db.syncDiag.Unlock()
+}
+
+func (db *DB) setSyncDiagnosticPhase(phase string, opts ...syncDiagnosticOption) {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if !db.syncDiag.active {
+		return
+	}
+	db.syncDiag.phase = phase
+	db.syncDiag.updatedAt = time.Now()
+	for _, opt := range opts {
+		opt(&db.syncDiag)
+	}
+}
+
+func (db *DB) finishSyncDiagnostic(err error) {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if !db.syncDiag.active {
+		return
+	}
+	db.syncDiag.active = false
+	db.syncDiag.updatedAt = time.Now()
+	if err != nil {
+		db.syncDiag.err = err.Error()
+	}
 }
 
 // IsOpen returns true if the database has been opened.
@@ -995,6 +1138,8 @@ func (db *DB) releaseReadLock() error {
 func (db *DB) Sync(ctx context.Context) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
+	db.beginSyncDiagnostic("sync")
+	defer func() { db.finishSyncDiagnostic(err) }()
 
 	// Track total sync metrics.
 	t := time.Now()
@@ -1015,10 +1160,12 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	}
 
 	// Ensure WAL has at least one frame in it.
+	db.setSyncDiagnosticPhase("ensure_wal", syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	if err := db.ensureWALExists(ctx); err != nil {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
+	db.setSyncDiagnosticPhase("verify_and_sync")
 	result, err := db.verifyAndSync(ctx, false)
 	if err != nil {
 		return err
@@ -1030,9 +1177,12 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		db.syncedSinceCheckpoint = true
 	}
 
+	db.setSyncDiagnosticPhase("checkpoint_if_needed", syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	if err := db.checkpointIfNeeded(ctx, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
+
+	db.setSyncDiagnosticPhase("update_metrics", syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 
 	// Compute current index and total shadow WAL size.
 	pos, err := db.Pos()
@@ -1073,6 +1223,7 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that the last sync position of the real WAL hasn't
 	// been overwritten by another process.
+	db.setSyncDiagnosticPhase("verify")
 	info, err := db.verify(ctx)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
@@ -1548,6 +1699,10 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 		return result, fmt.Errorf("pos: %w", err)
 	}
 	txID := pos.TXID + 1
+	db.setSyncDiagnosticPhase("sync_open_ltx",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 
 	filename := db.LTXPath(0, txID, txID)
 
@@ -1606,6 +1761,10 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Build a mapping of changed page numbers and their latest content.
+	db.setSyncDiagnosticPhase("sync_page_map",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
 	if err != nil {
 		return result, fmt.Errorf("page map: %w", err)
@@ -1619,6 +1778,11 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 		sz = maxOffset - info.offset
 	}
 	assert(sz >= 0, fmt.Sprintf("wal size must be positive: sz=%d, maxOffset=%d, info.offset=%d", sz, maxOffset, info.offset))
+	db.setSyncDiagnosticPhase("sync_prepare_ltx",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticWALSize(sz),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 
 	// Track total WAL bytes synced.
 	if sz > 0 {
@@ -1678,21 +1842,33 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	// If we need a full snapshot, then copy from the database & WAL.
 	// Otherwise, just copy incrementally from the WAL.
 	if info.snapshotting {
+		db.setSyncDiagnosticPhase("write_ltx_from_db",
+			syncDiagnosticTXID(txID),
+			syncDiagnosticWALSize(sz),
+			syncDiagnosticSnapshotting(true),
+			syncDiagnosticReason(info.reason))
 		if err := db.writeLTXFromDB(ctx, enc, walFile, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
+		db.setSyncDiagnosticPhase("write_ltx_from_wal",
+			syncDiagnosticTXID(txID),
+			syncDiagnosticWALSize(sz),
+			syncDiagnosticSnapshotting(false),
+			syncDiagnosticReason(info.reason))
 		if err := db.writeLTXFromWAL(ctx, enc, walFile, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
 
 	// Encode final trailer to the end of the LTX file.
+	db.setSyncDiagnosticPhase("close_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
 	if err := enc.Close(); err != nil {
 		return result, fmt.Errorf("close ltx encoder: %w", err)
 	}
 
 	// Sync & close LTX file.
+	db.setSyncDiagnosticPhase("fsync_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
 	if err := ltxFile.Sync(); err != nil {
 		return result, fmt.Errorf("sync ltx file: %w", err)
 	}
@@ -1701,6 +1877,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Atomically rename file to final path.
+	db.setSyncDiagnosticPhase("rename_ltx", syncDiagnosticTXID(txID), syncDiagnosticWALSize(sz))
 	if err := os.Rename(tmpFilename, filename); err != nil {
 		db.maxLTXFileInfos.Lock()
 		delete(db.maxLTXFileInfos.m, 0) // clear cache if in unknown state
@@ -1736,6 +1913,12 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	} else {
 		result.syncedToWALEnd = false
 	}
+	db.setSyncDiagnosticPhase("sync_complete",
+		syncDiagnosticTXID(txID),
+		syncDiagnosticWALSize(sz),
+		syncDiagnosticLastSyncedWALOffset(finalOffset),
+		syncDiagnosticSnapshotting(info.snapshotting),
+		syncDiagnosticReason(info.reason))
 
 	db.Logger.Debug("db sync", "status", "ok")
 
@@ -1822,12 +2005,18 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
+	db.beginSyncDiagnostic("checkpoint")
+	defer func() { db.finishSyncDiagnostic(err) }()
 	return db.checkpoint(ctx, mode)
 }
 
 // checkpoint performs a checkpoint on the WAL file and initializes a
 // new shadow WAL file.
 func (db *DB) checkpoint(ctx context.Context, mode string) error {
+	db.setSyncDiagnosticPhase("checkpoint_lock",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
+
 	// Try getting a checkpoint lock, will fail during snapshots.
 	if !db.chkMu.TryLock() {
 		return nil
@@ -1835,12 +2024,18 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	defer db.chkMu.Unlock()
 
 	// Read WAL header before checkpoint to check if it has been restarted.
+	db.setSyncDiagnosticPhase("checkpoint_read_wal_header",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	hdr, err := readWALHeader(db.WALPath())
 	if err != nil {
 		return err
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
+	db.setSyncDiagnosticPhase("checkpoint_copy_before",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	result, err := db.verifyAndSync(ctx, true)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
@@ -1849,6 +2044,9 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
+	db.setSyncDiagnosticPhase("checkpoint_exec",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	if err := db.execCheckpoint(ctx, mode); err != nil {
 		return err
 	} else if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
@@ -1856,6 +2054,9 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// If WAL hasn't been restarted, exit.
+	db.setSyncDiagnosticPhase("checkpoint_verify_restart",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	if other, err := readWALHeader(db.WALPath()); err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
@@ -1864,6 +2065,9 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Start a transaction. This will be promoted immediately after.
+	db.setSyncDiagnosticPhase("checkpoint_snapshot_boundary_lock",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	tx, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
@@ -1879,6 +2083,9 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
+	db.setSyncDiagnosticPhase("checkpoint_snapshot_boundary",
+		syncDiagnosticCheckpointMode(mode),
+		syncDiagnosticLastSyncedWALOffset(db.lastSyncedWALOffset))
 	result, err = db.verifyAndSync(ctx, true)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)

--- a/db.go
+++ b/db.go
@@ -72,7 +72,7 @@ type DB struct {
 	notify   chan struct{} // closes on WAL change
 	chkMu    sync.RWMutex  // checkpoint lock
 	opened   bool          // true if Open() was called and Close() not yet called
-	syncDiag syncDiagnosticState
+	syncDiag diagState
 
 	// syncedSinceCheckpoint tracks whether any data has been synced since
 	// the last checkpoint. Used to prevent time-based checkpoints from
@@ -198,45 +198,45 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type syncDiagnosticOperation string
+type diagOp string
 
 const (
-	syncDiagnosticOperationSync       syncDiagnosticOperation = "sync"
-	syncDiagnosticOperationCheckpoint syncDiagnosticOperation = "checkpoint"
+	diagOpSync       diagOp = "sync"
+	diagOpCheckpoint diagOp = "checkpoint"
 )
 
-type syncDiagnosticPhase string
+type diagPhase string
 
 const (
-	syncDiagnosticPhaseStarting                       syncDiagnosticPhase = "starting"
-	syncDiagnosticPhaseEnsureWAL                      syncDiagnosticPhase = "ensure_wal"
-	syncDiagnosticPhaseVerifyAndSync                  syncDiagnosticPhase = "verify_and_sync"
-	syncDiagnosticPhaseCheckpointIfNeeded             syncDiagnosticPhase = "checkpoint_if_needed"
-	syncDiagnosticPhaseUpdateMetrics                  syncDiagnosticPhase = "update_metrics"
-	syncDiagnosticPhaseVerify                         syncDiagnosticPhase = "verify"
-	syncDiagnosticPhaseSyncOpenLTX                    syncDiagnosticPhase = "sync_open_ltx"
-	syncDiagnosticPhaseSyncPageMap                    syncDiagnosticPhase = "sync_page_map"
-	syncDiagnosticPhaseSyncPrepareLTX                 syncDiagnosticPhase = "sync_prepare_ltx"
-	syncDiagnosticPhaseWriteLTXFromDB                 syncDiagnosticPhase = "write_ltx_from_db"
-	syncDiagnosticPhaseWriteLTXFromWAL                syncDiagnosticPhase = "write_ltx_from_wal"
-	syncDiagnosticPhaseCloseLTX                       syncDiagnosticPhase = "close_ltx"
-	syncDiagnosticPhaseFsyncLTX                       syncDiagnosticPhase = "fsync_ltx"
-	syncDiagnosticPhaseRenameLTX                      syncDiagnosticPhase = "rename_ltx"
-	syncDiagnosticPhaseSyncComplete                   syncDiagnosticPhase = "sync_complete"
-	syncDiagnosticPhaseCheckpointLock                 syncDiagnosticPhase = "checkpoint_lock"
-	syncDiagnosticPhaseCheckpointReadWALHeader        syncDiagnosticPhase = "checkpoint_read_wal_header"
-	syncDiagnosticPhaseCheckpointCopyBefore           syncDiagnosticPhase = "checkpoint_copy_before"
-	syncDiagnosticPhaseCheckpointExec                 syncDiagnosticPhase = "checkpoint_exec"
-	syncDiagnosticPhaseCheckpointVerifyRestart        syncDiagnosticPhase = "checkpoint_verify_restart"
-	syncDiagnosticPhaseCheckpointSnapshotBoundaryLock syncDiagnosticPhase = "checkpoint_snapshot_boundary_lock"
-	syncDiagnosticPhaseCheckpointSnapshotBoundary     syncDiagnosticPhase = "checkpoint_snapshot_boundary"
+	diagPhaseStarting                       diagPhase = "starting"
+	diagPhaseEnsureWAL                      diagPhase = "ensure_wal"
+	diagPhaseVerifyAndSync                  diagPhase = "verify_and_sync"
+	diagPhaseCheckpointIfNeeded             diagPhase = "checkpoint_if_needed"
+	diagPhaseUpdateMetrics                  diagPhase = "update_metrics"
+	diagPhaseVerify                         diagPhase = "verify"
+	diagPhaseSyncOpenLTX                    diagPhase = "sync_open_ltx"
+	diagPhaseSyncPageMap                    diagPhase = "sync_page_map"
+	diagPhaseSyncPrepareLTX                 diagPhase = "sync_prepare_ltx"
+	diagPhaseWriteLTXFromDB                 diagPhase = "write_ltx_from_db"
+	diagPhaseWriteLTXFromWAL                diagPhase = "write_ltx_from_wal"
+	diagPhaseCloseLTX                       diagPhase = "close_ltx"
+	diagPhaseFsyncLTX                       diagPhase = "fsync_ltx"
+	diagPhaseRenameLTX                      diagPhase = "rename_ltx"
+	diagPhaseSyncComplete                   diagPhase = "sync_complete"
+	diagPhaseCheckpointLock                 diagPhase = "checkpoint_lock"
+	diagPhaseCheckpointReadWALHeader        diagPhase = "checkpoint_read_wal_header"
+	diagPhaseCheckpointCopyBefore           diagPhase = "checkpoint_copy_before"
+	diagPhaseCheckpointExec                 diagPhase = "checkpoint_exec"
+	diagPhaseCheckpointVerifyRestart        diagPhase = "checkpoint_verify_restart"
+	diagPhaseCheckpointSnapshotBoundaryLock diagPhase = "checkpoint_snapshot_boundary_lock"
+	diagPhaseCheckpointSnapshotBoundary     diagPhase = "checkpoint_snapshot_boundary"
 )
 
-type syncDiagnosticState struct {
+type diagState struct {
 	sync.RWMutex
 	active              bool
-	operation           syncDiagnosticOperation
-	phase               syncDiagnosticPhase
+	operation           diagOp
+	phase               diagPhase
 	startedAt           time.Time
 	updatedAt           time.Time
 	txID                ltx.TXID
@@ -381,14 +381,14 @@ func (db *DB) SyncDiagnostic() SyncDiagnostic {
 	return diag
 }
 
-func (db *DB) beginSyncDiagnostic(operation syncDiagnosticOperation) {
+func (db *DB) beginSyncDiag(operation diagOp) {
 	now := time.Now()
 	walSize, _ := db.walFileSize()
 
 	db.syncDiag.Lock()
 	db.syncDiag.active = true
 	db.syncDiag.operation = operation
-	db.syncDiag.phase = syncDiagnosticPhaseStarting
+	db.syncDiag.phase = diagPhaseStarting
 	db.syncDiag.startedAt = now
 	db.syncDiag.updatedAt = now
 	db.syncDiag.txID = 0
@@ -401,7 +401,7 @@ func (db *DB) beginSyncDiagnostic(operation syncDiagnosticOperation) {
 	db.syncDiag.Unlock()
 }
 
-func (db *DB) setSyncDiagnosticPhase(phase syncDiagnosticPhase, updates ...func(*syncDiagnosticState)) {
+func (db *DB) setSyncDiagPhase(phase diagPhase, updates ...func(*diagState)) {
 	db.syncDiag.Lock()
 	defer db.syncDiag.Unlock()
 	if !db.syncDiag.active {
@@ -414,7 +414,7 @@ func (db *DB) setSyncDiagnosticPhase(phase syncDiagnosticPhase, updates ...func(
 	}
 }
 
-func (db *DB) finishSyncDiagnostic(err error) {
+func (db *DB) finishSyncDiag(err error) {
 	db.syncDiag.Lock()
 	defer db.syncDiag.Unlock()
 	if !db.syncDiag.active {
@@ -1146,8 +1146,8 @@ func (db *DB) releaseReadLock() error {
 func (db *DB) Sync(ctx context.Context) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	db.beginSyncDiagnostic(syncDiagnosticOperationSync)
-	defer func() { db.finishSyncDiagnostic(err) }()
+	db.beginSyncDiag(diagOpSync)
+	defer func() { db.finishSyncDiag(err) }()
 
 	// Track total sync metrics.
 	t := time.Now()
@@ -1168,14 +1168,14 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 	}
 
 	// Ensure WAL has at least one frame in it.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseEnsureWAL, func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseEnsureWAL, func(s *diagState) {
 		s.lastSyncedWALOffset = db.lastSyncedWALOffset
 	})
 	if err := db.ensureWALExists(ctx); err != nil {
 		return fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseVerifyAndSync)
+	db.setSyncDiagPhase(diagPhaseVerifyAndSync)
 	result, err := db.verifyAndSync(ctx, false)
 	if err != nil {
 		return err
@@ -1187,14 +1187,14 @@ func (db *DB) Sync(ctx context.Context) (err error) {
 		db.syncedSinceCheckpoint = true
 	}
 
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointIfNeeded, func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointIfNeeded, func(s *diagState) {
 		s.lastSyncedWALOffset = db.lastSyncedWALOffset
 	})
 	if err := db.checkpointIfNeeded(ctx, result.origWALSize, result.newWALSize); err != nil {
 		return fmt.Errorf("checkpoint: %w", err)
 	}
 
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseUpdateMetrics, func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseUpdateMetrics, func(s *diagState) {
 		s.lastSyncedWALOffset = db.lastSyncedWALOffset
 	})
 
@@ -1237,7 +1237,7 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool) (syncResult
 	// Verify our last sync matches the current state of the WAL.
 	// This ensures that the last sync position of the real WAL hasn't
 	// been overwritten by another process.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseVerify)
+	db.setSyncDiagPhase(diagPhaseVerify)
 	info, err := db.verify(ctx)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
@@ -1713,8 +1713,8 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 		return result, fmt.Errorf("pos: %w", err)
 	}
 	txID := pos.TXID + 1
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncOpenLTX,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseSyncOpenLTX,
+		func(s *diagState) {
 			s.txID = txID
 			s.snapshotting = info.snapshotting
 			s.reason = info.reason
@@ -1777,8 +1777,8 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Build a mapping of changed page numbers and their latest content.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncPageMap,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseSyncPageMap,
+		func(s *diagState) {
 			s.txID = txID
 			s.snapshotting = info.snapshotting
 			s.reason = info.reason
@@ -1796,8 +1796,8 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 		sz = maxOffset - info.offset
 	}
 	assert(sz >= 0, fmt.Sprintf("wal size must be positive: sz=%d, maxOffset=%d, info.offset=%d", sz, maxOffset, info.offset))
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncPrepareLTX,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseSyncPrepareLTX,
+		func(s *diagState) {
 			s.txID = txID
 			s.walSize = sz
 			s.snapshotting = info.snapshotting
@@ -1862,8 +1862,8 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	// If we need a full snapshot, then copy from the database & WAL.
 	// Otherwise, just copy incrementally from the WAL.
 	if info.snapshotting {
-		db.setSyncDiagnosticPhase(syncDiagnosticPhaseWriteLTXFromDB,
-			func(s *syncDiagnosticState) {
+		db.setSyncDiagPhase(diagPhaseWriteLTXFromDB,
+			func(s *diagState) {
 				s.txID = txID
 				s.walSize = sz
 				s.snapshotting = true
@@ -1873,8 +1873,8 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
-		db.setSyncDiagnosticPhase(syncDiagnosticPhaseWriteLTXFromWAL,
-			func(s *syncDiagnosticState) {
+		db.setSyncDiagPhase(diagPhaseWriteLTXFromWAL,
+			func(s *diagState) {
 				s.txID = txID
 				s.walSize = sz
 				s.snapshotting = false
@@ -1886,7 +1886,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Encode final trailer to the end of the LTX file.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCloseLTX, func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCloseLTX, func(s *diagState) {
 		s.txID = txID
 		s.walSize = sz
 	})
@@ -1895,7 +1895,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Sync & close LTX file.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseFsyncLTX, func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseFsyncLTX, func(s *diagState) {
 		s.txID = txID
 		s.walSize = sz
 	})
@@ -1907,7 +1907,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	}
 
 	// Atomically rename file to final path.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseRenameLTX, func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseRenameLTX, func(s *diagState) {
 		s.txID = txID
 		s.walSize = sz
 	})
@@ -1946,8 +1946,8 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, info syncInfo) (resu
 	} else {
 		result.syncedToWALEnd = false
 	}
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseSyncComplete,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseSyncComplete,
+		func(s *diagState) {
 			s.txID = txID
 			s.walSize = sz
 			s.lastSyncedWALOffset = finalOffset
@@ -2040,16 +2040,16 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	db.beginSyncDiagnostic(syncDiagnosticOperationCheckpoint)
-	defer func() { db.finishSyncDiagnostic(err) }()
+	db.beginSyncDiag(diagOpCheckpoint)
+	defer func() { db.finishSyncDiag(err) }()
 	return db.checkpoint(ctx, mode)
 }
 
 // checkpoint performs a checkpoint on the WAL file and initializes a
 // new shadow WAL file.
 func (db *DB) checkpoint(ctx context.Context, mode string) error {
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointLock,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointLock,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})
@@ -2061,8 +2061,8 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	defer db.chkMu.Unlock()
 
 	// Read WAL header before checkpoint to check if it has been restarted.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointReadWALHeader,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})
@@ -2072,8 +2072,8 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointCopyBefore,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointCopyBefore,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})
@@ -2085,8 +2085,8 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointExec,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointExec,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})
@@ -2097,8 +2097,8 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// If WAL hasn't been restarted, exit.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointVerifyRestart,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointVerifyRestart,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})
@@ -2110,8 +2110,8 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Start a transaction. This will be promoted immediately after.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointSnapshotBoundaryLock,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointSnapshotBoundaryLock,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})
@@ -2130,8 +2130,8 @@ func (db *DB) checkpoint(ctx context.Context, mode string) error {
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseCheckpointSnapshotBoundary,
-		func(s *syncDiagnosticState) {
+	db.setSyncDiagPhase(diagPhaseCheckpointSnapshotBoundary,
+		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = db.lastSyncedWALOffset
 		})

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -105,6 +105,60 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func TestDB_SyncDiagnostic(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+
+	db.beginSyncDiagnostic("sync")
+	db.setSyncDiagnosticPhase("write_ltx_from_wal",
+		syncDiagnosticTXID(ltx.TXID(7)),
+		syncDiagnosticWALSize(1024),
+		syncDiagnosticLastSyncedWALOffset(2048),
+		syncDiagnosticSnapshotting(false),
+		syncDiagnosticReason("test reason"),
+	)
+
+	diag := db.SyncDiagnostic()
+	if !diag.Active {
+		t.Fatal("expected active diagnostic")
+	}
+	if diag.Path != db.Path() {
+		t.Fatalf("path=%q, want %q", diag.Path, db.Path())
+	}
+	if diag.Operation != "sync" {
+		t.Fatalf("operation=%q, want sync", diag.Operation)
+	}
+	if diag.Phase != "write_ltx_from_wal" {
+		t.Fatalf("phase=%q, want write_ltx_from_wal", diag.Phase)
+	}
+	if diag.TXID != 7 {
+		t.Fatalf("txid=%d, want 7", diag.TXID)
+	}
+	if diag.WALSize != 1024 {
+		t.Fatalf("wal_size=%d, want 1024", diag.WALSize)
+	}
+	if diag.LastSyncedWALOffset != 2048 {
+		t.Fatalf("last_synced_wal_offset=%d, want 2048", diag.LastSyncedWALOffset)
+	}
+	if diag.Reason != "test reason" {
+		t.Fatalf("reason=%q, want test reason", diag.Reason)
+	}
+	if diag.StartedAt == nil || diag.UpdatedAt == nil {
+		t.Fatalf("started_at=%v updated_at=%v, want both set", diag.StartedAt, diag.UpdatedAt)
+	}
+
+	db.finishSyncDiagnostic(errors.New("boom"))
+	diag = db.SyncDiagnostic()
+	if diag.Active {
+		t.Fatal("expected inactive diagnostic")
+	}
+	if diag.Phase != "write_ltx_from_wal" {
+		t.Fatalf("phase=%q, want last phase retained", diag.Phase)
+	}
+	if diag.Error != "boom" {
+		t.Fatalf("error=%q, want boom", diag.Error)
+	}
+}
+
 // TestCalcWALSize ensures calcWALSize doesn't overflow with large page sizes.
 // Regression test for uint32 overflow bug where large page sizes (>=16KB)
 // caused incorrect WAL size calculations, triggering checkpoints too early.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -108,8 +108,8 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 func TestDB_SyncDiagnostic(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 
-	db.beginSyncDiagnostic(syncDiagnosticOperationSync)
-	db.setSyncDiagnosticPhase(syncDiagnosticPhaseWriteLTXFromWAL, func(s *syncDiagnosticState) {
+	db.beginSyncDiag(diagOpSync)
+	db.setSyncDiagPhase(diagPhaseWriteLTXFromWAL, func(s *diagState) {
 		s.txID = ltx.TXID(7)
 		s.walSize = 1024
 		s.lastSyncedWALOffset = 2048
@@ -146,7 +146,7 @@ func TestDB_SyncDiagnostic(t *testing.T) {
 		t.Fatalf("started_at=%v updated_at=%v, want both set", diag.StartedAt, diag.UpdatedAt)
 	}
 
-	db.finishSyncDiagnostic(errors.New("boom"))
+	db.finishSyncDiag(errors.New("boom"))
 	diag = db.SyncDiagnostic()
 	if diag.Active {
 		t.Fatal("expected inactive diagnostic")

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -108,14 +108,14 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 func TestDB_SyncDiagnostic(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 
-	db.beginSyncDiagnostic("sync")
-	db.setSyncDiagnosticPhase("write_ltx_from_wal",
-		syncDiagnosticTXID(ltx.TXID(7)),
-		syncDiagnosticWALSize(1024),
-		syncDiagnosticLastSyncedWALOffset(2048),
-		syncDiagnosticSnapshotting(false),
-		syncDiagnosticReason("test reason"),
-	)
+	db.beginSyncDiagnostic(syncDiagnosticOperationSync)
+	db.setSyncDiagnosticPhase(syncDiagnosticPhaseWriteLTXFromWAL, func(s *syncDiagnosticState) {
+		s.txID = ltx.TXID(7)
+		s.walSize = 1024
+		s.lastSyncedWALOffset = 2048
+		s.snapshotting = false
+		s.reason = "test reason"
+	})
 
 	diag := db.SyncDiagnostic()
 	if !diag.Active {

--- a/server.go
+++ b/server.go
@@ -80,6 +80,7 @@ func NewServer(store *Store) *Server {
 	mux.HandleFunc("POST /sync", s.handleSync)
 	mux.HandleFunc("GET /list", s.handleList)
 	mux.HandleFunc("GET /info", s.handleInfo)
+	mux.HandleFunc("GET /debug/sync-status", s.handleSyncStatus)
 
 	// pprof endpoints
 	mux.HandleFunc("GET /debug/pprof/", pprof.Index)
@@ -266,6 +267,35 @@ func (s *Server) handleTXID(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleSyncStatus(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	if path != "" {
+		expandedPath, err := s.expandPath(path)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err), nil)
+			return
+		}
+
+		db := s.store.FindDB(expandedPath)
+		if db == nil {
+			writeJSONError(w, http.StatusNotFound, "database not found", nil)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, SyncDiagnosticsResponse{
+			Databases: []SyncDiagnostic{db.SyncDiagnostic()},
+		})
+		return
+	}
+
+	dbs := s.store.DBs()
+	diagnostics := make([]SyncDiagnostic, 0, len(dbs))
+	for _, db := range dbs {
+		diagnostics = append(diagnostics, db.SyncDiagnostic())
+	}
+	writeJSON(w, http.StatusOK, SyncDiagnosticsResponse{Databases: diagnostics})
+}
+
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -314,6 +344,11 @@ type ErrorResponse struct {
 // TXIDResponse is the response body for the /txid endpoint.
 type TXIDResponse struct {
 	TXID uint64 `json:"txid"`
+}
+
+// SyncDiagnosticsResponse is the response body for /debug/sync-status.
+type SyncDiagnosticsResponse struct {
+	Databases []SyncDiagnostic `json:"databases"`
 }
 
 func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -656,6 +656,55 @@ func TestServer_HandleSync(t *testing.T) {
 	})
 }
 
+func TestServer_HandleSyncStatus(t *testing.T) {
+	t.Run("AllDatabases", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		require.NoError(t, store.Open(t.Context()))
+		defer store.Close(t.Context())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		require.NoError(t, server.Start())
+		defer server.Close()
+
+		client := newSocketClient(t, server.SocketPath)
+		resp, err := client.Get("http://localhost/debug/sync-status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result litestream.SyncDiagnosticsResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		require.Len(t, result.Databases, 1)
+		require.Equal(t, db.Path(), result.Databases[0].Path)
+		require.False(t, result.Databases[0].Active)
+	})
+
+	t.Run("DatabaseNotFound", func(t *testing.T) {
+		store := litestream.NewStore(nil, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		require.NoError(t, store.Open(t.Context()))
+		defer store.Close(t.Context())
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		require.NoError(t, server.Start())
+		defer server.Close()
+
+		client := newSocketClient(t, server.SocketPath)
+		resp, err := client.Get("http://localhost/debug/sync-status?path=/nonexistent/db")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
 func newSocketClient(t *testing.T, socketPath string) *http.Client {
 	t.Helper()
 	return &http.Client{


### PR DESCRIPTION
## Summary
Expose the latest database sync/checkpoint diagnostic state through the existing Unix control socket at `GET /debug/sync-status`.

## Problem
The PR #1265 soak incident required bounded failure snapshots to identify where sync was stuck. The useful signal was the current DB operation, phase, WAL size, snapshotting state, and last synced WAL offset. Without a runtime endpoint, the control plane has to infer this from repeated failures or ask for ad-hoc worker access.

## Solution
Add a protected diagnostic snapshot on `DB` and update it around existing sync/checkpoint phases. Expose all database diagnostics through the control socket, with optional `path` filtering.

## Scope
**In scope:**
- Sync/checkpoint phase diagnostics on `DB`
- `GET /debug/sync-status` control socket endpoint
- DB/server tests for the diagnostic response

**Not in scope:**
- Sync executor fairness or starvation fixes
- Memory/OOM mitigation
- Any change to sync, checkpoint, compaction, or restore behavior

## Test Plan
```bash
go test ./... -run 'SyncDiagnostic|SyncStatus|HandleSyncStatus' -count=1
go test ./... -count=1
git diff --check
```

Commit hooks also ran `goimports`, `go vet`, and `staticcheck`.

## Related
- Fixes #1279
- Parent: #1273
- Related to #1265
- Root-cause soak follow-up remains in #1280
