### PR TITLE
fix(db): harden checkpoint snapshots

### DIFF
--- a/db.go
+++ b/db.go
@@ -1870,14 +1870,6 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 		return
 	}
 
-	db.mu.Lock()
-	db.syncState = exec.state
-	if notify && exec.synced {
-		close(db.notify)
-		db.notify = make(chan struct{})
-	}
-	db.mu.Unlock()
-
 	// Only publish the position if this executor advanced it. Republishing
 	// the snapshot taken at executor start would clobber concurrent cache
 	// invalidation (e.g. ResetLocalState) with a stale position.
@@ -1894,6 +1886,14 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 		db.maxLTXFileInfos.m[0] = &info
 		db.maxLTXFileInfos.Unlock()
 	}
+
+	db.mu.Lock()
+	db.syncState = exec.state
+	if notify && exec.synced {
+		close(db.notify)
+		db.notify = make(chan struct{})
+	}
+	db.mu.Unlock()
 }
 
 func (exec *syncExecutor) applySyncResult(result syncResult) {
@@ -2358,7 +2358,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	if other, err := readWALHeader(db.WALPath()); err != nil {
+	other, err := readWALHeader(db.WALPath())
+	if err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
 		exec.state.syncedSinceCheckpoint = false
@@ -2391,9 +2392,16 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+	snapshotInfo := syncInfo{
+		offset:       WALHeaderSize,
+		salt1:        binary.BigEndian.Uint32(other[16:]),
+		salt2:        binary.BigEndian.Uint32(other[20:]),
+		snapshotting: true,
+		reason:       "checkpoint boundary snapshot",
+	}
+	result, err = db.sync(ctx, true, exec, snapshotInfo, 0)
 	if err != nil {
-		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+		return fmt.Errorf("cannot snapshot after checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 

--- a/db.go
+++ b/db.go
@@ -1507,10 +1507,8 @@ func calcWALSize(pageSize uint32, pageN uint32) int64 {
 	return int64(WALHeaderSize) + (int64(WALFrameHeaderSize+pageSize) * int64(pageN))
 }
 
-const bumpLitestreamSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
-
 func (db *DB) bumpLitestreamSeq(ctx context.Context) error {
-	_, err := db.db.ExecContext(ctx, bumpLitestreamSeqSQL)
+	_, err := db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`)
 	return err
 }
 

--- a/db.go
+++ b/db.go
@@ -1645,6 +1645,7 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
 	info.salt1 = dec.Header().WALSalt1
 	info.salt2 = dec.Header().WALSalt2
+	info.prevCommit = dec.Header().Commit
 
 	// If LTX WAL offset is larger than real WAL then the WAL has been truncated.
 	if fi, err := os.Stat(db.WALPath()); err != nil {
@@ -1830,6 +1831,7 @@ type syncInfo struct {
 	offset              int64 // end of the previous LTX read
 	salt1               uint32
 	salt2               uint32
+	prevCommit          uint32
 	snapshotting        bool   // if true, a full snapshot is required
 	reason              string // reason for snapshot
 	clearSyncedToWALEnd bool
@@ -2108,7 +2110,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 				s.snapshotting = false
 				s.reason = info.reason
 			})
-		if err := db.writeLTXFromWAL(ctx, enc, walFile, pageMap); err != nil {
+		if err := db.writeLTXFromWAL(ctx, enc, walFile, info.prevCommit, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
@@ -2235,11 +2237,23 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 	return nil
 }
 
-func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, pageMap map[uint32]int64) error {
+func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
+	}
+	lockPgno := ltx.LockPgno(uint32(db.pageSize))
+	if commit > prevCommit {
+		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if pgno == lockPgno {
+				continue
+			}
+			if _, ok := pageMap[pgno]; ok {
+				continue
+			}
+			pgnos = append(pgnos, pgno)
+		}
 	}
 	slices.Sort(pgnos)
 
@@ -2251,18 +2265,23 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		default:
 		}
 
-		offset := pageMap[pgno]
+		if offset, ok := pageMap[pgno]; ok {
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+			} else if n != len(data) {
+				return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			}
+		} else {
+			offset := int64(pgno-1) * int64(db.pageSize)
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
 
-		// Read source page using page map.
-		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-		} else if n != len(data) {
-			return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			if _, err := db.f.ReadAt(data, offset); err != nil {
+				return fmt.Errorf("read database page %d: %w", pgno, err)
+			}
 		}
 
-		// Write page to LTX encoder.
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {
 			return fmt.Errorf("encode ltx frame (pgno=%d): %w", pgno, err)
 		}

--- a/db.go
+++ b/db.go
@@ -2020,6 +2020,17 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	if walCommit > 0 {
 		commit = walCommit
 	}
+	if !info.snapshotting {
+		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
+			info.snapshotting = true
+			info.reason = fmt.Sprintf("missing WAL growth page %d, full LTX", pgno)
+			db.Logger.Info("missing WAL growth page, writing full LTX",
+				"txid", txID.String(),
+				"pgno", pgno,
+				"prev_commit", info.prevCommit,
+				"commit", commit)
+		}
+	}
 
 	var sz int64
 	if maxOffset > 0 {
@@ -2238,48 +2249,40 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 }
 
 func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
+	checkContext := func() error {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
+			return nil
+		}
+	}
+	if err := checkContext(); err != nil {
+		return err
+	}
+	if pgno, ok := missingGrowthPage(prevCommit, commit, uint32(db.pageSize), pageMap); ok {
+		return fmt.Errorf("missing WAL growth page %d between previous commit %d and commit %d", pgno, prevCommit, commit)
+	}
+
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
 	}
-	lockPgno := ltx.LockPgno(uint32(db.pageSize))
-	if commit > prevCommit {
-		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
-			if pgno == lockPgno {
-				continue
-			}
-			if _, ok := pageMap[pgno]; ok {
-				continue
-			}
-			pgnos = append(pgnos, pgno)
-		}
-	}
 	slices.Sort(pgnos)
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		default:
+		if err := checkContext(); err != nil {
+			return err
 		}
+		offset := pageMap[pgno]
+		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		if offset, ok := pageMap[pgno]; ok {
-			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
-
-			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-			} else if n != len(data) {
-				return fmt.Errorf("short read page %d @ %d", pgno, offset)
-			}
-		} else {
-			offset := int64(pgno-1) * int64(db.pageSize)
-			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
-
-			if _, err := db.f.ReadAt(data, offset); err != nil {
-				return fmt.Errorf("read database page %d: %w", pgno, err)
-			}
+		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+		} else if n != len(data) {
+			return fmt.Errorf("short read page %d @ %d", pgno, offset)
 		}
 
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {
@@ -2287,6 +2290,23 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		}
 	}
 	return nil
+}
+
+func missingGrowthPage(prevCommit, commit, pageSize uint32, pageMap map[uint32]int64) (uint32, bool) {
+	if commit <= prevCommit {
+		return 0, false
+	}
+
+	lockPgno := ltx.LockPgno(pageSize)
+	for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+		if pgno == lockPgno {
+			continue
+		}
+		if _, ok := pageMap[pgno]; !ok {
+			return pgno, true
+		}
+	}
+	return 0, false
 }
 
 // Checkpoint performs a checkpoint on the WAL file.

--- a/db.go
+++ b/db.go
@@ -1396,18 +1396,23 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	// This prevents unbounded WAL growth from long-lived read transactions.
 	if db.exceedsTruncateThreshold(origWALSize) {
 		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
-		db.Logger.Info("forcing truncate checkpoint",
-			"wal_size", origWALSize,
-			"threshold", truncateThreshold)
 
+		// Try a PASSIVE checkpoint first: if it restarts the WAL, the
+		// blocking TRUNCATE and its mandatory boundary snapshot are skipped.
 		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
 			if !isSQLiteBusyError(err) {
 				return err
 			}
 		} else if exec.state.lastSyncedWALOffset < truncateThreshold {
+			db.Logger.Info("wal restarted by passive checkpoint, skipping truncate checkpoint",
+				"wal_size", origWALSize,
+				"threshold", truncateThreshold)
 			return nil
 		}
 
+		db.Logger.Info("forcing truncate checkpoint",
+			"wal_size", origWALSize,
+			"threshold", truncateThreshold)
 		return db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
 	}
 
@@ -2022,7 +2027,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 	if !info.snapshotting {
 		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-			db.Logger.Info("missing WAL growth page, reading from database",
+			db.Logger.Debug("missing WAL growth page, reading from database",
 				"txid", txID.String(),
 				"pgno", pgno,
 				"prev_commit", info.prevCommit,
@@ -2661,6 +2666,11 @@ func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, erro
 		walEndOffset = WALHeaderSize
 	}
 
+	// Acquire the checkpoint read lock while the executor semaphore is still
+	// held (the deferred release runs after this function returns). Every
+	// checkpoint takes chkMu under execSem, so this handoff guarantees no
+	// checkpoint can run between capturing pos and locking chkMu — the
+	// snapshot always matches the advertised position.
 	db.chkMu.RLock()
 	return &snapshotReadPosition{
 		pos:          pos,
@@ -2670,6 +2680,9 @@ func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, erro
 	}, nil
 }
 
+// snapshotWALEndOffset returns the WAL offset a snapshot may read up to for
+// the given position. db.syncState is read without db.mu because every writer
+// mutates it while holding execSem, which the caller also holds.
 func (db *DB) snapshotWALEndOffset(ctx context.Context, pos ltx.Pos) (int64, error) {
 	if db.syncState.lastSyncedWALOffset > 0 {
 		return db.syncState.lastSyncedWALOffset, nil
@@ -2793,13 +2806,8 @@ func snapshotHeaderWALRange(walEndOffset, maxOffset, frameSize int64) (offset, s
 	if maxOffset <= WALHeaderSize || frameSize <= 0 {
 		return WALHeaderSize, 0
 	}
-	offset = maxOffset - frameSize
-	if offset < WALHeaderSize {
-		offset = WALHeaderSize
-	}
-	if maxOffset > walEndOffset {
-		maxOffset = walEndOffset
-	}
+	offset = max(maxOffset-frameSize, WALHeaderSize)
+	maxOffset = min(maxOffset, walEndOffset)
 	return offset, maxOffset - offset
 }
 

--- a/db.go
+++ b/db.go
@@ -2022,9 +2022,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 	if !info.snapshotting {
 		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-			info.snapshotting = true
-			info.reason = fmt.Sprintf("missing WAL growth page %d, full LTX", pgno)
-			db.Logger.Info("missing WAL growth page, writing full LTX",
+			db.Logger.Info("missing WAL growth page, reading from database",
 				"txid", txID.String(),
 				"pgno", pgno,
 				"prev_commit", info.prevCommit,
@@ -2260,14 +2258,26 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	if err := checkContext(); err != nil {
 		return err
 	}
-	if pgno, ok := missingGrowthPage(prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-		return fmt.Errorf("missing WAL growth page %d between previous commit %d and commit %d", pgno, prevCommit, commit)
-	}
 
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
+	}
+	lockPgno := ltx.LockPgno(uint32(db.pageSize))
+	if commit > prevCommit {
+		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if err := checkContext(); err != nil {
+				return err
+			}
+			if pgno == lockPgno {
+				continue
+			}
+			if _, ok := pageMap[pgno]; ok {
+				continue
+			}
+			pgnos = append(pgnos, pgno)
+		}
 	}
 	slices.Sort(pgnos)
 
@@ -2276,13 +2286,21 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		if err := checkContext(); err != nil {
 			return err
 		}
-		offset := pageMap[pgno]
-		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+		if offset, ok := pageMap[pgno]; ok {
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-		} else if n != len(data) {
-			return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+			} else if n != len(data) {
+				return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			}
+		} else {
+			offset := int64(pgno-1) * int64(db.pageSize)
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
+
+			if _, err := db.f.ReadAt(data, offset); err != nil {
+				return fmt.Errorf("read database page %d: %w", pgno, err)
+			}
 		}
 
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {

--- a/db.go
+++ b/db.go
@@ -1502,6 +1502,13 @@ func calcWALSize(pageSize uint32, pageN uint32) int64 {
 	return int64(WALHeaderSize) + (int64(WALFrameHeaderSize+pageSize) * int64(pageN))
 }
 
+const bumpLitestreamSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
+
+func (db *DB) bumpLitestreamSeq(ctx context.Context) error {
+	_, err := db.db.ExecContext(ctx, bumpLitestreamSeqSQL)
+	return err
+}
+
 // ensureWALExists checks that the real WAL exists and has a header.
 func (db *DB) ensureWALExists(ctx context.Context) (err error) {
 	// Exit early if WAL header exists.
@@ -1510,8 +1517,7 @@ func (db *DB) ensureWALExists(ctx context.Context) (err error) {
 	}
 
 	// Otherwise create transaction that updates the internal litestream table.
-	_, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`)
-	return err
+	return db.bumpLitestreamSeq(ctx)
 }
 
 // checkDatabaseBehindReplica detects when a database has been restored to an
@@ -2326,8 +2332,6 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	defer db.chkMu.Unlock()
 
-	const checkpointSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
-
 	// Read WAL header before checkpoint to check if it has been restarted.
 	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
 		func(s *diagState) {
@@ -2399,8 +2403,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		barrierTx = nil
 	}
 
-	if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
-		return err
+	if err = db.bumpLitestreamSeq(ctx); err != nil {
+		return fmt.Errorf("bump litestream seq: %w", err)
 	}
 
 	// If WAL hasn't been restarted, exit.

--- a/db.go
+++ b/db.go
@@ -2383,8 +2383,16 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	// Try getting a checkpoint lock, will fail during snapshots.
+	// Try getting a checkpoint lock, will fail during snapshots. Skipping
+	// is safe (the next sync retries) but must be observable: a snapshot
+	// that never drains its reader would otherwise disable checkpoints
+	// silently and the WAL would grow without explanation.
 	if !db.chkMu.TryLock() {
+		level := slog.LevelDebug
+		if mode == CheckpointModeTruncate {
+			level = slog.LevelInfo
+		}
+		db.Logger.Log(ctx, level, "checkpoint skipped, snapshot in progress", "mode", mode)
 		return nil
 	}
 	defer db.chkMu.Unlock()
@@ -2488,7 +2496,13 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		return nil
 	}
 
-	if checkpointRow[1] <= preCheckpointFrameN {
+	// A successful TRUNCATE checkpoint always reports zero frames because
+	// the WAL is reset before the counters are read, so the comparison
+	// below can never prove that no commits landed between the sealed
+	// sync and the checkpoint taking the writer lock. Those commits are
+	// backfilled and truncated unseen, so TRUNCATE must take the boundary
+	// snapshot unconditionally.
+	if mode != CheckpointModeTruncate && checkpointRow[1] <= preCheckpointFrameN {
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
 			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
@@ -2812,18 +2826,13 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 }
 
 // Snapshot writes a snapshot to the replica for the current database position.
+// It always writes, even when a snapshot already exists at the current
+// position, so operators can force a re-upload (replicate -force-snapshot).
+// Callers that want to skip duplicates check first, as Store.CompactDB does.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
-	}
-	if info, ok, err := db.existingSnapshotInfo(ctx, pos.pos.TXID); err != nil {
-		pos.close()
-		return nil, err
-	} else if ok {
-		pos.close()
-		db.Logger.Debug("snapshot already exists", "txid", pos.pos.TXID.String(), "snapshot", info.MaxTXID.String())
-		return info, nil
 	}
 
 	r, err := db.snapshotReader(ctx, pos)
@@ -2845,17 +2854,6 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	db.maxLTXFileInfos.Unlock()
 
 	return info, nil
-}
-
-func (db *DB) existingSnapshotInfo(ctx context.Context, txID ltx.TXID) (*ltx.FileInfo, bool, error) {
-	info, err := db.MaxLTXFileInfo(ctx, SnapshotLevel)
-	if err != nil {
-		return nil, false, err
-	}
-	if info.MaxTXID == 0 || info.MaxTXID < txID {
-		return nil, false, nil
-	}
-	return &info, true, nil
 }
 
 // EnforceSnapshotRetention enforces retention of the snapshot level in the database by timestamp.

--- a/db.go
+++ b/db.go
@@ -1395,9 +1395,19 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	// Priority 1: Emergency truncate checkpoint (TRUNCATE mode, blocking)
 	// This prevents unbounded WAL growth from long-lived read transactions.
 	if db.exceedsTruncateThreshold(origWALSize) {
+		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
-			"threshold", calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)))
+			"threshold", truncateThreshold)
+
+		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+			if !isSQLiteBusyError(err) {
+				return err
+			}
+		} else if exec.state.lastSyncedWALOffset < truncateThreshold {
+			return nil
+		}
+
 		return db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
 	}
 
@@ -2316,6 +2326,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	defer db.chkMu.Unlock()
 
+	const checkpointSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
+
 	// Read WAL header before checkpoint to check if it has been restarted.
 	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
 		func(s *diagState) {
@@ -2339,6 +2351,35 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	exec.applySyncResult(result)
 
+	var barrierTx *sql.Tx
+	if mode == CheckpointModePassive {
+		barrierTx, err = db.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin passive checkpoint barrier: %w", err)
+		}
+		defer func() {
+			if barrierTx != nil {
+				_ = rollback(barrierTx)
+			}
+		}()
+
+		if _, err := barrierTx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+			return fmt.Errorf("_litestream_lock: %w", err)
+		}
+
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+		if err != nil {
+			return fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
+	}
+
+	frameSize := int64(db.pageSize + WALFrameHeaderSize)
+	preCheckpointFrameN := 0
+	if exec.state.lastSyncedWALOffset > WALHeaderSize {
+		preCheckpointFrameN = int((exec.state.lastSyncedWALOffset - WALHeaderSize) / frameSize)
+	}
+
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
 	db.setSyncDiagPhase(diagPhaseCheckpointExec,
@@ -2346,9 +2387,21 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	if err := db.execCheckpoint(ctx, mode); err != nil {
+	checkpointRow, err := db.execCheckpoint(ctx, mode)
+	if err != nil {
 		return err
-	} else if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
+	}
+
+	if barrierTx != nil {
+		if _, err = barrierTx.ExecContext(ctx, checkpointSeqSQL); err != nil {
+			return err
+		} else if _, err = barrierTx.ExecContext(ctx, `DELETE FROM _litestream_lock`); err != nil {
+			return err
+		} else if err = barrierTx.Commit(); err != nil {
+			return err
+		}
+		barrierTx = nil
+	} else if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
 		return err
 	}
 
@@ -2362,6 +2415,26 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	if err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
+		exec.state.syncedSinceCheckpoint = false
+		return nil
+	}
+
+	if mode == CheckpointModePassive {
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+		if err != nil {
+			return fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
+		exec.state.syncedSinceCheckpoint = false
+		return nil
+	}
+
+	if checkpointRow[1] <= preCheckpointFrameN {
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+		if err != nil {
+			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
 		exec.state.syncedSinceCheckpoint = false
 		return nil
 	}
@@ -2416,10 +2489,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	return nil
 }
 
-func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
+func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err error) {
 	// Ignore if there is no underlying database.
 	if db.db == nil {
-		return nil
+		return row, nil
 	}
 
 	// Track checkpoint metrics.
@@ -2436,7 +2509,7 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// Ensure the read lock has been removed before issuing a checkpoint.
 	// We defer the re-acquire to ensure it occurs even on an early return.
 	if err := db.releaseReadLock(); err != nil {
-		return fmt.Errorf("release read lock: %w", err)
+		return row, fmt.Errorf("release read lock: %w", err)
 	}
 	defer func() { _ = db.acquireReadLock(ctx) }()
 
@@ -2448,18 +2521,17 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// See: https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
 	rawsql := `PRAGMA wal_checkpoint(` + mode + `);`
 
-	var row [3]int
 	if err := db.db.QueryRowContext(ctx, rawsql).Scan(&row[0], &row[1], &row[2]); err != nil {
-		return err
+		return row, err
 	}
 	db.Logger.Debug("checkpoint", "mode", mode, "result", fmt.Sprintf("%d,%d,%d", row[0], row[1], row[2]))
 
 	// Reacquire the read lock immediately after the checkpoint.
 	if err := db.acquireReadLock(ctx); err != nil {
-		return fmt.Errorf("reacquire read lock: %w", err)
+		return row, fmt.Errorf("reacquire read lock: %w", err)
 	}
 
-	return nil
+	return row, nil
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.

--- a/db.go
+++ b/db.go
@@ -2393,15 +2393,13 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	if barrierTx != nil {
-		if _, err = barrierTx.ExecContext(ctx, checkpointSeqSQL); err != nil {
-			return err
-		} else if _, err = barrierTx.ExecContext(ctx, `DELETE FROM _litestream_lock`); err != nil {
-			return err
-		} else if err = barrierTx.Commit(); err != nil {
-			return err
+		if err = rollback(barrierTx); err != nil {
+			return fmt.Errorf("rollback passive checkpoint barrier: %w", err)
 		}
 		barrierTx = nil
-	} else if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
+	}
+
+	if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
 		return err
 	}
 

--- a/db.go
+++ b/db.go
@@ -2595,21 +2595,36 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	if err := db.lockExec(ctx); err != nil {
-		return ltx.Pos{}, nil, err
+	pos, pageSize, err := db.snapshotPosition(ctx)
+	if err != nil {
+		return pos, nil, err
 	}
+
+	r, err := db.snapshotReader(ctx, pos, pageSize)
+	return pos, r, err
+}
+
+func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, 0, err
+	}
+	defer db.execSem.Release(1)
+
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execSem.Release(1)
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
-		return ltx.Pos{}, nil, &DBNotReadyError{Reason: "page size not initialized"}
+		return ltx.Pos{}, 0, &DBNotReadyError{Reason: "page size not initialized"}
 	}
 	if err != nil {
-		return pos, nil, fmt.Errorf("pos: %w", err)
+		return pos, pageSize, fmt.Errorf("pos: %w", err)
 	}
 
+	return pos, pageSize, nil
+}
+
+func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io.Reader, error) {
 	db.Logger.Debug("snapshot", "txid", pos.TXID.String())
 
 	// Prevent internal checkpoints during sync.
@@ -2620,7 +2635,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 
 	fi, err := db.f.Stat()
 	if err != nil {
-		return pos, nil, err
+		return nil, err
 	}
 	commit := uint32(fi.Size() / int64(pageSize))
 
@@ -2697,7 +2712,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 		_ = pw.Close()
 	}()
 
-	return pos, pr, nil
+	return pr, nil
 }
 
 // Compact performs a compaction of the LTX file at the previous level into dstLevel.
@@ -2722,12 +2737,24 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 	return info, nil
 }
 
-// SnapshotDB writes a snapshot to the replica for the current position of the database.
+// Snapshot writes a snapshot to the replica for the current database position.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, r, err := db.SnapshotReader(ctx)
+	pos, pageSize, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
 	}
+	if info, ok, err := db.existingSnapshotInfo(ctx, pos.TXID); err != nil {
+		return nil, err
+	} else if ok {
+		db.Logger.Debug("snapshot already exists", "txid", pos.TXID.String(), "snapshot", info.MaxTXID.String())
+		return info, nil
+	}
+
+	r, err := db.snapshotReader(ctx, pos, pageSize)
+	if err != nil {
+		return nil, err
+	}
+
 	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
 	if err != nil {
 		return info, err
@@ -2738,6 +2765,17 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	db.maxLTXFileInfos.Unlock()
 
 	return info, nil
+}
+
+func (db *DB) existingSnapshotInfo(ctx context.Context, txID ltx.TXID) (*ltx.FileInfo, bool, error) {
+	info, err := db.MaxLTXFileInfo(ctx, SnapshotLevel)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.MaxTXID == 0 || info.MaxTXID < txID {
+		return nil, false, nil
+	}
+	return &info, true, nil
 }
 
 // EnforceSnapshotRetention enforces retention of the snapshot level in the database by timestamp.

--- a/db.go
+++ b/db.go
@@ -2593,20 +2593,38 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 	return row, nil
 }
 
-// SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
-func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	pos, pageSize, err := db.snapshotPosition(ctx)
-	if err != nil {
-		return pos, nil, err
-	}
-
-	r, err := db.snapshotReader(ctx, pos, pageSize)
-	return pos, r, err
+type snapshotReadPosition struct {
+	pos          ltx.Pos
+	pageSize     int
+	walEndOffset int64
+	db           *DB
 }
 
-func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
+func (p *snapshotReadPosition) close() {
+	if p.db != nil {
+		p.db.chkMu.RUnlock()
+		p.db = nil
+	}
+}
+
+// SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
+func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
+	pos, err := db.snapshotPosition(ctx)
+	if err != nil {
+		return ltx.Pos{}, nil, err
+	}
+
+	r, err := db.snapshotReader(ctx, pos)
+	if err != nil {
+		pos.close()
+		return pos.pos, nil, err
+	}
+	return pos.pos, r, nil
+}
+
+func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, error) {
 	if err := db.lockExec(ctx); err != nil {
-		return ltx.Pos{}, 0, err
+		return nil, err
 	}
 	defer db.execSem.Release(1)
 
@@ -2615,21 +2633,53 @@ func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
-		return ltx.Pos{}, 0, &DBNotReadyError{Reason: "page size not initialized"}
+		return nil, &DBNotReadyError{Reason: "page size not initialized"}
 	}
 	if err != nil {
-		return pos, pageSize, fmt.Errorf("pos: %w", err)
+		return nil, fmt.Errorf("pos: %w", err)
 	}
 
-	return pos, pageSize, nil
+	walEndOffset, err := db.snapshotWALEndOffset(ctx, pos)
+	if err != nil {
+		return nil, err
+	}
+	if walEndOffset < WALHeaderSize {
+		walEndOffset = WALHeaderSize
+	}
+
+	db.chkMu.RLock()
+	return &snapshotReadPosition{
+		pos:          pos,
+		pageSize:     pageSize,
+		walEndOffset: walEndOffset,
+		db:           db,
+	}, nil
 }
 
-func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io.Reader, error) {
-	db.Logger.Debug("snapshot", "txid", pos.TXID.String())
+func (db *DB) snapshotWALEndOffset(ctx context.Context, pos ltx.Pos) (int64, error) {
+	if db.syncState.lastSyncedWALOffset > 0 {
+		return db.syncState.lastSyncedWALOffset, nil
+	}
+	if pos.TXID == 0 {
+		return WALHeaderSize, nil
+	}
 
-	// Prevent internal checkpoints during sync.
-	db.chkMu.RLock()
-	defer db.chkMu.RUnlock()
+	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	f, err := os.Open(ltxPath)
+	if err != nil {
+		return 0, NewLTXError("open", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), err)
+	}
+	defer func() { _ = f.Close() }()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.DecodeHeader(); err != nil {
+		return 0, NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+	}
+	return dec.Header().WALOffset + dec.Header().WALSize, nil
+}
+
+func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io.Reader, error) {
+	db.Logger.Debug("snapshot", "txid", pos.pos.TXID.String(), "walEndOffset", pos.walEndOffset)
 
 	// TODO(ltx): Read database size from database header.
 
@@ -2637,11 +2687,13 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 	if err != nil {
 		return nil, err
 	}
-	commit := uint32(fi.Size() / int64(pageSize))
+	commit := uint32(fi.Size() / int64(pos.pageSize))
 
 	// Execute encoding in a separate goroutine so the caller can initialize before reading.
 	pr, pw := io.Pipe()
 	go func() {
+		defer pos.close()
+
 		walFile, err := os.Open(db.WALPath())
 		if err != nil {
 			pw.CloseWithError(err)
@@ -2656,25 +2708,33 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 		}
 
 		// Build a mapping of changed page numbers and their latest content.
-		pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("page map: %w", err))
-			return
+		maxBytes := pos.walEndOffset - WALHeaderSize
+		pageMap := make(map[uint32]int64)
+		var maxOffset int64
+		var walCommit uint32
+		if maxBytes > 0 {
+			pageMap, maxOffset, walCommit, _, err = rd.pageMap(ctx, maxBytes)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("page map: %w", err))
+				return
+			}
 		}
 		if walCommit > 0 {
 			commit = walCommit
 		}
 
-		var sz int64
-		if maxOffset > 0 {
-			sz = maxOffset - rd.Offset()
+		walOffset, walSize := snapshotHeaderWALRange(pos.walEndOffset, maxOffset, int64(WALFrameHeaderSize+pos.pageSize))
+		if maxOffset > pos.walEndOffset {
+			pw.CloseWithError(fmt.Errorf("snapshot wal read exceeded bound: max offset %d > end offset %d", maxOffset, pos.walEndOffset))
+			return
 		}
 
 		db.Logger.Debug("encode snapshot header",
-			"txid", pos.TXID.String(),
+			"txid", pos.pos.TXID.String(),
 			"commit", commit,
-			"walOffset", rd.Offset(),
-			"walSize", sz,
+			"walOffset", walOffset,
+			"walSize", walSize,
+			"walEndOffset", pos.walEndOffset,
 			"salt1", rd.salt1,
 			"salt2", rd.salt2)
 
@@ -2686,13 +2746,13 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 		if err := enc.EncodeHeader(ltx.Header{
 			Version:   ltx.Version,
 			Flags:     ltx.HeaderFlagNoChecksum,
-			PageSize:  uint32(pageSize),
+			PageSize:  uint32(pos.pageSize),
 			Commit:    commit,
 			MinTXID:   1,
-			MaxTXID:   pos.TXID,
+			MaxTXID:   pos.pos.TXID,
 			Timestamp: time.Now().UnixMilli(),
-			WALOffset: rd.Offset(),
-			WALSize:   sz,
+			WALOffset: walOffset,
+			WALSize:   walSize,
 			WALSalt1:  rd.salt1,
 			WALSalt2:  rd.salt2,
 		}); err != nil {
@@ -2713,6 +2773,20 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 	}()
 
 	return pr, nil
+}
+
+func snapshotHeaderWALRange(walEndOffset, maxOffset, frameSize int64) (offset, size int64) {
+	if maxOffset <= WALHeaderSize || frameSize <= 0 {
+		return WALHeaderSize, 0
+	}
+	offset = maxOffset - frameSize
+	if offset < WALHeaderSize {
+		offset = WALHeaderSize
+	}
+	if maxOffset > walEndOffset {
+		maxOffset = walEndOffset
+	}
+	return offset, maxOffset - offset
 }
 
 // Compact performs a compaction of the LTX file at the previous level into dstLevel.
@@ -2739,24 +2813,30 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 
 // Snapshot writes a snapshot to the replica for the current database position.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, pageSize, err := db.snapshotPosition(ctx)
+	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if info, ok, err := db.existingSnapshotInfo(ctx, pos.TXID); err != nil {
+	if info, ok, err := db.existingSnapshotInfo(ctx, pos.pos.TXID); err != nil {
+		pos.close()
 		return nil, err
 	} else if ok {
-		db.Logger.Debug("snapshot already exists", "txid", pos.TXID.String(), "snapshot", info.MaxTXID.String())
+		pos.close()
+		db.Logger.Debug("snapshot already exists", "txid", pos.pos.TXID.String(), "snapshot", info.MaxTXID.String())
 		return info, nil
 	}
 
-	r, err := db.snapshotReader(ctx, pos, pageSize)
+	r, err := db.snapshotReader(ctx, pos)
 	if err != nil {
+		pos.close()
 		return nil, err
 	}
 
-	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
+	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.pos.TXID, r)
 	if err != nil {
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
 		return info, err
 	}
 

--- a/db.go
+++ b/db.go
@@ -1381,7 +1381,9 @@ func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool,
 // checkpointIfNeeded performs a checkpoint based on configured thresholds.
 // Checks thresholds in priority order: TruncatePageN → MinCheckpointPageN → CheckpointInterval.
 //
-// TruncatePageN uses TRUNCATE mode (blocking), others use PASSIVE mode (non-blocking).
+// TruncatePageN uses TRUNCATE mode (blocking). Others use PASSIVE mode, which
+// briefly holds the write lock to seal the WAL and can be skipped when the
+// database is busy.
 //
 // Time-based checkpoints only trigger if exec.state.syncedSinceCheckpoint is true, indicating
 // that data has been synced since the last checkpoint. This prevents creating unnecessary
@@ -1397,13 +1399,15 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	if db.exceedsTruncateThreshold(origWALSize) {
 		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
 
-		// Try a PASSIVE checkpoint first: if it restarts the WAL, the
-		// blocking TRUNCATE and its mandatory boundary snapshot are skipped.
-		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+		// Try a PASSIVE checkpoint first: if it restarts the WAL and brings
+		// the synced offset below the threshold, the blocking TRUNCATE and
+		// its mandatory boundary snapshot are skipped.
+		if restarted, err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
 			if !isSQLiteBusyError(err) {
 				return err
 			}
-		} else if exec.state.lastSyncedWALOffset < truncateThreshold {
+			db.Logger.Log(ctx, internal.LevelTrace, "passive checkpoint skipped", "reason", "database busy")
+		} else if restarted && !db.exceedsTruncateThreshold(exec.state.lastSyncedWALOffset) {
 			db.Logger.Info("wal restarted by passive checkpoint, skipping truncate checkpoint",
 				"wal_size", origWALSize,
 				"threshold", truncateThreshold)
@@ -1413,12 +1417,13 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
 			"threshold", truncateThreshold)
-		return db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
+		_, err := db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
+		return err
 	}
 
-	// Priority 2: Regular checkpoint at min threshold (PASSIVE mode, non-blocking)
+	// Priority 2: Regular checkpoint at min threshold (PASSIVE mode)
 	if newWALSize >= calcWALSize(uint32(db.pageSize), uint32(db.MinCheckpointPageN)) {
-		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+		if _, err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
 			// PASSIVE checkpoints can fail with SQLITE_BUSY when database is locked.
 			// This is expected behavior and not an error - just log and continue.
 			if isSQLiteBusyError(err) {
@@ -1430,7 +1435,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 		return nil
 	}
 
-	// Priority 3: Time-based checkpoint (PASSIVE mode, non-blocking)
+	// Priority 3: Time-based checkpoint (PASSIVE mode)
 	// Only trigger if there have been actual changes synced since the last
 	// checkpoint. This prevents creating unnecessary LTX files when the only
 	// WAL data is from internal bookkeeping (like _litestream_seq updates).
@@ -1443,7 +1448,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 
 		// Only checkpoint if enough time has passed and WAL has data
 		if time.Since(fi.ModTime()) > db.CheckpointInterval && newWALSize > calcWALSize(uint32(db.pageSize), 1) {
-			if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+			if _, err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
 				// PASSIVE checkpoints can fail with SQLITE_BUSY when database is locked.
 				// This is expected behavior and not an error - just log and continue.
 				if isSQLiteBusyError(err) {
@@ -2023,16 +2028,6 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	if walCommit > 0 {
 		commit = walCommit
 	}
-	if !info.snapshotting {
-		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-			db.Logger.Debug("missing WAL growth page, reading from database",
-				"txid", txID.String(),
-				"pgno", pgno,
-				"prev_commit", info.prevCommit,
-				"commit", commit)
-		}
-	}
-
 	var sz int64
 	if maxOffset > 0 {
 		sz = maxOffset - info.offset
@@ -2250,12 +2245,6 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 }
 
 func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
-	select {
-	case <-ctx.Done():
-		return context.Cause(ctx)
-	default:
-	}
-
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
@@ -2263,12 +2252,8 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	}
 	lockPgno := ltx.LockPgno(uint32(db.pageSize))
 	if commit > prevCommit {
+		walPgnoN := len(pgnos)
 		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
-			select {
-			case <-ctx.Done():
-				return context.Cause(ctx)
-			default:
-			}
 			if pgno == lockPgno {
 				continue
 			}
@@ -2276,6 +2261,13 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 				continue
 			}
 			pgnos = append(pgnos, pgno)
+		}
+		if growthPgnoN := len(pgnos) - walPgnoN; growthPgnoN > 0 {
+			db.Logger.Debug("filling wal growth pages from database",
+				"txid", enc.Header().MinTXID,
+				"n", growthPgnoN,
+				"prev_commit", prevCommit,
+				"commit", commit)
 		}
 	}
 	slices.Sort(pgnos)
@@ -2311,23 +2303,6 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	return nil
 }
 
-func missingGrowthPage(prevCommit, commit, pageSize uint32, pageMap map[uint32]int64) (uint32, bool) {
-	if commit <= prevCommit {
-		return 0, false
-	}
-
-	lockPgno := ltx.LockPgno(pageSize)
-	for pgno := prevCommit + 1; pgno <= commit; pgno++ {
-		if pgno == lockPgno {
-			continue
-		}
-		if _, ok := pageMap[pgno]; !ok {
-			return pgno, true
-		}
-	}
-	return 0, false
-}
-
 // Checkpoint performs a checkpoint on the WAL file.
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	if err := db.lockExec(ctx); err != nil {
@@ -2345,7 +2320,8 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	}
 	defer db.applySyncExecutor(exec, true)
 
-	return db.checkpointWithExecutor(ctx, mode, exec)
+	_, err = db.checkpointWithExecutor(ctx, mode, exec)
+	return err
 }
 
 // checkpoint performs a checkpoint on the WAL file and initializes a
@@ -2360,7 +2336,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 		state: *state,
 		pos:   pos,
 	}
-	if err := db.checkpointWithExecutor(ctx, mode, exec); err != nil {
+	if _, err := db.checkpointWithExecutor(ctx, mode, exec); err != nil {
 		return err
 	}
 
@@ -2378,23 +2354,24 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 	return nil
 }
 
-func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syncExecutor) error {
+// checkpointWithExecutor performs a checkpoint in the given mode and reports
+// whether the checkpoint restarted the WAL. It returns false without
+// checkpointing when the checkpoint lock is held by an in-progress snapshot.
+func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syncExecutor) (walRestarted bool, err error) {
 	db.setSyncDiagPhase(diagPhaseCheckpointLock,
 		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	// Try getting a checkpoint lock, will fail during snapshots. Skipping
-	// is safe (the next sync retries) but must be observable: a snapshot
-	// that never drains its reader would otherwise disable checkpoints
-	// silently and the WAL would grow without explanation.
+	// Try getting a checkpoint lock, will fail during snapshots. Skipping is
+	// safe since the next sync retries.
 	if !db.chkMu.TryLock() {
-		level := slog.LevelDebug
 		if mode == CheckpointModeTruncate {
-			level = slog.LevelInfo
+			db.Logger.Info("checkpoint skipped, snapshot in progress", "mode", mode)
+		} else {
+			db.Logger.Log(ctx, internal.LevelTrace, "checkpoint skipped, snapshot in progress", "mode", mode)
 		}
-		db.Logger.Log(ctx, level, "checkpoint skipped, snapshot in progress", "mode", mode)
-		return nil
+		return false, nil
 	}
 	defer db.chkMu.Unlock()
 
@@ -2406,7 +2383,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	hdr, err := readWALHeader(db.WALPath())
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Copy end of WAL before checkpoint to copy as much as possible.
@@ -2417,7 +2394,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
-		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
+		return false, fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 
@@ -2425,7 +2402,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	if mode == CheckpointModePassive {
 		barrierTx, err = db.db.BeginTx(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("begin passive checkpoint barrier: %w", err)
+			return false, fmt.Errorf("begin passive checkpoint barrier: %w", err)
 		}
 		defer func() {
 			if barrierTx != nil {
@@ -2434,12 +2411,12 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		}()
 
 		if _, err := barrierTx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
-			return fmt.Errorf("_litestream_lock: %w", err)
+			return false, fmt.Errorf("_litestream_lock: %w", err)
 		}
 
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
-			return fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
+			return false, fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
 		}
 		exec.applySyncResult(result)
 	}
@@ -2457,20 +2434,20 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	checkpointRow, err := db.execCheckpoint(ctx, mode)
+	walFrameN, err := db.execCheckpoint(ctx, mode)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if barrierTx != nil {
 		if err = rollback(barrierTx); err != nil {
-			return fmt.Errorf("rollback passive checkpoint barrier: %w", err)
+			return false, fmt.Errorf("rollback passive checkpoint barrier: %w", err)
 		}
 		barrierTx = nil
 	}
 
 	if err = db.bumpLitestreamSeq(ctx); err != nil {
-		return fmt.Errorf("bump litestream seq: %w", err)
+		return false, fmt.Errorf("bump litestream seq: %w", err)
 	}
 
 	// If WAL hasn't been restarted, exit.
@@ -2481,20 +2458,20 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	other, err := readWALHeader(db.WALPath())
 	if err != nil {
-		return err
+		return false, err
 	} else if bytes.Equal(hdr, other) {
 		exec.state.syncedSinceCheckpoint = false
-		return nil
+		return false, nil
 	}
 
 	if mode == CheckpointModePassive {
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
-			return fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
+			return false, fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
 		}
 		exec.applySyncResult(result)
 		exec.state.syncedSinceCheckpoint = false
-		return nil
+		return true, nil
 	}
 
 	// A successful TRUNCATE checkpoint always reports zero frames because
@@ -2503,14 +2480,14 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// sync and the checkpoint taking the writer lock. Those commits are
 	// backfilled and truncated unseen, so TRUNCATE must take the boundary
 	// snapshot unconditionally.
-	if mode != CheckpointModeTruncate && checkpointRow[1] <= preCheckpointFrameN {
+	if mode != CheckpointModeTruncate && walFrameN <= preCheckpointFrameN {
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
-			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+			return false, fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 		}
 		exec.applySyncResult(result)
 		exec.state.syncedSinceCheckpoint = false
-		return nil
+		return true, nil
 	}
 
 	// Start a transaction. This will be promoted immediately after.
@@ -2521,7 +2498,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	tx, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin: %w", err)
+		return false, fmt.Errorf("begin: %w", err)
 	}
 	defer func() { _ = rollback(tx) }()
 
@@ -2530,7 +2507,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// however, it will ensure our tx grabs the write lock. Unfortunately,
 	// we can't call "BEGIN IMMEDIATE" as we are already in a transaction.
 	if _, err := tx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
-		return fmt.Errorf("_litestream_lock: %w", err)
+		return false, fmt.Errorf("_litestream_lock: %w", err)
 	}
 
 	// Copy anything that may have occurred after the checkpoint.
@@ -2548,7 +2525,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	result, err = db.sync(ctx, true, exec, snapshotInfo, 0)
 	if err != nil {
-		return fmt.Errorf("cannot snapshot after checkpoint: %w", err)
+		return false, fmt.Errorf("cannot snapshot after checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 
@@ -2556,17 +2533,19 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// Use rollback() helper for consistency with releaseReadLock() and the
 	// defer above. See issue #934.
 	if err := rollback(tx); err != nil {
-		return fmt.Errorf("rollback post-checkpoint tx: %w", err)
+		return false, fmt.Errorf("rollback post-checkpoint tx: %w", err)
 	}
 
 	exec.state.syncedSinceCheckpoint = false
-	return nil
+	return true, nil
 }
 
-func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err error) {
+// execCheckpoint issues a wal_checkpoint PRAGMA in the given mode and returns
+// the number of frames in the WAL as reported by the checkpoint.
+func (db *DB) execCheckpoint(ctx context.Context, mode string) (walFrameN int, err error) {
 	// Ignore if there is no underlying database.
 	if db.db == nil {
-		return row, nil
+		return 0, nil
 	}
 
 	// Track checkpoint metrics.
@@ -2583,7 +2562,7 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 	// Ensure the read lock has been removed before issuing a checkpoint.
 	// We defer the re-acquire to ensure it occurs even on an early return.
 	if err := db.releaseReadLock(); err != nil {
-		return row, fmt.Errorf("release read lock: %w", err)
+		return 0, fmt.Errorf("release read lock: %w", err)
 	}
 	defer func() { _ = db.acquireReadLock(ctx) }()
 
@@ -2595,17 +2574,18 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 	// See: https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
 	rawsql := `PRAGMA wal_checkpoint(` + mode + `);`
 
+	var row [3]int
 	if err := db.db.QueryRowContext(ctx, rawsql).Scan(&row[0], &row[1], &row[2]); err != nil {
-		return row, err
+		return 0, err
 	}
 	db.Logger.Debug("checkpoint", "mode", mode, "result", fmt.Sprintf("%d,%d,%d", row[0], row[1], row[2]))
 
 	// Reacquire the read lock immediately after the checkpoint.
 	if err := db.acquireReadLock(ctx); err != nil {
-		return row, fmt.Errorf("reacquire read lock: %w", err)
+		return 0, fmt.Errorf("reacquire read lock: %w", err)
 	}
 
-	return row, nil
+	return row[1], nil
 }
 
 type snapshotReadPosition struct {
@@ -2623,6 +2603,9 @@ func (p *snapshotReadPosition) close() {
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
+// Internal checkpoints are disabled until the reader is fully drained or
+// closed (it implements io.Closer). An abandoned reader blocks checkpoints
+// for the life of the process.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
@@ -2654,7 +2637,7 @@ func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, erro
 		return nil, fmt.Errorf("pos: %w", err)
 	}
 
-	walEndOffset, err := db.snapshotWALEndOffset(ctx, pos)
+	walEndOffset, err := db.snapshotWALEndOffset(pos)
 	if err != nil {
 		return nil, err
 	}
@@ -2679,7 +2662,7 @@ func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, erro
 // snapshotWALEndOffset returns the WAL offset a snapshot may read up to for
 // the given position. db.syncState is read without db.mu because every writer
 // mutates it while holding execSem, which the caller also holds.
-func (db *DB) snapshotWALEndOffset(ctx context.Context, pos ltx.Pos) (int64, error) {
+func (db *DB) snapshotWALEndOffset(pos ltx.Pos) (int64, error) {
 	if db.syncState.lastSyncedWALOffset > 0 {
 		return db.syncState.lastSyncedWALOffset, nil
 	}
@@ -2698,6 +2681,22 @@ func (db *DB) snapshotWALEndOffset(ctx context.Context, pos ltx.Pos) (int64, err
 	if err := dec.DecodeHeader(); err != nil {
 		return 0, NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
 	}
+
+	// Compare WAL headers. If the WAL was restarted since this LTX file was
+	// written, its salts no longer match and its recorded extent does not
+	// apply to the current WAL.
+	hdr, err := readWALHeader(db.WALPath())
+	if os.IsNotExist(err) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return WALHeaderSize, nil
+	} else if err != nil {
+		return 0, fmt.Errorf("cannot read wal header: %w", err)
+	}
+	salt1 := binary.BigEndian.Uint32(hdr[16:])
+	salt2 := binary.BigEndian.Uint32(hdr[20:])
+	if salt1 != dec.Header().WALSalt1 || salt2 != dec.Header().WALSalt2 {
+		return WALHeaderSize, nil
+	}
+
 	return dec.Header().WALOffset + dec.Header().WALSize, nil
 }
 
@@ -2746,11 +2745,11 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 			commit = walCommit
 		}
 
-		walOffset, walSize := snapshotHeaderWALRange(pos.walEndOffset, maxOffset, int64(WALFrameHeaderSize+pos.pageSize))
 		if maxOffset > pos.walEndOffset {
 			pw.CloseWithError(fmt.Errorf("snapshot wal read exceeded bound: max offset %d > end offset %d", maxOffset, pos.walEndOffset))
 			return
 		}
+		walOffset, walSize := snapshotHeaderWALRange(maxOffset, int64(WALFrameHeaderSize+pos.pageSize))
 
 		db.Logger.Debug("encode snapshot header",
 			"txid", pos.pos.TXID.String(),
@@ -2798,12 +2797,11 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 	return pr, nil
 }
 
-func snapshotHeaderWALRange(walEndOffset, maxOffset, frameSize int64) (offset, size int64) {
+func snapshotHeaderWALRange(maxOffset, frameSize int64) (offset, size int64) {
 	if maxOffset <= WALHeaderSize || frameSize <= 0 {
 		return WALHeaderSize, 0
 	}
 	offset = max(maxOffset-frameSize, WALHeaderSize)
-	maxOffset = min(maxOffset, walEndOffset)
 	return offset, maxOffset - offset
 }
 
@@ -2834,18 +2832,12 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 // position, so operators can force a re-upload (replicate -force-snapshot).
 // Callers that want to skip duplicates check first, as Store.CompactDB does.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, err := db.snapshotPosition(ctx)
+	pos, r, err := db.SnapshotReader(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := db.snapshotReader(ctx, pos)
-	if err != nil {
-		pos.close()
-		return nil, err
-	}
-
-	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.pos.TXID, r)
+	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
 	if err != nil {
 		if closer, ok := r.(io.Closer); ok {
 			_ = closer.Close()
@@ -3152,7 +3144,7 @@ func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
 	defer db.applySyncExecutor(exec, true)
 
 	// Force a RESTART checkpoint to ensure the database is at the start of the WAL.
-	if err := db.checkpointWithExecutor(ctx, CheckpointModeRestart, exec); err != nil {
+	if _, err := db.checkpointWithExecutor(ctx, CheckpointModeRestart, exec); err != nil {
 		return 0, ltx.Pos{}, err
 	}
 

--- a/db.go
+++ b/db.go
@@ -2250,16 +2250,10 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 }
 
 func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
-	checkContext := func() error {
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		default:
-			return nil
-		}
-	}
-	if err := checkContext(); err != nil {
-		return err
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	default:
 	}
 
 	// Create an ordered list of page numbers since the LTX encoder requires it.
@@ -2270,8 +2264,10 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	lockPgno := ltx.LockPgno(uint32(db.pageSize))
 	if commit > prevCommit {
 		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
-			if err := checkContext(); err != nil {
-				return err
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			default:
 			}
 			if pgno == lockPgno {
 				continue
@@ -2286,8 +2282,10 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
-		if err := checkContext(); err != nil {
-			return err
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
 		}
 		if offset, ok := pageMap[pgno]; ok {
 			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -1109,7 +1109,7 @@ func TestDB_Checkpoint_ErrorMetrics(t *testing.T) {
 
 	db.db.Close()
 
-	if err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
+	if _, err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
 		t.Fatal("expected error from checkpoint with closed db")
 	}
 
@@ -2387,47 +2387,13 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 	// Verify a snapshot L0 was created during checkpoint.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
 	newL0Count := 0
-	newCoverageCount := 0
 	for _, entry := range l0AfterEntries {
 		if !l0BeforeNames[entry.Name()] {
 			newL0Count++
-
-			f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			dec := ltx.NewDecoder(f)
-			if err := dec.DecodeHeader(); err != nil {
-				_ = f.Close()
-				t.Fatal(err)
-			}
-			hdr := dec.Header()
-			buf := make([]byte, hdr.PageSize)
-			pageCount := 0
-			for {
-				var pageHdr ltx.PageHeader
-				if err := dec.DecodePage(&pageHdr, buf); err == io.EOF {
-					break
-				} else if err != nil {
-					_ = f.Close()
-					t.Fatal(err)
-				}
-				pageCount++
-			}
-			if pageCount > 1 {
-				newCoverageCount++
-			}
-			if err := f.Close(); err != nil {
-				t.Fatal(err)
-			}
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
-	}
-	if newCoverageCount == 0 {
-		t.Fatal("expected checkpoint to create an L0 file with more than one page")
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -674,11 +674,6 @@ func TestDB_SyncTruncateCheckpointFiresDuringChunkedCatchUp(t *testing.T) {
 		}
 	}
 
-	before, err := os.Stat(db.WALPath())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// A single bounded chunk leaves pending WAL frames, but the truncate
 	// threshold has been exceeded so the checkpoint must fire anyway.
 	result, err := db.syncOnce(t.Context(), db.MaxSyncWALBytes)
@@ -688,12 +683,159 @@ func TestDB_SyncTruncateCheckpointFiresDuringChunkedCatchUp(t *testing.T) {
 		t.Fatal("expected sync to stop at WAL byte limit")
 	}
 
-	after, err := os.Stat(db.WALPath())
+	db.mu.RLock()
+	syncedOffsetAfter := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+	if db.exceedsTruncateThreshold(syncedOffsetAfter) {
+		t.Fatalf("expected checkpoint during catch-up to restart the wal: offset=%d", syncedOffsetAfter)
+	}
+}
+
+func TestDB_CheckpointPassiveRestartSkipsTruncate(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if after.Size() >= before.Size() {
-		t.Fatalf("expected truncate checkpoint to shrink WAL during catch-up: before=%d after=%d", before.Size(), after.Size())
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB);`); err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	lastSyncedWALOffset := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+
+	db.TruncatePageN = 2
+	if !db.exceedsTruncateThreshold(lastSyncedWALOffset) {
+		t.Fatalf("precondition: synced WAL offset %d must exceed the truncate threshold", lastSyncedWALOffset)
+	}
+
+	passiveBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive))
+	truncateBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate))
+
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got == 0 {
+		t.Fatal("expected a passive checkpoint attempt before truncate")
+	}
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 0 {
+		t.Fatalf("truncate checkpoints=%v, want 0 after passive restarted the wal", got)
+	}
+
+	db.mu.RLock()
+	restartedOffset := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+	if db.exceedsTruncateThreshold(restartedOffset) {
+		t.Fatalf("expected passive checkpoint to restart the wal: offset=%d", restartedOffset)
+	}
+}
+
+func TestDB_CheckpointTruncateFallsThroughWhenPassiveCannotRestart(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.BusyTimeout = 50 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB);`); err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold a read transaction so neither checkpoint mode can restart the WAL.
+	tx, err := sqldb.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var n int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	lastSyncedWALOffset := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+
+	db.TruncatePageN = 2
+	if !db.exceedsTruncateThreshold(lastSyncedWALOffset) {
+		t.Fatalf("precondition: synced WAL offset %d must exceed the truncate threshold", lastSyncedWALOffset)
+	}
+
+	truncateBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate))
+
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got == 0 {
+		t.Fatal("expected fall-through to a truncate checkpoint attempt when passive cannot restart the wal")
+	}
+
+	db.mu.RLock()
+	blockedOffset := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+	if !db.exceedsTruncateThreshold(blockedOffset) {
+		t.Fatalf("expected wal to remain unrestarted while reader is open: offset=%d", blockedOffset)
 	}
 }
 
@@ -2260,7 +2402,7 @@ func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+	if err := db.writeLTXFromWAL(t.Context(), enc, walFile, 2, 5, pageMap); err != nil {
 		t.Fatal(err)
 	}
 	if err := enc.Close(); err != nil {

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2200,7 +2200,7 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 	}
 }
 
-func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
+func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 	walPath := filepath.Join(dir, "db-wal")
@@ -2260,12 +2260,88 @@ func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	err = db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap)
-	if err == nil {
-		t.Fatal("expected missing growth page error")
+	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "missing WAL growth page 4") {
-		t.Fatalf("unexpected error: %v", err)
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pgnos []uint32
+	got := make(map[uint32][]byte)
+	pageBuf := make([]byte, pageSize)
+	for {
+		var phdr ltx.PageHeader
+		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		pgnos = append(pgnos, phdr.Pgno)
+		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
+	}
+
+	wantPgnos := []uint32{3, 4, 5}
+	if len(pgnos) != len(wantPgnos) {
+		t.Fatalf("page numbers mismatch: got=%v want=%v", pgnos, wantPgnos)
+	}
+	for i := range wantPgnos {
+		if pgnos[i] != wantPgnos[i] {
+			t.Fatalf("page numbers mismatch: got=%v want=%v", pgnos, wantPgnos)
+		}
+	}
+	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
+		t.Fatal("expected page 3 to come from WAL")
+	}
+	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
+		t.Fatal("expected page 4 to come from database")
+	}
+	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
+		t.Fatal("expected page 5 to come from WAL")
+	}
+
+	snapshot := new(bytes.Buffer)
+	snapshotEnc, err := ltx.NewEncoder(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotEnc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, pgno := range []uint32{1, 2} {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := snapshotEnc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := new(bytes.Buffer)
+	c, err := ltx.NewCompactor(compacted, []io.Reader{
+		bytes.NewReader(snapshot.Bytes()),
+		bytes.NewReader(buf.Bytes()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	if err := c.Compact(context.Background()); err != nil {
+		t.Fatalf("compaction failed: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2387,13 +2387,47 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 	// Verify a snapshot L0 was created during checkpoint.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
 	newL0Count := 0
+	newCoverageCount := 0
 	for _, entry := range l0AfterEntries {
 		if !l0BeforeNames[entry.Name()] {
 			newL0Count++
+
+			f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			dec := ltx.NewDecoder(f)
+			if err := dec.DecodeHeader(); err != nil {
+				_ = f.Close()
+				t.Fatal(err)
+			}
+			hdr := dec.Header()
+			buf := make([]byte, hdr.PageSize)
+			pageCount := 0
+			for {
+				var pageHdr ltx.PageHeader
+				if err := dec.DecodePage(&pageHdr, buf); err == io.EOF {
+					break
+				} else if err != nil {
+					_ = f.Close()
+					t.Fatal(err)
+				}
+				pageCount++
+			}
+			if pageCount > 1 {
+				newCoverageCount++
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
+	}
+	if newCoverageCount == 0 {
+		t.Fatal("expected checkpoint to create an L0 file with more than one page")
 	}
 }
 
@@ -2520,10 +2554,18 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	case err := <-writerDone:
 		t.Fatalf("writer exited before starting: %v", err)
 	}
-	if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
-		cancelWriter()
-		<-writerDone
-		t.Fatal(err)
+	checkpointDeadline := time.Now().Add(5 * time.Second)
+	for {
+		err := db.Checkpoint(ctx, CheckpointModeTruncate)
+		if err == nil {
+			break
+		}
+		if !isSQLiteBusyError(err) || time.Now().After(checkpointDeadline) {
+			cancelWriter()
+			<-writerDone
+			t.Fatal(err)
+		}
+		time.Sleep(time.Millisecond)
 	}
 	cancelWriter()
 	if err := <-writerDone; err != nil {
@@ -2642,6 +2684,55 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	}
 
 	t.Logf("all %d pages present across L0 files (commit=%d)", len(allPages), maxCommit)
+
+	replicaDir := t.TempDir()
+	replicaL0Dir := filepath.Join(replicaDir, "l0")
+	if err := os.Mkdir(replicaL0Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l0Entries, err := os.ReadDir(db.LTXLevelDir(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range l0Entries {
+		srcPath := filepath.Join(db.LTXLevelDir(0), entry.Name())
+		dstPath := filepath.Join(replicaL0Dir, entry.Name())
+
+		src, err := os.Open(srcPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			_ = src.Close()
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			_ = src.Close()
+			_ = dst.Close()
+			t.Fatal(err)
+		}
+		if err := src.Close(); err != nil {
+			_ = dst.Close()
+			t.Fatal(err)
+		}
+		if err := dst.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	restorePath := filepath.Join(dir, "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreReplica := NewReplica(restoreDB)
+	restoreReplica.Client = &testReplicaClient{dir: replicaDir}
+
+	restoreOpt := NewRestoreOptions()
+	restoreOpt.OutputPath = restorePath
+	restoreOpt.IntegrityCheck = IntegrityCheckFull
+
+	if err := restoreReplica.Restore(ctx, restoreOpt); err != nil {
+		t.Fatalf("restore from local ltx chain: %v", err)
+	}
 }
 
 // TestDB_Sync_InitErrorMetrics verifies that sync error counter is incremented

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2529,16 +2529,53 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify a snapshot L0 was created during checkpoint.
+	// Verify a snapshot L0 was created during checkpoint. A TRUNCATE
+	// checkpoint reports zero frame counts, so it cannot prove that no
+	// commits landed between the pre-checkpoint sync and the checkpoint;
+	// it must take the boundary snapshot unconditionally. An incremental
+	// (non-snapshot) L0 here would silently drop those commits.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
-	newL0Count := 0
+	newL0Count, newSnapshotCount := 0, 0
 	for _, entry := range l0AfterEntries {
-		if !l0BeforeNames[entry.Name()] {
-			newL0Count++
+		if l0BeforeNames[entry.Name()] {
+			continue
+		}
+		newL0Count++
+
+		f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		dec := ltx.NewDecoder(f)
+		if err := dec.DecodeHeader(); err != nil {
+			f.Close()
+			t.Fatalf("decode header %s: %v", entry.Name(), err)
+		}
+		hdr := dec.Header()
+		pageCount := 0
+		pageData := make([]byte, hdr.PageSize)
+		for {
+			var phdr ltx.PageHeader
+			if err := dec.DecodePage(&phdr, pageData); err == io.EOF {
+				break
+			} else if err != nil {
+				f.Close()
+				t.Fatalf("decode page %s: %v", entry.Name(), err)
+			}
+			pageCount++
+		}
+		f.Close()
+
+		// A boundary snapshot contains every page up to the commit.
+		if uint32(pageCount) == hdr.Commit {
+			newSnapshotCount++
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
+	}
+	if newSnapshotCount == 0 {
+		t.Fatal("expected TRUNCATE checkpoint to create a boundary snapshot L0")
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2201,7 +2200,7 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 	}
 }
 
-func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
+func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 	walPath := filepath.Join(dir, "db-wal")
@@ -2261,82 +2260,12 @@ func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
-		t.Fatal(err)
+	err = db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap)
+	if err == nil {
+		t.Fatal("expected missing growth page error")
 	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
-	if err := dec.DecodeHeader(); err != nil {
-		t.Fatal(err)
-	}
-
-	var pgnos []uint32
-	got := make(map[uint32][]byte)
-	pageBuf := make([]byte, pageSize)
-	for {
-		var phdr ltx.PageHeader
-		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
-			break
-		} else if err != nil {
-			t.Fatal(err)
-		}
-		pgnos = append(pgnos, phdr.Pgno)
-		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
-	}
-
-	if !reflect.DeepEqual([]uint32{3, 4, 5}, pgnos) {
-		t.Fatalf("page numbers mismatch: got=%v", pgnos)
-	}
-	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
-		t.Fatal("expected page 3 to come from WAL")
-	}
-	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
-		t.Fatal("expected page 4 to come from database")
-	}
-	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
-		t.Fatal("expected page 5 to come from WAL")
-	}
-
-	snapshot := new(bytes.Buffer)
-	snapshotEnc, err := ltx.NewEncoder(snapshot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := snapshotEnc.EncodeHeader(ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    2,
-		MinTXID:   1,
-		MaxTXID:   1,
-		Timestamp: time.Now().UnixMilli(),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	for _, pgno := range []uint32{1, 2} {
-		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
-		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := snapshotEnc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	compacted := new(bytes.Buffer)
-	c, err := ltx.NewCompactor(compacted, []io.Reader{
-		bytes.NewReader(snapshot.Bytes()),
-		bytes.NewReader(buf.Bytes()),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.HeaderFlags = ltx.HeaderFlagNoChecksum
-	if err := c.Compact(context.Background()); err != nil {
-		t.Fatalf("compaction failed: %v", err)
+	if !strings.Contains(err.Error(), "missing WAL growth page 4") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -546,7 +547,7 @@ func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err = db.writeLTXFromWAL(ctx, enc, walFile, map[uint32]int64{1: 0})
+	err = db.writeLTXFromWAL(ctx, enc, walFile, 0, 1, map[uint32]int64{1: 0})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v, want context canceled", err)
 	}
@@ -2197,6 +2198,145 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 		last := missing[len(missing)-1]
 		t.Errorf("pages missing from incremental LTX: %d total (first=%d, last=%d, prevCommit=%d, newCommit=%d)",
 			len(missing), first, last, prevCommit, newCommit)
+	}
+}
+
+func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	walPath := filepath.Join(dir, "db-wal")
+
+	const pageSize = 1024
+
+	dbFile, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbFile.Close()
+
+	for pgno := 1; pgno <= 5; pgno++ {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if _, err := dbFile.WriteAt(page, int64(pgno-1)*pageSize); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	walFile, err := os.OpenFile(walPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer walFile.Close()
+
+	frameSize := int64(WALFrameHeaderSize + pageSize)
+	pageMap := map[uint32]int64{
+		3: 0,
+		5: frameSize,
+	}
+	for _, pgno := range []uint32{3, 5} {
+		offset := pageMap[pgno] + WALFrameHeaderSize
+		page := bytes.Repeat([]byte{byte(pgno + 10)}, pageSize)
+		if _, err := walFile.WriteAt(page, offset); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	db := NewDB(dbPath)
+	db.pageSize = pageSize
+	db.f = dbFile
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    5,
+		MinTXID:   2,
+		MaxTXID:   2,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pgnos []uint32
+	got := make(map[uint32][]byte)
+	pageBuf := make([]byte, pageSize)
+	for {
+		var phdr ltx.PageHeader
+		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		pgnos = append(pgnos, phdr.Pgno)
+		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
+	}
+
+	if !reflect.DeepEqual([]uint32{3, 4, 5}, pgnos) {
+		t.Fatalf("page numbers mismatch: got=%v", pgnos)
+	}
+	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
+		t.Fatal("expected page 3 to come from WAL")
+	}
+	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
+		t.Fatal("expected page 4 to come from database")
+	}
+	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
+		t.Fatal("expected page 5 to come from WAL")
+	}
+
+	snapshot := new(bytes.Buffer)
+	snapshotEnc, err := ltx.NewEncoder(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotEnc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, pgno := range []uint32{1, 2} {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := snapshotEnc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := new(bytes.Buffer)
+	c, err := ltx.NewCompactor(compacted, []io.Reader{
+		bytes.NewReader(snapshot.Bytes()),
+		bytes.NewReader(buf.Bytes()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	if err := c.Compact(context.Background()); err != nil {
+		t.Fatalf("compaction failed: %v", err)
 	}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/crc64"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,27 @@ import (
 	"github.com/benbjohnson/litestream/internal/testingutil"
 	"github.com/benbjohnson/litestream/mock"
 )
+
+type snapshotCountingClient struct {
+	litestream.ReplicaClient
+	mu sync.Mutex
+	n  int
+}
+
+func (c *snapshotCountingClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if level == litestream.SnapshotLevel {
+		c.mu.Lock()
+		c.n++
+		c.mu.Unlock()
+	}
+	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+func (c *snapshotCountingClient) writeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
 
 func TestDB_Path(t *testing.T) {
 	db := testingutil.NewDB(t, "/tmp/db")
@@ -547,6 +569,42 @@ func TestDB_Snapshot(t *testing.T) {
 		t.Fatal(err)
 	} else if got, want := h.Sum64(), chksum0; got != want {
 		t.Fatal("snapshot checksum mismatch")
+	}
+}
+
+func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	client := &snapshotCountingClient{ReplicaClient: db.Replica.Client}
+	db.Replica.Client = client
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+		t.Fatal(err)
+	} else if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+		t.Fatal(err)
+	} else if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	info0, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	info1, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := ltx.FormatFilename(info1.MinTXID, info1.MaxTXID), ltx.FormatFilename(info0.MinTXID, info0.MaxTXID); got != want {
+		t.Fatalf("Filename=%s, want %s", got, want)
+	}
+	if got, want := client.writeCount(), 1; got != want {
+		t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
 	}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -633,7 +633,7 @@ func TestDB_SnapshotExcludesUnsyncedWALFrames(t *testing.T) {
 	}
 }
 
-func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
+func TestDB_SnapshotAlwaysWrites(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)
 
@@ -652,6 +652,9 @@ func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Snapshot is a primitive that always writes, even at the same
+	// position, so -force-snapshot can re-upload a suspect snapshot.
+	// Duplicate skipping belongs to callers like Store.CompactDB.
 	info0, err := db.Snapshot(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -664,7 +667,7 @@ func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 	if got, want := ltx.FormatFilename(info1.MinTXID, info1.MaxTXID), ltx.FormatFilename(info0.MinTXID, info0.MaxTXID); got != want {
 		t.Fatalf("Filename=%s, want %s", got, want)
 	}
-	if got, want := client.writeCount(), 1; got != want {
+	if got, want := client.writeCount(), 2; got != want {
 		t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
 	}
 }

--- a/db_test.go
+++ b/db_test.go
@@ -572,6 +572,67 @@ func TestDB_Snapshot(t *testing.T) {
 	}
 }
 
+func TestDB_SnapshotExcludesUnsyncedWALFrames(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (1);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (2);`); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.MaxTXID != pos.TXID {
+		t.Fatalf("snapshot txid=%s, want %s", info.MaxTXID, pos.TXID)
+	}
+
+	rc, err := db.Replica.Client.OpenLTXFile(t.Context(), litestream.SnapshotLevel, 1, pos.TXID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	restorePath := filepath.Join(t.TempDir(), "snapshot.db")
+	f, err := os.Create(restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ltx.NewDecoder(rc).DecodeDatabaseTo(f); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := testingutil.MustOpenSQLDB(t, restorePath)
+	defer testingutil.MustCloseSQLDB(t, restored)
+
+	var count int
+	if err := restored.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM t;`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("restored row count=%d, want 1", count)
+	}
+}
+
 func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)

--- a/store.go
+++ b/store.go
@@ -762,6 +762,14 @@ func (s *Store) CompactDB(ctx context.Context, db *DB, lvl *CompactionLevel) (*l
 
 	// Shortcut if this is a snapshot since we are not pulling from a previous level.
 	if dstLevel == SnapshotLevel {
+		pos, err := db.Pos()
+		if err != nil {
+			return nil, fmt.Errorf("fetch db position: %w", err)
+		}
+		if dstInfo.MaxTXID != 0 && dstInfo.MaxTXID >= pos.TXID {
+			return nil, ErrNoCompaction
+		}
+
 		info, err := db.Snapshot(ctx)
 		if err != nil {
 			return info, err

--- a/store_test.go
+++ b/store_test.go
@@ -102,6 +102,43 @@ func TestStore_CompactDB(t *testing.T) {
 		}
 	})
 
+	t.Run("SnapshotNoProgress", func(t *testing.T) {
+		db0, sqldb0 := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db0, sqldb0)
+
+		client := &snapshotCountingClient{ReplicaClient: db0.Replica.Client}
+		db0.Replica.Client = client
+
+		s := litestream.NewStore([]*litestream.DB{db0}, litestream.CompactionLevels{{Level: 0}})
+		s.SnapshotInterval = time.Nanosecond
+		s.CompactionMonitorEnabled = false
+		if err := s.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close(t.Context())
+
+		if _, err := sqldb0.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrNoCompaction) {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got, want := client.writeCount(), 1; got != want {
+			t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
+		}
+	})
+
 	// Regression test for GitHub issue #877: level 9 compaction fails with
 	// "page size not initialized yet" error when attempted before DB initialization.
 	t.Run("DBNotReady", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This is the next stacked PR after #1291. It focuses on checkpoint/snapshot correctness after the sync wait/upload bounding work is in place.

The soak failures that led to #1265 exposed two separate classes of problems:

- sync work could wait too long or starve under high load, handled by the preceding wait-bounding PRs;
- checkpoint and snapshot boundaries could still produce bad or unnecessarily large LTX output when WAL state changed around a checkpoint.

This PR handles the second class. It keeps the scope inside the DB/checkpoint/snapshot path so Ben can review the correctness changes separately from the concurrency bounding changes.

## What Changed

- Snapshot across checkpoint restarts so a WAL salt reset cannot leave restore without the correct post-checkpoint boundary state.
- Reduce unnecessary checkpoint-boundary snapshots by checking checkpoint frame counts and falling back to a normal catch-up sync when possible.
- Roll back the passive checkpoint barrier instead of committing it, so the barrier does not become another persisted write.
- Reuse the Litestream sequence bump helper for checkpoint bookkeeping writes.
- Handle WAL growth gaps explicitly, including missing growth pages and gaps that should not require a full LTX.
- Skip duplicate snapshot uploads when the target snapshot already exists.
- Bound snapshot WAL reads so snapshot construction does not consume an unbounded moving WAL tail.

## Why

The long-running soak runs showed that once the sync executor was stabilized, correctness still depended on clean behavior at checkpoint boundaries. The key risk is that SQLite can restart or advance the WAL while Litestream is preparing LTX output. Without these guards, Litestream can either miss required page state, generate an oversized full LTX unnecessarily, or repeatedly upload equivalent snapshot data.

This PR makes those transitions explicit and tested.

## Non-Scope

- Replica upload wait bounding is in #1291.
- Sync executor lifecycle and diagnostics are in the earlier stacked PRs.
- S3/Tigris retry and upload tuning are intentionally left out for a later, smaller PR if still needed.
- Soak harness/control-plane changes are not included here.

## Validation

- `go test . -run 'Checkpoint|Snapshot|Growth|WAL' -count=1`
- `go test . -count=1`
- `go test ./... -count=1`
- `go test -race . -run 'Checkpoint|Snapshot|Growth' -count=1`
- `git diff --check origin/issue-1280-bound-replica-sync-work...HEAD`

