### PR TITLE
fix(vfs): malformed database from stale reads during sustained sync writes

### DIFF
--- a/cmd/litestream-vfs/vfs_write_integration_test.go
+++ b/cmd/litestream-vfs/vfs_write_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -126,6 +127,115 @@ func TestVFS_ReadYourWrites(t *testing.T) {
 	err = sqldb.QueryRow("SELECT name FROM users WHERE id = 2").Scan(&name)
 	require.NoError(t, err)
 	require.Equal(t, "Robert", name)
+}
+
+func TestVFS_WideRepeatedInsertsDuringSync_Private(t *testing.T) {
+	// No primary key or secondary index is required. This shape failed 20/20
+	// local runs before the VFS page-visibility fix; 80 batches was race-dependent.
+	runWideRepeatedInsertsDuringSyncPrivate(t, wideRepeatedInsertsConfig{
+		payloadColumnCount: 6,
+		indexCount:         0,
+		batchCount:         90,
+		rowsPerBatch:       1427,
+	})
+}
+
+type wideRepeatedInsertsConfig struct {
+	payloadColumnCount int
+	indexCount         int
+	batchCount         int
+	rowsPerBatch       int
+}
+
+func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInsertsConfig) {
+	t.Helper()
+
+	replicaDir := t.TempDir()
+	client := file.NewReplicaClient(replicaDir)
+
+	vfs := newWritableVFS(t, client, 100*time.Millisecond, t.TempDir())
+	vfsName := fmt.Sprintf("litestream-wide-private-inserts-%d", time.Now().UnixNano())
+	require.NoError(t, sqlite3vfs.RegisterVFS(vfsName, vfs))
+
+	dbPath := filepath.Join(t.TempDir(), "wide-inserts.db")
+	dsn := fmt.Sprintf("file:%s?vfs=%s&cache=private", dbPath, vfsName)
+
+	db, err := sql.Open("sqlite3", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	columns := []string{"id", "revision", "shard", "marker"}
+	var ddl strings.Builder
+	ddl.WriteString(`CREATE TABLE wide_syncing_rows (
+		id INTEGER NOT NULL,
+		revision INTEGER NOT NULL,
+		shard INTEGER NOT NULL,
+		marker INTEGER NOT NULL`)
+	for i := 0; i < cfg.payloadColumnCount; i++ {
+		name := fmt.Sprintf("payload_%c", 'a'+rune(i))
+		columns = append(columns, name)
+		ddl.WriteString(",\n\t\t")
+		ddl.WriteString(name)
+		ddl.WriteString(" TEXT NOT NULL")
+	}
+	ddl.WriteString("\n\t) STRICT;")
+
+	indexes := []struct {
+		sql             string
+		payloadRequired int
+	}{
+		{sql: "CREATE INDEX i_wide_syncing_rows_revision ON wide_syncing_rows (revision, id);"},
+		{sql: "CREATE INDEX i_wide_syncing_rows_shard_marker ON wide_syncing_rows (shard, marker, id);"},
+		{sql: "CREATE INDEX i_wide_syncing_rows_payload_a ON wide_syncing_rows (payload_a);", payloadRequired: 1},
+		{sql: "CREATE INDEX i_wide_syncing_rows_payload_e ON wide_syncing_rows (payload_e);", payloadRequired: 5},
+	}
+	for i := 0; i < cfg.indexCount && i < len(indexes); i++ {
+		if cfg.payloadColumnCount < indexes[i].payloadRequired {
+			continue
+		}
+		ddl.WriteByte('\n')
+		ddl.WriteString(indexes[i].sql)
+	}
+
+	_, err = db.Exec(ddl.String())
+	require.NoError(t, err)
+
+	placeholders := make([]string, len(columns))
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+	insertSQL := fmt.Sprintf(
+		"INSERT INTO wide_syncing_rows (%s) VALUES (%s)",
+		strings.Join(columns, ", "),
+		strings.Join(placeholders, ", "),
+	)
+	payloadMods := []int{101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151}
+
+	for batch := 0; batch < cfg.batchCount; batch++ {
+		start := 1 + batch*250
+		end := start + cfg.rowsPerBatch - 1
+		offset := batch * 1000000
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		stmt, err := tx.Prepare(insertSQL)
+		require.NoError(t, err)
+		for id := start; id <= end; id++ {
+			args := []any{id, id + offset, id % 17, id % 97}
+			for i := 0; i < cfg.payloadColumnCount; i++ {
+				mod := payloadMods[i%len(payloadMods)]
+				args = append(args, fmt.Sprintf("%d-%c-%d", id+offset, 'a'+rune(i), id%mod))
+			}
+			_, err = stmt.Exec(args...)
+			require.NoErrorf(t, err, "batch=%d id=%d", batch, id)
+		}
+		require.NoError(t, stmt.Close())
+		require.NoError(t, tx.Commit())
+
+		time.Sleep(125 * time.Millisecond)
+	}
 }
 
 // TestVFS_MultipleTransactions tests multiple sequential transactions.

--- a/cmd/litestream-vfs/vfs_write_integration_test.go
+++ b/cmd/litestream-vfs/vfs_write_integration_test.go
@@ -130,21 +130,27 @@ func TestVFS_ReadYourWrites(t *testing.T) {
 }
 
 func TestVFS_WideRepeatedInsertsDuringSync_Private(t *testing.T) {
-	// No primary key or secondary index is required. This shape failed 20/20
-	// local runs before the VFS page-visibility fix; 80 batches was race-dependent.
 	runWideRepeatedInsertsDuringSyncPrivate(t, wideRepeatedInsertsConfig{
-		payloadColumnCount: 6,
-		indexCount:         0,
-		batchCount:         90,
-		rowsPerBatch:       1427,
+		payloadColumnCount:   11,
+		indexCount:           4,
+		batchCount:           14,
+		rowsPerBatch:         1427,
+		intPrimaryKeyReplace: true,
+		syncInterval:         time.Second,
+		pollInterval:         time.Second,
+		sleepInterval:        500 * time.Millisecond,
 	})
 }
 
 type wideRepeatedInsertsConfig struct {
-	payloadColumnCount int
-	indexCount         int
-	batchCount         int
-	rowsPerBatch       int
+	payloadColumnCount   int
+	indexCount           int
+	batchCount           int
+	rowsPerBatch         int
+	intPrimaryKeyReplace bool
+	syncInterval         time.Duration
+	pollInterval         time.Duration
+	sleepInterval        time.Duration
 }
 
 func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInsertsConfig) {
@@ -153,7 +159,14 @@ func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInser
 	replicaDir := t.TempDir()
 	client := file.NewReplicaClient(replicaDir)
 
-	vfs := newWritableVFS(t, client, 100*time.Millisecond, t.TempDir())
+	syncInterval := cfg.syncInterval
+	if syncInterval == 0 {
+		syncInterval = 100 * time.Millisecond
+	}
+	vfs := newWritableVFS(t, client, syncInterval, t.TempDir())
+	if cfg.pollInterval > 0 {
+		vfs.PollInterval = cfg.pollInterval
+	}
 	vfsName := fmt.Sprintf("litestream-wide-private-inserts-%d", time.Now().UnixNano())
 	require.NoError(t, sqlite3vfs.RegisterVFS(vfsName, vfs))
 
@@ -165,11 +178,28 @@ func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInser
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
+	runWideRepeatedInsertsDuringSyncSQL(t, db, cfg)
+}
 
+func runWideRepeatedInsertsDuringSyncSQL(t *testing.T, db *sql.DB, cfg wideRepeatedInsertsConfig) {
+	t.Helper()
+	sleepInterval := cfg.sleepInterval
+	if sleepInterval == 0 {
+		sleepInterval = 125 * time.Millisecond
+	}
 	columns := []string{"id", "revision", "shard", "marker"}
+	idType := "INTEGER"
+	if cfg.intPrimaryKeyReplace {
+		idType = "INT"
+	}
 	var ddl strings.Builder
-	ddl.WriteString(`CREATE TABLE wide_syncing_rows (
-		id INTEGER NOT NULL,
+	ddl.WriteString("CREATE TABLE wide_syncing_rows (\n\t\tid ")
+	ddl.WriteString(idType)
+	ddl.WriteString(" NOT NULL")
+	if cfg.intPrimaryKeyReplace {
+		ddl.WriteString(" PRIMARY KEY ON CONFLICT REPLACE")
+	}
+	ddl.WriteString(`,
 		revision INTEGER NOT NULL,
 		shard INTEGER NOT NULL,
 		marker INTEGER NOT NULL`)
@@ -199,7 +229,7 @@ func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInser
 		ddl.WriteString(indexes[i].sql)
 	}
 
-	_, err = db.Exec(ddl.String())
+	_, err := db.Exec(ddl.String())
 	require.NoError(t, err)
 
 	placeholders := make([]string, len(columns))
@@ -217,7 +247,6 @@ func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInser
 		start := 1 + batch*250
 		end := start + cfg.rowsPerBatch - 1
 		offset := batch * 1000000
-
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		stmt, err := tx.Prepare(insertSQL)
@@ -233,8 +262,7 @@ func runWideRepeatedInsertsDuringSyncPrivate(t *testing.T, cfg wideRepeatedInser
 		}
 		require.NoError(t, stmt.Close())
 		require.NoError(t, tx.Commit())
-
-		time.Sleep(125 * time.Millisecond)
+		time.Sleep(sleepInterval)
 	}
 }
 

--- a/vfs.go
+++ b/vfs.go
@@ -1550,7 +1550,7 @@ func (f *VFSFile) ReadAt(p []byte, off int64) (n int, err error) {
 	return n, nil
 }
 
-// readLocalOverlayPageWithLock returns local write pages that must be visible
+// readOverlayPageWithLock returns local write pages that must be visible
 // before any hydrated file, cached remote page, or remote page index lookup.
 // Caller must hold f.mu.
 func (f *VFSFile) readOverlayPageWithLock(pgno uint32, pageSize uint32) (data []byte, source string, txid ltx.TXID, ok bool, err error) {
@@ -2316,7 +2316,10 @@ func (f *VFSFile) Unlock(elock sqlite3vfs.LockType) error {
 		f.logger.Debug("cache invalidated all pages", "count", count)
 		// Invalidate entire cache since we replaced the index
 		f.cache.Purge()
-		f.clearSyncedPagesThroughTXIDWithLock(f.pos.TXID)
+		for k, v := range f.index {
+			f.clearSyncedPageWithIndexElemWithLock(k, v)
+		}
+		f.clearSyncedPagesBeyondCommitWithLock(f.commit)
 	} else if len(f.pending) > 0 {
 		// Merge pending into index
 		count := len(f.pending)
@@ -2634,6 +2637,7 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 	if replaceIndex {
 		if f.lockType < sqlite3vfs.LockShared {
 			f.index = make(map[uint32]ltx.PageIndexElem)
+			f.cache.Purge()
 			target = f.index
 			targetIsMain = true
 			f.pendingReplace = false
@@ -2653,17 +2657,18 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 			invalidateN++
 		}
 	}
-	if replaceIndex && targetIsMain {
-		f.clearSyncedPagesThroughTXIDWithLock(applyTXID)
-	}
-
 	if invalidateN > 0 {
 		f.logger.Debug("cache invalidated pages due to new ltx files", "count", invalidateN)
 	}
 
+	commitUpdated := false
 	if (replaceIndex || len(combined) > 0) && (!f.writeEnabled || applyTXID >= f.commitTXID) {
 		f.commit = newCommit
 		f.commitTXID = applyTXID
+		commitUpdated = true
+	}
+	if replaceIndex && targetIsMain && commitUpdated {
+		f.clearSyncedPagesBeyondCommitWithLock(f.commit)
 	}
 	f.pos.TXID = applyTXID
 
@@ -2687,9 +2692,9 @@ func (f *VFSFile) clearSyncedPageWithIndexElemWithLock(pgno uint32, elem ltx.Pag
 	}
 }
 
-func (f *VFSFile) clearSyncedPagesThroughTXIDWithLock(txid ltx.TXID) {
-	for pgno, page := range f.synced {
-		if page.txid <= txid {
+func (f *VFSFile) clearSyncedPagesBeyondCommitWithLock(commit uint32) {
+	for pgno := range f.synced {
+		if pgno > commit {
 			delete(f.synced, pgno)
 		}
 	}

--- a/vfs.go
+++ b/vfs.go
@@ -2173,6 +2173,14 @@ func (f *VFSFile) FileSize() (size int64, err error) {
 			size = v
 		}
 	}
+	// Anchor size to f.commit which tracks the highest page written and
+	// survives syncToRemoteWithLock clearing f.dirty. Without this,
+	// FileSize can transiently shrink between a sync flush (which clears
+	// f.dirty) and the next poll (which repopulates f.index), causing
+	// SQLite to report "database disk image is malformed".
+	if v := int64(f.commit) * int64(pageSize); v > size {
+		size = v
+	}
 	f.mu.Unlock()
 
 	f.logger.Debug("file size", "size", size)

--- a/vfs.go
+++ b/vfs.go
@@ -965,6 +965,32 @@ func NewVFSFile(client ReplicaClient, name string, logger *slog.Logger) *VFSFile
 	return f
 }
 
+func cacheEntryCount(cacheSize int, pageSize uint32) int {
+	if pageSize == 0 {
+		pageSize = DefaultPageSize
+	}
+	n := cacheSize / int(pageSize)
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+func (f *VFSFile) resizeCacheWithLock() {
+	if f.cache == nil {
+		return
+	}
+
+	n := cacheEntryCount(f.CacheSize, f.pageSize)
+	indexLag := f.expectedTXID > f.pos.TXID || len(f.pending) > 0 || f.mainIndexCommitWithLock() < f.commit
+	if f.writeEnabled && indexLag {
+		if commit := int(f.commit); commit > n {
+			n = commit
+		}
+	}
+	f.cache.Resize(n)
+}
+
 // Pos returns the current position of the file.
 func (f *VFSFile) Pos() ltx.Pos {
 	f.mu.Lock()
@@ -1040,10 +1066,7 @@ func (f *VFSFile) Open() error {
 	f.pageSize = pageSize
 
 	// Initialize page cache. Convert byte size to number of pages.
-	cacheEntries := f.CacheSize / int(pageSize)
-	if cacheEntries < 1 {
-		cacheEntries = 1
-	}
+	cacheEntries := cacheEntryCount(f.CacheSize, pageSize)
 	cache, err := lru.New[uint32, []byte](cacheEntries)
 	if err != nil {
 		return fmt.Errorf("create page cache: %w", err)
@@ -1114,10 +1137,7 @@ func (f *VFSFile) openNewDatabase() error {
 	f.pageSize = DefaultPageSize
 
 	// Initialize page cache
-	cacheEntries := f.CacheSize / int(f.pageSize)
-	if cacheEntries < 1 {
-		cacheEntries = 1
-	}
+	cacheEntries := cacheEntryCount(f.CacheSize, f.pageSize)
 	cache, err := lru.New[uint32, []byte](cacheEntries)
 	if err != nil {
 		return fmt.Errorf("create page cache: %w", err)
@@ -1198,7 +1218,7 @@ func (f *VFSFile) ResetTime(ctx context.Context) error {
 
 // rebuildIndex constructs a fresh page index and swaps it into the VFSFile.
 func (f *VFSFile) rebuildIndex(ctx context.Context, infos []*ltx.FileInfo, target *time.Time) error {
-	index, err := f.buildIndexMap(ctx, infos)
+	index, commit, err := f.buildIndexMap(ctx, infos)
 	if err != nil {
 		return err
 	}
@@ -1221,6 +1241,7 @@ func (f *VFSFile) rebuildIndex(ctx context.Context, infos []*ltx.FileInfo, targe
 	f.pendingReplace = false
 	f.pos = pos
 	f.maxTXID1 = maxTXID1
+	f.commit = commit
 	if len(infos) > 0 {
 		f.latestLTXTime = infos[len(infos)-1].CreatedAt
 	}
@@ -1248,7 +1269,7 @@ func maxLevelTXID(infos []*ltx.FileInfo, level int) ltx.TXID {
 }
 
 // buildIndexMap constructs a lookup of pgno to LTX file offsets.
-func (f *VFSFile) buildIndexMap(ctx context.Context, infos []*ltx.FileInfo) (map[uint32]ltx.PageIndexElem, error) {
+func (f *VFSFile) buildIndexMap(ctx context.Context, infos []*ltx.FileInfo) (map[uint32]ltx.PageIndexElem, uint32, error) {
 	index := make(map[uint32]ltx.PageIndexElem)
 	var commit uint32
 	for _, info := range infos {
@@ -1257,7 +1278,7 @@ func (f *VFSFile) buildIndexMap(ctx context.Context, infos []*ltx.FileInfo) (map
 		// Read page index.
 		idx, err := FetchPageIndex(ctx, f.client, info)
 		if err != nil {
-			return nil, fmt.Errorf("fetch page index: %w", err)
+			return nil, 0, fmt.Errorf("fetch page index: %w", err)
 		}
 
 		// Replace pages in overall index with new pages.
@@ -1267,16 +1288,12 @@ func (f *VFSFile) buildIndexMap(ctx context.Context, infos []*ltx.FileInfo) (map
 		}
 		hdr, err := FetchLTXHeader(ctx, f.client, info)
 		if err != nil {
-			return nil, fmt.Errorf("fetch header: %w", err)
+			return nil, 0, fmt.Errorf("fetch header: %w", err)
 		}
 		commit = hdr.Commit
 	}
 
-	f.mu.Lock()
-	f.commit = commit
-	f.mu.Unlock()
-
-	return index, nil
+	return index, commit, nil
 }
 
 // buildIndex constructs a lookup of pgno to LTX file offsets (legacy wrapper).
@@ -1926,7 +1943,6 @@ func (f *VFSFile) syncToRemoteWithLock() error {
 
 	f.expectedTXID = f.pendingTXID
 	f.pendingTXID++
-	f.pos = ltx.Pos{TXID: f.expectedTXID}
 
 	if f.vfs != nil {
 		f.vfs.writeMu.Lock()
@@ -1937,6 +1953,7 @@ func (f *VFSFile) syncToRemoteWithLock() error {
 	}
 
 	// Update cache with synced pages (index will be populated naturally when pages are fetched)
+	f.resizeCacheWithLock()
 	for pgno, bufferOff := range f.dirty {
 		cachedData := make([]byte, f.pageSize)
 		if _, err := f.bufferFile.ReadAt(cachedData, bufferOff); err != nil {
@@ -2224,7 +2241,6 @@ func (f *VFSFile) Lock(elock sqlite3vfs.LockType) error {
 			if f.vfs.lastSyncedTXID > f.expectedTXID && len(f.dirty) == 0 {
 				f.expectedTXID = f.vfs.lastSyncedTXID
 				f.pendingTXID = f.vfs.lastSyncedTXID + 1
-				f.pos = ltx.Pos{TXID: f.expectedTXID}
 			}
 			f.vfs.writeMu.Unlock()
 		}
@@ -2280,6 +2296,7 @@ func (f *VFSFile) Unlock(elock sqlite3vfs.LockType) error {
 	}
 	f.pending = make(map[uint32]ltx.PageIndexElem)
 	f.pendingReplace = false
+	f.resizeCacheWithLock()
 
 	return nil
 }
@@ -2506,15 +2523,15 @@ func (f *VFSFile) monitorReplicaClient(ctx context.Context) {
 // pollReplicaClient fetches new LTX files from the replica client and updates
 // the page index & the current position.
 func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
-	pos := f.Pos()
+	f.mu.Lock()
+	pos := f.pos
+	baseCommit := f.indexCommitWithLock()
+	maxTXID1Snapshot := f.maxTXID1
+	f.mu.Unlock()
+
 	f.logger.Debug("polling replica client", "txid", pos.TXID.String())
 
 	combined := make(map[uint32]ltx.PageIndexElem)
-
-	f.mu.Lock()
-	baseCommit := f.commit
-	maxTXID1Snapshot := f.maxTXID1
-	f.mu.Unlock()
 
 	newCommit := baseCommit
 	replaceIndex := false
@@ -2568,6 +2585,10 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 		return nil
 	}
 
+	applyTXID := maxTXID0
+	if maxTXID1 > applyTXID {
+		applyTXID = maxTXID1
+	}
 	// Apply updates and invalidate cache entries for updated pages
 	invalidateN := 0
 	target := f.index
@@ -2605,16 +2626,13 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 	}
 
 	if replaceIndex {
-		f.commit = newCommit
+		if !f.writeEnabled || f.expectedTXID <= applyTXID || newCommit > f.commit {
+			f.commit = newCommit
+		}
 	} else if len(combined) > 0 && newCommit > f.commit {
 		f.commit = newCommit
 	}
-
-	if maxTXID0 > maxTXID1 {
-		f.pos.TXID = maxTXID0
-	} else {
-		f.pos.TXID = maxTXID1
-	}
+	f.pos.TXID = applyTXID
 
 	f.maxTXID1 = maxTXID1
 	f.logger.Debug("txid updated", "txid", f.pos.TXID.String(), "maxTXID1", f.maxTXID1.String())
@@ -2625,8 +2643,35 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 			f.logger.Error("failed to apply updates to hydrated file", "error", err)
 		}
 	}
+	f.resizeCacheWithLock()
 
 	return nil
+}
+
+// indexCommitWithLock returns the page high-water represented by the installed
+// page index state. Dirty pages and f.commit are intentionally excluded.
+// Caller must hold f.mu.
+func (f *VFSFile) indexCommitWithLock() uint32 {
+	var commit uint32
+	if !f.pendingReplace {
+		commit = f.mainIndexCommitWithLock()
+	}
+	for pgno := range f.pending {
+		if pgno > commit {
+			commit = pgno
+		}
+	}
+	return commit
+}
+
+func (f *VFSFile) mainIndexCommitWithLock() uint32 {
+	var commit uint32
+	for pgno := range f.index {
+		if pgno > commit {
+			commit = pgno
+		}
+	}
+	return commit
 }
 
 // pollLevel fetches LTX files for a specific level and returns the highest TXID seen,

--- a/vfs.go
+++ b/vfs.go
@@ -527,10 +527,12 @@ type VFSFile struct {
 	lockType        sqlite3vfs.LockType        // Current lock state
 	pageSize        uint32
 	commit          uint32
+	commitTXID      ltx.TXID
 
 	// Write support fields (only used when writeEnabled is true)
 	writeEnabled  bool             // Whether write support is enabled
 	dirty         map[uint32]int64 // Dirty pages: pgno -> offset in buffer file
+	synced        map[uint32]TPage // After dirty pages and before cache.
 	pendingTXID   ltx.TXID         // Next TXID to use for sync
 	expectedTXID  ltx.TXID         // Expected remote TXID (for conflict detection)
 	bufferFile    *os.File         // Temp file for durability
@@ -562,6 +564,11 @@ type VFSFile struct {
 	compactionWg     sync.WaitGroup
 	compactionCtx    context.Context
 	compactionCancel context.CancelFunc
+}
+
+type TPage struct {
+	txid ltx.TXID
+	data []byte
 }
 
 // Hydrator handles background hydration of the database to a local file.
@@ -956,6 +963,7 @@ func NewVFSFile(client ReplicaClient, name string, logger *slog.Logger) *VFSFile
 		name:         name,
 		index:        make(map[uint32]ltx.PageIndexElem),
 		pending:      make(map[uint32]ltx.PageIndexElem),
+		synced:       make(map[uint32]TPage),
 		logger:       logger,
 		PollInterval: DefaultPollInterval,
 		CacheSize:    DefaultCacheSize,
@@ -974,21 +982,6 @@ func cacheEntryCount(cacheSize int, pageSize uint32) int {
 		return 1
 	}
 	return n
-}
-
-func (f *VFSFile) resizeCacheWithLock() {
-	if f.cache == nil {
-		return
-	}
-
-	n := cacheEntryCount(f.CacheSize, f.pageSize)
-	indexLag := f.expectedTXID > f.pos.TXID || len(f.pending) > 0 || f.mainIndexCommitWithLock() < f.commit
-	if f.writeEnabled && indexLag {
-		if commit := int(f.commit); commit > n {
-			n = commit
-		}
-	}
-	f.cache.Resize(n)
 }
 
 // Pos returns the current position of the file.
@@ -1147,8 +1140,10 @@ func (f *VFSFile) openNewDatabase() error {
 	// Initialize empty index - no pages exist yet
 	f.index = make(map[uint32]ltx.PageIndexElem)
 	f.pending = make(map[uint32]ltx.PageIndexElem)
+	f.synced = make(map[uint32]TPage)
 	f.pos = ltx.Pos{TXID: 0}
 	f.commit = 0
+	f.commitTXID = 0
 
 	// Initialize write support for new database
 	f.expectedTXID = 0
@@ -1239,9 +1234,11 @@ func (f *VFSFile) rebuildIndex(ctx context.Context, infos []*ltx.FileInfo, targe
 	f.index = index
 	f.pending = make(map[uint32]ltx.PageIndexElem)
 	f.pendingReplace = false
+	f.synced = make(map[uint32]TPage)
 	f.pos = pos
 	f.maxTXID1 = maxTXID1
 	f.commit = commit
+	f.commitTXID = pos.TXID
 	if len(infos) > 0 {
 		f.latestLTXTime = infos[len(infos)-1].CreatedAt
 	}
@@ -1446,28 +1443,25 @@ func (f *VFSFile) ReadAt(p []byte, off int64) (n int, err error) {
 	pgno := uint32(off/int64(pageSize)) + 1
 	pageOffset := int(off % int64(pageSize))
 
-	// Check dirty pages first (takes priority over cache and remote)
+	// Visible page order: dirty -> synced -> hydration -> cache -> index.
 	f.mu.Lock()
-	if f.writeEnabled {
-		if bufferOff, ok := f.dirty[pgno]; ok {
-			// Read page from buffer file
-			data := make([]byte, pageSize)
-			if _, err := f.bufferFile.ReadAt(data, bufferOff); err != nil {
-				f.mu.Unlock()
-				return 0, fmt.Errorf("read dirty page from buffer: %w", err)
-			}
-			n = copy(p, data[pageOffset:])
-			f.mu.Unlock()
-			f.logger.Debug("dirty page hit", "page", pgno, "n", n)
+	overlayData, source, sourceTXID, ok, err := f.readOverlayPageWithLock(pgno, pageSize)
+	if err != nil {
+		f.mu.Unlock()
+		return 0, err
+	}
+	if ok {
+		n = copy(p, overlayData[pageOffset:])
+		f.mu.Unlock()
+		f.logger.Debug("local overlay page hit", "source", source, "page", pgno, "txid", sourceTXID, "n", n)
 
-			// Update the first page to pretend like we are in journal mode.
-			if off == 0 && len(p) >= 28 {
-				p[18], p[19] = 0x01, 0x01
-				_, _ = rand.Read(p[24:28])
-			}
-
-			return n, nil
+		// Update the first page to pretend like we are in journal mode.
+		if off == 0 && len(p) >= 28 {
+			p[18], p[19] = 0x01, 0x01
+			_, _ = rand.Read(p[24:28])
 		}
+
+		return n, nil
 	}
 	f.mu.Unlock()
 
@@ -1556,6 +1550,27 @@ func (f *VFSFile) ReadAt(p []byte, off int64) (n int, err error) {
 	return n, nil
 }
 
+// readLocalOverlayPageWithLock returns local write pages that must be visible
+// before any hydrated file, cached remote page, or remote page index lookup.
+// Caller must hold f.mu.
+func (f *VFSFile) readOverlayPageWithLock(pgno uint32, pageSize uint32) (data []byte, source string, txid ltx.TXID, ok bool, err error) {
+	if f.writeEnabled {
+		if bufferOff, ok := f.dirty[pgno]; ok {
+			data := make([]byte, pageSize)
+			if _, err := f.bufferFile.ReadAt(data, bufferOff); err != nil {
+				return nil, "", 0, false, fmt.Errorf("read dirty page from buffer: %w", err)
+			}
+			return data, "dirty", f.pendingTXID, true, nil
+		}
+	}
+
+	if page, ok := f.synced[pgno]; ok {
+		return page.data, "synced", page.txid, true, nil
+	}
+
+	return nil, "", 0, false, nil
+}
+
 func (f *VFSFile) WriteAt(b []byte, off int64) (n int, err error) {
 	f.logger.Debug("write at", "off", off, "len", len(b))
 
@@ -1581,19 +1596,10 @@ func (f *VFSFile) WriteAt(b []byte, off int64) (n int, err error) {
 		return 0, sqlite3vfs.ReadOnlyError
 	}
 
-	// Get page data - either from buffer file (if dirty) or from cache/remote
 	page := make([]byte, pageSize)
-	if bufferOff, ok := f.dirty[pgno]; ok {
-		// Page is already dirty - read from buffer file
-		if _, err := f.bufferFile.ReadAt(page, bufferOff); err != nil {
-			return 0, fmt.Errorf("read dirty page from buffer: %w", err)
-		}
-	} else {
-		// Page is not dirty - read from cache/remote
-		if err := f.readPageForWrite(pgno, page); err != nil {
-			// If page doesn't exist, use zero-filled page
-			f.logger.Debug("page not found, using empty page", "pgno", pgno)
-		}
+	if err := f.readPageForWrite(pgno, page); err != nil {
+		// If page doesn't exist, use zero-filled page
+		f.logger.Debug("page not found, using empty page", "pgno", pgno)
 	}
 
 	// Apply write to page
@@ -1603,6 +1609,7 @@ func (f *VFSFile) WriteAt(b []byte, off int64) (n int, err error) {
 	if pgno > f.commit {
 		f.commit = pgno
 	}
+	f.commitTXID = f.pendingTXID
 
 	// Write to buffer for durability (this updates f.dirty with the offset)
 	if err := f.writeToBuffer(pgno, page); err != nil {
@@ -1614,12 +1621,19 @@ func (f *VFSFile) WriteAt(b []byte, off int64) (n int, err error) {
 	return n, nil
 }
 
-// readPageForWrite reads a page into buf for modification.
+// readPageForWrite reads a page into buf for modification using this order:
+// dirty -> synced -> cache -> index.
 // Must be called with f.mu held.
 func (f *VFSFile) readPageForWrite(pgno uint32, buf []byte) error {
 	pageSize := uint32(len(buf))
 
-	// Check cache first (cache is thread-safe, but we hold the lock anyway)
+	if data, _, _, ok, err := f.readOverlayPageWithLock(pgno, pageSize); err != nil {
+		return err
+	} else if ok {
+		copy(buf, data)
+		return nil
+	}
+
 	if data, ok := f.cache.Get(pgno); ok {
 		copy(buf, data)
 		return nil
@@ -1670,8 +1684,14 @@ func (f *VFSFile) Truncate(size int64) error {
 			delete(f.dirty, pgno)
 		}
 	}
+	for pgno := range f.synced {
+		if pgno > newCommit {
+			delete(f.synced, pgno)
+		}
+	}
 
 	f.commit = newCommit
+	f.commitTXID = f.pendingTXID
 	f.logger.Debug("truncated", "newCommit", newCommit)
 
 	// Truncate hydrated file if hydration is complete
@@ -1823,6 +1843,9 @@ func (f *VFSFile) SetWriteEnabledWithTimeout(enabled bool, timeout time.Duration
 	if f.dirty == nil {
 		f.dirty = make(map[uint32]int64)
 	}
+	if f.synced == nil {
+		f.synced = make(map[uint32]TPage)
+	}
 
 	// Set sync interval from VFS config if not set, falling back to default
 	// This mirrors the startup behavior where WriteSyncInterval==0 uses DefaultSyncInterval
@@ -1943,6 +1966,7 @@ func (f *VFSFile) syncToRemoteWithLock() error {
 
 	f.expectedTXID = f.pendingTXID
 	f.pendingTXID++
+	f.commitTXID = f.expectedTXID
 
 	if f.vfs != nil {
 		f.vfs.writeMu.Lock()
@@ -1952,14 +1976,16 @@ func (f *VFSFile) syncToRemoteWithLock() error {
 		f.vfs.writeMu.Unlock()
 	}
 
-	// Update cache with synced pages (index will be populated naturally when pages are fetched)
-	f.resizeCacheWithLock()
+	// Keep locally synced pages visible until poll installs their TXID.
+	if f.synced == nil {
+		f.synced = make(map[uint32]TPage)
+	}
 	for pgno, bufferOff := range f.dirty {
 		cachedData := make([]byte, f.pageSize)
 		if _, err := f.bufferFile.ReadAt(cachedData, bufferOff); err != nil {
-			return fmt.Errorf("read page %d from buffer for cache: %w", pgno, err)
+			return fmt.Errorf("read page %d from buffer for synced page: %w", pgno, err)
 		}
-		f.cache.Add(pgno, cachedData)
+		f.synced[pgno] = TPage{txid: f.expectedTXID, data: cachedData}
 	}
 
 	// Apply synced pages to hydrated file if hydration is complete
@@ -2190,6 +2216,11 @@ func (f *VFSFile) FileSize() (size int64, err error) {
 			size = v
 		}
 	}
+	for pgno := range f.synced {
+		if v := int64(pgno) * int64(pageSize); v > size {
+			size = v
+		}
+	}
 	// Anchor size to f.commit which tracks the highest page written and
 	// survives syncToRemoteWithLock clearing f.dirty. Without this,
 	// FileSize can transiently shrink between a sync flush (which clears
@@ -2285,18 +2316,19 @@ func (f *VFSFile) Unlock(elock sqlite3vfs.LockType) error {
 		f.logger.Debug("cache invalidated all pages", "count", count)
 		// Invalidate entire cache since we replaced the index
 		f.cache.Purge()
+		f.clearSyncedPagesThroughTXIDWithLock(f.pos.TXID)
 	} else if len(f.pending) > 0 {
 		// Merge pending into index
 		count := len(f.pending)
 		for k, v := range f.pending {
 			f.index[k] = v
 			f.cache.Remove(k)
+			f.clearSyncedPageWithIndexElemWithLock(k, v)
 		}
 		f.logger.Debug("cache invalidated pages", "count", count)
 	}
 	f.pending = make(map[uint32]ltx.PageIndexElem)
 	f.pendingReplace = false
-	f.resizeCacheWithLock()
 
 	return nil
 }
@@ -2617,20 +2649,21 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 		// Invalidate cache if we're updating the main index
 		if targetIsMain {
 			f.cache.Remove(k)
+			f.clearSyncedPageWithIndexElemWithLock(k, v)
 			invalidateN++
 		}
+	}
+	if replaceIndex && targetIsMain {
+		f.clearSyncedPagesThroughTXIDWithLock(applyTXID)
 	}
 
 	if invalidateN > 0 {
 		f.logger.Debug("cache invalidated pages due to new ltx files", "count", invalidateN)
 	}
 
-	if replaceIndex {
-		if !f.writeEnabled || f.expectedTXID <= applyTXID || newCommit > f.commit {
-			f.commit = newCommit
-		}
-	} else if len(combined) > 0 && newCommit > f.commit {
+	if (replaceIndex || len(combined) > 0) && (!f.writeEnabled || applyTXID >= f.commitTXID) {
 		f.commit = newCommit
+		f.commitTXID = applyTXID
 	}
 	f.pos.TXID = applyTXID
 
@@ -2643,9 +2676,23 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 			f.logger.Error("failed to apply updates to hydrated file", "error", err)
 		}
 	}
-	f.resizeCacheWithLock()
 
 	return nil
+}
+
+func (f *VFSFile) clearSyncedPageWithIndexElemWithLock(pgno uint32, elem ltx.PageIndexElem) {
+	page, ok := f.synced[pgno]
+	if ok && elem.MaxTXID >= page.txid {
+		delete(f.synced, pgno)
+	}
+}
+
+func (f *VFSFile) clearSyncedPagesThroughTXIDWithLock(txid ltx.TXID) {
+	for pgno, page := range f.synced {
+		if page.txid <= txid {
+			delete(f.synced, pgno)
+		}
+	}
 }
 
 // indexCommitWithLock returns the page high-water represented by the installed

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -868,6 +868,8 @@ func (c *countingReplicaClient) DeleteLTXFiles(context.Context, []*ltx.FileInfo)
 
 func (c *countingReplicaClient) DeleteAll(context.Context) error { return nil }
 
+func (c *countingReplicaClient) SetLogger(*slog.Logger) {}
+
 func newMockReplicaClient() *mockReplicaClient {
 	return &mockReplicaClient{data: make(map[string][]byte)}
 }
@@ -932,6 +934,8 @@ func (c *mockReplicaClient) DeleteLTXFiles(context.Context, []*ltx.FileInfo) err
 func (c *mockReplicaClient) DeleteAll(context.Context) error {
 	return fmt.Errorf("not implemented")
 }
+
+func (c *mockReplicaClient) SetLogger(*slog.Logger) {}
 
 func (c *blockingReplicaClient) Type() string { return "blocking" }
 

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -101,6 +101,8 @@ func (c *writeTestReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.Fi
 	return nil
 }
 
+func (c *writeTestReplicaClient) SetLogger(_ *slog.Logger) {}
+
 func (c *writeTestReplicaClient) DeleteAll(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1985,5 +1987,93 @@ func TestVFS_CloseReleasesWriteSlot(t *testing.T) {
 	}
 	if err := f2.Unlock(sqlite3vfs.LockShared); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestVFSFile_FileSize_AfterSync verifies that FileSize does not shrink after
+// syncToRemoteWithLock clears f.dirty. Before the fix, if dirty pages extended
+// the database beyond f.index and a sync cleared them before the poll goroutine
+// repopulated f.index, FileSize would transiently return a smaller value,
+// causing SQLite to report "database disk image is malformed".
+func TestVFSFile_FileSize_AfterSync(t *testing.T) {
+	client := newWriteTestReplicaClient()
+
+	pageSize := uint32(4096)
+
+	// Seed with a 2-page database (pages 1 and 2 in the index).
+	pages := make(map[uint32][]byte)
+	for pgno := uint32(1); pgno <= 2; pgno++ {
+		pages[pgno] = make([]byte, pageSize)
+	}
+	createTestLTXFile(t, client, 1, pageSize, 2, pages)
+
+	f := setupWriteableVFSFile(t, client)
+	if err := f.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// FileSize before writes should reflect the 2-page index.
+	sizeBefore, err := f.FileSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(2) * int64(pageSize); sizeBefore != want {
+		t.Fatalf("initial FileSize = %d, want %d", sizeBefore, want)
+	}
+
+	// Write pages 3..10 to extend the database well beyond the index.
+	for pgno := uint32(3); pgno <= 10; pgno++ {
+		data := make([]byte, pageSize)
+		off := int64(pgno-1) * int64(pageSize)
+		if _, err := f.WriteAt(data, off); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// FileSize after writes should reflect 10 pages (via f.dirty).
+	sizeAfterWrite, err := f.FileSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(10) * int64(pageSize); sizeAfterWrite != want {
+		t.Fatalf("FileSize after write = %d, want %d", sizeAfterWrite, want)
+	}
+
+	// Sync: uploads dirty pages and clears f.dirty.
+	// We do NOT poll afterwards, so f.index still only knows about pages 1-2.
+	if err := f.Sync(0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify dirty was actually cleared (sync happened).
+	f.mu.Lock()
+	dirtyLen := len(f.dirty)
+	indexMax := uint32(0)
+	for pgno := range f.index {
+		if pgno > indexMax {
+			indexMax = pgno
+		}
+	}
+	f.mu.Unlock()
+
+	if dirtyLen != 0 {
+		t.Fatalf("expected 0 dirty pages after sync, got %d", dirtyLen)
+	}
+	if indexMax > 2 {
+		// If the index already covers the new pages, this test can't
+		// distinguish the fix from the old behavior. This shouldn't
+		// happen because we never polled.
+		t.Fatalf("index already covers page %d; test is ineffective", indexMax)
+	}
+
+	// This is the critical check: FileSize must not shrink after sync.
+	sizeAfterSync, err := f.FileSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sizeAfterSync < sizeAfterWrite {
+		t.Errorf("FileSize shrank after sync: was %d, now %d (index covers up to page %d, dirty cleared)",
+			sizeAfterWrite, sizeAfterSync, indexMax)
 	}
 }

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -101,8 +101,6 @@ func (c *writeTestReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.Fi
 	return nil
 }
 
-func (c *writeTestReplicaClient) SetLogger(_ *slog.Logger) {}
-
 func (c *writeTestReplicaClient) DeleteAll(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -2135,3 +2135,85 @@ func TestVFSFile_SyncedPagesStayReadableBeforePoll(t *testing.T) {
 		}
 	}
 }
+
+func TestVFSFile_PollReplacementEvictsSyncedByVisibleState(t *testing.T) {
+	client := newWriteTestReplicaClient()
+
+	pageSize := uint32(4096)
+	createTestLTXFile(t, client, 1, pageSize, 3, map[uint32][]byte{
+		1: bytes.Repeat([]byte{1}, int(pageSize)),
+		2: bytes.Repeat([]byte{2}, int(pageSize)),
+		3: bytes.Repeat([]byte{3}, int(pageSize)),
+	})
+
+	f := setupWriteableVFSFile(t, client)
+	f.CacheSize = int(pageSize * 8)
+	if err := f.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Seed cache entries that a direct index replacement must invalidate.
+	buf := make([]byte, pageSize)
+	if _, err := f.ReadAt(buf, int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.ReadAt(buf, int64(2*pageSize)); err != nil {
+		t.Fatal(err)
+	}
+
+	page2 := bytes.Repeat([]byte{9}, int(pageSize))
+	page3 := bytes.Repeat([]byte{8}, int(pageSize))
+	if _, err := f.WriteAt(page2, int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(page3, int64(2*pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Sync(0); err != nil {
+		t.Fatal(err)
+	}
+
+	createTestLTXFile(t, client, 3, pageSize, 2, map[uint32][]byte{
+		1: bytes.Repeat([]byte{4}, int(pageSize)),
+	})
+	if err := f.pollReplicaClient(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	f.mu.Lock()
+	_, page2Synced := f.synced[2]
+	_, page3Synced := f.synced[3]
+	_, page2Indexed := f.index[2]
+	commit := f.commit
+	f.mu.Unlock()
+
+	if !page2Synced {
+		t.Fatal("expected synced page 2 to remain until a visible page index covers it")
+	}
+	if page3Synced {
+		t.Fatal("expected synced page 3 to be evicted after replacement shrank commit to page 2")
+	}
+	if page2Indexed {
+		t.Fatal("test is ineffective: replacement index already covers page 2")
+	}
+	if commit != 2 {
+		t.Fatalf("commit = %d, want 2", commit)
+	}
+
+	buf = make([]byte, pageSize)
+	if _, err := f.ReadAt(buf, int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf, page2) {
+		t.Fatal("page 2 did not read from synced overlay after replacement")
+	}
+
+	buf = make([]byte, pageSize)
+	if _, err := f.ReadAt(buf, int64(2*pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if buf[0] != 0 {
+		t.Fatalf("page 3 read stale data after replacement: got first byte %d", buf[0])
+	}
+}

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -2077,3 +2077,61 @@ func TestVFSFile_FileSize_AfterSync(t *testing.T) {
 			sizeAfterWrite, sizeAfterSync, indexMax)
 	}
 }
+
+func TestVFSFile_SyncedPagesStayReadableBeforePoll(t *testing.T) {
+	client := newWriteTestReplicaClient()
+
+	pageSize := uint32(4096)
+	pages := make(map[uint32][]byte)
+	for pgno := uint32(1); pgno <= 2; pgno++ {
+		pages[pgno] = bytes.Repeat([]byte{byte(pgno)}, int(pageSize))
+	}
+	createTestLTXFile(t, client, 1, pageSize, 2, pages)
+
+	f := setupWriteableVFSFile(t, client)
+	f.CacheSize = int(pageSize)
+	if err := f.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	for pgno := uint32(3); pgno <= 10; pgno++ {
+		data := bytes.Repeat([]byte{byte(pgno)}, int(pageSize))
+		off := int64(pgno-1) * int64(pageSize)
+		if _, err := f.WriteAt(data, off); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := f.Sync(0); err != nil {
+		t.Fatal(err)
+	}
+
+	f.mu.Lock()
+	indexMax := uint32(0)
+	for pgno := range f.index {
+		if pgno > indexMax {
+			indexMax = pgno
+		}
+	}
+	f.mu.Unlock()
+
+	if indexMax > 2 {
+		t.Fatalf("index already covers page %d; test is ineffective", indexMax)
+	}
+
+	for pgno := uint32(3); pgno <= 10; pgno++ {
+		off := int64(pgno-1) * int64(pageSize)
+		if _, err := f.WriteAt([]byte{0xff}, off+100); err != nil {
+			t.Fatal(err)
+		}
+
+		buf := make([]byte, pageSize)
+		if _, err := f.ReadAt(buf, off); err != nil {
+			t.Fatal(err)
+		}
+		if buf[0] != byte(pgno) || buf[100] != 0xff || buf[101] != byte(pgno) {
+			t.Fatalf("page %d was not preserved after sync before poll", pgno)
+		}
+	}
+}

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -111,6 +111,8 @@ func (c *writeTestReplicaClient) DeleteAll(ctx context.Context) error {
 	return nil
 }
 
+func (c *writeTestReplicaClient) SetLogger(*slog.Logger) {}
+
 func ltxKey(level int, minTXID, maxTXID ltx.TXID) string {
 	return string(rune(level)) + "/" + minTXID.String() + "-" + maxTXID.String()
 }


### PR DESCRIPTION
## Description

Fixes writable VFS reads after a local sync by keeping uploaded page bytes in `f.synced` until `pollReplicaClient()` has made matching page entries visible in `f.index`.

This PR builds on #1157 (`9f7c95d`) and #1272 (`94d7c729`). It is partly blocked on those changes being merged or otherwise included.

## Motivation and Context

An app of ours saw `database disk image is malformed` after ca. 50 batches of 1000s row upserts.

Also probably fixes #1018.

`TestVFS_WideRepeatedInsertsDuringSync_Private` reproduces with one SQLite connection.

Failing order:

- `WriteAt()` added pages to `f.dirty` and raised `f.commit`.
- `syncToRemoteWithLock()` uploaded those pages and cleared `f.dirty`.
- `pollReplicaClient()` had not yet added those pages to visible `f.index`.
- `ReadAt()` then had no local page bytes to read before falling through to hydration, `f.cache`, or `f.index`.

Debug output from fail runs:

```text
poll invalidated cached pages while index lags writer count=129 applyTXID=0000000000000005 expectedTXID=0000000000000006 pendingTXID=0000000000000007
storage read uses index behind writer state page=1 elemMaxTXID=0000000000000005 expectedTXID=0000000000000006
```

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Local sync finishes before poll installs page entries | `f.dirty` is gone and reads can fall back to old/missing `f.index` entries | `f.synced` serves those pages until `f.index` catches up |
| Poll sees an older index entry for a synced page | Cache/index state can hide newer local bytes | `f.synced[pgno]` stays until `elem.MaxTXID >= TPage.txid` |
| Poll replaces `f.index` after a smaller `hdr.Commit` | Cache entries can remain stale, and synced pages can be dropped too broadly | `f.cache` is purged; `f.synced` is cleared by page entry or by pages beyond `f.commit` |


## How Has This Been Tested?

Integration reproducer:
```sh
go test -count=1 -mod=mod -tags vfs -run '^TestVFS_WideRepeatedInsertsDuringSync_Private$' ./cmd/litestream-vfs
```

Unit:
```sh
go test -count=1 -mod=mod -tags vfs -run '^TestVFSFile_PollReplacementEvictsSyncedByVisibleState$' .
go test -count=1 -mod=mod -tags vfs -run '^(TestVFSFile_SyncedPagesStayReadableBeforePoll|TestVFSFile_Truncate)$' .
```
Internal application check reported passing with the rebuilt VFS extension. A production run sustained writes of about 100MB/s for an initial migration copy and continuous upserts afterwards.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
