### PR TITLE
fix(config): respect explicit replica type

### DIFF
--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -281,6 +281,20 @@ func TestNewFileReplicaFromConfig(t *testing.T) {
 }
 
 func TestNewS3ReplicaFromConfig(t *testing.T) {
+	t.Run("ExplicitTypeWithEndpointLikeURL", func(t *testing.T) {
+		c := &main.ReplicaConfig{
+			Type: "s3",
+			URL:  "rook-ceph-rgw:8080",
+			Path: "path",
+			ReplicaSettings: main.ReplicaSettings{
+				Bucket: "bucket",
+			},
+		}
+		if got, want := c.ReplicaType(), "s3"; got != want {
+			t.Fatalf("ReplicaType=%s, want %s", got, want)
+		}
+	})
+
 	t.Run("URL", func(t *testing.T) {
 		r, err := main.NewReplicaFromConfig(&main.ReplicaConfig{URL: "s3://foo/bar"}, nil)
 		if err != nil {

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -290,8 +290,12 @@ func TestNewS3ReplicaFromConfig(t *testing.T) {
 				Bucket: "bucket",
 			},
 		}
-		if got, want := c.ReplicaType(), "s3"; got != want {
-			t.Fatalf("ReplicaType=%s, want %s", got, want)
+		_, err := main.NewReplicaFromConfig(c, nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got, want := err.Error(), "cannot specify url & path for s3 replica"; got != want {
+			t.Fatalf("error=%q, want %q", got, want)
 		}
 	})
 

--- a/replica_url.go
+++ b/replica_url.go
@@ -54,7 +54,7 @@ func NewReplicaClientFromURL(rawURL string) (ReplicaClient, error) {
 // ReplicaTypeFromURL returns the replica type from a URL string.
 // Returns empty string if the URL is invalid or has no scheme.
 func ReplicaTypeFromURL(rawURL string) string {
-	if !strings.Contains(rawURL, "://") {
+	if !IsURL(rawURL) {
 		return ""
 	}
 	scheme, _, _, _ := ParseReplicaURL(rawURL)

--- a/replica_url.go
+++ b/replica_url.go
@@ -54,6 +54,9 @@ func NewReplicaClientFromURL(rawURL string) (ReplicaClient, error) {
 // ReplicaTypeFromURL returns the replica type from a URL string.
 // Returns empty string if the URL is invalid or has no scheme.
 func ReplicaTypeFromURL(rawURL string) string {
+	if !strings.Contains(rawURL, "://") {
+		return ""
+	}
 	scheme, _, _, _ := ParseReplicaURL(rawURL)
 	if scheme == "" {
 		return ""

--- a/replica_url_test.go
+++ b/replica_url_test.go
@@ -467,6 +467,7 @@ func TestReplicaTypeFromURL(t *testing.T) {
 		{"webdavs://host/path", "webdav"},
 		{"nats://host/bucket", "nats"},
 		{"oss://bucket/path", "oss"},
+		{"rook-ceph-rgw:8080", ""},
 		{"", ""},
 		{"invalid", ""},
 	}


### PR DESCRIPTION
## Description
Stops replica type inference from treating endpoint-like strings such as `rook-ceph-rgw:8080` as replica URL schemes. Adds regression coverage for the shared URL type helper and S3 replica config type selection.

## Motivation and Context
Issue #1303 reports a config with `type: s3` and `url: ${BUCKET_HOST}:${BUCKET_PORT}` failing with `unknown replica type in config: "s3"`.

Investigation showed `ReplicaTypeFromURL("rook-ceph-rgw:8080")` returned `rook-ceph-rgw` because `url.Parse` treats the text before `:` as a scheme, and `ReplicaConfig.ReplicaType()` checked the derived URL type before the explicit config type. This change only infers a replica type from URL values that look like actual replica URLs with `://`, so `type: s3` is respected and the existing S3 config validation handles the remaining fields.

Fixes #1303

## How Has This Been Tested?
Red-state evidence before the fix:
- `go test -run TestReplicaTypeFromURL ./...` failed with `ReplicaTypeFromURL("rook-ceph-rgw:8080") = "rook-ceph-rgw", want ""`
- `go test -run 'TestNewS3ReplicaFromConfig/ExplicitTypeWithEndpointLikeURL' ./cmd/litestream` failed with `ReplicaType=rook-ceph-rgw, want s3`

Verification after the fix:
- `go test -run TestReplicaTypeFromURL ./...`
- `go test -run 'TestNewS3ReplicaFromConfig/ExplicitTypeWithEndpointLikeURL' ./cmd/litestream`
- `go test ./cmd/litestream`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `pre-commit run --all-files`

Additional lint note:
- `golangci-lint run` reports existing repo-wide `errcheck` findings in unrelated files such as `cmd/litestream-test/load.go`, `compactor.go`, and `db.go`; this PR does not touch those paths.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
