### PR TITLE
test(integration): add replicate restore soak test

### DIFF
--- a/.github/workflows/nightly-stability.yml
+++ b/.github/workflows/nightly-stability.yml
@@ -167,6 +167,52 @@ jobs:
           path: /tmp/litestream-minio-soak-*/
           retention-days: 14
 
+  replicate-restore-soak:
+    name: Replicate Restore Soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build binaries
+        run: |
+          go build -o bin/litestream ./cmd/litestream
+          go build -o bin/litestream-test ./cmd/litestream-test
+
+      - name: Determine duration
+        id: config
+        run: |
+          if [[ -n "${{ inputs.duration }}" ]]; then
+            echo "duration=${{ inputs.duration }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event.schedule }}" == "0 3 * * 6" ]]; then
+            echo "duration=2h" >> $GITHUB_OUTPUT
+          else
+            echo "duration=30m" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run replicate restore soak test
+        run: |
+          go test -tags 'integration,soak,docker' \
+            -run 'TestSoakReplicateRestore' \
+            -v -timeout 170m \
+            ./tests/integration/
+        env:
+          SOAK_KEEP_TEMP: "1"
+          SOAK_AUTO_PURGE: "yes"
+          SOAK_DURATION: ${{ steps.config.outputs.duration }}
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: replicate-restore-soak-results
+          path: /tmp/litestream-replicate-restore-*/
+          retention-days: 14
+
   comprehensive-soak:
     name: Comprehensive Soak
     runs-on: ubuntu-latest
@@ -215,7 +261,7 @@ jobs:
   notify-on-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [race-detector-sweep, ltx-behavioral-soak, ltx-snapshot-regression, minio-soak, comprehensive-soak]
+    needs: [race-detector-sweep, ltx-behavioral-soak, ltx-snapshot-regression, minio-soak, replicate-restore-soak, comprehensive-soak]
     if: failure()
     steps:
       - name: Create or update failure issue

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -3880,5 +3881,220 @@ func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
 	}
 	if count != 30*20 {
 		t.Fatalf("row count=%d, want %d", count, 30*20)
+	}
+}
+
+// TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints verifies that a
+// snapshot's content matches its advertised position while checkpoints and
+// writes run concurrently. The position capture and chkMu read lock must be
+// atomic with respect to checkpoints: if a checkpoint can run between them,
+// the snapshot reads post-position pages from the database file while its
+// header still claims the earlier transaction — the #1164 corruption class.
+func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.MinCheckpointPageN = 1000000
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE kv (id INTEGER PRIMARY KEY, v INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO kv VALUES (1, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// valueAt records which kv value was current at each synced position so
+	// snapshots can be checked against the state their header advertises.
+	var valueMu sync.Mutex
+	valueAt := map[ltx.TXID]int64{}
+	recordPos := func(v int64) error {
+		pos, err := db.Pos()
+		if err != nil {
+			return err
+		}
+		valueMu.Lock()
+		valueAt[pos.TXID] = v
+		valueMu.Unlock()
+		return nil
+	}
+	if err := recordPos(0); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for v := int64(1); ; v++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := sqldb.Exec(`UPDATE kv SET v = ? WHERE id = 1`, v); err != nil {
+				errCh <- err
+				return
+			}
+			if err := db.Sync(ctx); err != nil {
+				errCh <- err
+				return
+			}
+			if err := recordPos(v); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// TRUNCATE resets the WAL so subsequent snapshots must read
+			// cold pages from the database file — the path that exposes
+			// a checkpoint racing the position capture.
+			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil && !isSQLiteBusyError(err) {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 15; i++ {
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		default:
+		}
+
+		pos, r, err := db.SnapshotReader(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dec := ltx.NewDecoder(r)
+		if err := dec.DecodeHeader(); err != nil {
+			t.Fatal(err)
+		}
+		hdr := dec.Header()
+		if hdr.MaxTXID != pos.TXID {
+			t.Fatalf("snapshot header txid=%s, want advertised position %s", hdr.MaxTXID, pos.TXID)
+		}
+
+		restorePath := filepath.Join(t.TempDir(), fmt.Sprintf("restore-%d.db", i))
+		rf, err := os.Create(restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pageData := make([]byte, hdr.PageSize)
+		for {
+			var phdr ltx.PageHeader
+			if err := dec.DecodePage(&phdr, pageData); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := rf.WriteAt(pageData, int64(phdr.Pgno-1)*int64(hdr.PageSize)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := dec.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := rf.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
+
+		restoredDB, err := sql.Open("sqlite", restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var integrity string
+		if err := restoredDB.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+			t.Fatal(err)
+		}
+		var got int64
+		if err := restoredDB.QueryRow(`SELECT v FROM kv WHERE id = 1`).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		restoredDB.Close()
+		if integrity != "ok" {
+			t.Fatalf("snapshot %d integrity check failed: %s", i, integrity)
+		}
+
+		// Find the kv value recorded at the greatest synced position at or
+		// before the snapshot position. Skip if recording lags behind the
+		// snapshot position; intermediate unmapped TXIDs (checkpoint
+		// bookkeeping) never change kv.
+		valueMu.Lock()
+		var want int64
+		var bestTXID, maxTXID ltx.TXID
+		for txid, val := range valueAt {
+			if txid > maxTXID {
+				maxTXID = txid
+			}
+			if txid <= pos.TXID && txid >= bestTXID {
+				bestTXID, want = txid, val
+			}
+		}
+		valueMu.Unlock()
+		if pos.TXID > maxTXID {
+			continue
+		}
+		if got != want {
+			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s): content inconsistent with advertised position",
+				pos.TXID, got, want, bestTXID)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
 	}
 }

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3641,3 +3641,244 @@ func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
 		t.Fatal("read lock not released after Close with canceled context")
 	}
 }
+
+func TestSyncRestoreIntegrity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.MinCheckpointPageN = 50
+	db.CheckpointInterval = 100 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close(context.Background()) })
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := `
+		CREATE TABLE IF NOT EXISTS data (
+			ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+			_uid TEXT NOT NULL,
+			_resource_version INTEGER NOT NULL,
+			_updated_at DATETIME NOT NULL,
+			name TEXT,
+			data_json BLOB,
+			is_active INTEGER,
+			UNIQUE (_uid, _resource_version)
+		);
+		CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
+		CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
+	`
+	if _, err := sqldb.Exec(schema); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		for j := 0; j < 10; j++ {
+			uid := fmt.Sprintf("uid-%d-%d", i, j)
+			_, err := sqldb.ExecContext(ctx,
+				`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
+				 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
+				uid, fmt.Sprintf("item-%d-%d", i, j),
+				[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
+				j%2,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatalf("sync iteration %d: %v", i, err)
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatalf("close sqlite db: %v", err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreDB.Replica = NewReplica(restoreDB)
+	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
+	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatalf("open restored db: %v", err)
+	}
+	defer func() { _ = restoredDB.Close() }()
+
+	rows, err := restoredDB.QueryContext(ctx, `PRAGMA integrity_check`)
+	if err != nil {
+		t.Fatalf("integrity check: %v", err)
+	}
+	defer rows.Close()
+
+	var results []string
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			t.Fatal(err)
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("integrity check returned no results")
+	}
+	if results[0] != "ok" {
+		t.Fatalf("integrity check failed on restored database: %v", results)
+	}
+
+	var count int
+	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM data`).Scan(&count); err != nil {
+		t.Fatalf("count data: %v", err)
+	}
+	expectedRows := iterations * 10
+	if count != expectedRows {
+		t.Fatalf("restored row count=%d, want %d", count, expectedRows)
+	}
+}
+
+func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.MinCheckpointPageN = 20
+	db.TruncatePageN = 200
+	db.CheckpointInterval = 50 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close(context.Background()) })
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	for i := 0; i < 30; i++ {
+		for j := 0; j < 20; j++ {
+			_, err := sqldb.ExecContext(ctx,
+				`INSERT INTO t (val, extra) VALUES (?, ?)`,
+				fmt.Sprintf("val-%d-%d", i, j),
+				bytes.Repeat([]byte{byte(i)}, 512),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatalf("sync %d: %v", i, err)
+		}
+
+		if i%5 == 4 {
+			if _, err := sqldb.ExecContext(ctx, `PRAGMA wal_checkpoint(PASSIVE)`); err != nil {
+				t.Logf("passive checkpoint %d: %v", i, err)
+			}
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatalf("close sqlite db: %v", err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreDB.Replica = NewReplica(restoreDB)
+	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
+	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = restoredDB.Close() }()
+
+	var result string
+	if err := restoredDB.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result != "ok" {
+		t.Fatalf("integrity check failed: %s", result)
+	}
+
+	var count int
+	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM t`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 30*20 {
+		t.Fatalf("row count=%d, want %d", count, 30*20)
+	}
+}

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3643,24 +3643,39 @@ func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
 	}
 }
 
-func TestSyncRestoreIntegrity(t *testing.T) {
+// syncRestoreIntegrityConfig parameterizes runSyncRestoreIntegrity with the
+// pieces that differ between the sync/restore integrity test variants.
+type syncRestoreIntegrityConfig struct {
+	configure  func(db *DB)
+	schema     string
+	iterations int
+	insertRows func(t *testing.T, ctx context.Context, sqldb *sql.DB, iteration int)
+	afterSync  func(t *testing.T, ctx context.Context, sqldb *sql.DB, iteration int)
+	countQuery string
+	wantRows   int
+}
+
+// runSyncRestoreIntegrity opens a replicated database, runs insert/sync
+// iterations, closes everything, restores from the replica, and verifies
+// integrity and row count of the restored database.
+func runSyncRestoreIntegrity(t *testing.T, cfg syncRestoreIntegrityConfig) {
+	t.Helper()
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
 
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
+	dbPath := filepath.Join(t.TempDir(), "test.db")
 	replicaDir := t.TempDir()
 
 	db := NewDB(dbPath)
 	db.MonitorInterval = 0
 	db.ShutdownSyncTimeout = 0
-	db.MinCheckpointPageN = 50
-	db.CheckpointInterval = 100 * time.Millisecond
 	db.Replica = NewReplica(db)
 	db.Replica.Client = &testReplicaClient{dir: replicaDir}
 	db.Replica.MonitorEnabled = false
 	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg.configure(db)
 	if err := db.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -3677,45 +3692,21 @@ func TestSyncRestoreIntegrity(t *testing.T) {
 	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
 		t.Fatal(err)
 	}
-
-	schema := `
-		CREATE TABLE IF NOT EXISTS data (
-			ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
-			_uid TEXT NOT NULL,
-			_resource_version INTEGER NOT NULL,
-			_updated_at DATETIME NOT NULL,
-			name TEXT,
-			data_json BLOB,
-			is_active INTEGER,
-			UNIQUE (_uid, _resource_version)
-		);
-		CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
-		CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
-	`
-	if _, err := sqldb.Exec(schema); err != nil {
+	if _, err := sqldb.Exec(cfg.schema); err != nil {
 		t.Fatal(err)
 	}
 
 	ctx := context.Background()
 
-	const iterations = 20
-	for i := 0; i < iterations; i++ {
-		for j := 0; j < 10; j++ {
-			uid := fmt.Sprintf("uid-%d-%d", i, j)
-			_, err := sqldb.ExecContext(ctx,
-				`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
-				 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
-				uid, fmt.Sprintf("item-%d-%d", i, j),
-				[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
-				j%2,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
+	for i := 0; i < cfg.iterations; i++ {
+		cfg.insertRows(t, ctx, sqldb, i)
 
 		if err := db.Sync(ctx); err != nil {
 			t.Fatalf("sync iteration %d: %v", i, err)
+		}
+
+		if cfg.afterSync != nil {
+			cfg.afterSync(t, ctx, sqldb, i)
 		}
 	}
 
@@ -3769,118 +3760,95 @@ func TestSyncRestoreIntegrity(t *testing.T) {
 	}
 
 	var count int
-	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM data`).Scan(&count); err != nil {
-		t.Fatalf("count data: %v", err)
+	if err := restoredDB.QueryRowContext(ctx, cfg.countQuery).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
 	}
-	expectedRows := iterations * 10
-	if count != expectedRows {
-		t.Fatalf("restored row count=%d, want %d", count, expectedRows)
+	if count != cfg.wantRows {
+		t.Fatalf("restored row count=%d, want %d", count, cfg.wantRows)
 	}
 }
 
-func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping in short mode")
-	}
-
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
-	replicaDir := t.TempDir()
-
-	db := NewDB(dbPath)
-	db.MonitorInterval = 0
-	db.ShutdownSyncTimeout = 0
-	db.MinCheckpointPageN = 20
-	db.TruncatePageN = 200
-	db.CheckpointInterval = 50 * time.Millisecond
-	db.Replica = NewReplica(db)
-	db.Replica.Client = &testReplicaClient{dir: replicaDir}
-	db.Replica.MonitorEnabled = false
-	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
-	if err := db.Open(); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = db.Close(context.Background()) })
-
-	sqldb, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = sqldb.Close() }()
-	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`); err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := context.Background()
-
-	for i := 0; i < 30; i++ {
-		for j := 0; j < 20; j++ {
-			_, err := sqldb.ExecContext(ctx,
-				`INSERT INTO t (val, extra) VALUES (?, ?)`,
-				fmt.Sprintf("val-%d-%d", i, j),
-				bytes.Repeat([]byte{byte(i)}, 512),
-			)
-			if err != nil {
-				t.Fatal(err)
+func TestSyncRestoreIntegrity(t *testing.T) {
+	runSyncRestoreIntegrity(t, syncRestoreIntegrityConfig{
+		configure: func(db *DB) {
+			db.MinCheckpointPageN = 50
+			db.CheckpointInterval = 100 * time.Millisecond
+		},
+		schema: `
+			CREATE TABLE IF NOT EXISTS data (
+				ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+				_uid TEXT NOT NULL,
+				_resource_version INTEGER NOT NULL,
+				_updated_at DATETIME NOT NULL,
+				name TEXT,
+				data_json BLOB,
+				is_active INTEGER,
+				UNIQUE (_uid, _resource_version)
+			);
+			CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
+			CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
+		`,
+		iterations: 20,
+		insertRows: func(t *testing.T, ctx context.Context, sqldb *sql.DB, i int) {
+			t.Helper()
+			for j := 0; j < 10; j++ {
+				uid := fmt.Sprintf("uid-%d-%d", i, j)
+				_, err := sqldb.ExecContext(ctx,
+					`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
+					 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
+					uid, fmt.Sprintf("item-%d-%d", i, j),
+					[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
+					j%2,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
-		}
+		},
+		countQuery: `SELECT COUNT(*) FROM data`,
+		wantRows:   20 * 10,
+	})
+}
 
-		if err := db.Sync(ctx); err != nil {
-			t.Fatalf("sync %d: %v", i, err)
-		}
-
-		if i%5 == 4 {
+func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
+	var checkpointN int
+	runSyncRestoreIntegrity(t, syncRestoreIntegrityConfig{
+		configure: func(db *DB) {
+			db.MinCheckpointPageN = 20
+			db.TruncatePageN = 200
+			db.CheckpointInterval = 50 * time.Millisecond
+		},
+		schema:     `CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`,
+		iterations: 30,
+		insertRows: func(t *testing.T, ctx context.Context, sqldb *sql.DB, i int) {
+			t.Helper()
+			for j := 0; j < 20; j++ {
+				_, err := sqldb.ExecContext(ctx,
+					`INSERT INTO t (val, extra) VALUES (?, ?)`,
+					fmt.Sprintf("val-%d-%d", i, j),
+					bytes.Repeat([]byte{byte(i)}, 512),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		},
+		afterSync: func(t *testing.T, ctx context.Context, sqldb *sql.DB, i int) {
+			t.Helper()
+			if i%5 != 4 {
+				return
+			}
 			if _, err := sqldb.ExecContext(ctx, `PRAGMA wal_checkpoint(PASSIVE)`); err != nil {
 				t.Logf("passive checkpoint %d: %v", i, err)
+				return
 			}
-		}
-	}
-
-	if err := db.Sync(ctx); err != nil {
-		t.Fatalf("final sync: %v", err)
-	}
-	if err := sqldb.Close(); err != nil {
-		t.Fatalf("close sqlite db: %v", err)
-	}
-	if err := db.Close(ctx); err != nil {
-		t.Fatalf("close db: %v", err)
-	}
-
-	restorePath := filepath.Join(t.TempDir(), "restored.db")
-	restoreDB := NewDB(restorePath)
-	restoreDB.Replica = NewReplica(restoreDB)
-	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
-	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
-	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
-		t.Fatalf("restore: %v", err)
-	}
-
-	restoredDB, err := sql.Open("sqlite", restorePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = restoredDB.Close() }()
-
-	var result string
-	if err := restoredDB.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&result); err != nil {
-		t.Fatal(err)
-	}
-	if result != "ok" {
-		t.Fatalf("integrity check failed: %s", result)
-	}
-
-	var count int
-	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM t`).Scan(&count); err != nil {
-		t.Fatal(err)
-	}
-	if count != 30*20 {
-		t.Fatalf("row count=%d, want %d", count, 30*20)
+			checkpointN++
+		},
+		countQuery: `SELECT COUNT(*) FROM t`,
+		wantRows:   30 * 20,
+	})
+	if checkpointN == 0 {
+		t.Fatal("no passive checkpoints succeeded; variant did not exercise the checkpoint path")
 	}
 }
 
@@ -4003,6 +3971,7 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 		}
 	}()
 
+	var loMatchN, hiMatchN int
 	for i := range 15 {
 		select {
 		case err := <-errCh:
@@ -4068,29 +4037,48 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 			t.Fatalf("snapshot %d integrity check failed: %s", i, integrity)
 		}
 
-		// Find the kv value recorded at the greatest synced position at or
-		// before the snapshot position. Skip if recording lags behind the
-		// snapshot position; intermediate unmapped TXIDs (checkpoint
-		// bookkeeping) never change kv.
+		// The snapshot content must match the kv value recorded at a mapped
+		// TXID bracketing the snapshot position: the nearest at or before it,
+		// or the nearest after it. The writer records its commit under
+		// db.Pos() read after Sync returns, so a concurrent TRUNCATE boundary
+		// snapshot can mint the next TXID first and the commit lands under
+		// that later TXID while the commit's own TXID stays unmapped. Skip if
+		// recording lags behind the snapshot position entirely.
 		valueMu.Lock()
-		var want int64
-		var bestTXID, maxTXID ltx.TXID
+		var wantLo, wantHi int64
+		var loTXID, hiTXID, maxTXID ltx.TXID
 		for txid, val := range valueAt {
 			if txid > maxTXID {
 				maxTXID = txid
 			}
-			if txid <= pos.TXID && txid >= bestTXID {
-				bestTXID, want = txid, val
+			if txid <= pos.TXID && txid >= loTXID {
+				loTXID, wantLo = txid, val
+			}
+			if txid > pos.TXID && (hiTXID == 0 || txid < hiTXID) {
+				hiTXID, wantHi = txid, val
 			}
 		}
 		valueMu.Unlock()
 		if pos.TXID > maxTXID {
 			continue
 		}
-		if got != want {
-			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s): content inconsistent with advertised position",
-				pos.TXID, got, want, bestTXID)
+		switch {
+		case loTXID != 0 && got == wantLo:
+			loMatchN++
+		case hiTXID != 0 && got == wantHi:
+			hiMatchN++
+		default:
+			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s) or %d (recorded at txid %s): content inconsistent with advertised position",
+				pos.TXID, got, wantLo, loTXID, wantHi, hiTXID)
 		}
+	}
+
+	// A hi-bracket match is ambiguous: it tolerates the rare recording race
+	// but is also what a snapshot with content ahead of its advertised
+	// position produces. The race is a narrow window while a chkMu handoff
+	// regression is systematic, so require at least one unambiguous match.
+	if loMatchN == 0 {
+		t.Fatalf("no snapshot matched the value recorded at or before its position (hi-bracket matches=%d): content may be ahead of advertised position", hiMatchN)
 	}
 
 	close(stop)

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3930,7 +3930,7 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := db.Sync(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -3993,14 +3993,17 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 			// TRUNCATE resets the WAL so subsequent snapshots must read
 			// cold pages from the database file — the path that exposes
 			// a checkpoint racing the position capture.
-			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil && !isSQLiteBusyError(err) {
-				errCh <- err
-				return
+			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
+				if !isSQLiteBusyError(err) {
+					errCh <- err
+					return
+				}
+				time.Sleep(time.Millisecond)
 			}
 		}
 	}()
 
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		select {
 		case err := <-errCh:
 			t.Fatal(err)

--- a/replica.go
+++ b/replica.go
@@ -970,6 +970,9 @@ func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileIn
 	}
 
 	if hdr.Commit > 0 {
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("sync before truncate: %w", err)
+		}
 		newSize := int64(hdr.Commit) * int64(pageSize)
 		if err := f.Truncate(newSize); err != nil {
 			return fmt.Errorf("truncate: %w", err)

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -410,5 +411,147 @@ func TestCheckIntegrity_CorruptDB(t *testing.T) {
 	err = checkIntegrity(context.Background(), dbPath, IntegrityCheckFull)
 	if err == nil {
 		t.Fatal("expected integrity check to fail on corrupt database")
+	}
+}
+
+func TestApplyLTXFile_TruncatesAfterWrite(t *testing.T) {
+	const pageSize = 4096
+
+	info := &ltx.FileInfo{Level: 0, MinTXID: 10, MaxTXID: 10}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   info.MinTXID,
+		MaxTXID:   info.MaxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	page1 := make([]byte, pageSize)
+	copy(page1, []byte("SQLite format 3\000"))
+	page1[18], page1[19] = 0x01, 0x01
+	binary.BigEndian.PutUint16(page1[16:18], pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1); err != nil {
+		t.Fatal(err)
+	}
+	page2 := bytes.Repeat([]byte{0xAB}, pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, page2); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ltxData := buf.Bytes()
+	client := &followTestReplicaClient{}
+	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(ltxData)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	if err := r.applyLTXFile(context.Background(), f, info, pageSize); err != nil {
+		t.Fatalf("applyLTXFile: %v", err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSize := int64(2) * int64(pageSize)
+	if fi.Size() != expectedSize {
+		t.Fatalf("file size=%d, want %d", fi.Size(), expectedSize)
+	}
+
+	readBuf := make([]byte, pageSize)
+	if _, err := f.ReadAt(readBuf, int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(readBuf, page2) {
+		t.Fatal("page 2 data mismatch after applyLTXFile")
+	}
+}
+
+func TestApplyLTXFile_MultiplePages(t *testing.T) {
+	const pageSize = 4096
+	const numPages = 5
+
+	info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    numPages,
+		MinTXID:   info.MinTXID,
+		MaxTXID:   info.MaxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := make([][]byte, numPages)
+	for i := uint32(0); i < numPages; i++ {
+		pages[i] = bytes.Repeat([]byte{byte(0x10 + i)}, pageSize)
+		if i == 0 {
+			copy(pages[i], []byte("SQLite format 3\000"))
+			pages[i][18], pages[i][19] = 0x01, 0x01
+		}
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: i + 1}, pages[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ltxData := buf.Bytes()
+	client := &followTestReplicaClient{}
+	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(ltxData)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	if err := r.applyLTXFile(context.Background(), f, info, pageSize); err != nil {
+		t.Fatalf("applyLTXFile: %v", err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSize := int64(numPages) * int64(pageSize)
+	if fi.Size() != expectedSize {
+		t.Fatalf("file size=%d, want %d", fi.Size(), expectedSize)
+	}
+
+	readBuf := make([]byte, pageSize)
+	for i := uint32(0); i < numPages; i++ {
+		if _, err := f.ReadAt(readBuf, int64(i)*int64(pageSize)); err != nil {
+			t.Fatalf("read page %d: %v", i+1, err)
+		}
+		if i > 0 && !bytes.Equal(readBuf, pages[i]) {
+			t.Fatalf("page %d data mismatch", i+1)
+		}
 	}
 }

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -315,6 +315,50 @@ func mustBuildIncrementalLTX(tb testing.TB, minTXID, maxTXID ltx.TXID, pageSize,
 	return buf.Bytes()
 }
 
+// mustBuildSnapshotLTX encodes an LTX file containing the given pages
+// numbered sequentially from pgno 1 with commit set to the page count.
+func mustBuildSnapshotLTX(tb testing.TB, minTXID, maxTXID ltx.TXID, pageSize uint32, pages [][]byte) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    uint32(len(pages)),
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		tb.Fatal(err)
+	}
+	for i, page := range pages {
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: uint32(i + 1)}, page); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+// newSQLiteHeaderPage returns a page containing a minimal SQLite file header.
+func newSQLiteHeaderPage(pageSize uint32) []byte {
+	page := make([]byte, pageSize)
+	copy(page, "SQLite format 3\x00")
+	binary.BigEndian.PutUint16(page[16:18], uint16(pageSize))
+	page[18], page[19] = 0x01, 0x01
+	return page
+}
+
 func mustCreateWritableDBFile(tb testing.TB) *os.File {
 	tb.Helper()
 
@@ -419,39 +463,11 @@ func TestApplyLTXFile_TruncatesAfterWrite(t *testing.T) {
 
 	info := &ltx.FileInfo{Level: 0, MinTXID: 10, MaxTXID: 10}
 
-	var buf bytes.Buffer
-	enc, err := ltx.NewEncoder(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	hdr := ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    2,
-		MinTXID:   info.MinTXID,
-		MaxTXID:   info.MaxTXID,
-		Timestamp: time.Now().UnixMilli(),
-	}
-	if err := enc.EncodeHeader(hdr); err != nil {
-		t.Fatal(err)
-	}
-	page1 := make([]byte, pageSize)
-	copy(page1, []byte("SQLite format 3\000"))
-	page1[18], page1[19] = 0x01, 0x01
-	binary.BigEndian.PutUint16(page1[16:18], pageSize)
-	if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1); err != nil {
-		t.Fatal(err)
-	}
 	page2 := bytes.Repeat([]byte{0xAB}, pageSize)
-	if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, page2); err != nil {
-		t.Fatal(err)
-	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	ltxData := buf.Bytes()
+	ltxData := mustBuildSnapshotLTX(t, info.MinTXID, info.MaxTXID, pageSize, [][]byte{
+		newSQLiteHeaderPage(pageSize),
+		page2,
+	})
 	client := &followTestReplicaClient{}
 	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(ltxData)), nil
@@ -489,40 +505,12 @@ func TestApplyLTXFile_MultiplePages(t *testing.T) {
 
 	info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
 
-	var buf bytes.Buffer
-	enc, err := ltx.NewEncoder(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	hdr := ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    numPages,
-		MinTXID:   info.MinTXID,
-		MaxTXID:   info.MaxTXID,
-		Timestamp: time.Now().UnixMilli(),
-	}
-	if err := enc.EncodeHeader(hdr); err != nil {
-		t.Fatal(err)
-	}
-
 	pages := make([][]byte, numPages)
-	for i := uint32(0); i < numPages; i++ {
+	for i := range pages {
 		pages[i] = bytes.Repeat([]byte{byte(0x10 + i)}, pageSize)
-		if i == 0 {
-			copy(pages[i], []byte("SQLite format 3\000"))
-			pages[i][18], pages[i][19] = 0x01, 0x01
-		}
-		if err := enc.EncodePage(ltx.PageHeader{Pgno: i + 1}, pages[i]); err != nil {
-			t.Fatal(err)
-		}
 	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	ltxData := buf.Bytes()
+	pages[0] = newSQLiteHeaderPage(pageSize)
+	ltxData := mustBuildSnapshotLTX(t, info.MinTXID, info.MaxTXID, pageSize, pages)
 	client := &followTestReplicaClient{}
 	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(ltxData)), nil

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -61,6 +61,7 @@ Long-running soak tests live alongside the other integration tests and share the
 | --- | --- | --- | --- | --- |
 | `TestComprehensiveSoak` | `integration,soak` | 2h duration, 50 MB DB, 500 writes/s | File-backed end-to-end stress | Litestream binaries in `./bin` |
 | `TestMinIOSoak` | `integration,soak,docker` | 2h duration, 5 MB DB (short=2 m), 100 writes/s | S3-compatible replication via MinIO | Docker daemon, `docker` CLI |
+| `TestSoakReplicateRestore` | `integration,soak,docker` | 5m duration (short=1 m), 100 writes/s, restore every 30s | Issue #1164 repro: stop→restore→integrity_check cycles against MinIO | Docker daemon, `docker` CLI |
 | `TestOvernightS3Soak` | `integration,soak,aws` | 8h duration, 50 MB DB | Real S3 replication & restore | AWS credentials, `aws` CLI |
 
 All soak tests support `go test -test.short` to scale the default duration down to roughly two minutes for smoke verification.
@@ -439,6 +440,7 @@ Metrics reported during execution:
 |------|----------|--------------|---------------|
 | TestComprehensiveSoak | 2h | None | File-based replication with aggressive compaction |
 | TestMinIOSoak | 2h | Docker | S3-compatible storage via MinIO container |
+| TestSoakReplicateRestore | 5m | Docker | Issue #1164 repro: periodic stop→restore→integrity_check |
 | TestOvernightS3Soak | 8h | AWS credentials | Real S3 replication, overnight stability |
 
 ## Benefits Over Bash

--- a/tests/integration/soak_replicate_restore_test.go
+++ b/tests/integration/soak_replicate_restore_test.go
@@ -1,0 +1,373 @@
+//go:build integration && soak && docker
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestSoakReplicateRestore reproduces issue #1164: intermittent database corruption
+// ("wrong # of entries in index") after restoring from S3-compatible replicas.
+//
+// This test mirrors fuchstim's exact setup:
+// - SQLite DB in WAL mode with tables + indexes
+// - Litestream replication to MinIO (S3)
+// - ~100 rows/sec concurrent writes
+// - Periodic stop→restore→integrity_check cycles
+//
+// Default duration: 5 minutes (override with SOAK_DURATION env var)
+// Can be shortened with: go test -test.short (runs for 1 minute)
+//
+// Requirements:
+// - Docker must be running
+// - Binaries must be built: go build -o bin/litestream ./cmd/litestream
+func TestSoakReplicateRestore(t *testing.T) {
+	RequireBinaries(t)
+	RequireDocker(t)
+
+	duration := parseSoakDuration(t, 5*time.Minute)
+	if testing.Short() {
+		duration = 1 * time.Minute
+	}
+	restoreInterval := 30 * time.Second
+	writeRate := 100
+
+	t.Logf("================================================")
+	t.Logf("Issue #1164 Reproduction: Replicate+Restore Soak")
+	t.Logf("================================================")
+	t.Logf("Duration:          %v", duration)
+	t.Logf("Restore interval:  %v", restoreInterval)
+	t.Logf("Write rate:        %d rows/sec", writeRate)
+	t.Logf("Start time:        %s", time.Now().Format(time.RFC3339))
+	t.Log("")
+
+	containerID, endpoint, dataVolume := StartMinIOContainer(t)
+	defer StopMinIOContainer(t, containerID, dataVolume)
+
+	bucket := "litestream-test"
+	CreateMinIOBucket(t, containerID, bucket)
+
+	db := SetupTestDB(t, "replicate-restore")
+	defer db.Cleanup()
+
+	if err := db.Create(); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite3", db.Path)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer sqlDB.Close()
+
+	if _, err := sqlDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL mode: %v", err)
+	}
+
+	// Create schema matching fuchstim's setup: table with indexes
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE IF NOT EXISTS resources (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			_uid TEXT NOT NULL,
+			_resource_version INTEGER NOT NULL DEFAULT 0,
+			name TEXT NOT NULL,
+			data TEXT,
+			created_at INTEGER NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_uid ON resources(_uid);
+		CREATE INDEX IF NOT EXISTS idx_resources_rv ON resources(_resource_version);
+		CREATE INDEX IF NOT EXISTS idx_resources_name ON resources(name);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	s3Path := fmt.Sprintf("replicate-restore-%d", time.Now().Unix())
+	s3URL := fmt.Sprintf("s3://%s/%s", bucket, s3Path)
+	db.ReplicaURL = s3URL
+
+	configPath := writeReplicateRestoreConfig(t, db.Path, s3URL, endpoint)
+	db.ConfigPath = configPath
+
+	if err := db.StartLitestreamWithConfig(configPath); err != nil {
+		t.Fatalf("start litestream: %v", err)
+	}
+	t.Logf("Litestream running (PID: %d)", db.LitestreamPID)
+
+	// Wait for initial sync
+	time.Sleep(3 * time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	// Performance tracking
+	var (
+		latencies   latencyTracker
+		totalWrites atomic.Int64
+		writeErrs   atomic.Int64
+	)
+
+	// Writer goroutine: ~writeRate rows/sec
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(time.Second / time.Duration(writeRate))
+		defer ticker.Stop()
+
+		rv := int64(0)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				rv++
+				start := time.Now()
+				_, err := sqlDB.ExecContext(ctx, `
+					INSERT INTO resources (_uid, _resource_version, name, data, created_at)
+					VALUES (?, ?, ?, ?, ?)`,
+					fmt.Sprintf("uid-%d-%d", time.Now().UnixNano(), rv),
+					rv,
+					fmt.Sprintf("resource-%d", rv%1000),
+					fmt.Sprintf("payload data for resource version %d with some padding to simulate real workload size", rv),
+					time.Now().Unix(),
+				)
+				elapsed := time.Since(start)
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					writeErrs.Add(1)
+					continue
+				}
+				totalWrites.Add(1)
+				latencies.record(elapsed)
+			}
+		}
+	}()
+
+	// Periodic restore+integrity check loop
+	var (
+		restoreCount    int
+		corruptionCount int
+		restoreErrors   []string
+	)
+
+	restoreTicker := time.NewTicker(restoreInterval)
+	defer restoreTicker.Stop()
+
+	t.Log("Running replicate+restore cycles...")
+	t.Log("")
+
+	startTime := time.Now()
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+		case <-restoreTicker.C:
+			restoreCount++
+			elapsed := time.Since(startTime)
+			sourceRows := countRowsSafe(sqlDB)
+
+			t.Logf("[%v] Restore cycle #%d (source rows: %d, writes: %d, write errors: %d)",
+				elapsed.Round(time.Second), restoreCount, sourceRows, totalWrites.Load(), writeErrs.Load())
+
+			// Stop litestream for clean restore
+			if err := db.StopLitestream(); err != nil {
+				t.Logf("  Warning: stop litestream: %v", err)
+			}
+			time.Sleep(1 * time.Second)
+
+			// Restore to new path
+			restoredPath := filepath.Join(db.TempDir, fmt.Sprintf("restored-%d.db", restoreCount))
+			if err := db.Restore(restoredPath); err != nil {
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restore: %v", restoreCount, err))
+				t.Logf("  RESTORE FAILED: %v", err)
+				// Restart litestream and continue
+				if err := db.StartLitestreamWithConfig(configPath); err != nil {
+					t.Fatalf("restart litestream after failed restore: %v", err)
+				}
+				continue
+			}
+
+			// Integrity check on restored DB
+			restoredDB, err := sql.Open("sqlite3", restoredPath)
+			if err != nil {
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: open restored: %v", restoreCount, err))
+				t.Logf("  OPEN FAILED: %v", err)
+			} else {
+				var result string
+				if err := restoredDB.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil {
+					restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: integrity_check query: %v", restoreCount, err))
+					t.Logf("  INTEGRITY CHECK QUERY FAILED: %v", err)
+				} else if result != "ok" {
+					corruptionCount++
+					restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: CORRUPTION: %s", restoreCount, result))
+					t.Errorf("  CORRUPTION DETECTED: %s", result)
+				} else {
+					// Verify row count is reasonable (restored may lag behind source)
+					var restoredRows int
+					restoredDB.QueryRow("SELECT COUNT(*) FROM resources").Scan(&restoredRows)
+					t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
+				}
+				restoredDB.Close()
+			}
+
+			// Clean up restored DB
+			os.Remove(restoredPath)
+			os.Remove(restoredPath + "-wal")
+			os.Remove(restoredPath + "-shm")
+
+			// Restart litestream
+			if err := db.StartLitestreamWithConfig(configPath); err != nil {
+				t.Fatalf("restart litestream: %v", err)
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	cancel()
+	wg.Wait()
+
+	// Final report
+	t.Log("")
+	t.Log("================================================")
+	t.Log("Results")
+	t.Log("================================================")
+	t.Logf("Duration:          %v", time.Since(startTime).Round(time.Second))
+	t.Logf("Total writes:      %d", totalWrites.Load())
+	t.Logf("Write errors:      %d", writeErrs.Load())
+	t.Logf("Restore cycles:    %d", restoreCount)
+	t.Logf("Corruptions:       %d", corruptionCount)
+
+	stats := latencies.stats()
+	t.Logf("Write latency P50: %v", stats.p50)
+	t.Logf("Write latency P95: %v", stats.p95)
+	t.Logf("Write latency P99: %v", stats.p99)
+	t.Logf("Write latency max: %v", stats.max)
+
+	if len(restoreErrors) > 0 {
+		t.Log("")
+		t.Log("Restore errors:")
+		for _, e := range restoreErrors {
+			t.Logf("  %s", e)
+		}
+	}
+
+	t.Log("================================================")
+
+	if corruptionCount > 0 {
+		t.Fatalf("FAILED: %d corruption(s) detected in %d restore cycles", corruptionCount, restoreCount)
+	}
+
+	if stats.p99 > 500*time.Millisecond {
+		t.Errorf("P99 write latency %v exceeds 500ms threshold", stats.p99)
+	}
+
+	t.Log("PASSED: no corruption detected")
+}
+
+func writeReplicateRestoreConfig(t *testing.T, dbPath, s3URL, endpoint string) string {
+	t.Helper()
+	configPath := filepath.Join(filepath.Dir(dbPath), "litestream.yml")
+	config := fmt.Sprintf(`access-key-id: minioadmin
+secret-access-key: minioadmin
+
+dbs:
+  - path: %s
+    checkpoint-interval: 1m
+    min-checkpoint-page-count: 100
+    replicas:
+      - url: %s
+        endpoint: %s
+        region: us-east-1
+        force-path-style: true
+        skip-verify: true
+        sync-interval: 1s
+        snapshot-interval: 30s
+`, filepath.ToSlash(dbPath), s3URL, endpoint)
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func parseSoakDuration(t *testing.T, defaultDuration time.Duration) time.Duration {
+	t.Helper()
+	if v := os.Getenv("SOAK_DURATION"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		if mins, err := strconv.Atoi(v); err == nil {
+			return time.Duration(mins) * time.Minute
+		}
+		t.Logf("Warning: invalid SOAK_DURATION %q, using default %v", v, defaultDuration)
+	}
+	return defaultDuration
+}
+
+func countRowsSafe(db *sql.DB) int {
+	var count int
+	db.QueryRow("SELECT COUNT(*) FROM resources").Scan(&count)
+	return count
+}
+
+type latencyTracker struct {
+	mu      sync.Mutex
+	samples []time.Duration
+}
+
+func (lt *latencyTracker) record(d time.Duration) {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	lt.samples = append(lt.samples, d)
+}
+
+type latencyStats struct {
+	p50, p95, p99, max time.Duration
+}
+
+func (lt *latencyTracker) stats() latencyStats {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+
+	if len(lt.samples) == 0 {
+		return latencyStats{}
+	}
+
+	sorted := make([]time.Duration, len(lt.samples))
+	copy(sorted, lt.samples)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	percentile := func(p float64) time.Duration {
+		idx := int(math.Ceil(p/100*float64(len(sorted)))) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(sorted) {
+			idx = len(sorted) - 1
+		}
+		return sorted[idx]
+	}
+
+	return latencyStats{
+		p50: percentile(50),
+		p95: percentile(95),
+		p99: percentile(99),
+		max: sorted[len(sorted)-1],
+	}
+}

--- a/tests/integration/soak_replicate_restore_test.go
+++ b/tests/integration/soak_replicate_restore_test.go
@@ -38,10 +38,12 @@ func TestSoakReplicateRestore(t *testing.T) {
 	RequireBinaries(t)
 	RequireDocker(t)
 
-	duration := parseSoakDuration(t, 5*time.Minute)
+	// An explicit SOAK_DURATION wins over the -short default.
+	defaultDuration := 5 * time.Minute
 	if testing.Short() {
-		duration = 1 * time.Minute
+		defaultDuration = 1 * time.Minute
 	}
+	duration := parseSoakDuration(t, defaultDuration)
 	restoreInterval := 30 * time.Second
 	writeRate := 100
 
@@ -109,6 +111,11 @@ func TestSoakReplicateRestore(t *testing.T) {
 	// Wait for initial sync
 	time.Sleep(3 * time.Second)
 
+	// Register before cancel so the deferred cancel stops the writer
+	// before wg.Wait runs, even on t.Fatalf paths.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
@@ -120,7 +127,6 @@ func TestSoakReplicateRestore(t *testing.T) {
 	)
 
 	// Writer goroutine: ~writeRate rows/sec
-	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -160,9 +166,10 @@ func TestSoakReplicateRestore(t *testing.T) {
 
 	// Periodic restore+integrity check loop
 	var (
-		restoreCount    int
-		corruptionCount int
-		restoreErrors   []string
+		restoreCount     int
+		corruptionCount  int
+		restoreErrors    []string
+		lastRestoredRows int
 	)
 
 	restoreTicker := time.NewTicker(restoreInterval)
@@ -186,9 +193,11 @@ loop:
 			t.Logf("[%v] Restore cycle #%d (source rows: %d, writes: %d, write errors: %d)",
 				elapsed.Round(time.Second), restoreCount, sourceRows, totalWrites.Load(), writeErrs.Load())
 
-			// Stop litestream for clean restore
+			// Stop litestream for clean restore. A failed stop usually
+			// means the process died mid-soak, which is itself a failure.
 			if err := db.StopLitestream(); err != nil {
-				t.Logf("  Warning: stop litestream: %v", err)
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: stop litestream: %v", restoreCount, err))
+				t.Errorf("  STOP LITESTREAM FAILED: %v", err)
 			}
 			time.Sleep(1 * time.Second)
 
@@ -219,10 +228,26 @@ loop:
 					restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: CORRUPTION: %s", restoreCount, result))
 					t.Errorf("  CORRUPTION DETECTED: %s", result)
 				} else {
-					// Verify row count is reasonable (restored may lag behind source)
+					// The restore may lag behind the source, but row count
+					// must never be zero with data written nor shrink
+					// between cycles — either means lost data that passes
+					// integrity_check.
 					var restoredRows int
-					restoredDB.QueryRow("SELECT COUNT(*) FROM resources").Scan(&restoredRows)
-					t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
+					if err := restoredDB.QueryRow("SELECT COUNT(*) FROM resources").Scan(&restoredRows); err != nil {
+						restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: count restored rows: %v", restoreCount, err))
+						t.Errorf("  COUNT RESTORED ROWS FAILED: %v", err)
+					} else {
+						if restoredRows == 0 && sourceRows > 0 {
+							restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restored 0 rows, source has %d", restoreCount, sourceRows))
+							t.Errorf("  EMPTY RESTORE: source has %d rows", sourceRows)
+						}
+						if restoredRows < lastRestoredRows {
+							restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restored rows shrank %d -> %d", restoreCount, lastRestoredRows, restoredRows))
+							t.Errorf("  RESTORED ROWS SHRANK: %d -> %d", lastRestoredRows, restoredRows)
+						}
+						lastRestoredRows = restoredRows
+						t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
+					}
 				}
 				restoredDB.Close()
 			}
@@ -274,11 +299,32 @@ loop:
 		t.Fatalf("FAILED: %d corruption(s) detected in %d restore cycles", corruptionCount, restoreCount)
 	}
 
-	if stats.p99 > 500*time.Millisecond {
-		t.Errorf("P99 write latency %v exceeds 500ms threshold", stats.p99)
+	// The test exists to prove restores work; a failed restore, open, or
+	// verification is a failure even when no corruption was detected.
+	if len(restoreErrors) > 0 {
+		t.Fatalf("FAILED: %d restore error(s) in %d restore cycles", len(restoreErrors), restoreCount)
+	}
+
+	if totalWrites.Load() == 0 {
+		t.Fatal("FAILED: no writes succeeded; soak applied no load")
+	}
+
+	if threshold := parseSoakP99Threshold(t, 500*time.Millisecond); stats.p99 > threshold {
+		t.Errorf("P99 write latency %v exceeds %v threshold", stats.p99, threshold)
 	}
 
 	t.Log("PASSED: no corruption detected")
+}
+
+func parseSoakP99Threshold(t *testing.T, defaultThreshold time.Duration) time.Duration {
+	t.Helper()
+	if v := os.Getenv("SOAK_P99_THRESHOLD"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		t.Logf("Warning: invalid SOAK_P99_THRESHOLD %q, using default %v", v, defaultThreshold)
+	}
+	return defaultThreshold
 }
 
 func writeReplicateRestoreConfig(t *testing.T, dbPath, s3URL, endpoint string) string {

--- a/tests/integration/soak_replicate_restore_test.go
+++ b/tests/integration/soak_replicate_restore_test.go
@@ -183,11 +183,12 @@ func TestSoakReplicateRestore(t *testing.T) {
 
 	// Periodic restore+integrity check loop
 	var (
-		restoreCount     int
-		corruptionCount  int
-		restoreErrors    []string
-		lastRestoredRows int
-		prevSourceRows   int
+		restoreCount         int
+		corruptionCount      int
+		restoreErrors        []string
+		lastRestoredRows     int
+		prevSourceRows       int
+		firstCycleSourceRows int
 	)
 
 	restoreTicker := time.NewTicker(restoreInterval)
@@ -205,11 +206,15 @@ loop:
 			break loop
 		case <-restoreTicker.C:
 			restoreCount++
+			cycleErrsBefore := len(restoreErrors)
 			elapsed := time.Since(startTime)
 			sourceRows, err := countRows(sqlDB)
 			if err != nil {
 				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: count source rows: %v", restoreCount, err))
 				t.Errorf("  COUNT SOURCE ROWS FAILED: %v", err)
+			}
+			if restoreCount == 1 {
+				firstCycleSourceRows = sourceRows
 			}
 
 			t.Logf("[%v] Restore cycle #%d (source rows: %d, writes: %d, write errors: %d)",
@@ -281,10 +286,18 @@ loop:
 				restoredDB.Close()
 			}
 
-			// Clean up restored DB
-			os.Remove(restoredPath)
-			os.Remove(restoredPath + "-wal")
-			os.Remove(restoredPath + "-shm")
+			// Clean up restored DB, but keep the files for any cycle that
+			// recorded an error or corruption: they live in db.TempDir,
+			// which the nightly workflow uploads for post-mortem when
+			// SOAK_KEEP_TEMP is set. Healthy restores are removed to bound
+			// disk use over long soaks.
+			if len(restoreErrors) > cycleErrsBefore {
+				t.Logf("  keeping restored DB for post-mortem: %s", restoredPath)
+			} else {
+				os.Remove(restoredPath)
+				os.Remove(restoredPath + "-wal")
+				os.Remove(restoredPath + "-shm")
+			}
 
 			// Restart litestream. The helper waits for startup internally.
 			if err := db.StartLitestreamWithConfig(configPath); err != nil {
@@ -342,6 +355,20 @@ loop:
 		t.Fatal("FAILED: no writes succeeded; soak applied no load")
 	}
 
+	// Write-path liveness: a writer that dies mid-soak leaves counts flat,
+	// so the shrink/lag checks above pass trivially.
+	if attempts := totalWrites.Load() + writeErrs.Load(); writeErrs.Load()*100 > attempts {
+		t.Fatalf("FAILED: %d write error(s) in %d attempts exceeds 1%% threshold", writeErrs.Load(), attempts)
+	}
+
+	finalSourceRows, err := countRows(sqlDB)
+	if err != nil {
+		t.Fatalf("count final source rows: %v", err)
+	}
+	if finalSourceRows <= firstCycleSourceRows {
+		t.Fatalf("FAILED: source rows did not grow after first restore cycle (first=%d, final=%d); write path died mid-soak", firstCycleSourceRows, finalSourceRows)
+	}
+
 	if threshold := parseSoakP99Threshold(t, 500*time.Millisecond); stats.p99 > threshold {
 		t.Errorf("P99 write latency %v exceeds %v threshold", stats.p99, threshold)
 	}
@@ -352,10 +379,11 @@ loop:
 func parseSoakP99Threshold(t *testing.T, defaultThreshold time.Duration) time.Duration {
 	t.Helper()
 	if v := os.Getenv("SOAK_P99_THRESHOLD"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			return d
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			t.Fatalf("invalid SOAK_P99_THRESHOLD %q: %v", v, err)
 		}
-		t.Logf("Warning: invalid SOAK_P99_THRESHOLD %q, using default %v", v, defaultThreshold)
+		return d
 	}
 	return defaultThreshold
 }
@@ -396,7 +424,7 @@ func parseSoakDuration(t *testing.T, defaultDuration time.Duration) time.Duratio
 		if mins, err := strconv.Atoi(v); err == nil {
 			return time.Duration(mins) * time.Minute
 		}
-		t.Logf("Warning: invalid SOAK_DURATION %q, using default %v", v, defaultDuration)
+		t.Fatalf("invalid SOAK_DURATION %q: must be a duration (e.g. 30m) or whole minutes", v)
 	}
 	return defaultDuration
 }

--- a/tests/integration/soak_replicate_restore_test.go
+++ b/tests/integration/soak_replicate_restore_test.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -45,6 +45,9 @@ func TestSoakReplicateRestore(t *testing.T) {
 	}
 	duration := parseSoakDuration(t, defaultDuration)
 	restoreInterval := 30 * time.Second
+	if testing.Short() {
+		restoreInterval = 15 * time.Second
+	}
 	writeRate := 100
 
 	t.Logf("================================================")
@@ -108,15 +111,29 @@ func TestSoakReplicateRestore(t *testing.T) {
 	}
 	t.Logf("Litestream running (PID: %d)", db.LitestreamPID)
 
-	// Wait for initial sync
-	time.Sleep(3 * time.Second)
+	// Wait until the replica is restorable rather than sleeping a fixed time.
+	initialSyncDeadline := time.Now().Add(30 * time.Second)
+	for {
+		probePath := filepath.Join(db.TempDir, "restore-probe.db")
+		err := db.Restore(probePath)
+		os.Remove(probePath)
+		os.Remove(probePath + "-wal")
+		os.Remove(probePath + "-shm")
+		if err == nil {
+			break
+		}
+		if time.Now().After(initialSyncDeadline) {
+			t.Fatalf("replica not restorable after initial sync window: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 
 	// Register before cancel so the deferred cancel stops the writer
 	// before wg.Wait runs, even on t.Fatalf paths.
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	ctx, cancel := context.WithTimeout(t.Context(), duration)
 	defer cancel()
 
 	// Performance tracking
@@ -170,6 +187,7 @@ func TestSoakReplicateRestore(t *testing.T) {
 		corruptionCount  int
 		restoreErrors    []string
 		lastRestoredRows int
+		prevSourceRows   int
 	)
 
 	restoreTicker := time.NewTicker(restoreInterval)
@@ -188,18 +206,22 @@ loop:
 		case <-restoreTicker.C:
 			restoreCount++
 			elapsed := time.Since(startTime)
-			sourceRows := countRowsSafe(sqlDB)
+			sourceRows, err := countRows(sqlDB)
+			if err != nil {
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: count source rows: %v", restoreCount, err))
+				t.Errorf("  COUNT SOURCE ROWS FAILED: %v", err)
+			}
 
 			t.Logf("[%v] Restore cycle #%d (source rows: %d, writes: %d, write errors: %d)",
 				elapsed.Round(time.Second), restoreCount, sourceRows, totalWrites.Load(), writeErrs.Load())
 
 			// Stop litestream for clean restore. A failed stop usually
 			// means the process died mid-soak, which is itself a failure.
+			// StopLitestream waits for the process to exit.
 			if err := db.StopLitestream(); err != nil {
 				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: stop litestream: %v", restoreCount, err))
 				t.Errorf("  STOP LITESTREAM FAILED: %v", err)
 			}
-			time.Sleep(1 * time.Second)
 
 			// Restore to new path
 			restoredPath := filepath.Join(db.TempDir, fmt.Sprintf("restored-%d.db", restoreCount))
@@ -245,6 +267,13 @@ loop:
 							restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restored rows shrank %d -> %d", restoreCount, lastRestoredRows, restoredRows))
 							t.Errorf("  RESTORED ROWS SHRANK: %d -> %d", lastRestoredRows, restoredRows)
 						}
+						// The restore must contain at least everything the
+						// source held a full cycle ago: bigger lag means
+						// silent data loss that still passes integrity_check.
+						if restoredRows < prevSourceRows {
+							restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restored rows %d behind source count %d from previous cycle", restoreCount, restoredRows, prevSourceRows))
+							t.Errorf("  RESTORE LAGGED A FULL CYCLE: restored=%d, source at previous cycle=%d", restoredRows, prevSourceRows)
+						}
 						lastRestoredRows = restoredRows
 						t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
 					}
@@ -257,11 +286,11 @@ loop:
 			os.Remove(restoredPath + "-wal")
 			os.Remove(restoredPath + "-shm")
 
-			// Restart litestream
+			// Restart litestream. The helper waits for startup internally.
 			if err := db.StartLitestreamWithConfig(configPath); err != nil {
 				t.Fatalf("restart litestream: %v", err)
 			}
-			time.Sleep(2 * time.Second)
+			prevSourceRows = sourceRows
 		}
 	}
 
@@ -303,6 +332,10 @@ loop:
 	// verification is a failure even when no corruption was detected.
 	if len(restoreErrors) > 0 {
 		t.Fatalf("FAILED: %d restore error(s) in %d restore cycles", len(restoreErrors), restoreCount)
+	}
+
+	if restoreCount == 0 {
+		t.Fatalf("FAILED: no restore cycles ran; duration %v must exceed the %v restore interval", duration, restoreInterval)
 	}
 
 	if totalWrites.Load() == 0 {
@@ -352,6 +385,8 @@ dbs:
 	return configPath
 }
 
+// parseSoakDuration reads SOAK_DURATION; unlike GetTestDuration, an explicit
+// env value wins over the -short default so CI can pin exact soak lengths.
 func parseSoakDuration(t *testing.T, defaultDuration time.Duration) time.Duration {
 	t.Helper()
 	if v := os.Getenv("SOAK_DURATION"); v != "" {
@@ -366,10 +401,10 @@ func parseSoakDuration(t *testing.T, defaultDuration time.Duration) time.Duratio
 	return defaultDuration
 }
 
-func countRowsSafe(db *sql.DB) int {
+func countRows(db *sql.DB) (int, error) {
 	var count int
-	db.QueryRow("SELECT COUNT(*) FROM resources").Scan(&count)
-	return count
+	err := db.QueryRow("SELECT COUNT(*) FROM resources").Scan(&count)
+	return count, err
 }
 
 type latencyTracker struct {
@@ -395,19 +430,12 @@ func (lt *latencyTracker) stats() latencyStats {
 		return latencyStats{}
 	}
 
-	sorted := make([]time.Duration, len(lt.samples))
-	copy(sorted, lt.samples)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	sorted := slices.Clone(lt.samples)
+	slices.Sort(sorted)
 
 	percentile := func(p float64) time.Duration {
 		idx := int(math.Ceil(p/100*float64(len(sorted)))) - 1
-		if idx < 0 {
-			idx = 0
-		}
-		if idx >= len(sorted) {
-			idx = len(sorted) - 1
-		}
-		return sorted[idx]
+		return sorted[max(0, min(idx, len(sorted)-1))]
 	}
 
 	return latencyStats{


### PR DESCRIPTION
> 📍 **Stack map:** part of a stacked series — see the [canonical PR map](https://gist.github.com/corylanou/f2709d9868cad1943c63096bf978e881) for review order, scope, and current blockers.

## Description
Adds `TestSoakReplicateRestore`, an integration soak test that mirrors the issue #1164 replicate/restore corruption scenario against MinIO-backed S3 storage.

This test was moved out of #1166 so #1166 can stay limited to the product fix and focused internal/unit tests.

## Motivation and Context
The soak test exercises the longer-running reproduce-and-restore path separately from the smaller product-fix PR. It runs a WAL-mode SQLite database with indexed tables, writes under sustained load, periodically restores from S3-compatible storage, and checks `PRAGMA integrity_check` on each restored database.

Refs #1164
Refs #1166
Refs #1281

## How Has This Been Tested?
`gofmt` ran on the added test file.

The commit hook passed:

```text
trim trailing whitespace: Passed
fix end of files: Passed
check yaml: Skipped
go-imports-repo: Passed
go-vet-repo-mod: Passed
go-staticcheck-repo-mod: Passed
```

The full soak test was split out but not run in this branch. On the underlying #1166 stacked branch, the previously red WAL-growth integration test passed:

```bash
go test -tags "integration,soak,docker" -run TestWALGrowth -v -timeout 10m ./tests/integration/
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [ ] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)

