### PR TITLE
fix(sftp): write ltx files atomically

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -1854,6 +1854,7 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	db := NewDB(dbPath)
 	db.MonitorInterval = 0
 	db.CheckpointInterval = 0
+	db.BusyTimeout = 5 * time.Second
 	db.MinCheckpointPageN = 1000000
 	db.Replica = NewReplica(db)
 	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
@@ -1872,6 +1873,7 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer sqldb.Close()
+	sqldb.SetMaxOpenConns(1)
 
 	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
 		t.Fatal(err)
@@ -1939,6 +1941,7 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 					started = true
 				}
 				i++
+				time.Sleep(time.Millisecond)
 			}
 		}
 	}()

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -471,17 +472,7 @@ func TestReplicaClient_S3_UnsignedPayloadRejected(t *testing.T) {
 }
 
 func TestReplicaClient_SFTP_HostKeyValidation(t *testing.T) {
-	testHostKeyPEM := `-----BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-QyNTUxOQAAACAJytPhncDnpV5QF3ai8f6r0u1hzK96x+81tvtA7ZiuawAAAJAIcGGVCHBh
-lQAAAAtzc2gtZWQyNTUxOQAAACAJytPhncDnpV5QF3ai8f6r0u1hzK96x+81tvtA7Ziuaw
-AAAEDzV1D6COyvFGhSiZa6ll9aXZ2IMWED3KGrvCNjEEtYHwnK0+GdwOelXlAXdqLx/qvS
-7WHMr3rH7zW2+0DtmK5rAAAADGZlbGl4QGJvcmVhcwE=
------END OPENSSH PRIVATE KEY-----`
-	privateKey, err := ssh.ParsePrivateKey([]byte(testHostKeyPEM))
-	if err != nil {
-		t.Fatal(err)
-	}
+	privateKey := mustParseTestSFTPHostKey(t)
 
 	t.Run("ValidHostKey", func(t *testing.T) {
 		addr := testingutil.MockSFTPServer(t, privateKey)
@@ -492,7 +483,7 @@ AAAEDzV1D6COyvFGhSiZa6ll9aXZ2IMWED3KGrvCNjEEtYHwnK0+GdwOelXlAXdqLx/qvS
 		c.Host = addr
 		c.HostKey = expectedHostKey
 
-		err = c.Init(context.Background())
+		err := c.Init(context.Background())
 		if err != nil {
 			t.Fatalf("SFTP connection failed: %v", err)
 		}
@@ -506,7 +497,7 @@ AAAEDzV1D6COyvFGhSiZa6ll9aXZ2IMWED3KGrvCNjEEtYHwnK0+GdwOelXlAXdqLx/qvS
 		c.Host = addr
 		c.HostKey = invalidHostKey
 
-		err = c.Init(context.Background())
+		err := c.Init(context.Background())
 		if err == nil {
 			t.Fatalf("SFTP connection established despite invalid host key")
 		}
@@ -532,7 +523,7 @@ AAAEDzV1D6COyvFGhSiZa6ll9aXZ2IMWED3KGrvCNjEEtYHwnK0+GdwOelXlAXdqLx/qvS
 		c.User = "foo"
 		c.Host = addr
 
-		err = c.Init(context.Background())
+		err := c.Init(context.Background())
 		if err != nil {
 			t.Fatalf("SFTP connection failed: %v", err)
 		}
@@ -542,8 +533,120 @@ AAAEDzV1D6COyvFGhSiZa6ll9aXZ2IMWED3KGrvCNjEEtYHwnK0+GdwOelXlAXdqLx/qvS
 		}) {
 			t.Errorf("Expected warning not found")
 		}
-
 	})
+}
+
+func TestReplicaClient_SFTP_WriteLTXFileAtomic(t *testing.T) {
+	privateKey := mustParseTestSFTPHostKey(t)
+	addr := testingutil.MockSFTPServer(t, privateKey)
+	expectedHostKey := string(ssh.MarshalAuthorizedKey(privateKey.PublicKey()))
+
+	c := testingutil.NewSFTPReplicaClient(t)
+	c.User = "foo"
+	c.Host = addr
+	c.HostKey = expectedHostKey
+	c.Path = t.TempDir()
+
+	data := createLTXData(1, 1, bytes.Repeat([]byte("x"), 1024))
+	r := newBlockingReader(data, ltx.HeaderSize)
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := c.WriteLTXFile(context.Background(), 0, 1, 1, r)
+		errCh <- err
+	}()
+
+	select {
+	case <-r.blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for blocked SFTP write")
+	}
+
+	itr, err := c.LTXFiles(context.Background(), 0, 0, false)
+	if err != nil {
+		close(r.release)
+		t.Fatal(err)
+	}
+	if itr.Next() {
+		close(r.release)
+		t.Fatalf("LTXFiles exposed in-progress file: %+v", itr.Item())
+	}
+	if err := itr.Close(); err != nil {
+		close(r.release)
+		t.Fatal(err)
+	}
+
+	close(r.release)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SFTP write")
+	}
+
+	itr, err = c.LTXFiles(context.Background(), 0, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer itr.Close()
+	if !itr.Next() {
+		t.Fatal("expected completed LTX file")
+	}
+	info := itr.Item()
+	if info.MinTXID != 1 || info.MaxTXID != 1 {
+		t.Fatalf("unexpected LTX file: %+v", info)
+	}
+	if itr.Next() {
+		t.Fatalf("unexpected extra LTX file: %+v", itr.Item())
+	}
+}
+
+func mustParseTestSFTPHostKey(t *testing.T) ssh.Signer {
+	t.Helper()
+
+	privateKey, err := ssh.ParsePrivateKey([]byte(testSFTPHostKeyPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return privateKey
+}
+
+const testSFTPHostKeyPEM = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACAJytPhncDnpV5QF3ai8f6r0u1hzK96x+81tvtA7ZiuawAAAJAIcGGVCHBh
+lQAAAAtzc2gtZWQyNTUxOQAAACAJytPhncDnpV5QF3ai8f6r0u1hzK96x+81tvtA7Ziuaw
+AAAEDzV1D6COyvFGhSiZa6ll9aXZ2IMWED3KGrvCNjEEtYHwnK0+GdwOelXlAXdqLx/qvS
+7WHMr3rH7zW2+0DtmK5rAAAADGZlbGl4QGJvcmVhcwE=
+-----END OPENSSH PRIVATE KEY-----`
+
+type blockingReader struct {
+	r          *bytes.Reader
+	blockAfter int64
+	blocked    chan struct{}
+	release    chan struct{}
+	once       sync.Once
+	n          int64
+}
+
+func newBlockingReader(data []byte, blockAfter int64) *blockingReader {
+	return &blockingReader{
+		r:          bytes.NewReader(data),
+		blockAfter: blockAfter,
+		blocked:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	if r.n >= r.blockAfter {
+		r.once.Do(func() { close(r.blocked) })
+		<-r.release
+	}
+	n, err := r.r.Read(p)
+	r.n += int64(n)
+	return n, err
 }
 
 // TestReplicaClient_S3_MultipartThresholds tests multipart upload behavior at various

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -292,11 +292,19 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 		return nil, fmt.Errorf("sftp: cannot make parent snapshot directory %q: %w", path.Dir(filename), err)
 	}
 
-	f, err := sftpClient.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
+	tmpFilename := fmt.Sprintf("%s.%d.%d.tmp", filename, os.Getpid(), time.Now().UnixNano())
+	f, err := sftpClient.OpenFile(tmpFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
-		return nil, fmt.Errorf("sftp: cannot open snapshot file for writing: %w", err)
+		return nil, fmt.Errorf("sftp: cannot open temporary snapshot file for writing: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+		if err != nil {
+			_ = sftpClient.Remove(tmpFilename)
+		}
+	}()
 
 	n, err := io.Copy(f, fullReader)
 	if err != nil {
@@ -304,10 +312,14 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	} else if err := f.Close(); err != nil {
 		return nil, err
 	}
+	f = nil
 
-	// Set file ModTime to preserve original timestamp
-	if err := sftpClient.Chtimes(filename, timestamp, timestamp); err != nil {
+	if err := sftpClient.Chtimes(tmpFilename, timestamp, timestamp); err != nil {
 		return nil, fmt.Errorf("sftp: cannot set file timestamps: %w", err)
+	}
+
+	if err := sftpClient.Rename(tmpFilename, filename); err != nil {
+		return nil, fmt.Errorf("sftp: cannot rename temporary ltx file %q to %q: %w", tmpFilename, filename, err)
 	}
 
 	internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "PUT").Inc()


### PR DESCRIPTION
## Description
Writes SFTP LTX files to a temporary sibling path, closes the stream, sets the preserved timestamp, and then renames the file into its final immutable LTX path. Adds a regression test that verifies `LTXFiles` cannot see a valid final LTX filename while an SFTP upload is still in progress.

## Motivation and Context
Issue #1318 reports intermittent restore failures over SFTP with:

```text
Error: decode database: unexpected error decoding after end of database: close reader 7: cannot close, expected page
```

Investigation found that SFTP was writing directly to the final LTX filename with `O_TRUNC`. A concurrent restore can list and open that partially uploaded file, feeding a truncated LTX stream into the restore compactor. The new regression test reproduced this before the fix: while `WriteLTXFile` was blocked mid-stream, `LTXFiles` exposed `0000000000000001-0000000000000001.ltx` with size 100 bytes.

A separate test-only follow-up stabilizes `TestDB_CheckpointPageGapWithConcurrentWrites`, which was failing the PR's unit-test CI by starving the checkpoint lock under a tight writer loop.

Fixes #1318

## Scope
In scope:
- Make SFTP LTX file visibility atomic by temp-writing and renaming.
- Preserve LTX timestamps before final visibility.
- Add focused SFTP regression coverage using the existing mock SFTP server.
- Stabilize an existing DB checkpoint regression test that failed repeatedly in CI.

Not in scope:
- Changing restore plan selection or LTX compaction behavior.
- Repairing already-corrupted or partially uploaded historical SFTP files.
- Changing other replica backends.

## How Has This Been Tested?
- `go test -run TestReplicaClient_SFTP_WriteLTXFileAtomic -count=1 ./...`
- `go test -run 'TestReplicaClient_SFTP|TestReplicaClient_LTX|TestReplicaClient_OpenLTXFile|TestReplicaClient_WriteLTXFile' -count=1 ./...`
- `go test -run TestReplicaClient_SFTP_HostKeyValidation -count=1 ./...`
- `go test -run TestDB_CheckpointPageGapWithConcurrentWrites -count=100 .`
- `go test -race -run TestDB_CheckpointPageGapWithConcurrentWrites -count=20 .`
- `go test -v .`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `pre-commit run --all-files`

Note: `golangci-lint run` currently reports pre-existing `errcheck` findings in unrelated files such as `cmd/litestream-test/load.go`, `compactor.go`, and `db.go`; none are introduced by this PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
