### PR TITLE
fix(retention): retain prior snapshot txid

### DIFF
--- a/db.go
+++ b/db.go
@@ -2867,9 +2867,11 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 	defer itr.Close()
 
 	var deleted []*ltx.FileInfo
+	var snapshots []*ltx.FileInfo
 	var lastInfo *ltx.FileInfo
 	for itr.Next() {
 		info := itr.Item()
+		snapshots = append(snapshots, info)
 		lastInfo = info
 
 		// If this snapshot is before the retention timestamp, mark it for deletion.
@@ -2877,17 +2879,23 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 			deleted = append(deleted, info)
 			continue
 		}
-
-		// Track the lowest snapshot TXID so we can enforce retention in lower levels.
-		// This is only tracked for snapshots not marked for deletion.
-		if minSnapshotTXID == 0 || info.MaxTXID < minSnapshotTXID {
-			minSnapshotTXID = info.MaxTXID
-		}
 	}
 
 	// If this is the snapshot level, we need to ensure that at least one snapshot exists.
 	if len(deleted) > 0 && deleted[len(deleted)-1] == lastInfo {
 		deleted = deleted[:len(deleted)-1]
+	}
+
+	for i, info := range snapshots {
+		if slices.Contains(deleted, info) {
+			continue
+		}
+		if i > 0 {
+			minSnapshotTXID = snapshots[i-1].MaxTXID
+		} else {
+			minSnapshotTXID = info.MaxTXID
+		}
+		break
 	}
 
 	// Remove files marked for deletion from remote storage (unless retention disabled).

--- a/db_test.go
+++ b/db_test.go
@@ -718,7 +718,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 	retentionTime := time.Now().Add(-150 * time.Millisecond)
 	if minSnapshotTXID, err := db.EnforceSnapshotRetention(t.Context(), retentionTime); err != nil {
 		t.Fatal(err)
-	} else if got, want := minSnapshotTXID, ltx.TXID(4); got != want {
+	} else if got, want := minSnapshotTXID, ltx.TXID(3); got != want {
 		t.Fatalf("MinSnapshotTXID=%s, want %s", got, want)
 	}
 
@@ -801,6 +801,62 @@ func TestDB_EnforceSnapshotRetention_RetentionDisabled(t *testing.T) {
 	afterCount := countFiles()
 	if afterCount != beforeCount {
 		t.Fatalf("expected %d remote snapshots (no remote deletion), got %d", beforeCount, afterCount)
+	}
+}
+
+func TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db := testingutil.NewDB(t, filepath.Join(dir, "db"))
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	client := file.NewReplicaClient(filepath.Join(dir, "replica"))
+	db.Replica = litestream.NewReplicaWithClient(db, client)
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer testingutil.MustCloseDB(t, db)
+
+	oldTime := time.Now().Add(-2 * time.Hour)
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 5, oldTime)
+	createTestLTXFileWithTimestamp(t, client, 1, 6, 10, oldTime.Add(time.Minute))
+
+	plan, err := litestream.CalcRestorePlan(ctx, client, 10, time.Time{}, db.Logger)
+	if err != nil {
+		t.Fatalf("calc restore plan: %v", err)
+	}
+
+	var plannedInfo *ltx.FileInfo
+	for _, info := range plan {
+		if info.Level == 1 && info.MinTXID == 6 && info.MaxTXID == 10 {
+			plannedInfo = info
+			break
+		}
+	}
+	if plannedInfo == nil {
+		t.Fatalf("restore plan does not include L1 6-10: %#v", plan)
+	}
+
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 11, time.Now())
+	createTestLTXFileWithTimestamp(t, client, 1, 11, 11, time.Now())
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{
+		{Level: 0},
+		{Level: 1, Interval: time.Hour},
+	})
+	store.SnapshotRetention = time.Hour
+
+	if err := store.EnforceSnapshotRetention(ctx, db); err != nil {
+		t.Fatalf("enforce snapshot retention: %v", err)
+	}
+
+	rc, err := client.OpenLTXFile(ctx, plannedInfo.Level, plannedInfo.MinTXID, plannedInfo.MaxTXID, 0, 0)
+	if err != nil {
+		t.Fatalf("planned LTX file was deleted by retention: level=%d min=%s max=%s: %v", plannedInfo.Level, plannedInfo.MinTXID, plannedInfo.MaxTXID, err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close planned LTX file: %v", err)
 	}
 }
 


### PR DESCRIPTION
> 📍 **Stack map:** part of a stacked series — see the [canonical PR map](https://gist.github.com/corylanou/f2709d9868cad1943c63096bf978e881) for review order, scope, and current blockers.

## Description
Retains one extra snapshot generation for lower-level LTX retention by deriving the cascade watermark from the snapshot immediately before the first retained snapshot when one exists. This keeps LTX files already selected by an in-flight restore plan from being deleted as soon as the next snapshot raises the latest snapshot TXID.

The change is localized to `DB.EnforceSnapshotRetention()` and the existing store propagation path to lower-level `EnforceRetentionByTXID()` calls. The snapshot-level "always keep at least one snapshot" guard remains intact.

Stack gist and soak dispatch are intentionally not touched here; those are handled separately from this PR workflow.

## Motivation and Context
A long-running restore computes its LTX plan once, then streams those files lazily. If snapshot retention runs after a new snapshot appears, the old watermark can advance to the new snapshot TXID and delete lower-level files that the restore plan still references. That produces mid-restore failures such as `reopen ltx file ... file does not exist`.

This implements issue #1307 option 2: retain one extra snapshot generation's lower-level history, so a restore plan computed against the prior snapshot remains usable until another snapshot generation lands.

Fixes #1307

## How Has This Been Tested?
The regression test fails on the unfixed code:

```text
--- FAIL: TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles (0.03s)
    db_test.go:856: planned LTX file was deleted by retention: level=1 min=0000000000000006 max=000000000000000a: open ltx file ... no such file or directory
FAIL
FAIL    github.com/benbjohnson/litestream    1.253s
```

After the fix:

```text
go test -run 'Test(Store_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles|DB_EnforceRetention)$' -count=1 .
go build ./...
go test ./...
pre-commit run --all-files
```

All commands passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
