### PR TITLE
fix(db): bound sync executor work

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -716,6 +716,7 @@ type DBConfig struct {
 	BusyTimeout        *time.Duration `yaml:"busy-timeout"`
 	MinCheckpointPageN *int           `yaml:"min-checkpoint-page-count"`
 	TruncatePageN      *int           `yaml:"truncate-page-n"`
+	MaxSyncWALBytes    *int64         `yaml:"max-sync-wal-bytes"`
 
 	RestoreIfDBNotExists bool `yaml:"restore-if-db-not-exists"`
 
@@ -760,6 +761,9 @@ func NewDBFromConfig(dbc *DBConfig) (*litestream.DB, error) {
 	}
 	if dbc.TruncatePageN != nil {
 		db.TruncatePageN = *dbc.TruncatePageN
+	}
+	if dbc.MaxSyncWALBytes != nil {
+		db.MaxSyncWALBytes = *dbc.MaxSyncWALBytes
 	}
 
 	// Instantiate and attach replica.

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -1671,6 +1671,86 @@ dbs:
 	})
 }
 
+// TestDBConfig_MaxSyncWALBytes tests that the max-sync-wal-bytes configuration
+// field is properly parsed from YAML and applied to the DB instance.
+func TestDBConfig_MaxSyncWALBytes(t *testing.T) {
+	t.Run("Specified", func(t *testing.T) {
+		filename := filepath.Join(t.TempDir(), "litestream.yml")
+		if err := os.WriteFile(filename, []byte(`
+dbs:
+  - path: /tmp/test.db
+    max-sync-wal-bytes: 16777216
+    replica:
+      url: file:///tmp/replica
+`[1:]), 0666); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := main.ReadConfigFile(filename, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(config.DBs) != 1 {
+			t.Fatal("expected one database config")
+		}
+
+		dbc := config.DBs[0]
+		if dbc.MaxSyncWALBytes == nil {
+			t.Fatal("expected max-sync-wal-bytes to be set")
+		}
+		if got, want := *dbc.MaxSyncWALBytes, int64(16777216); got != want {
+			t.Errorf("MaxSyncWALBytes = %d, want %d", got, want)
+		}
+
+		// Test that the value is properly applied to the DB
+		db, err := main.NewDBFromConfig(dbc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := db.MaxSyncWALBytes, int64(16777216); got != want {
+			t.Errorf("db.MaxSyncWALBytes = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("NotSpecified_UsesDefault", func(t *testing.T) {
+		filename := filepath.Join(t.TempDir(), "litestream.yml")
+		if err := os.WriteFile(filename, []byte(`
+dbs:
+  - path: /tmp/test.db
+    replica:
+      url: file:///tmp/replica
+`[1:]), 0666); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := main.ReadConfigFile(filename, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(config.DBs) != 1 {
+			t.Fatal("expected one database config")
+		}
+
+		dbc := config.DBs[0]
+		if dbc.MaxSyncWALBytes != nil {
+			t.Errorf("expected MaxSyncWALBytes to be nil when not specified, got %v", *dbc.MaxSyncWALBytes)
+		}
+
+		// Test that the DB uses the default value
+		db, err := main.NewDBFromConfig(dbc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := db.MaxSyncWALBytes, int64(litestream.DefaultMaxSyncWALBytes); got != want {
+			t.Errorf("db.MaxSyncWALBytes = %d, want default %d", got, want)
+		}
+	})
+}
+
 func TestFindSQLiteDatabases(t *testing.T) {
 	// Create a temporary directory using t.TempDir() - automatically cleaned up
 	tmpDir := t.TempDir()

--- a/db.go
+++ b/db.go
@@ -1265,7 +1265,11 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 		exec.state.syncedSinceCheckpoint = true
 	}
 
-	if !result.limited || result.syncedToWALEnd {
+	// Checkpoint checks normally wait until the WAL is fully synced, but the
+	// emergency truncate threshold must be honored even mid catch-up:
+	// sustained writes could otherwise keep every chunk limited and defer the
+	// truncate checkpoint indefinitely, growing the WAL without bound.
+	if !result.limited || result.syncedToWALEnd || db.exceedsTruncateThreshold(result.origWALSize) {
 		db.setSyncDiagPhase(diagPhaseCheckpointIfNeeded, func(s *diagState) {
 			s.txID = exec.pos.TXID
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
@@ -1363,7 +1367,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 
 	// Priority 1: Emergency truncate checkpoint (TRUNCATE mode, blocking)
 	// This prevents unbounded WAL growth from long-lived read transactions.
-	if db.TruncatePageN > 0 && origWALSize >= calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)) {
+	if db.exceedsTruncateThreshold(origWALSize) {
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
 			"threshold", calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)))
@@ -1411,6 +1415,13 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	}
 
 	return nil
+}
+
+// exceedsTruncateThreshold returns true once walSize has grown past the
+// emergency truncate checkpoint threshold.
+func (db *DB) exceedsTruncateThreshold(walSize int64) bool {
+	return db.TruncatePageN > 0 && db.pageSize != 0 &&
+		walSize >= calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
 }
 
 // isSQLiteBusyError returns true if the error is an SQLITE_BUSY error.

--- a/db.go
+++ b/db.go
@@ -33,6 +33,7 @@ const (
 	DefaultBusyTimeout          = 1 * time.Second
 	DefaultMinCheckpointPageN   = 1000
 	DefaultTruncatePageN        = 121359 // ~500MB with 4KB page size
+	DefaultMaxSyncWALBytes      = 64 << 20
 	DefaultShutdownSyncTimeout  = 30 * time.Second
 	DefaultShutdownSyncInterval = 500 * time.Millisecond
 
@@ -139,6 +140,10 @@ type DB struct {
 	// Frequency at which to perform db sync.
 	MonitorInterval time.Duration
 
+	// Maximum WAL bytes to process in a single sync executor run.
+	// Set to zero to process all committed WAL frames in one run.
+	MaxSyncWALBytes int64
+
 	// The timeout to wait for EBUSY from SQLite.
 	BusyTimeout time.Duration
 
@@ -227,7 +232,9 @@ const (
 	diagPhaseVerifyAndSync                  diagPhase = "verify_and_sync"
 	diagPhaseCheckpointIfNeeded             diagPhase = "checkpoint_if_needed"
 	diagPhaseUpdateMetrics                  diagPhase = "update_metrics"
+	diagPhaseStatWAL                        diagPhase = "stat_wal"
 	diagPhaseVerify                         diagPhase = "verify"
+	diagPhaseSyncLTX                        diagPhase = "sync_ltx"
 	diagPhaseSyncOpenLTX                    diagPhase = "sync_open_ltx"
 	diagPhaseSyncPageMap                    diagPhase = "sync_page_map"
 	diagPhaseSyncPrepareLTX                 diagPhase = "sync_prepare_ltx"
@@ -293,6 +300,7 @@ func NewDB(path string) *DB {
 		TruncatePageN:        DefaultTruncatePageN,
 		CheckpointInterval:   DefaultCheckpointInterval,
 		MonitorInterval:      DefaultMonitorInterval,
+		MaxSyncWALBytes:      DefaultMaxSyncWALBytes,
 		BusyTimeout:          DefaultBusyTimeout,
 		L0Retention:          DefaultL0Retention,
 		RetentionEnabled:     true,
@@ -773,7 +781,7 @@ func (db *DB) Close(ctx context.Context) (err error) {
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
-		if e := db.syncLocked(ctx); e != nil {
+		if _, e := db.syncLocked(ctx, 0); e != nil {
 			err = e
 		}
 	}
@@ -1162,16 +1170,58 @@ func (db *DB) releaseReadLock() error {
 }
 
 // Sync copies pending data from the WAL to the shadow WAL.
-func (db *DB) Sync(ctx context.Context) (err error) {
-	db.execMu.Lock()
+func (db *DB) Sync(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
+
+		result, err := db.syncOnce(ctx, db.MaxSyncWALBytes)
+		if err != nil {
+			return err
+		} else if !result.synced || !result.limited || result.syncedToWALEnd {
+			return nil
+		}
+	}
+}
+
+func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, error) {
+	if err := db.lockExec(ctx); err != nil {
+		return syncResult{}, err
+	}
 	defer db.execMu.Unlock()
+
+	return db.syncLocked(ctx, maxSyncWALBytes)
+}
+
+func (db *DB) lockExec(ctx context.Context) error {
+	if db.execMu.TryLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			err := context.Cause(ctx)
+			if err == nil {
+				err = ctx.Err()
+			}
+			return fmt.Errorf("wait for db sync executor: %w", err)
+		case <-ticker.C:
+			if db.execMu.TryLock() {
+				return nil
+			}
+		}
+	}
+}
+
+func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {
 	db.beginSyncDiag(diagOpSync)
 	defer func() { db.finishSyncDiag(err) }()
 
-	return db.syncLocked(ctx)
-}
-
-func (db *DB) syncLocked(ctx context.Context) (err error) {
 	// Track total sync metrics.
 	t := time.Now()
 	defer func() {
@@ -1184,10 +1234,10 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {
-		return err
+		return result, err
 	} else if exec == nil {
 		db.Logger.Debug("sync: no database found")
-		return nil
+		return result, nil
 	}
 	defer db.applySyncExecutor(exec, true)
 
@@ -1196,13 +1246,15 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 	})
 	if err := db.ensureWALExists(ctx); err != nil {
-		return fmt.Errorf("ensure wal exists: %w", err)
+		return result, fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	db.setSyncDiagPhase(diagPhaseVerifyAndSync)
-	result, err := db.verifyAndSyncWithExecutor(ctx, false, exec)
+	db.setSyncDiagPhase(diagPhaseVerifyAndSync, func(s *diagState) {
+		s.txID = exec.pos.TXID + 1
+	})
+	result, err = db.verifyAndSyncWithExecutor(ctx, false, exec, maxSyncWALBytes)
 	if err != nil {
-		return err
+		return result, err
 	}
 	exec.applySyncResult(result)
 
@@ -1211,14 +1263,18 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		exec.state.syncedSinceCheckpoint = true
 	}
 
-	db.setSyncDiagPhase(diagPhaseCheckpointIfNeeded, func(s *diagState) {
-		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
-	})
-	if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
-		return fmt.Errorf("checkpoint: %w", err)
+	if !result.limited || result.syncedToWALEnd {
+		db.setSyncDiagPhase(diagPhaseCheckpointIfNeeded, func(s *diagState) {
+			s.txID = exec.pos.TXID
+			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+		})
+		if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
+			return result, fmt.Errorf("checkpoint: %w", err)
+		}
 	}
 
 	db.setSyncDiagPhase(diagPhaseUpdateMetrics, func(s *diagState) {
+		s.txID = exec.pos.TXID
 		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 	})
 
@@ -1231,7 +1287,7 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 	}
 	db.walSizeGauge.Set(float64(exec.state.lastSyncedWALOffset))
 
-	return nil
+	return result, nil
 }
 
 func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *syncState) (syncResult, error) {
@@ -1243,10 +1299,15 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *sync
 	return db.verifyAndSyncWithExecutor(ctx, checkpointing, &syncExecutor{
 		state: *state,
 		pos:   pos,
-	})
+	}, 0)
 }
 
-func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor) (syncResult, error) {
+func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor, maxSyncWALBytes int64) (syncResult, error) {
+	db.setSyncDiagPhase(diagPhaseStatWAL, func(s *diagState) {
+		s.txID = exec.pos.TXID + 1
+		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+	})
+
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
 	// This avoids using file size which may include stale frames with old salt
 	// values after a checkpoint. See issue #997.
@@ -1269,7 +1330,13 @@ func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool,
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
-	result, err := db.sync(ctx, checkpointing, exec, info)
+	db.setSyncDiagPhase(diagPhaseSyncLTX, func(s *diagState) {
+		s.txID = exec.pos.TXID + 1
+		s.snapshotting = info.snapshotting
+		s.reason = info.reason
+		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+	})
+	result, err := db.sync(ctx, checkpointing, exec, info, maxSyncWALBytes)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
 	}
@@ -1716,6 +1783,7 @@ type syncResult struct {
 	origWALSize    int64
 	newWALSize     int64
 	synced         bool
+	limited        bool
 	syncedToWALEnd bool
 	pos            *ltx.Pos
 	l0FileInfo     *ltx.FileInfo
@@ -1804,7 +1872,7 @@ func (exec *syncExecutor) applySyncResult(result syncResult) {
 
 // sync copies pending bytes from the real WAL to LTX.
 // Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
-func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo) (result syncResult, err error) {
+func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo, maxSyncWALBytes int64) (result syncResult, err error) {
 	result.newWALSize = exec.state.lastSyncedWALOffset
 	result.syncedToWALEnd = exec.state.syncedToWALEnd
 	if info.clearSyncedToWALEnd {
@@ -1883,10 +1951,14 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 			s.snapshotting = info.snapshotting
 			s.reason = info.reason
 		})
-	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
+	if info.snapshotting {
+		maxSyncWALBytes = 0
+	}
+	pageMap, maxOffset, walCommit, limited, err := rd.pageMap(ctx, maxSyncWALBytes)
 	if err != nil {
 		return result, fmt.Errorf("page map: %w", err)
 	}
+	result.limited = limited
 	if walCommit > 0 {
 		commit = walCommit
 	}
@@ -2117,6 +2189,12 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
+		}
+
 		offset := pageMap[pgno]
 
 		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
@@ -2213,7 +2291,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec)
+	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
@@ -2271,7 +2349,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 	}
@@ -2703,7 +2781,7 @@ func (db *DB) monitor() {
 		}
 
 		// Sync the database to the shadow WAL.
-		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if _, err := db.syncOnce(db.ctx, db.MaxSyncWALBytes); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max

--- a/db.go
+++ b/db.go
@@ -141,7 +141,9 @@ type DB struct {
 	MonitorInterval time.Duration
 
 	// Maximum WAL bytes to process in a single sync executor run.
-	// Set to zero to process all committed WAL frames in one run.
+	// The limit is checked at commit boundaries so a single transaction
+	// larger than this may exceed it. Set to zero to process all
+	// committed WAL frames in one run.
 	MaxSyncWALBytes int64
 
 	// The timeout to wait for EBUSY from SQLite.
@@ -2780,8 +2782,13 @@ func (db *DB) monitor() {
 			}
 		}
 
-		// Sync the database to the shadow WAL.
-		if _, err := db.syncOnce(db.ctx, db.MaxSyncWALBytes); err != nil && !errors.Is(err, context.Canceled) {
+		// Sync the database to the shadow WAL. Sync() loops over bounded
+		// chunks, releasing the executor lock between each so checkpoints
+		// and snapshots can interleave, but always catches up to the WAL
+		// end so checkpointIfNeeded() runs. A single bounded chunk per
+		// tick would cap drain throughput and starve the TruncatePageN
+		// emergency checkpoint while behind, growing the WAL unbounded.
+		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -159,6 +159,139 @@ func TestDB_SyncDiagnostic(t *testing.T) {
 	}
 }
 
+func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	walPath := filepath.Join(dir, "db-wal")
+
+	walFile, err := os.OpenFile(walPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer walFile.Close()
+
+	db := NewDB(dbPath)
+	db.pageSize = 1024
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:  ltx.Version,
+		Flags:    ltx.HeaderFlagNoChecksum,
+		PageSize: 1024,
+		Commit:   1,
+		MinTXID:  1,
+		MaxTXID:  1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = db.writeLTXFromWAL(ctx, enc, walFile, map[uint32]int64{1: 0})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+}
+
+func TestDB_SyncChunksWALAtCommitBoundary(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.MaxSyncWALBytes = int64(WALFrameHeaderSize + 4096)
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := db.syncOnce(context.Background(), db.MaxSyncWALBytes)
+	if err != nil {
+		t.Fatal(err)
+	} else if !result.synced {
+		t.Fatal("expected sync to create an LTX file")
+	} else if !result.limited {
+		t.Fatal("expected sync to stop at WAL byte limit")
+	} else if result.syncedToWALEnd {
+		t.Fatal("expected first bounded sync to leave pending WAL frames")
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	syncedToWALEnd := db.syncState.syncedToWALEnd
+	db.mu.RUnlock()
+	if !syncedToWALEnd {
+		t.Fatal("expected public Sync to finish remaining WAL chunks")
+	}
+}
+
+func TestWALReaderPageMapLimitStopsAtCommittedFrame(t *testing.T) {
+	b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewWALReader(bytes.NewReader(b), slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pageMap, maxOffset, commit, limited, err := r.pageMap(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !limited {
+		t.Fatal("expected page map to stop at limit")
+	}
+	if got, want := maxOffset, int64(8272); got != want {
+		t.Fatalf("maxOffset=%d, want %d", got, want)
+	}
+	if got, want := commit, uint32(2); got != want {
+		t.Fatalf("commit=%d, want %d", got, want)
+	}
+	if got, want := len(pageMap), 2; got != want {
+		t.Fatalf("len(pageMap)=%d, want %d", got, want)
+	}
+}
+
 // TestCalcWALSize ensures calcWALSize doesn't overflow with large page sizes.
 // Regression test for uint32 overflow bug where large page sizes (>=16KB)
 // caused incorrect WAL size calculations, triggering checkpoints too early.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -234,7 +234,7 @@ func TestDB_SyncChunksWALAtCommitBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
 			t.Fatal(err)
 		}
@@ -260,6 +260,87 @@ func TestDB_SyncChunksWALAtCommitBoundary(t *testing.T) {
 	db.mu.RUnlock()
 	if !syncedToWALEnd {
 		t.Fatal("expected public Sync to finish remaining WAL chunks")
+	}
+}
+
+func TestDB_SyncTruncateCheckpointFiresDuringChunkedCatchUp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB);`); err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Sync fully with the truncate threshold disabled so the last synced WAL
+	// offset ends up past the threshold without a checkpoint having run.
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	lastSyncedWALOffset := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+
+	db.TruncatePageN = 2
+	db.MaxSyncWALBytes = int64(WALFrameHeaderSize + 4096)
+	if !db.exceedsTruncateThreshold(lastSyncedWALOffset) {
+		t.Fatalf("precondition: synced WAL offset %d must exceed the truncate threshold", lastSyncedWALOffset)
+	}
+
+	for range 20 {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	before, err := os.Stat(db.WALPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A single bounded chunk leaves pending WAL frames, but the truncate
+	// threshold has been exceeded so the checkpoint must fire anyway.
+	result, err := db.syncOnce(t.Context(), db.MaxSyncWALBytes)
+	if err != nil {
+		t.Fatal(err)
+	} else if !result.limited {
+		t.Fatal("expected sync to stop at WAL byte limit")
+	}
+
+	after, err := os.Stat(db.WALPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Size() >= before.Size() {
+		t.Fatalf("expected truncate checkpoint to shrink WAL during catch-up: before=%d after=%d", before.Size(), after.Size())
 	}
 }
 

--- a/store.go
+++ b/store.go
@@ -405,7 +405,8 @@ type SyncDBResult struct {
 // SyncDB forces an immediate sync for a database. If wait is true, blocks
 // until both WAL-to-LTX and LTX-to-remote sync complete. If wait is false,
 // only performs the WAL-to-LTX sync and lets the replica monitor handle upload.
-// The timeout is best-effort as internal lock acquisition is not context-aware.
+// The timeout is best-effort: the database's sync executor lock wait is
+// context-aware, but the replica sync lock wait is not.
 func (s *Store) SyncDB(ctx context.Context, path string, wait bool) (SyncDBResult, error) {
 	db := s.FindDB(path)
 	if db == nil {

--- a/wal_reader.go
+++ b/wal_reader.go
@@ -134,7 +134,13 @@ func (r *WALReader) ReadFrame(ctx context.Context, data []byte) (pgno, commit ui
 	return r.readFrame(ctx, data, true)
 }
 
-func (r *WALReader) readFrame(_ context.Context, data []byte, verifyChecksum bool) (pgno, commit uint32, err error) {
+func (r *WALReader) readFrame(ctx context.Context, data []byte, verifyChecksum bool) (pgno, commit uint32, err error) {
+	select {
+	case <-ctx.Done():
+		return 0, 0, context.Cause(ctx)
+	default:
+	}
+
 	if len(data) != int(r.pageSize) {
 		return 0, 0, fmt.Errorf("WALReader.ReadFrame(): buffer size (%d) must match page size (%d)", len(data), r.pageSize)
 	}
@@ -190,15 +196,22 @@ func (r *WALReader) readFrame(_ context.Context, data []byte, verifyChecksum boo
 // map of pgno to offset of the latest version of each page. Also returns the
 // max offset of the wal segment read, and the final database size, in pages.
 func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset int64, commit uint32, err error) {
+	m, maxOffset, commit, _, err = r.pageMap(ctx, 0)
+	return m, maxOffset, commit, err
+}
+
+func (r *WALReader) pageMap(ctx context.Context, maxBytes int64) (m map[uint32]int64, maxOffset int64, commit uint32, limited bool, err error) {
 	m = make(map[uint32]int64)
 	txMap := make(map[uint32]int64)
 	data := make([]byte, r.pageSize)
-	for i := 0; ; i++ {
+	frameSize := int64(WALFrameHeaderSize + r.pageSize)
+	startOffset := WALHeaderSize + int64(r.frameN)*frameSize
+	for {
 		pgno, fcommit, err := r.ReadFrame(ctx, data)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
-			return nil, 0, 0, err
+			return nil, 0, 0, false, err
 		}
 
 		// Update latest offset for the page for this transaction.
@@ -211,7 +224,13 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 			for pgno, offset := range txMap {
 				m[pgno] = offset
 			}
+			txMap = make(map[uint32]int64)
 			commit = fcommit
+
+			if maxBytes > 0 && r.Offset()+frameSize-startOffset >= maxBytes {
+				limited = true
+				break
+			}
 		}
 	}
 
@@ -225,7 +244,7 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 
 	// If full transactions available, return the original offset.
 	if len(m) == 0 {
-		return m, 0, 0, nil
+		return m, 0, 0, limited, nil
 	}
 
 	// Compute the highest page offsets.
@@ -240,7 +259,7 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 	end += WALFrameHeaderSize + int64(r.pageSize)
 
 	r.logger.Log(ctx, internal.LevelTrace, "page map complete", "n", len(m), "end", end, "commit", commit)
-	return m, end, commit, nil
+	return m, end, commit, limited, nil
 }
 
 // FrameSaltsUntil returns a set of all unique frame salts in the WAL file.

--- a/wal_reader.go
+++ b/wal_reader.go
@@ -65,9 +65,13 @@ func NewWALReaderWithOffset(ctx context.Context, rd io.ReaderAt, offset int64, s
 	}
 	r.frameN = int((offset - WALHeaderSize) / frameSize)
 
-	// Read previous page to load checksum.
+	// Read previous page to load checksum. Context errors are returned as-is
+	// so callers don't mistake a cancellation for a frame mismatch.
 	r.frameN--
 	if _, _, err := r.readFrame(ctx, make([]byte, r.pageSize), false); err != nil {
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
 		return nil, &PrevFrameMismatchError{Err: err}
 	}
 

--- a/wal_reader_test.go
+++ b/wal_reader_test.go
@@ -244,6 +244,24 @@ func TestWALReader(t *testing.T) {
 			t.Fatalf("unexpected error: %#v", err)
 		}
 	})
+
+	t.Run("ErrContextCanceled", func(t *testing.T) {
+		b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r, err := litestream.NewWALReader(bytes.NewReader(b), slog.Default())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, _, err := r.ReadFrame(ctx, make([]byte, 4096)); !errors.Is(err, context.Canceled) {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	})
 }
 
 func TestWALReader_FrameSaltsUntil(t *testing.T) {

--- a/wal_reader_test.go
+++ b/wal_reader_test.go
@@ -256,10 +256,30 @@ func TestWALReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 		if _, _, err := r.ReadFrame(ctx, make([]byte, 4096)); !errors.Is(err, context.Canceled) {
 			t.Fatalf("unexpected error: %#v", err)
+		}
+	})
+
+	t.Run("ErrContextCanceledWithOffset", func(t *testing.T) {
+		b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		offset := int64(litestream.WALHeaderSize + litestream.WALFrameHeaderSize + 4096)
+		_, err = litestream.NewWALReaderWithOffset(ctx, bytes.NewReader(b), offset, 0, 0, slog.Default())
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+		var pfmError *litestream.PrevFrameMismatchError
+		if errors.As(err, &pfmError) {
+			t.Fatal("context cancellation must not be reported as a prev frame mismatch")
 		}
 	})
 }


### PR DESCRIPTION
## What this changes

This is the next stacked PR after #1289. It keeps the sync executor lifecycle split from #1289 and adds the first behavior change needed for the soak failure path: background syncs no longer try to drain an arbitrarily large WAL in one executor run.

The monitor now processes WAL work in commit-bound chunks, defaulting to 64 MiB per sync executor run. A public `Sync()` call still catches up fully by looping over chunks until there is no more committed WAL to copy, so callers that explicitly request a sync keep the old catch-up behavior.

## Why this exists

The soak failures we investigated were not just one symptom. We saw disk-capacity failures on undersized GH Archive workers, but PR-1265 later exposed a separate sync timeout/OOM envelope: the worker had a multi-GB WAL, Litestream was inside compaction/snapshot/S3 upload paths, and `/sync` calls timed out while the sync executor was monopolized.

This PR addresses the smallest DB-layer part of that problem. Large WAL segments should not let the background monitor hold the executor for an unbounded amount of work. By stopping only at committed transaction boundaries, Litestream can yield between chunks without splitting an SQLite transaction or producing partial LTX state.

## Implementation notes

- Adds `DB.MaxSyncWALBytes`, defaulting to 64 MiB.
- Changes monitor syncs to call one bounded `syncOnce()` instead of public `Sync()`.
- Keeps public `Sync()` as a full catch-up operation by looping while bounded chunks report more WAL remains.
- Teaches `WALReader` to build page maps with an optional byte limit, but only stop after a committed frame.
- Defers checkpoint checks until the bounded sync either reaches the WAL end or is running unbounded.
- Checks cancellation while encoding WAL pages so long sync work can stop promptly.

## What this intentionally does not include

- Replica upload batching or S3-specific tuning.
- Sync wait fairness changes beyond the executor wait made explicit in #1289.
- Snapshot/checkpoint correctness changes from the soak reference branch.
- Harness/control-plane changes.

Those remain separate review units so this PR stays focused on bounding DB executor work.

## Validation

- `go test . -run 'TestDB_(WriteLTXFromWALHonorsCanceledContext|SyncChunksWALAtCommitBoundary)|TestWALReaderPageMapLimitStopsAtCommittedFrame' -count=1`
- `go test . -count=1`
- `go test ./... -count=1`
- `go test -race . -run 'TestDB_(WriteLTXFromWALHonorsCanceledContext|SyncChunksWALAtCommitBoundary)|TestWALReaderPageMapLimitStopsAtCommittedFrame' -count=1`
- `git diff --check origin/issue-1280-sync-executor-lifecycle...HEAD`
