### PR TITLE
fix(security): bump Go toolchain to 1.25.11 to clear govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/benbjohnson/litestream
 
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Description

Bump the Go toolchain directive in `go.mod` from `go1.25.10` to `go1.25.11`.

govulncheck reports two standard-library vulnerabilities, both fixed in **go1.25.11**:

- **GO-2026-5039** — `net/textproto`
- **GO-2026-5037** — `crypto/x509`

CI's `analyze-deps` job builds with the toolchain from `go.mod` (`setup-go` + `go-version-file`), so bumping this one line clears both advisories for every PR built on top of main. No module changes — `go.sum` is untouched.

## Motivation and Context

These are stdlib vulns fixed by the Go toolchain, not by any module bump (the earlier #1294 `x/crypto`/`x/net` bump did not address them). Same pattern as #1283 (which bumped to 1.25.10). Fixing it here at main means the open PR stack rebased on top stops showing `metrics: vulns-found` / `go-update`.

## How Has This Been Tested?

```
GOTOOLCHAIN=go1.25.11 govulncheck ./...
# => No vulnerabilities found.
```
- `go build ./...` clean under go1.25.11
- pre-commit (go-vet, go-staticcheck) pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project
- [x] I have tested my changes