### PR TITLE
fix(sync): bound replica sync waits

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1097,6 +1097,10 @@ type ReplicaSettings struct {
 	SyncInterval       *time.Duration `yaml:"sync-interval"`
 	ValidationInterval *time.Duration `yaml:"validation-interval"`
 
+	// Maximum L0 files to upload in a single monitor sync run.
+	// Set to zero to process all pending L0 files in one run.
+	MaxSyncLTXFiles *int `yaml:"max-sync-ltx-files"`
+
 	// If true, automatically reset local state when LTX errors are detected.
 	// This allows recovery from corrupted/missing LTX files by forcing a fresh sync.
 	// Disabled by default to prevent silent data loss scenarios.
@@ -1177,6 +1181,9 @@ func (rs *ReplicaSettings) SetDefaults(src *ReplicaSettings) {
 	}
 	if rs.ValidationInterval == nil && src.ValidationInterval != nil {
 		rs.ValidationInterval = src.ValidationInterval
+	}
+	if rs.MaxSyncLTXFiles == nil && src.MaxSyncLTXFiles != nil {
+		rs.MaxSyncLTXFiles = src.MaxSyncLTXFiles
 	}
 
 	// Recovery settings
@@ -1338,6 +1345,9 @@ func NewReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *litestream.Re
 	r := litestream.NewReplica(db)
 	if v := c.SyncInterval; v != nil {
 		r.SyncInterval = *v
+	}
+	if v := c.MaxSyncLTXFiles; v != nil {
+		r.MaxSyncLTXFiles = *v
 	}
 	if v := c.AutoRecover; v != nil {
 		r.AutoRecoverEnabled = *v

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -1001,6 +1001,91 @@ dbs:
 	})
 }
 
+// TestReplicaConfig_MaxSyncLTXFiles tests that max-sync-ltx-files is parsed
+// from YAML and applied to the replica.
+func TestReplicaConfig_MaxSyncLTXFiles(t *testing.T) {
+	t.Run("Specified", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/test.db
+    replica:
+      url: file:///tmp/replica
+      max-sync-ltx-files: 32
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(config.DBs) != 1 {
+			t.Fatal("expected one database")
+		}
+		if config.DBs[0].Replica == nil {
+			t.Fatal("expected replica to be set")
+		}
+		if config.DBs[0].Replica.MaxSyncLTXFiles == nil {
+			t.Fatal("expected max-sync-ltx-files to be set")
+		}
+		if *config.DBs[0].Replica.MaxSyncLTXFiles != 32 {
+			t.Errorf("expected max-sync-ltx-files of 32, got %v", *config.DBs[0].Replica.MaxSyncLTXFiles)
+		}
+
+		r, err := main.NewReplicaFromConfig(config.DBs[0].Replica, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := r.MaxSyncLTXFiles, 32; got != want {
+			t.Errorf("Replica.MaxSyncLTXFiles=%v, want %v", got, want)
+		}
+	})
+
+	t.Run("NotSpecified", func(t *testing.T) {
+		yaml := `
+dbs:
+  - path: /tmp/test.db
+    replica:
+      url: file:///tmp/replica
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if config.DBs[0].Replica.MaxSyncLTXFiles != nil {
+			t.Errorf("expected max-sync-ltx-files to be nil when not specified, got %v", *config.DBs[0].Replica.MaxSyncLTXFiles)
+		}
+
+		r, err := main.NewReplicaFromConfig(config.DBs[0].Replica, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := r.MaxSyncLTXFiles, litestream.DefaultMaxSyncLTXFiles; got != want {
+			t.Errorf("Replica.MaxSyncLTXFiles=%v, want %v", got, want)
+		}
+	})
+
+	t.Run("GlobalDefault", func(t *testing.T) {
+		yaml := `
+max-sync-ltx-files: 16
+dbs:
+  - path: /tmp/test.db
+    replica:
+      url: file:///tmp/replica
+`
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if config.DBs[0].Replica.MaxSyncLTXFiles == nil {
+			t.Fatal("expected max-sync-ltx-files to be inherited from global settings")
+		}
+		if *config.DBs[0].Replica.MaxSyncLTXFiles != 16 {
+			t.Errorf("expected max-sync-ltx-files of 16, got %v", *config.DBs[0].Replica.MaxSyncLTXFiles)
+		}
+	})
+}
+
 // TestConfig_Validate_CompactionLevels tests validation of compaction level intervals
 func TestConfig_Validate_CompactionLevels(t *testing.T) {
 	t.Run("ValidLevels", func(t *testing.T) {

--- a/db.go
+++ b/db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 	"modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -64,7 +65,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execMu    contextMutex
+	execGate  syncGate
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -185,56 +186,36 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type contextMutex struct {
+type syncGate struct {
 	once sync.Once
-	ch   chan struct{}
+	sem  *semaphore.Weighted
 }
 
-func (m *contextMutex) init() {
-	m.once.Do(func() {
-		m.ch = make(chan struct{}, 1)
+func (g *syncGate) init() {
+	g.once.Do(func() {
+		g.sem = semaphore.NewWeighted(1)
 	})
 }
 
-func (m *contextMutex) Lock() {
-	m.init()
-	m.ch <- struct{}{}
-}
-
-func (m *contextMutex) LockContext(ctx context.Context) error {
-	m.init()
-
-	select {
-	case m.ch <- struct{}{}:
-		return nil
-	case <-ctx.Done():
-		err := context.Cause(ctx)
-		if err == nil {
-			err = ctx.Err()
+func (g *syncGate) Acquire(ctx context.Context) error {
+	g.init()
+	if err := g.sem.Acquire(ctx, 1); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return cause
 		}
 		return err
 	}
+	return nil
 }
 
-func (m *contextMutex) TryLock() bool {
-	m.init()
-
-	select {
-	case m.ch <- struct{}{}:
-		return true
-	default:
-		return false
-	}
+func (g *syncGate) TryAcquire() bool {
+	g.init()
+	return g.sem.TryAcquire(1)
 }
 
-func (m *contextMutex) Unlock() {
-	m.init()
-
-	select {
-	case <-m.ch:
-	default:
-		panic("unlock of unlocked contextMutex")
-	}
+func (g *syncGate) Release() {
+	g.init()
+	g.sem.Release(1)
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -862,8 +843,10 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.execGate.Acquire(ctx); err != nil {
+		return err
+	}
+	defer db.execGate.Release()
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -1275,19 +1258,19 @@ func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, 
 	if err := db.lockExec(ctx); err != nil {
 		return syncResult{}, err
 	}
-	defer db.execMu.Unlock()
+	defer db.execGate.Release()
 
 	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
-	if db.execMu.TryLock() {
+	if db.execGate.TryAcquire() {
 		return nil
 	}
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	if err := db.execMu.LockContext(ctx); err != nil {
+	if err := db.execGate.Acquire(ctx); err != nil {
 		return fmt.Errorf("wait for db sync executor: %w", err)
 	}
 	return nil
@@ -2302,8 +2285,10 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 // Checkpoint performs a checkpoint on the WAL file.
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.lockExec(ctx); err != nil {
+		return err
+	}
+	defer db.execGate.Release()
 	db.beginSyncDiag(diagOpCheckpoint)
 	defer func() { db.finishSyncDiag(err) }()
 
@@ -2500,10 +2485,12 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	db.execMu.Lock()
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, nil, err
+	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execMu.Unlock()
+	db.execGate.Release()
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
@@ -2921,8 +2908,10 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.execGate.Acquire(ctx); err != nil {
+		return 0, ltx.Pos{}, err
+	}
+	defer db.execGate.Release()
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -465,27 +465,6 @@ func (db *DB) finishSyncDiag(err error) {
 	}
 }
 
-func (db *DB) beginSyncExecutorWait() {
-	db.syncDiag.Lock()
-	defer db.syncDiag.Unlock()
-	if db.syncDiag.executorWaiterCount == 0 {
-		db.syncDiag.executorWaitStarted = time.Now()
-	}
-	db.syncDiag.executorWaiterCount++
-}
-
-func (db *DB) finishSyncExecutorWait() {
-	db.syncDiag.Lock()
-	defer db.syncDiag.Unlock()
-	if db.syncDiag.executorWaiterCount == 0 {
-		return
-	}
-	db.syncDiag.executorWaiterCount--
-	if db.syncDiag.executorWaiterCount == 0 {
-		db.syncDiag.executorWaitStarted = time.Time{}
-	}
-}
-
 // IsOpen returns true if the database has been opened.
 func (db *DB) IsOpen() bool {
 	db.mu.RLock()
@@ -1242,8 +1221,22 @@ func (db *DB) lockExec(ctx context.Context) error {
 	if db.execSem.TryAcquire(1) {
 		return nil
 	}
-	db.beginSyncExecutorWait()
-	defer db.finishSyncExecutorWait()
+	db.syncDiag.Lock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Now()
+	}
+	db.syncDiag.executorWaiterCount++
+	db.syncDiag.Unlock()
+	defer func() {
+		db.syncDiag.Lock()
+		if db.syncDiag.executorWaiterCount > 0 {
+			db.syncDiag.executorWaiterCount--
+			if db.syncDiag.executorWaiterCount == 0 {
+				db.syncDiag.executorWaitStarted = time.Time{}
+			}
+		}
+		db.syncDiag.Unlock()
+	}()
 
 	if err := db.execSem.Acquire(ctx, 1); err != nil {
 		return fmt.Errorf("wait for db sync executor: %w", cmp.Or(context.Cause(ctx), err))

--- a/db.go
+++ b/db.go
@@ -819,8 +819,13 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	if err := db.execSem.Acquire(ctx, 1); err != nil {
-		return contextCause(ctx, err)
+	// Acquire without honoring caller cancellation: the cleanup below
+	// (read lock release, handle closes, state reset) must always run or
+	// the DB is left half-closed with its read lock held. Semaphore
+	// acquisition fails immediately on an already-done context even when
+	// the semaphore is free.
+	if err := db.execSem.Acquire(context.WithoutCancel(ctx), 1); err != nil {
+		return err
 	}
 	defer db.execSem.Release(1)
 

--- a/db.go
+++ b/db.go
@@ -2,7 +2,6 @@ package litestream
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -462,6 +461,24 @@ func (db *DB) finishSyncDiag(err error) {
 	db.syncDiag.updatedAt = time.Now()
 	if err != nil {
 		db.syncDiag.err = err.Error()
+	}
+}
+
+func (db *DB) beginSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Now()
+	}
+	db.syncDiag.executorWaiterCount++
+}
+
+func (db *DB) finishSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	db.syncDiag.executorWaiterCount--
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Time{}
 	}
 }
 
@@ -1221,25 +1238,11 @@ func (db *DB) lockExec(ctx context.Context) error {
 	if db.execSem.TryAcquire(1) {
 		return nil
 	}
-	db.syncDiag.Lock()
-	if db.syncDiag.executorWaiterCount == 0 {
-		db.syncDiag.executorWaitStarted = time.Now()
-	}
-	db.syncDiag.executorWaiterCount++
-	db.syncDiag.Unlock()
-	defer func() {
-		db.syncDiag.Lock()
-		if db.syncDiag.executorWaiterCount > 0 {
-			db.syncDiag.executorWaiterCount--
-			if db.syncDiag.executorWaiterCount == 0 {
-				db.syncDiag.executorWaitStarted = time.Time{}
-			}
-		}
-		db.syncDiag.Unlock()
-	}()
+	db.beginSyncExecutorWait()
+	defer db.finishSyncExecutorWait()
 
 	if err := db.execSem.Acquire(ctx, 1); err != nil {
-		return fmt.Errorf("wait for db sync executor: %w", cmp.Or(context.Cause(ctx), err))
+		return fmt.Errorf("wait for db sync executor: %w", context.Cause(ctx))
 	}
 	return nil
 }

--- a/db.go
+++ b/db.go
@@ -269,6 +269,8 @@ type diagState struct {
 	checkpointMode      string
 	reason              string
 	err                 string
+	executorWaiterCount int
+	executorWaitStarted time.Time
 }
 
 // SyncDiagnostic reports the latest DB sync/checkpoint activity.
@@ -287,6 +289,9 @@ type SyncDiagnostic struct {
 	CheckpointMode      string     `json:"checkpoint_mode,omitempty"`
 	Reason              string     `json:"reason,omitempty"`
 	Error               string     `json:"error,omitempty"`
+	ExecutorWaiterCount int        `json:"executor_waiter_count,omitempty"`
+	ExecutorWaitStarted *time.Time `json:"executor_wait_started_at,omitempty"`
+	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
 }
 
 // NewDB returns a new instance of DB for a given path.
@@ -386,6 +391,12 @@ func (db *DB) SyncDiagnostic() SyncDiagnostic {
 		CheckpointMode:      db.syncDiag.checkpointMode,
 		Reason:              db.syncDiag.reason,
 		Error:               db.syncDiag.err,
+		ExecutorWaiterCount: db.syncDiag.executorWaiterCount,
+	}
+	if !db.syncDiag.executorWaitStarted.IsZero() {
+		startedAt := db.syncDiag.executorWaitStarted
+		diag.ExecutorWaitStarted = &startedAt
+		diag.ExecutorWaitSeconds = time.Since(db.syncDiag.executorWaitStarted).Seconds()
 	}
 	if !db.syncDiag.startedAt.IsZero() {
 		startedAt := db.syncDiag.startedAt
@@ -448,6 +459,27 @@ func (db *DB) finishSyncDiag(err error) {
 	db.syncDiag.updatedAt = time.Now()
 	if err != nil {
 		db.syncDiag.err = err.Error()
+	}
+}
+
+func (db *DB) beginSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Now()
+	}
+	db.syncDiag.executorWaiterCount++
+}
+
+func (db *DB) finishSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		return
+	}
+	db.syncDiag.executorWaiterCount--
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Time{}
 	}
 }
 
@@ -1200,6 +1232,8 @@ func (db *DB) lockExec(ctx context.Context) error {
 	if db.execMu.TryLock() {
 		return nil
 	}
+	db.beginSyncExecutorWait()
+	defer db.finishSyncExecutorWait()
 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()

--- a/db.go
+++ b/db.go
@@ -2,6 +2,7 @@ package litestream
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -293,13 +294,6 @@ type SyncDiagnostic struct {
 	ExecutorWaiterCount int        `json:"executor_waiter_count,omitempty"`
 	ExecutorWaitStarted *time.Time `json:"executor_wait_started_at,omitempty"`
 	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
-}
-
-func contextCause(ctx context.Context, err error) error {
-	if cause := context.Cause(ctx); cause != nil {
-		return cause
-	}
-	return err
 }
 
 // NewDB returns a new instance of DB for a given path.
@@ -1252,7 +1246,7 @@ func (db *DB) lockExec(ctx context.Context) error {
 	defer db.finishSyncExecutorWait()
 
 	if err := db.execSem.Acquire(ctx, 1); err != nil {
-		return fmt.Errorf("wait for db sync executor: %w", contextCause(ctx, err))
+		return fmt.Errorf("wait for db sync executor: %w", cmp.Or(context.Cause(ctx), err))
 	}
 	return nil
 }
@@ -2889,8 +2883,8 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	if err := db.execSem.Acquire(ctx, 1); err != nil {
-		return 0, ltx.Pos{}, contextCause(ctx, err)
+	if err := db.lockExec(ctx); err != nil {
+		return 0, ltx.Pos{}, err
 	}
 	defer db.execSem.Release(1)
 

--- a/db.go
+++ b/db.go
@@ -64,7 +64,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execMu    sync.Mutex
+	execMu    contextMutex
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -183,6 +183,58 @@ type DB struct {
 
 	// Where to send log messages, defaults to global slog with database epath.
 	Logger *slog.Logger
+}
+
+type contextMutex struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+func (m *contextMutex) init() {
+	m.once.Do(func() {
+		m.ch = make(chan struct{}, 1)
+	})
+}
+
+func (m *contextMutex) Lock() {
+	m.init()
+	m.ch <- struct{}{}
+}
+
+func (m *contextMutex) LockContext(ctx context.Context) error {
+	m.init()
+
+	select {
+	case m.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		err := context.Cause(ctx)
+		if err == nil {
+			err = ctx.Err()
+		}
+		return err
+	}
+}
+
+func (m *contextMutex) TryLock() bool {
+	m.init()
+
+	select {
+	case m.ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *contextMutex) Unlock() {
+	m.init()
+
+	select {
+	case <-m.ch:
+	default:
+		panic("unlock of unlocked contextMutex")
+	}
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -1235,23 +1287,10 @@ func (db *DB) lockExec(ctx context.Context) error {
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if err == nil {
-				err = ctx.Err()
-			}
-			return fmt.Errorf("wait for db sync executor: %w", err)
-		case <-ticker.C:
-			if db.execMu.TryLock() {
-				return nil
-			}
-		}
+	if err := db.execMu.LockContext(ctx); err != nil {
+		return fmt.Errorf("wait for db sync executor: %w", err)
 	}
+	return nil
 }
 
 func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {

--- a/db.go
+++ b/db.go
@@ -65,7 +65,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execGate  syncGate
+	execSem   *semaphore.Weighted
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -186,38 +186,6 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type syncGate struct {
-	once sync.Once
-	sem  *semaphore.Weighted
-}
-
-func (g *syncGate) init() {
-	g.once.Do(func() {
-		g.sem = semaphore.NewWeighted(1)
-	})
-}
-
-func (g *syncGate) Acquire(ctx context.Context) error {
-	g.init()
-	if err := g.sem.Acquire(ctx, 1); err != nil {
-		if cause := context.Cause(ctx); cause != nil {
-			return cause
-		}
-		return err
-	}
-	return nil
-}
-
-func (g *syncGate) TryAcquire() bool {
-	g.init()
-	return g.sem.TryAcquire(1)
-}
-
-func (g *syncGate) Release() {
-	g.init()
-	g.sem.Release(1)
-}
-
 // syncState holds mutable sync-tracking fields extracted from DB.
 // These fields are threaded through sync/checkpoint methods via pointer.
 type syncState struct {
@@ -327,6 +295,13 @@ type SyncDiagnostic struct {
 	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
 }
 
+func contextCause(ctx context.Context, err error) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return err
+}
+
 // NewDB returns a new instance of DB for a given path.
 func NewDB(path string) *DB {
 	dir, file := filepath.Split(path)
@@ -334,6 +309,7 @@ func NewDB(path string) *DB {
 	db := &DB{
 		path:     path,
 		metaPath: filepath.Join(dir, "."+file+MetaDirSuffix),
+		execSem:  semaphore.NewWeighted(1),
 		notify:   make(chan struct{}),
 
 		MinCheckpointPageN:   DefaultMinCheckpointPageN,
@@ -843,10 +819,10 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return err
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return contextCause(ctx, err)
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -1258,20 +1234,20 @@ func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, 
 	if err := db.lockExec(ctx); err != nil {
 		return syncResult{}, err
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
-	if db.execGate.TryAcquire() {
+	if db.execSem.TryAcquire(1) {
 		return nil
 	}
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return fmt.Errorf("wait for db sync executor: %w", err)
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("wait for db sync executor: %w", contextCause(ctx, err))
 	}
 	return nil
 }
@@ -2288,7 +2264,7 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	if err := db.lockExec(ctx); err != nil {
 		return err
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 	db.beginSyncDiag(diagOpCheckpoint)
 	defer func() { db.finishSyncDiag(err) }()
 
@@ -2490,7 +2466,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execGate.Release()
+	db.execSem.Release(1)
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
@@ -2908,10 +2884,10 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return 0, ltx.Pos{}, err
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return 0, ltx.Pos{}, contextCause(ctx, err)
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -169,6 +169,71 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	}
 }
 
+func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		err := db.lockExec(ctx)
+		if err == nil {
+			db.execMu.Unlock()
+		}
+		done <- err
+	}()
+
+	deadline := time.After(100 * time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if db.SyncDiagnostic().ExecutorWaiterCount == 1 {
+			break
+		}
+
+		select {
+		case err := <-done:
+			t.Fatalf("lockExec returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("lockExec did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+
+	hogReady := make(chan struct{})
+	hogAcquired := make(chan struct{})
+	hogDone := make(chan struct{})
+	go func() {
+		close(hogReady)
+		db.execMu.Lock()
+		close(hogAcquired)
+		time.Sleep(150 * time.Millisecond)
+		db.execMu.Unlock()
+		close(hogDone)
+	}()
+	<-hogReady
+	time.Sleep(5 * time.Millisecond)
+
+	db.execMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lockExec returned error: %v", err)
+		}
+	case <-hogAcquired:
+		<-hogDone
+		err := <-done
+		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+	case <-ctx.Done():
+		err := <-done
+		t.Fatalf("lockExec timed out waiting behind later lock attempt: %v", err)
+	}
+}
+
 func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -186,10 +186,10 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		err := db.lockExec(ctx)
+		done <- err
 		if err == nil {
 			db.execSem.Release(1)
 		}
-		done <- err
 	}()
 
 	deadline := time.After(100 * time.Millisecond)
@@ -232,9 +232,18 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 			t.Fatalf("lockExec returned error: %v", err)
 		}
 	case <-hogAcquired:
-		<-hogDone
-		err := <-done
-		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		// The hog legitimately acquires right after the queued waiter
+		// releases, so only fail if the waiter had not already succeeded.
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("lockExec returned error: %v", err)
+			}
+		default:
+			<-hogDone
+			err := <-done
+			t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		}
 	case <-ctx.Done():
 		err := <-done
 		t.Fatalf("lockExec timed out waiting behind later lock attempt: %v", err)
@@ -283,10 +292,10 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		err := r.lockSync(ctx)
+		done <- err
 		if err == nil {
 			r.syncSem.Release(1)
 		}
-		done <- err
 	}()
 
 	time.Sleep(5 * time.Millisecond)
@@ -313,9 +322,18 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 			t.Fatalf("lockSync returned error: %v", err)
 		}
 	case <-hogAcquired:
-		<-hogDone
-		err := <-done
-		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		// The hog legitimately acquires right after the queued waiter
+		// releases, so only fail if the waiter had not already succeeded.
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("lockSync returned error: %v", err)
+			}
+		default:
+			<-hogDone
+			err := <-done
+			t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		}
 	case <-ctx.Done():
 		err := <-done
 		t.Fatalf("lockSync timed out waiting behind later lock attempt: %v", err)
@@ -386,8 +404,8 @@ func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
 	if got, want := r.Pos().TXID, dpos.TXID-1; got != want {
 		t.Fatalf("replica txid=%s, want %s", got, want)
 	}
-	if !db.LastSuccessfulSyncAt().IsZero() {
-		t.Fatal("limited replica sync should not record full sync success")
+	if db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("limited replica sync with successful uploads should record sync health")
 	}
 
 	result, err = r.syncOnce(context.Background(), 10)
@@ -3152,5 +3170,61 @@ func TestReplicaMonitor_RecoversFromPositionError(t *testing.T) {
 			t.Fatal("replication did not resume after auto-recovery")
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A canceled context may fail the final sync, but cleanup (read lock
+	// release, handle closes, state reset) must always run.
+	_ = db.Close(ctx)
+
+	db.mu.Lock()
+	opened, sqlDB, f, rtx := db.opened, db.db, db.f, db.rtx
+	db.mu.Unlock()
+
+	if opened {
+		t.Fatal("db still marked open after Close with canceled context")
+	}
+	if sqlDB != nil {
+		t.Fatal("sql handle not released after Close with canceled context")
+	}
+	if f != nil {
+		t.Fatal("file handle not released after Close with canceled context")
+	}
+	if rtx != nil {
+		t.Fatal("read lock not released after Close with canceled context")
 	}
 }

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 	_ "modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -105,16 +106,16 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
-func mustAcquireGate(g *syncGate) {
-	if err := g.Acquire(context.Background()); err != nil {
+func mustAcquireSemaphore(s *semaphore.Weighted) {
+	if err := s.Acquire(context.Background(), 1); err != nil {
 		panic(err)
 	}
 }
 
 func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
-	defer db.execGate.Release()
+	mustAcquireSemaphore(db.execSem)
+	defer db.execSem.Release(1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -130,8 +131,8 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 
 func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
-	defer db.execGate.Release()
+	mustAcquireSemaphore(db.execSem)
+	defer db.execSem.Release(1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -177,7 +178,7 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 
 func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
+	mustAcquireSemaphore(db.execSem)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -186,7 +187,7 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := db.lockExec(ctx)
 		if err == nil {
-			db.execGate.Release()
+			db.execSem.Release(1)
 		}
 		done <- err
 	}()
@@ -214,16 +215,16 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		mustAcquireGate(&db.execGate)
+		mustAcquireSemaphore(db.execSem)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		db.execGate.Release()
+		db.execSem.Release(1)
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	db.execGate.Release()
+	db.execSem.Release(1)
 
 	select {
 	case err := <-done:
@@ -244,7 +245,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
 
-	mustAcquireGate(&r.syncGate)
+	mustAcquireSemaphore(r.syncSem)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
@@ -253,7 +254,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("err=%v, want context deadline exceeded", err)
 		}
@@ -261,7 +262,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 			t.Fatalf("err=%q, want replica sync context", err)
 		}
 	case <-time.After(100 * time.Millisecond):
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		select {
 		case <-done:
 		case <-time.After(time.Second):
@@ -274,7 +275,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
-	mustAcquireGate(&r.syncGate)
+	mustAcquireSemaphore(r.syncSem)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -283,7 +284,7 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := r.lockSync(ctx)
 		if err == nil {
-			r.syncGate.Release()
+			r.syncSem.Release(1)
 		}
 		done <- err
 	}()
@@ -295,16 +296,16 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		mustAcquireGate(&r.syncGate)
+		mustAcquireSemaphore(r.syncSem)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	r.syncGate.Release()
+	r.syncSem.Release(1)
 
 	select {
 	case err := <-done:

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -105,6 +105,187 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	err := db.Sync(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v, want context deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), "wait for db sync executor") {
+		t.Fatalf("err=%q, want sync executor context", err)
+	}
+}
+
+func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- db.Sync(ctx) }()
+
+	deadline := time.After(100 * time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	var diag SyncDiagnostic
+	for {
+		diag = db.SyncDiagnostic()
+		if diag.ExecutorWaiterCount == 1 {
+			break
+		}
+
+		select {
+		case err := <-done:
+			t.Fatalf("sync returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("sync diagnostic did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+
+	if diag.ExecutorWaitStarted == nil {
+		t.Fatal("expected executor wait start time")
+	}
+	if diag.ExecutorWaitSeconds <= 0 {
+		t.Fatalf("executor_wait_seconds=%f, want positive", diag.ExecutorWaitSeconds)
+	}
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+	if got := db.SyncDiagnostic().ExecutorWaiterCount; got != 0 {
+		t.Fatalf("executor_waiter_count=%d, want 0", got)
+	}
+}
+
+func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+
+	r.syncMu.Lock()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Sync(ctx) }()
+
+	select {
+	case err := <-done:
+		r.syncMu.Unlock()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err=%v, want context deadline exceeded", err)
+		}
+		if !strings.Contains(err.Error(), "wait for replica sync") {
+			t.Fatalf("err=%q, want replica sync context", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		r.syncMu.Unlock()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("replica sync did not return after lock release")
+		}
+		t.Fatal("replica sync did not honor context while waiting for sync lock")
+	}
+}
+
+func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	client := &testReplicaClient{dir: t.TempDir()}
+	r := NewReplicaWithClient(db, client)
+	r.MonitorEnabled = false
+	db.Replica = r
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t DEFAULT VALUES;`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dpos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dpos.TXID < 2 {
+		t.Fatalf("db txid=%s, want at least 2", dpos.TXID)
+	}
+	r.SetPos(ltx.Pos{TXID: dpos.TXID - 2})
+
+	result, err := r.syncOnce(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("expected limited replica sync to upload one file")
+	}
+	if !result.limited {
+		t.Fatal("expected limited replica sync to stop before catching up")
+	}
+	if got, want := r.Pos().TXID, dpos.TXID-1; got != want {
+		t.Fatalf("replica txid=%s, want %s", got, want)
+	}
+	if !db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("limited replica sync should not record full sync success")
+	}
+
+	result, err = r.syncOnce(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("expected final replica sync to upload remaining files")
+	}
+	if result.limited {
+		t.Fatal("expected final replica sync to catch up")
+	}
+	if got, want := r.Pos().TXID, dpos.TXID; got != want {
+		t.Fatalf("replica txid=%s, want %s", got, want)
+	}
+	if db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("full replica sync should record sync success")
+	}
+}
+
 func TestDB_SyncDiagnostic(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -265,6 +265,56 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	}
 }
 
+func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+	r.syncMu.Lock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		err := r.lockSync(ctx)
+		if err == nil {
+			r.syncMu.Unlock()
+		}
+		done <- err
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	hogReady := make(chan struct{})
+	hogAcquired := make(chan struct{})
+	hogDone := make(chan struct{})
+	go func() {
+		close(hogReady)
+		r.syncMu.Lock()
+		close(hogAcquired)
+		time.Sleep(150 * time.Millisecond)
+		r.syncMu.Unlock()
+		close(hogDone)
+	}()
+	<-hogReady
+	time.Sleep(5 * time.Millisecond)
+
+	r.syncMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lockSync returned error: %v", err)
+		}
+	case <-hogAcquired:
+		<-hogDone
+		err := <-done
+		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+	case <-ctx.Done():
+		err := <-done
+		t.Fatalf("lockSync timed out waiting behind later lock attempt: %v", err)
+	}
+}
+
 func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -105,10 +105,16 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func mustAcquireGate(g *syncGate) {
+	if err := g.Acquire(context.Background()); err != nil {
+		panic(err)
+	}
+}
+
 func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	mustAcquireGate(&db.execGate)
+	defer db.execGate.Release()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -124,8 +130,8 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 
 func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	mustAcquireGate(&db.execGate)
+	defer db.execGate.Release()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -171,7 +177,7 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 
 func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
+	mustAcquireGate(&db.execGate)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -180,7 +186,7 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := db.lockExec(ctx)
 		if err == nil {
-			db.execMu.Unlock()
+			db.execGate.Release()
 		}
 		done <- err
 	}()
@@ -208,16 +214,16 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		db.execMu.Lock()
+		mustAcquireGate(&db.execGate)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		db.execMu.Unlock()
+		db.execGate.Release()
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	db.execMu.Unlock()
+	db.execGate.Release()
 
 	select {
 	case err := <-done:
@@ -238,7 +244,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
 
-	r.syncMu.Lock()
+	mustAcquireGate(&r.syncGate)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
@@ -247,7 +253,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("err=%v, want context deadline exceeded", err)
 		}
@@ -255,7 +261,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 			t.Fatalf("err=%q, want replica sync context", err)
 		}
 	case <-time.After(100 * time.Millisecond):
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		select {
 		case <-done:
 		case <-time.After(time.Second):
@@ -268,7 +274,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
-	r.syncMu.Lock()
+	mustAcquireGate(&r.syncGate)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -277,7 +283,7 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := r.lockSync(ctx)
 		if err == nil {
-			r.syncMu.Unlock()
+			r.syncGate.Release()
 		}
 		done <- err
 	}()
@@ -289,16 +295,16 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		r.syncMu.Lock()
+		mustAcquireGate(&r.syncGate)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	r.syncMu.Unlock()
+	r.syncGate.Release()
 
 	select {
 	case err := <-done:

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -117,12 +117,31 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	mustAcquireSemaphore(db.execSem)
 	defer db.execSem.Release(1)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	err := db.Sync(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("err=%v, want context deadline exceeded", err)
+	done := make(chan error, 1)
+	go func() { done <- db.Sync(ctx) }()
+
+	// Cancel only once the sync is observably queued on the executor so the
+	// error always comes from the semaphore wait, not an earlier ctx check.
+	deadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for db.SyncDiagnostic().ExecutorWaiterCount != 1 {
+		select {
+		case err := <-done:
+			t.Fatalf("sync returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("sync diagnostic did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+	cancel()
+
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
 	}
 	if !strings.Contains(err.Error(), "wait for db sync executor") {
 		t.Fatalf("err=%q, want sync executor context", err)
@@ -298,7 +317,20 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(5 * time.Millisecond)
+	// Wait until the waiter is observably queued so the hog cannot jump
+	// ahead of it in the semaphore FIFO.
+	waitDeadline := time.After(5 * time.Second)
+	waitTicker := time.NewTicker(time.Millisecond)
+	defer waitTicker.Stop()
+	for r.syncWaiters.Load() != 1 {
+		select {
+		case err := <-done:
+			t.Fatalf("lockSync returned before queueing on semaphore: %v", err)
+		case <-waitDeadline:
+			t.Fatal("lockSync did not report queued waiter")
+		case <-waitTicker.C:
+		}
+	}
 
 	hogReady := make(chan struct{})
 	hogAcquired := make(chan struct{})

--- a/replica.go
+++ b/replica.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/benbjohnson/litestream/internal"
 )
@@ -36,7 +37,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncGate syncGate
+	syncSem *semaphore.Weighted
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -67,8 +68,9 @@ type Replica struct {
 
 func NewReplica(db *DB) *Replica {
 	r := &Replica{
-		db:     db,
-		cancel: func() {},
+		db:      db,
+		syncSem: semaphore.NewWeighted(1),
+		cancel:  func() {},
 
 		SyncInterval:    DefaultSyncInterval,
 		MaxSyncLTXFiles: DefaultMaxSyncLTXFiles,
@@ -151,7 +153,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	if err := r.lockSync(ctx); err != nil {
 		return result, err
 	}
-	defer r.syncGate.Release()
+	defer r.syncSem.Release(1)
 
 	// Clear last position if if an error occurs during sync.
 	defer func() {
@@ -213,11 +215,11 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 }
 
 func (r *Replica) lockSync(ctx context.Context) error {
-	if r.syncGate.TryAcquire() {
+	if r.syncSem.TryAcquire(1) {
 		return nil
 	}
-	if err := r.syncGate.Acquire(ctx); err != nil {
-		return fmt.Errorf("wait for replica sync: %w", err)
+	if err := r.syncSem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("wait for replica sync: %w", contextCause(ctx, err))
 	}
 	return nil
 }

--- a/replica.go
+++ b/replica.go
@@ -36,7 +36,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncMu contextMutex // protects Sync() from concurrent calls
+	syncGate syncGate
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -151,7 +151,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	if err := r.lockSync(ctx); err != nil {
 		return result, err
 	}
-	defer r.syncMu.Unlock()
+	defer r.syncGate.Release()
 
 	// Clear last position if if an error occurs during sync.
 	defer func() {
@@ -213,10 +213,10 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 }
 
 func (r *Replica) lockSync(ctx context.Context) error {
-	if r.syncMu.TryLock() {
+	if r.syncGate.TryAcquire() {
 		return nil
 	}
-	if err := r.syncMu.LockContext(ctx); err != nil {
+	if err := r.syncGate.Acquire(ctx); err != nil {
 		return fmt.Errorf("wait for replica sync: %w", err)
 	}
 	return nil

--- a/replica.go
+++ b/replica.go
@@ -195,6 +195,13 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	for txID, syncedFileN := r.Pos().TXID+1, 0; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
 		if maxSyncLTXFiles > 0 && syncedFileN >= maxSyncLTXFiles {
 			result.limited = true
+			// Uploads succeeded, so record sync health; otherwise a
+			// sustained backlog reads as unhealthy while progressing.
+			r.db.RecordSuccessfulSync()
+			r.Logger().Debug("replica sync limited",
+				"synced_files", syncedFileN,
+				"db_txid", dpos.TXID.String(),
+				"replica_txid", r.Pos().TXID.String())
 			return result, nil
 		}
 		if err := ctx.Err(); err != nil {

--- a/replica.go
+++ b/replica.go
@@ -1,7 +1,6 @@
 package litestream
 
 import (
-	"cmp"
 	"context"
 	"crypto/rand"
 	"database/sql"
@@ -40,7 +39,7 @@ type Replica struct {
 	pos ltx.Pos // current replicated position
 
 	syncSem     *semaphore.Weighted
-	syncWaiters atomic.Int64 // goroutines queued on syncSem
+	syncWaiters atomic.Int64 // diagnostic instrumentation: goroutines queued on syncSem
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -231,7 +230,7 @@ func (r *Replica) lockSync(ctx context.Context) error {
 	r.syncWaiters.Add(1)
 	defer r.syncWaiters.Add(-1)
 	if err := r.syncSem.Acquire(ctx, 1); err != nil {
-		return fmt.Errorf("wait for replica sync: %w", cmp.Or(context.Cause(ctx), err))
+		return fmt.Errorf("wait for replica sync: %w", context.Cause(ctx))
 	}
 	return nil
 }

--- a/replica.go
+++ b/replica.go
@@ -21,7 +21,8 @@ import (
 
 // Default replica settings.
 const (
-	DefaultSyncInterval = 1 * time.Second
+	DefaultSyncInterval    = 1 * time.Second
+	DefaultMaxSyncLTXFiles = 256
 )
 
 var errReplicaWaitForData = errors.New("no position, waiting for data")
@@ -49,6 +50,10 @@ type Replica struct {
 	// Time between syncs with the shadow WAL.
 	SyncInterval time.Duration
 
+	// Maximum L0 files to upload in a single monitor sync run.
+	// Set to zero to process all pending L0 files in one run.
+	MaxSyncLTXFiles int
+
 	// If true, replica monitors database for changes automatically.
 	// Set to false if replica is being used synchronously (such as in tests).
 	MonitorEnabled bool
@@ -65,8 +70,9 @@ func NewReplica(db *DB) *Replica {
 		db:     db,
 		cancel: func() {},
 
-		SyncInterval:   DefaultSyncInterval,
-		MonitorEnabled: true,
+		SyncInterval:    DefaultSyncInterval,
+		MaxSyncLTXFiles: DefaultMaxSyncLTXFiles,
+		MonitorEnabled:  true,
 	}
 
 	return r
@@ -132,7 +138,19 @@ func (r *Replica) Stop(hard bool) (err error) {
 // Sync copies new WAL frames from the shadow WAL to the replica client.
 // Only one Sync can run at a time to prevent concurrent uploads of the same file.
 func (r *Replica) Sync(ctx context.Context) (err error) {
-	r.syncMu.Lock()
+	_, err = r.syncOnce(ctx, 0)
+	return err
+}
+
+type replicaSyncResult struct {
+	synced  bool
+	limited bool
+}
+
+func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result replicaSyncResult, err error) {
+	if err := r.lockSync(ctx); err != nil {
+		return result, err
+	}
 	defer r.syncMu.Unlock()
 
 	// Clear last position if if an error occurs during sync.
@@ -144,11 +162,15 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		}
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return result, context.Cause(ctx)
+	}
+
 	// Calculate current replica position, if unknown.
 	if r.Pos().IsZero() {
 		pos, err := r.calcPos(ctx)
 		if err != nil {
-			return fmt.Errorf("calc pos: %w", err)
+			return result, fmt.Errorf("calc pos: %w", err)
 		}
 		r.SetPos(pos)
 	}
@@ -156,9 +178,9 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 	// Find current position of database.
 	dpos, err := r.db.Pos()
 	if err != nil {
-		return fmt.Errorf("cannot determine current position: %w", err)
+		return result, fmt.Errorf("cannot determine current position: %w", err)
 	} else if dpos.IsZero() {
-		return errReplicaWaitForData
+		return result, errReplicaWaitForData
 	}
 
 	r.Logger().Info("replica sync",
@@ -168,17 +190,50 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		))
 
 	// Replicate all L0 LTX files since last replica position.
-	for txID := r.Pos().TXID + 1; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+	for txID, syncedFileN := r.Pos().TXID+1, 0; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+		if maxSyncLTXFiles > 0 && syncedFileN >= maxSyncLTXFiles {
+			result.limited = true
+			return result, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return result, context.Cause(ctx)
+		}
 		if err := r.uploadLTXFile(ctx, 0, txID, txID); err != nil {
-			return err
+			return result, err
 		}
 		r.SetPos(ltx.Pos{TXID: txID})
+		result.synced = true
+		syncedFileN++
 	}
 
 	// Record successful sync for heartbeat monitoring.
 	r.db.RecordSuccessfulSync()
 
-	return nil
+	return result, nil
+}
+
+func (r *Replica) lockSync(ctx context.Context) error {
+	if r.syncMu.TryLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			err := context.Cause(ctx)
+			if err == nil {
+				err = ctx.Err()
+			}
+			return fmt.Errorf("wait for replica sync: %w", err)
+		case <-ticker.C:
+			if r.syncMu.TryLock() {
+				return nil
+			}
+		}
+	}
 }
 
 func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {
@@ -373,7 +428,7 @@ func (r *Replica) monitor(ctx context.Context) {
 		notify = r.db.Notify()
 
 		// Synchronize the shadow wal into the replication directory.
-		if err := r.Sync(ctx); err != nil {
+		if _, err := r.syncOnce(ctx, r.MaxSyncLTXFiles); err != nil {
 			if errors.Is(err, errReplicaWaitForData) {
 				continue
 			}

--- a/replica.go
+++ b/replica.go
@@ -36,7 +36,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncMu sync.Mutex // protects Sync() from concurrent calls
+	syncMu contextMutex // protects Sync() from concurrent calls
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -216,24 +216,10 @@ func (r *Replica) lockSync(ctx context.Context) error {
 	if r.syncMu.TryLock() {
 		return nil
 	}
-
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if err == nil {
-				err = ctx.Err()
-			}
-			return fmt.Errorf("wait for replica sync: %w", err)
-		case <-ticker.C:
-			if r.syncMu.TryLock() {
-				return nil
-			}
-		}
+	if err := r.syncMu.LockContext(ctx); err != nil {
+		return fmt.Errorf("wait for replica sync: %w", err)
 	}
+	return nil
 }
 
 func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {

--- a/replica.go
+++ b/replica.go
@@ -1,6 +1,7 @@
 package litestream
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"database/sql"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/superfly/ltx"
@@ -37,7 +39,8 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncSem *semaphore.Weighted
+	syncSem     *semaphore.Weighted
+	syncWaiters atomic.Int64 // goroutines queued on syncSem
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -225,8 +228,10 @@ func (r *Replica) lockSync(ctx context.Context) error {
 	if r.syncSem.TryAcquire(1) {
 		return nil
 	}
+	r.syncWaiters.Add(1)
+	defer r.syncWaiters.Add(-1)
 	if err := r.syncSem.Acquire(ctx, 1); err != nil {
-		return fmt.Errorf("wait for replica sync: %w", contextCause(ctx, err))
+		return fmt.Errorf("wait for replica sync: %w", cmp.Or(context.Cause(ctx), err))
 	}
 	return nil
 }

--- a/store.go
+++ b/store.go
@@ -405,8 +405,8 @@ type SyncDBResult struct {
 // SyncDB forces an immediate sync for a database. If wait is true, blocks
 // until both WAL-to-LTX and LTX-to-remote sync complete. If wait is false,
 // only performs the WAL-to-LTX sync and lets the replica monitor handle upload.
-// The timeout is best-effort: the database's sync executor lock wait is
-// context-aware, but the replica sync lock wait is not.
+// Lock waits are context-aware: the timeout is honored while waiting for
+// the database sync executor and the replica sync lock.
 func (s *Store) SyncDB(ctx context.Context, path string, wait bool) (SyncDBResult, error) {
 	db := s.FindDB(path)
 	if db == nil {


### PR DESCRIPTION
## What this changes

This is the next stacked PR after #1290. It keeps the bounded DB executor work separate and adds the corresponding wait and upload bounds around sync coordination:

- DB sync/checkpoint/snapshot entry points now use context-aware semaphore acquisition instead of polling a mutex.
- Sync diagnostics now expose executor waiter count and wait duration so a stuck `/sync` can distinguish active work from lock contention.
- Replica sync uses the same context-aware wait behavior instead of polling a mutex.
- Replica monitor syncs now upload L0 files in bounded batches, defaulting to 256 files per monitor run.
- Public `Replica.Sync()` remains a full catch-up operation by running unbounded.

## Why this exists

The soak reference branch showed two separate envelopes. #1290 addressed unbounded DB WAL work inside a single background sync executor run. This PR handles the next queueing layer: callers waiting for DB sync/checkpoint/snapshot access and replica monitor uploads waiting on large L0 backlogs.

Without this, a worker can still look like Litestream is unresponsive even after WAL chunking because a monitor pass or concurrent caller can hold or repeatedly reacquire the sync lock while other sync requests time out. The semaphore path gives queued waiters a fairer acquisition path and lets cancellation interrupt lock waits directly.

## Implementation notes

- Uses `golang.org/x/sync/semaphore.Weighted` for DB executor and replica sync gates.
- Tracks DB executor waiters in `SyncDiagnostic` for control-plane/debug-snapshot visibility.
- Adds bounded `Replica.syncOnce()` for monitor use while preserving unbounded public `Sync()`.
- Records successful sync heartbeat only after the replica is fully caught up, not after a limited monitor batch.

## What this intentionally does not include

- Checkpoint restart/passive barrier correctness changes.
- WAL growth snapshot hardening.
- Snapshot duplicate detection or bounded snapshot WAL reads.
- S3/Tigris retry or upload tuning.
- Soak harness/control-plane changes.

Those stay separate so this PR is reviewable as synchronization and replica upload bounding only.

## Validation

- `go test . -run 'TestDB_(SyncHonorsContextWaitingForExecLock|SyncDiagnosticReportsExecutorWait|LockExecDoesNotStarveQueuedWaiter)|TestReplica_(SyncHonorsContextWaitingForSyncLock|SyncOnceLimitsLTXFiles|LockSyncDoesNotStarveQueuedWaiter)' -count=1`
- `go test . -count=1`
- `go test ./... -count=1`
- `go test -race . -run 'TestDB_(SyncHonorsContextWaitingForExecLock|SyncDiagnosticReportsExecutorWait|LockExecDoesNotStarveQueuedWaiter)|TestReplica_(SyncHonorsContextWaitingForSyncLock|SyncOnceLimitsLTXFiles|LockSyncDoesNotStarveQueuedWaiter)' -count=1`
- `git diff --check origin/issue-1280-bound-sync-executor-work...HEAD`
