### PR TITLE
feat(cli): read config from stdin

### DIFF
--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -15,7 +15,7 @@ type DatabasesCommand struct{}
 // Run executes the command.
 func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-databases", flag.ContinueOnError)
-	configPath, noExpandEnv := registerConfigFlag(fs)
+	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -25,10 +25,7 @@ func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 	}
 
 	// Load configuration.
-	if *configPath == "" {
-		*configPath = DefaultConfigPath()
-	}
-	config, err := ReadConfigFile(*configPath, !*noExpandEnv)
+	config, err := ReadConfig(*configPath, *stdin, !*noExpandEnv)
 	if err != nil {
 		return err
 	}
@@ -89,6 +86,9 @@ Arguments:
 	-json
 	    Output raw JSON instead of human-readable text.
 
+	-stdin
+	    Read configuration from standard input.
+
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
@@ -96,6 +96,7 @@ Examples:
 
 	$ litestream databases
 	$ litestream databases -config /path/to/litestream.yml
+	$ cat /path/to/litestream.yml | litestream databases -stdin
 	$ litestream databases -no-expand-env -config /path/to/litestream.yml
 
 `[1:],

--- a/cmd/litestream/databases.go
+++ b/cmd/litestream/databases.go
@@ -15,7 +15,7 @@ type DatabasesCommand struct{}
 // Run executes the command.
 func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-databases", flag.ContinueOnError)
-	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
+	configPath, noExpandEnv := registerConfigFlag(fs)
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -25,7 +25,7 @@ func (c *DatabasesCommand) Run(_ context.Context, args []string) (err error) {
 	}
 
 	// Load configuration.
-	config, err := ReadConfig(*configPath, *stdin, !*noExpandEnv)
+	config, err := ReadConfig(*configPath, !*noExpandEnv)
 	if err != nil {
 		return err
 	}
@@ -80,14 +80,11 @@ Usage:
 Arguments:
 
 	-config PATH
-	    Specifies the configuration file.
+	    Specifies the configuration file. Use "-" to read from standard input.
 	    Defaults to %s
 
 	-json
 	    Output raw JSON instead of human-readable text.
-
-	-stdin
-	    Read configuration from standard input.
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
@@ -96,7 +93,7 @@ Examples:
 
 	$ litestream databases
 	$ litestream databases -config /path/to/litestream.yml
-	$ cat /path/to/litestream.yml | litestream databases -stdin
+	$ cat /path/to/litestream.yml | litestream databases -config -
 	$ litestream databases -no-expand-env -config /path/to/litestream.yml
 
 `[1:],

--- a/cmd/litestream/databases_test.go
+++ b/cmd/litestream/databases_test.go
@@ -65,6 +65,45 @@ func TestDatabasesCommand_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("StdinJSONOutput", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+
+		if err := os.WriteFile(dbPath, []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		withStdin(t, `dbs:
+  - path: `+dbPath+`
+    replicas:
+      - url: file://`+filepath.Join(dir, "replica")+`
+`)
+
+		output := captureStdout(t, func() {
+			cmd := &main.DatabasesCommand{}
+			if err := cmd.Run(context.Background(), []string{"-stdin", "-json"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		var got []struct {
+			Path    string `json:"path"`
+			Replica string `json:"replica"`
+		}
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("failed to parse output: %v\n%s", err, output)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 database row, got %d", len(got))
+		}
+		if got[0].Path != dbPath {
+			t.Fatalf("unexpected database path: %s", got[0].Path)
+		}
+		if got[0].Replica != "file" {
+			t.Fatalf("unexpected replica type: %s", got[0].Replica)
+		}
+	})
+
 	t.Run("EmptyJSONOutput", func(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "litestream.yml")

--- a/cmd/litestream/databases_test.go
+++ b/cmd/litestream/databases_test.go
@@ -81,7 +81,7 @@ func TestDatabasesCommand_Run(t *testing.T) {
 
 		output := captureStdout(t, func() {
 			cmd := &main.DatabasesCommand{}
-			if err := cmd.Run(context.Background(), []string{"-stdin", "-json"}); err != nil {
+			if err := cmd.Run(context.Background(), []string{"-config", "-", "-json"}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})

--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -19,7 +19,7 @@ type LTXCommand struct{}
 // Run executes the command.
 func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-ltx", flag.ContinueOnError)
-	configPath, noExpandEnv := registerConfigFlag(fs)
+	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	var level levelVar
 	fs.Var(&level, "level", "compaction level (0-9 or \"all\")")
@@ -40,17 +40,16 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		if *configPath != "" {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
 		}
+		if *stdin {
+			return fmt.Errorf("cannot specify a replica URL and the -stdin flag")
+		}
 		if r, err = NewReplicaFromConfig(&ReplicaConfig{URL: fs.Arg(0)}, nil); err != nil {
 			return err
 		}
 		internal.InitLog(os.Stdout, "INFO", "text", false)
 	} else {
-		if *configPath == "" {
-			*configPath = DefaultConfigPath()
-		}
-
 		// Load configuration.
-		config, err := ReadConfigFile(*configPath, !*noExpandEnv)
+		config, err := ReadConfig(*configPath, *stdin, !*noExpandEnv)
 		if err != nil {
 			return err
 		}
@@ -158,6 +157,9 @@ Arguments:
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
+	-stdin
+	    Read configuration from standard input.
+
 	-level LEVEL
 	    Compaction level to list (0-9 or "all").
 	    Defaults to 0.
@@ -169,6 +171,9 @@ Examples:
 
 	# List all LTX files for a database.
 	$ litestream ltx /path/to/db
+
+	# List all LTX files using configuration from standard input.
+	$ cat /path/to/litestream.yml | litestream ltx -stdin /path/to/db
 
 	# List all LTX files for replica URL.
 	$ litestream ltx s3://mybkt/db

--- a/cmd/litestream/ltx.go
+++ b/cmd/litestream/ltx.go
@@ -19,7 +19,7 @@ type LTXCommand struct{}
 // Run executes the command.
 func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-ltx", flag.ContinueOnError)
-	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
+	configPath, noExpandEnv := registerConfigFlag(fs)
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	var level levelVar
 	fs.Var(&level, "level", "compaction level (0-9 or \"all\")")
@@ -40,16 +40,13 @@ func (c *LTXCommand) Run(ctx context.Context, args []string) (err error) {
 		if *configPath != "" {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
 		}
-		if *stdin {
-			return fmt.Errorf("cannot specify a replica URL and the -stdin flag")
-		}
 		if r, err = NewReplicaFromConfig(&ReplicaConfig{URL: fs.Arg(0)}, nil); err != nil {
 			return err
 		}
 		internal.InitLog(os.Stdout, "INFO", "text", false)
 	} else {
 		// Load configuration.
-		config, err := ReadConfig(*configPath, *stdin, !*noExpandEnv)
+		config, err := ReadConfig(*configPath, !*noExpandEnv)
 		if err != nil {
 			return err
 		}
@@ -151,14 +148,11 @@ Usage:
 Arguments:
 
 	-config PATH
-	    Specifies the configuration file.
+	    Specifies the configuration file. Use "-" to read from standard input.
 	    Defaults to %s
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
-
-	-stdin
-	    Read configuration from standard input.
 
 	-level LEVEL
 	    Compaction level to list (0-9 or "all").
@@ -173,7 +167,7 @@ Examples:
 	$ litestream ltx /path/to/db
 
 	# List all LTX files using configuration from standard input.
-	$ cat /path/to/litestream.yml | litestream ltx -stdin /path/to/db
+	$ cat /path/to/litestream.yml | litestream ltx -config - /path/to/db
 
 	# List all LTX files for replica URL.
 	$ litestream ltx s3://mybkt/db

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -608,6 +608,19 @@ func ReadConfigFile(filename string, expandEnv bool) (Config, error) {
 	return ParseConfig(f, expandEnv)
 }
 
+func ReadConfig(configPath string, fromStdin, expandEnv bool) (Config, error) {
+	if fromStdin {
+		if configPath != "" {
+			return DefaultConfig(), fmt.Errorf("cannot specify both -config and -stdin flags")
+		}
+		return ParseConfig(os.Stdin, expandEnv)
+	}
+	if configPath == "" {
+		configPath = DefaultConfigPath()
+	}
+	return ReadConfigFile(configPath, expandEnv)
+}
+
 // ParseConfig unmarshals config from a reader.
 // If expandEnv is true then environment variables are expanded in the config.
 func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
@@ -2037,8 +2050,9 @@ func DefaultConfigPath() string {
 	return defaultConfigPath
 }
 
-func registerConfigFlag(fs *flag.FlagSet) (configPath *string, noExpandEnv *bool) {
+func registerConfigFlag(fs *flag.FlagSet) (configPath *string, stdin *bool, noExpandEnv *bool) {
 	return fs.String("config", "", "config path"),
+		fs.Bool("stdin", false, "read config from stdin"),
 		fs.Bool("no-expand-env", false, "do not expand env vars in config")
 }
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -608,15 +608,18 @@ func ReadConfigFile(filename string, expandEnv bool) (Config, error) {
 	return ParseConfig(f, expandEnv)
 }
 
-func ReadConfig(configPath string, fromStdin, expandEnv bool) (Config, error) {
-	if fromStdin {
-		if configPath != "" {
-			return DefaultConfig(), fmt.Errorf("cannot specify both -config and -stdin flags")
-		}
-		return ParseConfig(os.Stdin, expandEnv)
-	}
-	if configPath == "" {
+// stdinConfigPath is the -config value that reads the configuration from STDIN.
+const stdinConfigPath = "-"
+
+// ReadConfig unmarshals config from configPath. If configPath is blank then the
+// default config path is used. If configPath is "-" then config is read from STDIN.
+// If expandEnv is true then environment variables are expanded in the config.
+func ReadConfig(configPath string, expandEnv bool) (Config, error) {
+	switch configPath {
+	case "":
 		configPath = DefaultConfigPath()
+	case stdinConfigPath:
+		return ParseConfig(os.Stdin, expandEnv)
 	}
 	return ReadConfigFile(configPath, expandEnv)
 }
@@ -2050,9 +2053,8 @@ func DefaultConfigPath() string {
 	return defaultConfigPath
 }
 
-func registerConfigFlag(fs *flag.FlagSet) (configPath *string, stdin *bool, noExpandEnv *bool) {
-	return fs.String("config", "", "config path"),
-		fs.Bool("stdin", false, "read config from stdin"),
+func registerConfigFlag(fs *flag.FlagSet) (configPath *string, noExpandEnv *bool) {
+	return fs.String("config", "", "config path, or \"-\" to read from stdin"),
 		fs.Bool("no-expand-env", false, "do not expand env vars in config")
 }
 

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -98,6 +98,62 @@ func TestOpenConfigFile(t *testing.T) {
 	})
 }
 
+func TestReadConfig(t *testing.T) {
+	t.Run("ReadsFromStdin", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "db")
+		t.Setenv("LITESTREAM_STDIN_DB", dbPath)
+		withStdin(t, `
+dbs:
+  - path: $LITESTREAM_STDIN_DB
+    replicas:
+      - url: file:///tmp/replica
+`[1:])
+
+		config, err := main.ReadConfig("", true, true)
+		if err != nil {
+			t.Fatal(err)
+		} else if got, want := len(config.DBs), 1; got != want {
+			t.Fatalf("len(DBs)=%v, want %v", got, want)
+		} else if got, want := config.DBs[0].Path, dbPath; got != want {
+			t.Fatalf("DB.Path=%v, want %v", got, want)
+		} else if got, want := config.DBs[0].Replicas[0].URL, "file:///tmp/replica"; got != want {
+			t.Fatalf("Replica.URL=%v, want %v", got, want)
+		}
+	})
+
+	t.Run("RejectsConfigPathWithStdin", func(t *testing.T) {
+		_, err := main.ReadConfig("litestream.yml", true, true)
+		if err == nil {
+			t.Fatal("expected error")
+		} else if got, want := err.Error(), "cannot specify both -config and -stdin flags"; got != want {
+			t.Fatalf("error=%q, want %q", got, want)
+		}
+	})
+}
+
+func withStdin(t *testing.T, s string) {
+	t.Helper()
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestReadConfigFile(t *testing.T) {
 	// Ensure global AWS settings are propagated down to replica configurations.
 	t.Run("PropagateGlobalSettings", func(t *testing.T) {

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -109,7 +109,7 @@ dbs:
       - url: file:///tmp/replica
 `[1:])
 
-		config, err := main.ReadConfig("", true, true)
+		config, err := main.ReadConfig("-", true)
 		if err != nil {
 			t.Fatal(err)
 		} else if got, want := len(config.DBs), 1; got != want {
@@ -121,12 +121,19 @@ dbs:
 		}
 	})
 
-	t.Run("RejectsConfigPathWithStdin", func(t *testing.T) {
-		_, err := main.ReadConfig("litestream.yml", true, true)
-		if err == nil {
-			t.Fatal("expected error")
-		} else if got, want := err.Error(), "cannot specify both -config and -stdin flags"; got != want {
-			t.Fatalf("error=%q, want %q", got, want)
+	t.Run("ReadsFromFile", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "litestream.yml")
+		if err := os.WriteFile(configPath, []byte("dbs:\n  - path: /tmp/db\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := main.ReadConfig(configPath, true)
+		if err != nil {
+			t.Fatal(err)
+		} else if got, want := len(config.DBs), 1; got != want {
+			t.Fatalf("len(DBs)=%v, want %v", got, want)
+		} else if got, want := config.DBs[0].Path, "/tmp/db"; got != want {
+			t.Fatalf("DB.Path=%v, want %v", got, want)
 		}
 	})
 }

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -71,7 +71,7 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 	onceFlag := fs.Bool("once", false, "replicate once and exit")
 	forceSnapshotFlag := fs.Bool("force-snapshot", false, "force snapshot when replicating once")
 	enforceRetentionFlag := fs.Bool("enforce-retention", false, "enforce retention of old snapshots when replicating once")
-	configPath, noExpandEnv := registerConfigFlag(fs)
+	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -81,10 +81,10 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 	switch fs.NArg() {
 	case 0:
 		// No arguments provided, use config file
-		if *configPath == "" {
+		if *configPath == "" && !*stdin {
 			*configPath = DefaultConfigPath()
 		}
-		if c.Config, err = ReadConfigFile(*configPath, !*noExpandEnv); err != nil {
+		if c.Config, err = ReadConfig(*configPath, *stdin, !*noExpandEnv); err != nil {
 			return err
 		}
 		// Override log level if CLI flag provided (takes precedence over env var)
@@ -107,6 +107,9 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 		// Database path and replica URLs provided via CLI
 		if *configPath != "" {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
+		}
+		if *stdin {
+			return fmt.Errorf("cannot specify a replica URL and the -stdin flag")
 		}
 
 		// Initialize config with defaults when using command-line arguments
@@ -556,6 +559,9 @@ Arguments:
 	-log-level LEVEL
 	    Sets the log level. Overrides the config file setting.
 	    Valid values: trace, debug, info, warn, error
+
+	-stdin
+	    Read configuration from standard input.
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -71,7 +71,7 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 	onceFlag := fs.Bool("once", false, "replicate once and exit")
 	forceSnapshotFlag := fs.Bool("force-snapshot", false, "force snapshot when replicating once")
 	enforceRetentionFlag := fs.Bool("enforce-retention", false, "enforce retention of old snapshots when replicating once")
-	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
+	configPath, noExpandEnv := registerConfigFlag(fs)
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -81,10 +81,10 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 	switch fs.NArg() {
 	case 0:
 		// No arguments provided, use config file
-		if *configPath == "" && !*stdin {
+		if *configPath == "" {
 			*configPath = DefaultConfigPath()
 		}
-		if c.Config, err = ReadConfig(*configPath, *stdin, !*noExpandEnv); err != nil {
+		if c.Config, err = ReadConfig(*configPath, !*noExpandEnv); err != nil {
 			return err
 		}
 		// Override log level if CLI flag provided (takes precedence over env var)
@@ -107,9 +107,6 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 		// Database path and replica URLs provided via CLI
 		if *configPath != "" {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
-		}
-		if *stdin {
-			return fmt.Errorf("cannot specify a replica URL and the -stdin flag")
 		}
 
 		// Initialize config with defaults when using command-line arguments
@@ -143,7 +140,9 @@ func (c *ReplicateCommand) ParseFlags(_ context.Context, args []string) (err err
 		c.Config.DBs = []*DBConfig{dbConfig}
 	}
 
-	c.Config.ConfigPath = *configPath
+	if *configPath != stdinConfigPath {
+		c.Config.ConfigPath = *configPath
+	}
 
 	// Override config exec command, if specified.
 	if *execFlag != "" {
@@ -535,7 +534,7 @@ Usage:
 Arguments:
 
 	-config PATH
-	    Specifies the configuration file.
+	    Specifies the configuration file. Use "-" to read from standard input.
 	    Defaults to %s
 
 	-exec CMD
@@ -559,9 +558,6 @@ Arguments:
 	-log-level LEVEL
 	    Sets the log level. Overrides the config file setting.
 	    Valid values: trace, debug, info, warn, error
-
-	-stdin
-	    Read configuration from standard input.
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.

--- a/cmd/litestream/reset.go
+++ b/cmd/litestream/reset.go
@@ -17,7 +17,7 @@ type ResetCommand struct{}
 // Run executes the command.
 func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-reset", flag.ContinueOnError)
-	configPath, noExpandEnv := registerConfigFlag(fs)
+	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
 	dryRun := fs.Bool("dry-run", false, "print local state that would be removed without deleting")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -45,8 +45,8 @@ func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Load configuration to find the database (if config exists)
 	var dbConfig *DBConfig
-	if *configPath != "" {
-		config, configErr := ReadConfigFile(*configPath, !*noExpandEnv)
+	if *configPath != "" || *stdin {
+		config, configErr := ReadConfig(*configPath, *stdin, !*noExpandEnv)
 		if configErr != nil {
 			return fmt.Errorf("cannot read config: %w", configErr)
 		}
@@ -169,6 +169,9 @@ Arguments:
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
+	-stdin
+	    Read configuration from standard input.
+
 	-dry-run
 	    Print the local LTX files that would be removed without deleting them.
 
@@ -182,6 +185,9 @@ Examples:
 
 	# Reset using a specific configuration file
 	litestream reset -config /etc/litestream.yml /path/to/database.db
+
+	# Reset using configuration from standard input
+	cat /etc/litestream.yml | litestream reset -stdin /path/to/database.db
 
 `[1:],
 		DefaultConfigPath(),

--- a/cmd/litestream/reset.go
+++ b/cmd/litestream/reset.go
@@ -17,7 +17,7 @@ type ResetCommand struct{}
 // Run executes the command.
 func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-reset", flag.ContinueOnError)
-	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
+	configPath, noExpandEnv := registerConfigFlag(fs)
 	dryRun := fs.Bool("dry-run", false, "print local state that would be removed without deleting")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -45,8 +45,8 @@ func (c *ResetCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Load configuration to find the database (if config exists)
 	var dbConfig *DBConfig
-	if *configPath != "" || *stdin {
-		config, configErr := ReadConfig(*configPath, *stdin, !*noExpandEnv)
+	if *configPath != "" {
+		config, configErr := ReadConfig(*configPath, !*noExpandEnv)
 		if configErr != nil {
 			return fmt.Errorf("cannot read config: %w", configErr)
 		}
@@ -163,14 +163,11 @@ Usage:
 Arguments:
 
 	-config PATH
-	    Specifies the configuration file.
+	    Specifies the configuration file. Use "-" to read from standard input.
 	    Defaults to %s
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
-
-	-stdin
-	    Read configuration from standard input.
 
 	-dry-run
 	    Print the local LTX files that would be removed without deleting them.
@@ -187,7 +184,7 @@ Examples:
 	litestream reset -config /etc/litestream.yml /path/to/database.db
 
 	# Reset using configuration from standard input
-	cat /etc/litestream.yml | litestream reset -stdin /path/to/database.db
+	cat /etc/litestream.yml | litestream reset -config - /path/to/database.db
 
 `[1:],
 		DefaultConfigPath(),

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -26,7 +26,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	opt := litestream.NewRestoreOptions()
 
 	fs := flag.NewFlagSet("litestream-restore", flag.ContinueOnError)
-	configPath, noExpandEnv := registerConfigFlag(fs)
+	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
 	fs.StringVar(&opt.OutputPath, "o", "", "output path")
 	fs.Var((*txidVar)(&opt.TXID), "txid", "transaction ID")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
@@ -97,6 +97,9 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		if *configPath != "" {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
 		}
+		if *stdin {
+			return fmt.Errorf("cannot specify a replica URL and the -stdin flag")
+		}
 		if r, err = c.loadFromURL(ctx, fs.Arg(0), *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
 			slog.Info("database already exists, skipping")
 			return nil
@@ -104,10 +107,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 			return err
 		}
 	} else {
-		if *configPath == "" {
-			*configPath = DefaultConfigPath()
-		}
-		if r, err = c.loadFromConfig(ctx, fs.Arg(0), *configPath, !*noExpandEnv, *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
+		if r, err = c.loadFromConfig(ctx, fs.Arg(0), *configPath, *stdin, !*noExpandEnv, *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
 			slog.Info("database already exists, skipping")
 			return nil
 		} else if err != nil {
@@ -325,9 +325,9 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 }
 
 // loadFromConfig returns a replica & updates the restore options from a DB reference.
-func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath string, expandEnv, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
+func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath string, fromStdin, expandEnv, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	// Load configuration.
-	config, err := ReadConfigFile(configPath, expandEnv)
+	config, err := ReadConfig(configPath, fromStdin, expandEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -377,6 +377,9 @@ Arguments:
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
+
+	-stdin
+	    Read configuration from standard input.
 
 	-txid TXID
 	    Restore up to a specific hex-encoded transaction ID (inclusive).
@@ -429,6 +432,9 @@ Examples:
 
 	# Restore latest replica for database to original location.
 	$ litestream restore /path/to/db
+
+	# Restore latest replica using configuration from standard input.
+	$ cat /path/to/litestream.yml | litestream restore -stdin /path/to/db
 
 	# Restore replica for database to a given point in time.
 	$ litestream restore -timestamp 2020-01-01T00:00:00Z /path/to/db

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -26,7 +26,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	opt := litestream.NewRestoreOptions()
 
 	fs := flag.NewFlagSet("litestream-restore", flag.ContinueOnError)
-	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
+	configPath, noExpandEnv := registerConfigFlag(fs)
 	fs.StringVar(&opt.OutputPath, "o", "", "output path")
 	fs.Var((*txidVar)(&opt.TXID), "txid", "transaction ID")
 	fs.IntVar(&opt.Parallelism, "parallelism", opt.Parallelism, "parallelism")
@@ -97,9 +97,6 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		if *configPath != "" {
 			return fmt.Errorf("cannot specify a replica URL and the -config flag")
 		}
-		if *stdin {
-			return fmt.Errorf("cannot specify a replica URL and the -stdin flag")
-		}
 		if r, err = c.loadFromURL(ctx, fs.Arg(0), *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
 			slog.Info("database already exists, skipping")
 			return nil
@@ -107,7 +104,7 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 			return err
 		}
 	} else {
-		if r, err = c.loadFromConfig(ctx, fs.Arg(0), *configPath, *stdin, !*noExpandEnv, *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
+		if r, err = c.loadFromConfig(ctx, fs.Arg(0), *configPath, !*noExpandEnv, *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
 			slog.Info("database already exists, skipping")
 			return nil
 		} else if err != nil {
@@ -325,9 +322,9 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 }
 
 // loadFromConfig returns a replica & updates the restore options from a DB reference.
-func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath string, fromStdin, expandEnv, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
+func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath string, expandEnv, ifDBNotExists bool, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	// Load configuration.
-	config, err := ReadConfig(configPath, fromStdin, expandEnv)
+	config, err := ReadConfig(configPath, expandEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -372,14 +369,11 @@ Usage:
 Arguments:
 
 	-config PATH
-	    Specifies the configuration file.
+	    Specifies the configuration file. Use "-" to read from standard input.
 	    Defaults to %s
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
-
-	-stdin
-	    Read configuration from standard input.
 
 	-txid TXID
 	    Restore up to a specific hex-encoded transaction ID (inclusive).
@@ -434,7 +428,7 @@ Examples:
 	$ litestream restore /path/to/db
 
 	# Restore latest replica using configuration from standard input.
-	$ cat /path/to/litestream.yml | litestream restore -stdin /path/to/db
+	$ cat /path/to/litestream.yml | litestream restore -config - /path/to/db
 
 	# Restore replica for database to a given point in time.
 	$ litestream restore -timestamp 2020-01-01T00:00:00Z /path/to/db

--- a/cmd/litestream/status.go
+++ b/cmd/litestream/status.go
@@ -19,7 +19,7 @@ type StatusCommand struct{}
 // Run executes the command.
 func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-status", flag.ContinueOnError)
-	configPath, noExpandEnv := registerConfigFlag(fs)
+	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -27,10 +27,7 @@ func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	// Load configuration.
-	if *configPath == "" {
-		*configPath = DefaultConfigPath()
-	}
-	config, err := ReadConfigFile(*configPath, !*noExpandEnv)
+	config, err := ReadConfig(*configPath, *stdin, !*noExpandEnv)
 	if err != nil {
 		return err
 	}
@@ -146,6 +143,9 @@ Arguments:
 	-json
 	    Output raw JSON instead of human-readable text.
 
+	-stdin
+	    Read configuration from standard input.
+
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
 
@@ -166,6 +166,7 @@ Examples:
 	$ litestream status
 	$ litestream status /path/to/db
 	$ litestream status -json
+	$ cat /path/to/litestream.yml | litestream status -stdin
 
 `[1:],
 		DefaultConfigPath(),

--- a/cmd/litestream/status.go
+++ b/cmd/litestream/status.go
@@ -19,7 +19,7 @@ type StatusCommand struct{}
 // Run executes the command.
 func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-status", flag.ContinueOnError)
-	configPath, stdin, noExpandEnv := registerConfigFlag(fs)
+	configPath, noExpandEnv := registerConfigFlag(fs)
 	jsonOutput := fs.Bool("json", false, "output raw JSON")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
@@ -27,7 +27,7 @@ func (c *StatusCommand) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	// Load configuration.
-	config, err := ReadConfig(*configPath, *stdin, !*noExpandEnv)
+	config, err := ReadConfig(*configPath, !*noExpandEnv)
 	if err != nil {
 		return err
 	}
@@ -137,14 +137,11 @@ Usage:
 Arguments:
 
 	-config PATH
-	    Specifies the configuration file.
+	    Specifies the configuration file. Use "-" to read from standard input.
 	    Defaults to %s
 
 	-json
 	    Output raw JSON instead of human-readable text.
-
-	-stdin
-	    Read configuration from standard input.
 
 	-no-expand-env
 	    Disables environment variable expansion in configuration file.
@@ -166,7 +163,7 @@ Examples:
 	$ litestream status
 	$ litestream status /path/to/db
 	$ litestream status -json
-	$ cat /path/to/litestream.yml | litestream status -stdin
+	$ cat /path/to/litestream.yml | litestream status -config -
 
 `[1:],
 		DefaultConfigPath(),

--- a/docs/CLI_JSON_OUTPUT.md
+++ b/docs/CLI_JSON_OUTPUT.md
@@ -14,7 +14,7 @@ such as `already_registered`, `already_running`, `already_stopped`, or
 
 ## `litestream databases -json`
 
-Outputs an array of databases loaded from the configuration file.
+Outputs an array of databases loaded from the selected configuration source.
 
 ```json
 [


### PR DESCRIPTION
## Description
Adds a `-stdin` config source for CLI commands that already read Litestream configuration. The shared config loader now reads from either `-config`, standard input, or the default config path, and rejects `-config` plus `-stdin` together.

Scope:
- In scope: `databases`, `status`, `replicate`, `ltx`, `restore`, and `reset` config loading.
- In scope: rejecting `-stdin` with direct replica URL/positional replica URL flows where `-config` is already invalid.
- Not in scope: changing the YAML config format or adding a persistent config path for stdin-loaded MCP tools.

## Motivation and Context
Issue #1205 requests passing dynamically generated configuration through standard input so integrations do not need to create temporary config files that may contain credentials.

Fixes #1205

## How Has This Been Tested?
- `go test -run 'TestReadConfig|TestDatabasesCommand_Run/StdinJSONOutput' ./cmd/litestream`
- `go test ./cmd/litestream`
- `go build ./...`
- `go test ./...`
- `pre-commit run --all-files`
- `go test -race ./...`
- `golangci-lint run --new-from-rev=c30c5ffc364d6ee35b0b37d8ce4278371c8107a8`

`golangci-lint run` without a diff base currently reports existing `errcheck` findings outside this change; the diff-scoped run reports `0 issues`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
