### PR TITLE
fix(compaction): resume remote source reads

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // Compactor handles compaction and retention for LTX files.
@@ -147,7 +149,7 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		if err != nil {
 			return nil, fmt.Errorf("open ltx file: %w", err)
 		}
-		rdrs = append(rdrs, f)
+		rdrs = append(rdrs, internal.NewResumableReader(ctx, c.client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, c.logger))
 	}
 	if len(rdrs) == 0 {
 		return nil, ErrNoCompaction

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -119,6 +119,35 @@ func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
 	}
 }
 
+func TestCompactor_CompactResumesRemoteSourceAfterDisconnect(t *testing.T) {
+	client := newDisconnectingCompactionClient(t.TempDir(), 16)
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+
+	info, err := compactor.Compact(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Level != 1 {
+		t.Errorf("Level=%d, want 1", info.Level)
+	}
+	if info.MinTXID != 1 || info.MaxTXID != 1 {
+		t.Errorf("TXID range=%d-%d, want 1-1", info.MinTXID, info.MaxTXID)
+	}
+
+	var resumed bool
+	for _, offset := range client.openOffsets[1:] {
+		if offset > 0 {
+			resumed = true
+			break
+		}
+	}
+	if !resumed {
+		t.Fatalf("OpenLTXFile offsets=%v, want reopen at non-zero offset", client.openOffsets)
+	}
+}
+
 func TestCompactor_MaxLTXFileInfo(t *testing.T) {
 	t.Run("WithFiles", func(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
@@ -649,6 +678,58 @@ func (c *earlyReturnCompactionClient) WriteLTXFile(ctx context.Context, level in
 		return nil, fmt.Errorf("early write failure")
 	}
 	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+type disconnectingCompactionClient struct {
+	litestream.ReplicaClient
+	dropAfter   int64
+	dropped     bool
+	openOffsets []int64
+}
+
+func newDisconnectingCompactionClient(path string, dropAfter int64) *disconnectingCompactionClient {
+	return &disconnectingCompactionClient{
+		ReplicaClient: file.NewReplicaClient(path),
+		dropAfter:     dropAfter,
+	}
+}
+
+func (c *disconnectingCompactionClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	c.openOffsets = append(c.openOffsets, offset)
+
+	rc, err := c.ReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+	if err != nil {
+		return nil, err
+	}
+	if !c.dropped && offset == 0 {
+		c.dropped = true
+		return &disconnectingReadCloser{ReadCloser: rc, remaining: c.dropAfter}, nil
+	}
+	return rc, nil
+}
+
+type disconnectingReadCloser struct {
+	io.ReadCloser
+	remaining int64
+}
+
+func (r *disconnectingReadCloser) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:int(r.remaining)]
+	}
+
+	n, err := r.ReadCloser.Read(p)
+	r.remaining -= int64(n)
+	if err != nil {
+		return n, err
+	}
+	if r.remaining <= 0 {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
 func countCompactorPipeWriters() int {

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -63,9 +64,21 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 
 const resumableReaderMaxRetries = 3
 
+// resumableReaderBackoff is the base delay between retry attempts, doubling
+// per attempt. Zero-delay retries land every attempt inside the same provider
+// throttle window (e.g. Tigris 408 load shedding), guaranteeing exhaustion.
+const resumableReaderBackoff = 250 * time.Millisecond
+
 func (r *ResumableReader) Read(p []byte) (int, error) {
 	var lastErr error
 	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-r.ctx.Done():
+				return 0, r.ctx.Err()
+			case <-time.After(resumableReaderBackoff << (attempt - 1)):
+			}
+		}
 		// Reopen the stream from the current offset if the previous
 		// connection was closed (rc is nil after a retry).
 		if r.rc == nil {

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -309,4 +310,58 @@ func (r *errorAfterN) Read(p []byte) (int, error) {
 	n := copy(p, r.data[r.pos:r.pos+len(p)])
 	r.pos += n
 	return n, nil
+}
+
+func TestResumableReader_BackoffBetweenReopens(t *testing.T) {
+	// Burst-retrying a throttling provider (e.g. Tigris load-shedding with
+	// 408 RequestCanceled) lands every reopen attempt inside the same
+	// throttle window. Reopens must back off between attempts.
+	data := []byte("hello world")
+	var callTimes []time.Time
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			callTimes = append(callTimes, time.Now())
+			if len(callTimes) <= 2 {
+				return nil, fmt.Errorf("operation error S3: GetObject, api error RequestCanceled: Request is canceled.")
+			}
+			return io.NopCloser(bytes.NewReader(data[offset:])), nil
+		},
+	}
+
+	r := NewResumableReader(context.Background(), client, 2, 1, 2, int64(len(data)), nil, slog.Default())
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q, want %q", got, data)
+	}
+	if len(callTimes) != 3 {
+		t.Fatalf("expected 3 OpenLTXFile calls, got %d", len(callTimes))
+	}
+	for i := 1; i < len(callTimes); i++ {
+		if gap := callTimes[i].Sub(callTimes[i-1]); gap < 100*time.Millisecond {
+			t.Fatalf("reopen attempt %d fired %v after attempt %d; want >= 100ms backoff", i+1, gap, i)
+		}
+	}
+}
+
+func TestResumableReader_ContextCancelAbortsBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			cancel()
+			return nil, fmt.Errorf("connection reset")
+		},
+	}
+
+	r := NewResumableReader(ctx, client, 2, 1, 2, 11, nil, slog.Default())
+	start := time.Now()
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("read blocked %v after cancellation; backoff must abort on ctx.Done", elapsed)
+	}
 }

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -567,6 +567,19 @@ func newTransportRetryer() aws.Retryer {
 	return retry.NewStandard(func(o *retry.StandardOptions) {
 		o.MaxAttempts = transportRetryMaxAttempts
 		o.RateLimiter = ratelimit.None
+		// S3-compatible providers (observed: Tigris) load-shed with HTTP 408
+		// and api error code "RequestCanceled", neither of which the SDK
+		// classifies as retryable by default. Genuine client-side context
+		// cancellation stays non-retryable via the standard retryer's
+		// canceled-context check, which runs before these.
+		o.Retryables = append(o.Retryables,
+			retry.RetryableHTTPStatusCode{Codes: map[int]struct{}{
+				http.StatusRequestTimeout: {},
+			}},
+			retry.RetryableErrorCode{Codes: map[string]struct{}{
+				"RequestCanceled": {},
+			}},
+		)
 	})
 }
 

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2138,3 +2138,25 @@ func TestReplicaClient_RetryerSurvivesSustainedFailures(t *testing.T) {
 		}
 	}
 }
+
+// TestTransportRetryer_RetriesProviderThrottleResponses covers S3-compatible
+// providers that load-shed with HTTP 408 / api error "RequestCanceled"
+// (observed from Tigris during soak testing). The SDK defaults treat neither
+// as retryable, so restores failed after effectively zero patience.
+func TestTransportRetryer_RetriesProviderThrottleResponses(t *testing.T) {
+	retryer := newTransportRetryer()
+
+	status408 := &smithyhttp.ResponseError{Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusRequestTimeout}}, Err: fmt.Errorf("request timeout")}
+	if !retryer.IsErrorRetryable(status408) {
+		t.Fatal("HTTP 408 must be retryable for S3-compatible providers")
+	}
+
+	canceledCode := &smithy.GenericAPIError{Code: "RequestCanceled", Message: "Request is canceled."}
+	if !retryer.IsErrorRetryable(canceledCode) {
+		t.Fatal(`api error code "RequestCanceled" (server-side load shed) must be retryable`)
+	}
+
+	if retryer.IsErrorRetryable(fmt.Errorf("wrapped: %w", context.Canceled)) {
+		t.Fatal("genuine client-side context cancellation must NOT be retryable")
+	}
+}


### PR DESCRIPTION
> 📍 **Stack map:** part of a stacked series — see the [canonical PR map](https://gist.github.com/corylanou/f2709d9868cad1943c63096bf978e881) for review order, scope, and current blockers.

## Summary
Wrap remote compaction source readers in `internal.ResumableReader` so a provider-side idle disconnect can reopen from the last byte offset. The `LocalFileOpener` fast path remains unchanged.

## Problem
`Compactor.Compact` opened remote source LTX files as raw `OpenLTXFile` streams before sending them through `ltx.NewCompactor`. If the provider closed an idle source stream mid-compact, compaction failed even though the source object still existed and range reads could recover it.

The regression test demonstrates the failure by returning a source reader that cuts off after 16 bytes. On the unfixed code it fails with:

```text
write ltx file: extract timestamp from LTX header: EOF
```

## Solution
The remote fallback path now wraps the opened source stream with `internal.NewResumableReader`, passing `info.Size` from the listed LTX metadata. Premature EOF and transient read errors reopen through `OpenLTXFile` at the current offset.

## Scope
**In scope:**
- Remote compaction source reads
- Regression coverage for a mid-read disconnect and non-zero-offset reopen

**Not in scope:**
- Local compaction reads via `LocalFileOpener`
- Retry/backoff policy changes
- Storage backend behavior changes

Fixes #1308

## Test Plan
- `go test -run TestCompactor_CompactResumesRemoteSourceAfterDisconnect ./`
- `go test -run 'TestCompactor' ./`
- `go build ./...`
- `go test ./...`
- `golangci-lint run --new-from-rev=fix-restore-throttle-retry`
- `go test -race ./...`
- `pre-commit run --all-files`

`golangci-lint run` against the full stack still reports existing baseline errcheck/staticcheck findings outside this patch; the new-code check above is clean.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`gofmt`, repo import hook)
- [x] I have tested my changes (`go test ./...`, `go test -race ./...`)
- [ ] I have updated the documentation accordingly (not needed)
