### PR TITLE
fix(cli): polish agent-facing errors

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -33,7 +33,7 @@ func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 		return err
 	}
 
-	var databases []DatabaseInfo
+	databases := make([]DatabaseInfo, 0, len(config.DBs))
 	for _, dbConfig := range config.DBs {
 		db, err := NewDBFromConfig(dbConfig)
 		if err != nil {

--- a/cmd/litestream/databases_test.go
+++ b/cmd/litestream/databases_test.go
@@ -64,4 +64,23 @@ func TestDatabasesCommand_Run(t *testing.T) {
 			t.Fatalf("unexpected replica type: %s", got[0].Replica)
 		}
 	})
+
+	t.Run("EmptyJSONOutput", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "litestream.yml")
+		if err := os.WriteFile(configPath, []byte("dbs: []\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		output := captureStdout(t, func() {
+			cmd := &main.DatabasesCommand{}
+			if err := cmd.Run(context.Background(), []string{"-config", configPath, "-json"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		if output != "[]\n" {
+			t.Fatalf("unexpected output: %q", output)
+		}
+	})
 }

--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -27,7 +27,7 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 	if err := fs.Parse(args); err != nil {
 		return err
 	} else if fs.NArg() == 0 || fs.Arg(0) == "" {
-		return fmt.Errorf("database path required")
+		return newUsageError("database path or replica URL required", "litestream ltx /path/to/db")
 	} else if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}
@@ -81,7 +81,7 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		levels = []int{int(level)}
 	}
 
-	var files []LTXFileInfo
+	files := make([]LTXFileInfo, 0)
 	for _, lvl := range levels {
 		itr, err := r.Client.LTXFiles(ctx, lvl, 0, false)
 		if err != nil {
@@ -155,9 +155,6 @@ Arguments:
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
-	-replica NAME
-	    Optional, filter by a specific replica.
-
 	-level LEVEL
 	    Compaction level to list (0-9 or "all").
 	    Defaults to 0.
@@ -169,9 +166,6 @@ Examples:
 
 	# List all LTX files for a database.
 	$ litestream ltx /path/to/db
-
-	# List all LTX files on S3
-	$ litestream ltx -replica s3 /path/to/db
 
 	# List all LTX files for replica URL.
 	$ litestream ltx s3://mybkt/db

--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -27,7 +27,10 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 	if err := fs.Parse(args); err != nil {
 		return err
 	} else if fs.NArg() == 0 || fs.Arg(0) == "" {
-		return newUsageError("database path or replica URL required", "litestream ltx /path/to/db")
+		return &usageError{
+			message: "database path or replica URL required",
+			hint:    "litestream ltx /path/to/db",
+		}
 	} else if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}

--- a/cmd/litestream/ltx_test.go
+++ b/cmd/litestream/ltx_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,33 @@ func TestLTXCommand_Run_JSONOutput(t *testing.T) {
 	}
 	if got[0].Timestamp != timestamp.Format(time.RFC3339) {
 		t.Fatalf("unexpected timestamp: %s", got[0].Timestamp)
+	}
+}
+
+func TestLTXCommand_Run_EmptyJSONOutput(t *testing.T) {
+	replicaURL := "file://" + filepath.Join(t.TempDir(), "replica")
+
+	output := captureLTXCommandStdout(t, func() {
+		cmd := &LTXCommand{}
+		if err := cmd.Run(context.Background(), []string{"-json", replicaURL}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if output != "[]\n" {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+func TestLTXCommand_UsageOmitsReplicaFlag(t *testing.T) {
+	output := captureLTXCommandStdout(t, func() {
+		(&LTXCommand{}).Usage()
+	})
+
+	for _, substr := range []string{"-replica NAME", "litestream ltx -replica"} {
+		if strings.Contains(output, substr) {
+			t.Fatalf("usage contains stale replica flag text %q:\n%s", substr, output)
+		}
 	}
 }
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -83,8 +83,30 @@ func main() {
 	if err := m.Run(context.Background(), os.Args[1:]); errors.Is(err, flag.ErrHelp) || errors.Is(err, errStop) {
 		os.Exit(1)
 	} else if err != nil {
-		slog.Error("failed to run", "error", err)
+		printCLIError(os.Stderr, err)
 		os.Exit(1)
+	}
+}
+
+type usageError struct {
+	message string
+	hint    string
+}
+
+func newUsageError(message, hint string) error {
+	return &usageError{message: message, hint: hint}
+}
+
+func (e *usageError) Error() string {
+	return e.message
+}
+
+func printCLIError(w io.Writer, err error) {
+	_, _ = fmt.Fprintf(w, "Error: %s\n", err)
+
+	var usageErr *usageError
+	if errors.As(err, &usageErr) && usageErr.hint != "" {
+		_, _ = fmt.Fprintf(w, "Try: %s\n", usageErr.hint)
 	}
 }
 
@@ -116,11 +138,11 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 
 	switch cmd {
 	case "databases":
-		return (&DatabasesCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&DatabasesCommand{}).Run(ctx, args))
 	case "replicate":
 		c := NewReplicateCommand()
 		if err := c.ParseFlags(ctx, args); err != nil {
-			return err
+			return filterExplicitHelp(args, err)
 		}
 
 		// Setup signal handler.
@@ -174,33 +196,33 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		return err
 
 	case "start":
-		return (&StartCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&StartCommand{}).Run(ctx, args))
 	case "stop":
-		return (&StopCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&StopCommand{}).Run(ctx, args))
 	case "register":
-		return (&RegisterCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&RegisterCommand{}).Run(ctx, args))
 	case "unregister":
-		return (&UnregisterCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&UnregisterCommand{}).Run(ctx, args))
 	case "reset":
-		return (&ResetCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&ResetCommand{}).Run(ctx, args))
 	case "restore":
-		return (&RestoreCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&RestoreCommand{}).Run(ctx, args))
 	case "status":
-		return (&StatusCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&StatusCommand{}).Run(ctx, args))
 	case "sync":
-		return (&SyncCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&SyncCommand{}).Run(ctx, args))
 	case "list":
-		return (&ListCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&ListCommand{}).Run(ctx, args))
 	case "info":
-		return (&InfoCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&InfoCommand{}).Run(ctx, args))
 	case "version":
-		return (&VersionCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&VersionCommand{}).Run(ctx, args))
 	case "ltx":
-		return (&LTXCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&LTXCommand{}).Run(ctx, args))
 	case "wal":
 		// Deprecated: Keep for backward compatibility
 		fmt.Fprintln(os.Stderr, "Warning: 'wal' command is deprecated, please use 'ltx' instead")
-		return (&LTXCommand{}).Run(ctx, args)
+		return filterExplicitHelp(args, (&LTXCommand{}).Run(ctx, args))
 	default:
 		if cmd == "help" || cmd == "-h" || cmd == "--help" {
 			m.Usage()
@@ -211,6 +233,23 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		}
 		return fmt.Errorf("litestream %s: unknown command", cmd)
 	}
+}
+
+func filterExplicitHelp(args []string, err error) error {
+	if errors.Is(err, flag.ErrHelp) && hasExplicitHelpFlag(args) {
+		return nil
+	}
+	return err
+}
+
+func hasExplicitHelpFlag(args []string) bool {
+	for _, arg := range args {
+		switch arg {
+		case "-h", "-help", "--help":
+			return true
+		}
+	}
+	return false
 }
 
 // Usage prints the help screen to STDOUT.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -83,7 +83,11 @@ func main() {
 	if err := m.Run(context.Background(), os.Args[1:]); errors.Is(err, flag.ErrHelp) || errors.Is(err, errStop) {
 		os.Exit(1)
 	} else if err != nil {
-		printCLIError(os.Stderr, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		var usageErr *usageError
+		if errors.As(err, &usageErr) && usageErr.hint != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "Try: %s\n", usageErr.hint)
+		}
 		os.Exit(1)
 	}
 }
@@ -95,15 +99,6 @@ type usageError struct {
 
 func (e *usageError) Error() string {
 	return e.message
-}
-
-func printCLIError(w io.Writer, err error) {
-	_, _ = fmt.Fprintf(w, "Error: %s\n", err)
-
-	var usageErr *usageError
-	if errors.As(err, &usageErr) && usageErr.hint != "" {
-		_, _ = fmt.Fprintf(w, "Try: %s\n", usageErr.hint)
-	}
 }
 
 // Main represents the main program execution.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -93,10 +93,6 @@ type usageError struct {
 	hint    string
 }
 
-func newUsageError(message, hint string) error {
-	return &usageError{message: message, hint: hint}
-}
-
 func (e *usageError) Error() string {
 	return e.message
 }

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -80,7 +80,14 @@ func main() {
 	internal.InitLog(os.Stdout, "INFO", "text", false)
 
 	m := NewMain()
-	if err := m.Run(context.Background(), os.Args[1:]); errors.Is(err, flag.ErrHelp) || errors.Is(err, errStop) {
+	if err := m.Run(context.Background(), os.Args[1:]); errors.Is(err, errStop) {
+		os.Exit(1)
+	} else if errors.Is(err, flag.ErrHelp) {
+		for _, arg := range os.Args[1:] {
+			if arg == "-h" || arg == "-help" || arg == "--help" {
+				os.Exit(0)
+			}
+		}
 		os.Exit(1)
 	} else if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
@@ -129,11 +136,11 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 
 	switch cmd {
 	case "databases":
-		return filterExplicitHelp(args, (&DatabasesCommand{}).Run(ctx, args))
+		return (&DatabasesCommand{}).Run(ctx, args)
 	case "replicate":
 		c := NewReplicateCommand()
 		if err := c.ParseFlags(ctx, args); err != nil {
-			return filterExplicitHelp(args, err)
+			return err
 		}
 
 		// Setup signal handler.
@@ -187,35 +194,35 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		return err
 
 	case "start":
-		return filterExplicitHelp(args, (&StartCommand{}).Run(ctx, args))
+		return (&StartCommand{}).Run(ctx, args)
 	case "stop":
-		return filterExplicitHelp(args, (&StopCommand{}).Run(ctx, args))
+		return (&StopCommand{}).Run(ctx, args)
 	case "register":
-		return filterExplicitHelp(args, (&RegisterCommand{}).Run(ctx, args))
+		return (&RegisterCommand{}).Run(ctx, args)
 	case "unregister":
-		return filterExplicitHelp(args, (&UnregisterCommand{}).Run(ctx, args))
+		return (&UnregisterCommand{}).Run(ctx, args)
 	case "reset":
-		return filterExplicitHelp(args, (&ResetCommand{}).Run(ctx, args))
+		return (&ResetCommand{}).Run(ctx, args)
 	case "restore":
-		return filterExplicitHelp(args, (&RestoreCommand{}).Run(ctx, args))
+		return (&RestoreCommand{}).Run(ctx, args)
 	case "status":
-		return filterExplicitHelp(args, (&StatusCommand{}).Run(ctx, args))
+		return (&StatusCommand{}).Run(ctx, args)
 	case "sync":
-		return filterExplicitHelp(args, (&SyncCommand{}).Run(ctx, args))
+		return (&SyncCommand{}).Run(ctx, args)
 	case "list":
-		return filterExplicitHelp(args, (&ListCommand{}).Run(ctx, args))
+		return (&ListCommand{}).Run(ctx, args)
 	case "info":
-		return filterExplicitHelp(args, (&InfoCommand{}).Run(ctx, args))
+		return (&InfoCommand{}).Run(ctx, args)
 	case "version":
-		return filterExplicitHelp(args, (&VersionCommand{}).Run(ctx, args))
+		return (&VersionCommand{}).Run(ctx, args)
 	case "ltx":
-		return filterExplicitHelp(args, (&LTXCommand{}).Run(ctx, args))
+		return (&LTXCommand{}).Run(ctx, args)
 	case "wal":
 		// Deprecated: Keep for backward compatibility
 		fmt.Fprintln(os.Stderr, "Warning: 'wal' command is deprecated, please use 'ltx' instead")
-		return filterExplicitHelp(args, (&LTXCommand{}).Run(ctx, args))
+		return (&LTXCommand{}).Run(ctx, args)
 	default:
-		if cmd == "help" || cmd == "-h" || cmd == "--help" {
+		if cmd == "help" || cmd == "-h" || cmd == "-help" || cmd == "--help" {
 			m.Usage()
 			return nil
 		} else if cmd == "" || strings.HasPrefix(cmd, "-") {
@@ -224,23 +231,6 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		}
 		return fmt.Errorf("litestream %s: unknown command", cmd)
 	}
-}
-
-func filterExplicitHelp(args []string, err error) error {
-	if errors.Is(err, flag.ErrHelp) && hasExplicitHelpFlag(args) {
-		return nil
-	}
-	return err
-}
-
-func hasExplicitHelpFlag(args []string) bool {
-	for _, arg := range args {
-		switch arg {
-		case "-h", "-help", "--help":
-			return true
-		}
-	}
-	return false
 }
 
 // Usage prints the help screen to STDOUT.

--- a/cmd/litestream/main_cli_test.go
+++ b/cmd/litestream/main_cli_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestMainRequiredArgumentErrorsIncludeTryHints(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		message string
+		hint    string
+	}{
+		{
+			name:    "Register",
+			args:    []string{"register"},
+			message: "database path required",
+			hint:    "litestream register -replica s3://bucket/prefix /path/to/db",
+		},
+		{
+			name:    "RegisterReplica",
+			args:    []string{"register", "/tmp/example.db"},
+			message: "-replica is required",
+			hint:    "litestream register -replica s3://bucket/prefix /path/to/db",
+		},
+		{
+			name:    "Unregister",
+			args:    []string{"unregister"},
+			message: "database path required",
+			hint:    "litestream unregister /path/to/db",
+		},
+		{
+			name:    "Start",
+			args:    []string{"start"},
+			message: "database path required",
+			hint:    "litestream start /path/to/db",
+		},
+		{
+			name:    "Stop",
+			args:    []string{"stop"},
+			message: "database path required",
+			hint:    "litestream stop /path/to/db",
+		},
+		{
+			name:    "Sync",
+			args:    []string{"sync"},
+			message: "database path required",
+			hint:    "litestream sync /path/to/db",
+		},
+		{
+			name:    "LTX",
+			args:    []string{"ltx"},
+			message: "database path or replica URL required",
+			hint:    "litestream ltx /path/to/db",
+		},
+		{
+			name:    "Reset",
+			args:    []string{"reset"},
+			message: "database path required",
+			hint:    "litestream reset /path/to/db",
+		},
+		{
+			name:    "Restore",
+			args:    []string{"restore"},
+			message: "database path or replica URL required",
+			hint:    "litestream restore -o /path/to/db s3://bucket/prefix",
+		},
+		{
+			name:    "RestoreOutputPath",
+			args:    []string{"restore", "s3://bucket/prefix"},
+			message: "-o is required when restoring from a replica URL",
+			hint:    "litestream restore -o /path/to/db s3://bucket/prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runLitestreamMain(t, tt.args...)
+			if exitCode == 0 {
+				t.Fatal("expected non-zero exit code")
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got:\n%s", stdout)
+			}
+			want := "Error: " + tt.message + "\nTry: " + tt.hint + "\n"
+			if stderr != want {
+				t.Fatalf("unexpected stderr:\n%s\nwant:\n%s", stderr, want)
+			}
+		})
+	}
+}
+
+func TestMainHarness(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MAIN") != "1" {
+		t.Skip("helper process only")
+	}
+
+	var args []string
+	if err := json.Unmarshal([]byte(os.Getenv("LITESTREAM_TEST_ARGS")), &args); err != nil {
+		t.Fatal(err)
+	}
+	os.Args = append([]string{"litestream"}, args...)
+	main()
+}
+
+func TestMainSubcommandExplicitHelpExitsZero(t *testing.T) {
+	stdout, stderr, exitCode := runLitestreamMain(t, "register", "-help")
+	if exitCode != 0 {
+		t.Fatalf("exit code=%d, want 0\nstderr:\n%s", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "usage: litestream register") {
+		t.Fatalf("expected register usage on stdout, got:\n%s", stdout)
+	}
+}
+
+func TestReplicateCommandUsageMentionsControlSocketConfig(t *testing.T) {
+	output := captureLTXCommandStdout(t, func() {
+		(&ReplicateCommand{}).Usage()
+	})
+
+	for _, substr := range []string{
+		"Runtime control commands require the daemon control socket.",
+		"socket:",
+		"enabled: true",
+		"path: /tmp/litestream.sock",
+	} {
+		if !strings.Contains(output, substr) {
+			t.Fatalf("usage missing %q:\n%s", substr, output)
+		}
+	}
+}
+
+func runLitestreamMain(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainHarness")
+	cmd.Env = append(os.Environ(),
+		"LITESTREAM_TEST_MAIN=1",
+		"LITESTREAM_TEST_ARGS="+string(argsJSON),
+	)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err = cmd.Run()
+	if err == nil {
+		return out.String(), errOut.String(), 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("unexpected command error: %v", err)
+	}
+	return out.String(), errOut.String(), exitErr.ExitCode()
+}

--- a/cmd/litestream/register.go
+++ b/cmd/litestream/register.go
@@ -28,13 +28,19 @@ func (c *RegisterCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return newUsageError("database path required", "litestream register -replica s3://bucket/prefix /path/to/db")
+		return &usageError{
+			message: "database path required",
+			hint:    "litestream register -replica s3://bucket/prefix /path/to/db",
+		}
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}
 	if *replicaFlag == "" {
-		return newUsageError("-replica is required", "litestream register -replica s3://bucket/prefix /path/to/db")
+		return &usageError{
+			message: "-replica is required",
+			hint:    "litestream register -replica s3://bucket/prefix /path/to/db",
+		}
 	}
 	if *timeout <= 0 {
 		return fmt.Errorf("timeout must be greater than 0")

--- a/cmd/litestream/register.go
+++ b/cmd/litestream/register.go
@@ -28,13 +28,13 @@ func (c *RegisterCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return fmt.Errorf("database path required")
+		return newUsageError("database path required", "litestream register -replica s3://bucket/prefix /path/to/db")
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}
 	if *replicaFlag == "" {
-		return fmt.Errorf("-replica is required. Try: litestream register -replica s3://bucket/prefix /path/to/db")
+		return newUsageError("-replica is required", "litestream register -replica s3://bucket/prefix /path/to/db")
 	}
 	if *timeout <= 0 {
 		return fmt.Errorf("timeout must be greater than 0")
@@ -118,7 +118,7 @@ type RegisterResult struct {
 }
 
 func registerDisplayStatus(status string) string {
-	if status == "already_exists" {
+	if status == "already_registered" {
 		return "already registered"
 	}
 	return status

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -71,18 +71,14 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = store.Close(context.Background())
-		}()
+		defer store.Close(context.Background())
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = server.Close()
-		}()
+		defer server.Close()
 
 		// Create a temporary database file.
 		db, sqldb := testingutil.MustOpenDBs(t)
@@ -113,18 +109,14 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = store.Close(context.Background())
-		}()
+		defer store.Close(context.Background())
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = server.Close()
-		}()
+		defer server.Close()
 
 		// Create a temp directory for backup.
 		backupDir := filepath.Join(t.TempDir(), "backup")
@@ -201,18 +193,14 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = store.Close(context.Background())
-		}()
+		defer store.Close(context.Background())
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = server.Close()
-		}()
+		defer server.Close()
 
 		output := captureStdout(t, func() {
 			cmd := &main.RegisterCommand{}

--- a/cmd/litestream/register_test.go
+++ b/cmd/litestream/register_test.go
@@ -30,7 +30,7 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for missing replica flag")
 		}
-		if err.Error() != "-replica is required. Try: litestream register -replica s3://bucket/prefix /path/to/db" {
+		if err.Error() != "-replica is required" {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -71,14 +71,18 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer store.Close(context.Background())
+		defer func() {
+			_ = store.Close(context.Background())
+		}()
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer server.Close()
+		defer func() {
+			_ = server.Close()
+		}()
 
 		// Create a temporary database file.
 		db, sqldb := testingutil.MustOpenDBs(t)
@@ -109,14 +113,18 @@ func TestRegisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer store.Close(context.Background())
+		defer func() {
+			_ = store.Close(context.Background())
+		}()
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer server.Close()
+		defer func() {
+			_ = server.Close()
+		}()
 
 		// Create a temp directory for backup.
 		backupDir := filepath.Join(t.TempDir(), "backup")
@@ -181,6 +189,45 @@ func TestRegisterCommand_Run(t *testing.T) {
 		}
 		if got.Socket != server.SocketPath {
 			t.Fatalf("unexpected socket: %s", got.Socket)
+		}
+	})
+
+	t.Run("JSONAlreadyExistsStatus", func(t *testing.T) {
+		db, sqldb := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db, sqldb)
+
+		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = store.Close(context.Background())
+		}()
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = server.Close()
+		}()
+
+		output := captureStdout(t, func() {
+			cmd := &main.RegisterCommand{}
+			err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, "-replica", "file://" + t.TempDir(), db.Path()})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got main.RegisterResult
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if got.Status != "already_registered" {
+			t.Fatalf("unexpected status: %s", got.Status)
 		}
 	})
 

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -564,5 +564,12 @@ Arguments:
 	    Restores the database from the replica if it doesn't exist.
 	    On first start with no backup, proceeds normally.
 
+Runtime control commands require the daemon control socket. This includes
+start, stop, sync, register, unregister, info, and list. Enable it in the config:
+
+	socket:
+	  enabled: true
+	  path: /tmp/litestream.sock
+
 `[1:], DefaultConfigPath())
 }

--- a/cmd/litestream/reset.go
+++ b/cmd/litestream/reset.go
@@ -26,7 +26,10 @@ func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Validate arguments - need exactly one database path
 	if fs.NArg() == 0 {
-		return newUsageError("database path required", "litestream reset /path/to/db")
+		return &usageError{
+			message: "database path required",
+			hint:    "litestream reset /path/to/db",
+		}
 	} else if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}

--- a/cmd/litestream/reset.go
+++ b/cmd/litestream/reset.go
@@ -26,7 +26,7 @@ func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Validate arguments - need exactly one database path
 	if fs.NArg() == 0 {
-		return fmt.Errorf("database path required")
+		return newUsageError("database path required", "litestream reset /path/to/db")
 	} else if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -43,7 +43,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	if err := fs.Parse(args); err != nil {
 		return err
 	} else if fs.NArg() == 0 || fs.Arg(0) == "" {
-		return fmt.Errorf("database path or replica URL required")
+		return newUsageError("database path or replica URL required", "litestream restore -o /path/to/db s3://bucket/prefix")
 	} else if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}
@@ -296,7 +296,7 @@ func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {
 // loadFromURL creates a replica & updates the restore options from a replica URL.
 func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	if opt.OutputPath == "" {
-		return nil, fmt.Errorf("-o is required when restoring from a replica URL. Try: litestream restore -o /path/to/db %s", replicaURL)
+		return nil, newUsageError("-o is required when restoring from a replica URL", fmt.Sprintf("litestream restore -o /path/to/db %s", replicaURL))
 	}
 
 	// Exit successfully if the output file already exists.

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -43,7 +43,10 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	if err := fs.Parse(args); err != nil {
 		return err
 	} else if fs.NArg() == 0 || fs.Arg(0) == "" {
-		return newUsageError("database path or replica URL required", "litestream restore -o /path/to/db s3://bucket/prefix")
+		return &usageError{
+			message: "database path or replica URL required",
+			hint:    "litestream restore -o /path/to/db s3://bucket/prefix",
+		}
 	} else if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")
 	}
@@ -296,7 +299,10 @@ func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {
 // loadFromURL creates a replica & updates the restore options from a replica URL.
 func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	if opt.OutputPath == "" {
-		return nil, newUsageError("-o is required when restoring from a replica URL", fmt.Sprintf("litestream restore -o /path/to/db %s", replicaURL))
+		return nil, &usageError{
+			message: "-o is required when restoring from a replica URL",
+			hint:    fmt.Sprintf("litestream restore -o /path/to/db %s", replicaURL),
+		}
 	}
 
 	// Exit successfully if the output file already exists.

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -73,7 +73,7 @@ func TestRestoreCommand_RunMissingOutputPathForReplicaURL(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing output path")
 	}
-	if err.Error() != "-o is required when restoring from a replica URL. Try: litestream restore -o /path/to/db s3://bucket/prefix" {
+	if err.Error() != "-o is required when restoring from a replica URL" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/litestream/start.go
+++ b/cmd/litestream/start.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/benbjohnson/litestream"
@@ -30,12 +29,7 @@ func (c *StartCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		os.Stderr.WriteString(`
-Note: 'litestream start' enables replication for a single database on a running daemon.
-To start the replication daemon, use 'litestream replicate' instead.
-Run 'litestream start -h' for usage details.
-`)
-		return fmt.Errorf("database path required")
+		return newUsageError("database path required", "litestream start /path/to/db")
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/start.go
+++ b/cmd/litestream/start.go
@@ -29,7 +29,10 @@ func (c *StartCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return newUsageError("database path required", "litestream start /path/to/db")
+		return &usageError{
+			message: "database path required",
+			hint:    "litestream start /path/to/db",
+		}
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/status.go
+++ b/cmd/litestream/status.go
@@ -41,7 +41,7 @@ func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 		filterPath = fs.Arg(0)
 	}
 
-	var statuses []DBStatus
+	statuses := make([]DBStatus, 0, len(config.DBs))
 
 	for _, dbConfig := range config.DBs {
 		db, err := NewDBFromConfig(dbConfig)
@@ -158,7 +158,7 @@ Output columns:
   local txid    Latest local transaction ID
   wal size      Current WAL file size
 
-Note: To see replica TXID and sync status, use the MCP tools or check logs
+Note: To see replica TXID and sync status, inspect daemon diagnostics or logs
 while the replication daemon is running.
 
 Examples:

--- a/cmd/litestream/status_test.go
+++ b/cmd/litestream/status_test.go
@@ -119,4 +119,23 @@ func TestStatusCommand_Run(t *testing.T) {
 			t.Fatalf("unexpected wal size: %s", got[0].WALSize)
 		}
 	})
+
+	t.Run("EmptyJSONOutput", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "litestream.yml")
+		if err := os.WriteFile(configPath, []byte("dbs: []\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		output := captureStdout(t, func() {
+			cmd := &main.StatusCommand{}
+			if err := cmd.Run(context.Background(), []string{"-config", configPath, "-json"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		if output != "[]\n" {
+			t.Fatalf("unexpected output: %q", output)
+		}
+	})
 }

--- a/cmd/litestream/stop.go
+++ b/cmd/litestream/stop.go
@@ -29,7 +29,7 @@ func (c *StopCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return fmt.Errorf("database path required")
+		return newUsageError("database path required", "litestream stop /path/to/db")
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/stop.go
+++ b/cmd/litestream/stop.go
@@ -29,7 +29,10 @@ func (c *StopCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return newUsageError("database path required", "litestream stop /path/to/db")
+		return &usageError{
+			message: "database path required",
+			hint:    "litestream stop /path/to/db",
+		}
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/sync.go
+++ b/cmd/litestream/sync.go
@@ -30,7 +30,10 @@ func (c *SyncCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return newUsageError("database path required", "litestream sync /path/to/db")
+		return &usageError{
+			message: "database path required",
+			hint:    "litestream sync /path/to/db",
+		}
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/sync.go
+++ b/cmd/litestream/sync.go
@@ -30,7 +30,7 @@ func (c *SyncCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return fmt.Errorf("database path required")
+		return newUsageError("database path required", "litestream sync /path/to/db")
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/unregister.go
+++ b/cmd/litestream/unregister.go
@@ -28,7 +28,10 @@ func (c *UnregisterCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return newUsageError("database path required", "litestream unregister /path/to/db")
+		return &usageError{
+			message: "database path required",
+			hint:    "litestream unregister /path/to/db",
+		}
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/unregister.go
+++ b/cmd/litestream/unregister.go
@@ -28,7 +28,7 @@ func (c *UnregisterCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	if fs.NArg() == 0 {
-		return fmt.Errorf("database path required")
+		return newUsageError("database path required", "litestream unregister /path/to/db")
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("too many arguments")

--- a/cmd/litestream/unregister_test.go
+++ b/cmd/litestream/unregister_test.go
@@ -93,14 +93,18 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer store.Close(context.Background())
+		defer func() {
+			_ = store.Close(context.Background())
+		}()
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer server.Close()
+		defer func() {
+			_ = server.Close()
+		}()
 
 		output := captureStdout(t, func() {
 			cmd := &main.UnregisterCommand{}
@@ -110,8 +114,8 @@ func TestUnregisterCommand_Run(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
-		if !strings.Contains(output, "status: not_registered") {
-			t.Fatalf("expected not_registered status, got:\n%s", output)
+		if !strings.Contains(output, "status: already_unregistered") {
+			t.Fatalf("expected already_unregistered status, got:\n%s", output)
 		}
 		if !strings.Contains(output, "final_txid: 0") {
 			t.Fatalf("expected zero final txid, got:\n%s", output)
@@ -128,7 +132,9 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer store.Close(context.Background())
+		defer func() {
+			_ = store.Close(context.Background())
+		}()
 
 		// Verify database is initially in store.
 		if len(store.DBs()) != 1 {
@@ -140,7 +146,9 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer server.Close()
+		defer func() {
+			_ = server.Close()
+		}()
 
 		cmd := &main.UnregisterCommand{}
 		err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, dbPath})
@@ -207,6 +215,45 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		}
 		if len(store.DBs()) != 0 {
 			t.Errorf("expected 0 databases in store, got %d", len(store.DBs()))
+		}
+	})
+
+	t.Run("JSONNotFoundStatus", func(t *testing.T) {
+		store := litestream.NewStore(nil, litestream.CompactionLevels{{Level: 0}})
+		store.CompactionMonitorEnabled = false
+		if err := store.Open(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = store.Close(context.Background())
+		}()
+
+		server := litestream.NewServer(store)
+		server.SocketPath = testSocketPath(t)
+		if err := server.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = server.Close()
+		}()
+
+		output := captureStdout(t, func() {
+			cmd := &main.UnregisterCommand{}
+			err := cmd.Run(context.Background(), []string{"-json", "-socket", server.SocketPath, "/nonexistent/db"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got main.UnregisterResult
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if got.Status != "already_unregistered" {
+			t.Fatalf("unexpected status: %s", got.Status)
+		}
+		if got.FinalTXID != 0 {
+			t.Fatalf("unexpected final txid: %d", got.FinalTXID)
 		}
 	})
 }

--- a/cmd/litestream/unregister_test.go
+++ b/cmd/litestream/unregister_test.go
@@ -93,18 +93,14 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = store.Close(context.Background())
-		}()
+		defer store.Close(context.Background())
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = server.Close()
-		}()
+		defer server.Close()
 
 		output := captureStdout(t, func() {
 			cmd := &main.UnregisterCommand{}
@@ -132,9 +128,7 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = store.Close(context.Background())
-		}()
+		defer store.Close(context.Background())
 
 		// Verify database is initially in store.
 		if len(store.DBs()) != 1 {
@@ -146,9 +140,7 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = server.Close()
-		}()
+		defer server.Close()
 
 		cmd := &main.UnregisterCommand{}
 		err := cmd.Run(context.Background(), []string{"-socket", server.SocketPath, dbPath})
@@ -224,18 +216,14 @@ func TestUnregisterCommand_Run(t *testing.T) {
 		if err := store.Open(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = store.Close(context.Background())
-		}()
+		defer store.Close(context.Background())
 
 		server := litestream.NewServer(store)
 		server.SocketPath = testSocketPath(t)
 		if err := server.Start(); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = server.Close()
-		}()
+		defer server.Close()
 
 		output := captureStdout(t, func() {
 			cmd := &main.UnregisterCommand{}

--- a/docs/CLI_JSON_OUTPUT.md
+++ b/docs/CLI_JSON_OUTPUT.md
@@ -7,6 +7,11 @@ status.
 The fields below are the stable output contract for CLI consumers. New fields
 may be added in future releases, so consumers should ignore unknown fields.
 
+Runtime commands use `status` values that name the completed state. When a
+command is already in its requested state, the status uses `already_<state>`,
+such as `already_registered`, `already_running`, `already_stopped`, or
+`already_unregistered`.
+
 ## `litestream databases -json`
 
 Outputs an array of databases loaded from the configuration file.

--- a/server.go
+++ b/server.go
@@ -594,7 +594,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Check if database already exists.
 	if existing := s.store.FindDB(expandedPath); existing != nil {
 		writeJSON(w, http.StatusOK, RegisterDatabaseResponse{
-			Status: "already_exists",
+			Status: "already_registered",
 			Path:   expandedPath,
 		})
 		return
@@ -661,7 +661,7 @@ func (s *Server) handleUnregister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var txID uint64
-	status := "not_registered"
+	status := "already_unregistered"
 	if db != nil {
 		_, maxTXID, err := db.MaxLTX()
 		if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -411,7 +411,7 @@ func TestServer_HandleRegister(t *testing.T) {
 
 		var result litestream.RegisterDatabaseResponse
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
-		require.Equal(t, "already_exists", result.Status)
+		require.Equal(t, "already_registered", result.Status)
 	})
 }
 
@@ -462,7 +462,7 @@ func TestServer_HandleUnregister(t *testing.T) {
 
 		var result litestream.UnregisterDatabaseResponse
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
-		require.Equal(t, "not_registered", result.Status)
+		require.Equal(t, "already_unregistered", result.Status)
 		require.Zero(t, result.TXID)
 	})
 


### PR DESCRIPTION
## Description
Polishes the agent-facing CLI behavior from #1296:

- Emits `[]` instead of `null` for empty top-level JSON arrays from `databases`, `status`, and `ltx`.
- Renders top-level CLI user errors as plain stderr output with optional `Try:` hints instead of slog-framed stdout records.
- Adds required-argument hints for `register`, `unregister`, `start`, `stop`, `sync`, `ltx`, `reset`, and `restore`.
- Normalizes idempotent runtime statuses to `already_<state>` for register/unregister, matching the existing start/stop convention.
- Removes stale `ltx -replica` help text and documents the control socket config in `replicate -help`.
- Makes explicit subcommand help exit successfully.

## Motivation and Context
Issue #1296 verified that the #1232 CLI surface mostly works, but a few edges still made scripted and agent usage inconsistent.

Observed before this PR:

```bash
litestream databases -json -config empty.yml
# null

litestream register >out 2>err || true
# out contained: time=... level=ERROR msg="failed to run" error="database path required"
# err was empty

litestream ltx -help
# documented -replica even though the command does not register that flag
```

Verified after this PR with a built binary:

```bash
databases-json=[]
status-json=[]
ltx-json=[]
register-stdout-bytes=0
register-stderr=Error: database path required
Try: litestream register -replica s3://bucket/prefix /path/to/db
register-help-exit=0 stdout-has-usage=yes stderr-bytes=0
ltx-help-replica=absent
replicate-help-socket=yes
```

Fixes #1296

Closes #1232 — this PR completes the final error-surface items in the tracking checklist; the deferred resource+verb RFC was spun out to its own design issue (#1298).

## Scope
**In scope:**
- CLI output/error/help polish requested in #1296.
- Control socket response status string normalization for register/unregister no-op cases.
- JSON output docs for the idempotent status convention.
- Regression tests for the visible CLI contracts.

**Not in scope:**
- Changes to replication, restore mechanics, storage backends, or LTX file formats.
- Broader lint cleanup unrelated to this CLI issue.

## How Has This Been Tested?

```bash
go test ./cmd/litestream -run 'Test(MainRequiredArgumentErrorsIncludeTryHints|MainSubcommandExplicitHelpExitsZero|ReplicateCommandUsageMentionsControlSocketConfig|DatabasesCommand_Run|StatusCommand_Run|LTXCommand_Run_EmptyJSONOutput|LTXCommand_UsageOmitsReplicaFlag|RegisterCommand_Run|UnregisterCommand_Run|RestoreCommand_RunMissingOutputPathForReplicaURL)'
go test . -run 'TestServer_Handle(Register|Unregister|Start|Stop)'
go test ./cmd/litestream
go test .
go build ./...
go test ./...
go test -race ./...
golangci-lint run --new-from-rev=8e9b9074db19a1d88dc0172d9c61614bfa2ea35e
pre-commit run --all-files
```

`golangci-lint run` without `--new-from-rev` still reports existing repo-wide errcheck findings unrelated to this diff.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)

