### PR TITLE
fix(restore): retry through provider throttle responses

### DIFF
--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -63,9 +64,21 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 
 const resumableReaderMaxRetries = 3
 
+// resumableReaderBackoff is the base delay between retry attempts, doubling
+// per attempt. Zero-delay retries land every attempt inside the same provider
+// throttle window (e.g. Tigris 408 load shedding), guaranteeing exhaustion.
+const resumableReaderBackoff = 250 * time.Millisecond
+
 func (r *ResumableReader) Read(p []byte) (int, error) {
 	var lastErr error
 	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-r.ctx.Done():
+				return 0, r.ctx.Err()
+			case <-time.After(resumableReaderBackoff << (attempt - 1)):
+			}
+		}
 		// Reopen the stream from the current offset if the previous
 		// connection was closed (rc is nil after a retry).
 		if r.rc == nil {

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -309,4 +310,58 @@ func (r *errorAfterN) Read(p []byte) (int, error) {
 	n := copy(p, r.data[r.pos:r.pos+len(p)])
 	r.pos += n
 	return n, nil
+}
+
+func TestResumableReader_BackoffBetweenReopens(t *testing.T) {
+	// Burst-retrying a throttling provider (e.g. Tigris load-shedding with
+	// 408 RequestCanceled) lands every reopen attempt inside the same
+	// throttle window. Reopens must back off between attempts.
+	data := []byte("hello world")
+	var callTimes []time.Time
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			callTimes = append(callTimes, time.Now())
+			if len(callTimes) <= 2 {
+				return nil, fmt.Errorf("operation error S3: GetObject, api error RequestCanceled: Request is canceled.")
+			}
+			return io.NopCloser(bytes.NewReader(data[offset:])), nil
+		},
+	}
+
+	r := NewResumableReader(context.Background(), client, 2, 1, 2, int64(len(data)), nil, slog.Default())
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q, want %q", got, data)
+	}
+	if len(callTimes) != 3 {
+		t.Fatalf("expected 3 OpenLTXFile calls, got %d", len(callTimes))
+	}
+	for i := 1; i < len(callTimes); i++ {
+		if gap := callTimes[i].Sub(callTimes[i-1]); gap < 100*time.Millisecond {
+			t.Fatalf("reopen attempt %d fired %v after attempt %d; want >= 100ms backoff", i+1, gap, i)
+		}
+	}
+}
+
+func TestResumableReader_ContextCancelAbortsBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			cancel()
+			return nil, fmt.Errorf("connection reset")
+		},
+	}
+
+	r := NewResumableReader(ctx, client, 2, 1, 2, 11, nil, slog.Default())
+	start := time.Now()
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("read blocked %v after cancellation; backoff must abort on ctx.Done", elapsed)
+	}
 }

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -567,6 +567,19 @@ func newTransportRetryer() aws.Retryer {
 	return retry.NewStandard(func(o *retry.StandardOptions) {
 		o.MaxAttempts = transportRetryMaxAttempts
 		o.RateLimiter = ratelimit.None
+		// S3-compatible providers (observed: Tigris) load-shed with HTTP 408
+		// and api error code "RequestCanceled", neither of which the SDK
+		// classifies as retryable by default. Genuine client-side context
+		// cancellation stays non-retryable via the standard retryer's
+		// canceled-context check, which runs before these.
+		o.Retryables = append(o.Retryables,
+			retry.RetryableHTTPStatusCode{Codes: map[int]struct{}{
+				http.StatusRequestTimeout: {},
+			}},
+			retry.RetryableErrorCode{Codes: map[string]struct{}{
+				"RequestCanceled": {},
+			}},
+		)
 	})
 }
 

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2138,3 +2138,25 @@ func TestReplicaClient_RetryerSurvivesSustainedFailures(t *testing.T) {
 		}
 	}
 }
+
+// TestTransportRetryer_RetriesProviderThrottleResponses covers S3-compatible
+// providers that load-shed with HTTP 408 / api error "RequestCanceled"
+// (observed from Tigris during soak testing). The SDK defaults treat neither
+// as retryable, so restores failed after effectively zero patience.
+func TestTransportRetryer_RetriesProviderThrottleResponses(t *testing.T) {
+	retryer := newTransportRetryer()
+
+	status408 := &smithyhttp.ResponseError{Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusRequestTimeout}}, Err: fmt.Errorf("request timeout")}
+	if !retryer.IsErrorRetryable(status408) {
+		t.Fatal("HTTP 408 must be retryable for S3-compatible providers")
+	}
+
+	canceledCode := &smithy.GenericAPIError{Code: "RequestCanceled", Message: "Request is canceled."}
+	if !retryer.IsErrorRetryable(canceledCode) {
+		t.Fatal(`api error code "RequestCanceled" (server-side load shed) must be retryable`)
+	}
+
+	if retryer.IsErrorRetryable(fmt.Errorf("wrapped: %w", context.Canceled)) {
+		t.Fatal("genuine client-side context cancellation must NOT be retryable")
+	}
+}


### PR DESCRIPTION
> 📍 **Stack map:** part of a stacked series — see the [canonical PR map](https://gist.github.com/corylanou/f2709d9868cad1943c63096bf978e881) for review order, scope, and current blockers.

## Description
Makes restores survive provider throttling: marks HTTP 408 and api error code `RequestCanceled` as retryable on the transport retryer (introduced in the previous PR of this stack), and gives the restore path's `ResumableReader` capped exponential backoff (250ms doubling, context-aware) instead of zero-delay retries.

## Motivation and Context
Production soak testing caught a restore failing against Tigris load-shedding with `408 / api error RequestCanceled: Request is canceled.` Two compounding gaps:

1. The SDK's `DefaultRetryableHTTPStatusCodes` is only `{500, 502, 503, 504}` and `RequestCanceled` appears in no retryable set — every such response failed the S3 operation instantly with zero retries.
2. `ResumableReader` retried reopen failures with no delay between attempts, burning its entire retry budget inside a single throttle window.

Net effect: a restore during a transient provider throttle failed after effectively zero patience — at the disaster-recovery moment where persistence matters most.

Genuine client-side context cancellation remains non-retryable: the standard retryer's canceled-context check runs before these classifiers, and the reader's backoff aborts on `ctx.Done()`.

## How Has This Been Tested?
`TestTransportRetryer_RetriesProviderThrottleResponses` (408 retryable, `RequestCanceled` retryable, `context.Canceled` not), `TestResumableReader_BackoffBetweenReopens`, and `TestResumableReader_ContextCancelAbortsBackoff` — the throttle-classification and backoff tests fail on the unfixed code. Full `go test ./...` green.

The commit hook passed:

```text
trim trailing whitespace: Passed
fix end of files: Passed
check yaml: Skipped
go-imports-repo: Passed
go-vet-repo-mod: Passed
go-staticcheck-repo-mod: Passed
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)