### PR TITLE
fix(s3): keep retrying through sustained transport flaps

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -382,10 +384,7 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// Build configuration options
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithRegion(region),
-		// Use adaptive retry mode for better resilience with 24 hour timeout
-		// This matches Azure's approach for long-running operations
-		config.WithRetryMode(aws.RetryModeAdaptive),
-		config.WithRetryMaxAttempts(10), // Increase retry attempts for resilience
+		config.WithRetryer(newTransportRetryer),
 	}
 
 	// Add HTTP client with proper timeout
@@ -554,10 +553,29 @@ func (c *ReplicaClient) validateSSEConfig() error {
 	return nil
 }
 
+// transportRetryMaxAttempts caps total attempts per operation; exponential
+// backoff between attempts still bounds request rate during outages.
+const transportRetryMaxAttempts = 10
+
+// newTransportRetryer returns a retryer that keeps retrying through sustained
+// object-store transport flaps. The SDK's default token bucket (and the
+// adaptive mode previously configured here) only refills retry quota on
+// successful responses, so a sustained provider flap drains it to zero and
+// every subsequent operation fails fast ("retry quota exceeded, 0 available")
+// precisely when retrying matters most for a replication tool.
+func newTransportRetryer() aws.Retryer {
+	return retry.NewStandard(func(o *retry.StandardOptions) {
+		o.MaxAttempts = transportRetryMaxAttempts
+		o.RateLimiter = ratelimit.None
+	})
+}
+
 // findBucketRegion looks up the AWS region for a bucket. Returns blank if non-S3.
 func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (string, error) {
 	// Build a config with credentials but no region
-	configOpts := []func(*config.LoadOptions) error{}
+	configOpts := []func(*config.LoadOptions) error{
+		config.WithRetryer(newTransportRetryer),
+	}
 
 	// Add static credentials if provided
 	if c.AccessKeyID != "" && c.SecretAccessKey != "" {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2084,3 +2084,57 @@ func TestNewReplicaClientFromURL_EndpointEnvVar(t *testing.T) {
 		})
 	}
 }
+
+// TestTransportRetryer_SurvivesSustainedFailures reproduces the soak finding where
+// sustained S3 transport flaps (e.g. Tigris returning unexpected EOF) exhausted the
+// SDK retryer's client-side token bucket ("retry quota exceeded, 0 available,
+// 5 requested") and Litestream stopped retrying exactly when retries mattered.
+// The bucket only refills on success, so 100+ consecutive failures starve it.
+func TestTransportRetryer_SurvivesSustainedFailures(t *testing.T) {
+	retryer := newTransportRetryer()
+
+	if got := retryer.MaxAttempts(); got != transportRetryMaxAttempts {
+		t.Fatalf("MaxAttempts() = %d, want %d", got, transportRetryMaxAttempts)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 200; i++ {
+		release, err := retryer.GetRetryToken(ctx, io.ErrUnexpectedEOF)
+		if err != nil {
+			t.Fatalf("retry token denied after %d consecutive transport failures: %v", i, err)
+		}
+		if err := release(io.ErrUnexpectedEOF); err != nil {
+			t.Fatalf("release after failure %d: %v", i, err)
+		}
+	}
+}
+
+// TestReplicaClient_RetryerSurvivesSustainedFailures verifies the configured S3
+// client actually carries the starvation-proof retryer (guards the config wiring,
+// not just the constructor).
+func TestReplicaClient_RetryerSurvivesSustainedFailures(t *testing.T) {
+	client := NewReplicaClient()
+	client.Bucket = "test-bucket"
+	client.Path = "replica"
+	client.Region = "us-east-1"
+	client.Endpoint = "http://localhost:1"
+	client.ForcePathStyle = true
+	client.AccessKeyID = "test-access-key"
+	client.SecretAccessKey = "test-secret-key"
+
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	retryer := client.s3.Options().Retryer
+	for i := 0; i < 200; i++ {
+		release, err := retryer.GetRetryToken(ctx, io.ErrUnexpectedEOF)
+		if err != nil {
+			t.Fatalf("configured client denied retry token after %d consecutive failures: %v", i, err)
+		}
+		if err := release(io.ErrUnexpectedEOF); err != nil {
+			t.Fatalf("release after failure %d: %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
> 📍 **Stack map:** part of a stacked series — see the [canonical PR map](https://gist.github.com/corylanou/f2709d9868cad1943c63096bf978e881) for review order, scope, and current blockers.

## Description
Replaces the S3 client's adaptive retry mode with a standard retryer using an unlimited rate limiter (same 10-attempt cap). Applies the same retryer to the region-lookup client, which previously used bare SDK defaults.

## Motivation and Context
The adaptive retry mode's client-side token bucket only refills retry quota on successful responses. During a sustained object-store transport flap, the bucket drains to zero and every operation fails fast with `retry quota exceeded, 0 available, 5 requested` — exactly when a replication tool most needs to keep retrying. Observed in production soak testing against Tigris: repeated 5+ minute windows where replica sync could not complete on `PutObject`/`ListObjectsV2` because retries were abandoned, e.g.:

```
sync database: replica sync: write ltx file: s3: ... operation error S3: PutObject ...
unexpected EOF / failed to get rate limit token, retry quota exceeded, 0 available, 5 requested
```

Exponential backoff between attempts still bounds request rate during outages.

## How Has This Been Tested?
`TestTransportRetryer_SurvivesSustainedFailures` and `TestReplicaClient_RetryerSurvivesSustainedFailures` simulate 200 consecutive transport failures and assert retry tokens are never denied — both fail on the previous adaptive configuration. Full `go test ./...` green.

The commit hook passed:

```text
trim trailing whitespace: Passed
fix end of files: Passed
check yaml: Skipped
go-imports-repo: Passed
go-vet-repo-mod: Passed
go-staticcheck-repo-mod: Passed
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)