### PR TITLE
feat(s3): add storage class option

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1108,6 +1108,7 @@ type ReplicaSettings struct {
 	SignPayload       *bool     `yaml:"sign-payload"`
 	RequireContentMD5 *bool     `yaml:"require-content-md5"`
 	SkipVerify        bool      `yaml:"skip-verify"`
+	StorageClass      string    `yaml:"storage-class"`
 	PartSize          *ByteSize `yaml:"part-size"`
 	Concurrency       *int      `yaml:"concurrency"`
 
@@ -1206,6 +1207,9 @@ func (rs *ReplicaSettings) SetDefaults(src *ReplicaSettings) {
 	}
 	if src.SkipVerify {
 		rs.SkipVerify = true
+	}
+	if rs.StorageClass == "" {
+		rs.StorageClass = src.StorageClass
 	}
 
 	// S3 SSE settings
@@ -1421,6 +1425,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 
 	bucket, configPath := c.Bucket, c.Path
 	region, endpoint, skipVerify := c.Region, c.Endpoint, c.SkipVerify
+	storageClass := c.StorageClass
 	signSetting := newBoolSetting(true)
 	if v := c.SignPayload; v != nil {
 		signSetting.Set(*v)
@@ -1444,6 +1449,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 		usignPayloadSet       bool
 		urequireContentMD5    bool
 		urequireContentMD5Set bool
+		ustorageClass         string
 	)
 	if endpoint != "" {
 		endpointWasSet = true
@@ -1497,6 +1503,11 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 			urequireContentMD5 = v
 			urequireContentMD5Set = true
 		}
+		if v := query.Get("storageClass"); v != "" {
+			ustorageClass = v
+		} else if v := query.Get("storage-class"); v != "" {
+			ustorageClass = v
+		}
 
 		// Only apply URL parts to field that have not been overridden.
 		if configPath == "" {
@@ -1510,6 +1521,9 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 		}
 		if endpoint == "" {
 			endpoint = uendpoint
+		}
+		if storageClass == "" {
+			storageClass = ustorageClass
 		}
 		if !forcePathStyle {
 			forcePathStyle = uforcePathStyle
@@ -1572,6 +1586,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 	client.Endpoint = endpoint
 	client.ForcePathStyle = forcePathStyle
 	client.SkipVerify = skipVerify
+	client.StorageClass = storageClass
 
 	client.SignPayload = signSetting.value
 	client.RequireContentMD5 = requireSetting.value

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -2752,7 +2752,7 @@ func createSQLiteDB(t *testing.T, path string) {
 func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 	t.Run("URLWithEndpointQuery", func(t *testing.T) {
 		config := &main.ReplicaConfig{
-			URL: "s3://mybucket/path/to/db?endpoint=localhost:9000&region=us-west-2&forcePathStyle=true&skipVerify=true",
+			URL: "s3://mybucket/path/to/db?endpoint=localhost:9000&region=us-west-2&forcePathStyle=true&skipVerify=true&storage-class=ONEZONE_IA",
 		}
 
 		client, err := main.NewS3ReplicaClientFromConfig(config, nil)
@@ -2777,6 +2777,9 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		}
 		if !client.SkipVerify {
 			t.Error("expected SkipVerify to be true")
+		}
+		if client.StorageClass != "ONEZONE_IA" {
+			t.Errorf("expected storage class 'ONEZONE_IA', got %q", client.StorageClass)
 		}
 	})
 
@@ -2807,10 +2810,11 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 
 	t.Run("ConfigOverridesQuery", func(t *testing.T) {
 		config := &main.ReplicaConfig{
-			URL: "s3://mybucket/path?endpoint=from-query&region=us-east-1",
+			URL: "s3://mybucket/path?endpoint=from-query&region=us-east-1&storage-class=ONEZONE_IA",
 			ReplicaSettings: main.ReplicaSettings{
-				Endpoint: "from-config",
-				Region:   "us-west-1",
+				Endpoint:     "from-config",
+				Region:       "us-west-1",
+				StorageClass: "GLACIER_IR",
 			},
 		}
 
@@ -2825,6 +2829,9 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		}
 		if client.Region != "us-west-1" {
 			t.Errorf("expected region from config 'us-west-1', got %q", client.Region)
+		}
+		if client.StorageClass != "GLACIER_IR" {
+			t.Errorf("expected storage class from config 'GLACIER_IR', got %q", client.StorageClass)
 		}
 	})
 
@@ -3199,6 +3206,7 @@ access-key-id: GLOBAL_S3_KEY
 secret-access-key: GLOBAL_S3_SECRET
 region: global-region
 endpoint: global.endpoint.com
+storage-class: GLACIER_IR
 account-name: global-abs-account
 account-key: global-abs-key
 host: global.sftp.host
@@ -3245,6 +3253,9 @@ dbs:
 		}
 		if got, want := s3Replica.Endpoint, "global.endpoint.com"; got != want {
 			t.Errorf("s3Replica.Endpoint=%v, want %v", got, want)
+		}
+		if got, want := s3Replica.StorageClass, "GLACIER_IR"; got != want {
+			t.Errorf("s3Replica.StorageClass=%v, want %v", got, want)
 		}
 		if s3Replica.SyncInterval == nil || *s3Replica.SyncInterval != expectedSyncInterval {
 			t.Errorf("s3Replica.SyncInterval=%v, want %v", s3Replica.SyncInterval, expectedSyncInterval)

--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -321,6 +321,7 @@ Parameters with an alias accept both camelCase and hyphenated forms
 | `requireContentMD5` | `require-content-md5` | Require Content-MD5 header | `true` |
 | `concurrency` | | Multipart upload concurrency | `5` |
 | `partSize` | `part-size` | Multipart upload part size | `5MB` |
+| `storageClass` | `storage-class` | Storage class for uploaded objects | None |
 | `sseCustomerAlgorithm` | `sse-customer-algorithm` | SSE-C encryption algorithm | None |
 | `sseCustomerKey` | `sse-customer-key` | SSE-C encryption key | None |
 | `sseCustomerKeyMD5` | `sse-customer-key-md5` | SSE-C key MD5 checksum | None |

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -94,6 +94,7 @@ type ReplicaClient struct {
 	SkipVerify        bool
 	SignPayload       bool
 	RequireContentMD5 bool
+	StorageClass      string
 
 	// Upload configuration
 	PartSize    int64 // Part size for multipart uploads (default: 5MB)
@@ -146,6 +147,7 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 		concurrency    int
 		concurrencySet bool
 		partSize       int64
+		storageClass   string
 	)
 
 	// Parse host for bucket and region
@@ -197,6 +199,11 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			partSize = n
 		}
+	}
+	if v := query.Get("storageClass"); v != "" {
+		storageClass = v
+	} else if v := query.Get("storage-class"); v != "" {
+		storageClass = v
 	}
 
 	// Ensure bucket is set
@@ -285,6 +292,7 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 	if partSize > 0 {
 		client.PartSize = partSize
 	}
+	client.StorageClass = storageClass
 
 	// Parse SSE-C parameters from query string
 	if v := query.Get("sseCustomerAlgorithm"); v != "" {
@@ -686,6 +694,9 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 		Key:      aws.String(key),
 		Body:     rc,
 		Metadata: metadata,
+	}
+	if c.StorageClass != "" {
+		input.StorageClass = types.StorageClass(c.StorageClass)
 	}
 
 	// Add SSE-C parameters if configured

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -1736,8 +1736,16 @@ func TestReplicaClient_StorageClassHeader(t *testing.T) {
 
 	headers := make(chan http.Header, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() { _ = r.Body.Close() }()
-		_, _ = io.Copy(io.Discard, r.Body)
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				t.Errorf("close request body: %v", err)
+			}
+		}()
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Errorf("copy request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 
 		if r.Method == http.MethodPut {
 			select {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -1731,6 +1731,57 @@ func TestReplicaClient_SSE_KMS_Headers(t *testing.T) {
 	}
 }
 
+func TestReplicaClient_StorageClassHeader(t *testing.T) {
+	data := mustLTX(t)
+
+	headers := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		_, _ = io.Copy(io.Discard, r.Body)
+
+		if r.Method == http.MethodPut {
+			select {
+			case headers <- r.Header.Clone():
+			default:
+			}
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewReplicaClient()
+	client.Bucket = "test-bucket"
+	client.Path = "replica"
+	client.Region = "us-east-1"
+	client.Endpoint = server.URL
+	client.ForcePathStyle = true
+	client.AccessKeyID = "test-access-key"
+	client.SecretAccessKey = "test-secret-key"
+	client.StorageClass = "ONEZONE_IA"
+
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	if _, err := client.WriteLTXFile(ctx, 0, 2, 2, bytes.NewReader(data)); err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
+
+	select {
+	case hdr := <-headers:
+		if got, want := hdr.Get("x-amz-storage-class"), "ONEZONE_IA"; got != want {
+			t.Errorf("storage class header = %q, want %q", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for PUT request")
+	}
+}
+
 // TestReplicaClient_NoSSE_Headers tests that no SSE headers are sent when SSE is not configured
 func TestReplicaClient_NoSSE_Headers(t *testing.T) {
 	data := mustLTX(t)
@@ -1945,6 +1996,7 @@ func TestNewReplicaClientFromURL_QueryParamAliases(t *testing.T) {
 		wantSkipVerify     bool
 		wantConcurrency    int
 		wantPartSize       int64
+		wantStorageClass   string
 	}{
 		{
 			name:               "forcePathStyle_camelCase",
@@ -1987,12 +2039,23 @@ func TestNewReplicaClientFromURL_QueryParamAliases(t *testing.T) {
 			wantPartSize: 10485760,
 		},
 		{
+			name:             "storage-class_hyphenated",
+			url:              "s3://mybucket/path?storage-class=ONEZONE_IA",
+			wantStorageClass: "ONEZONE_IA",
+		},
+		{
+			name:             "storageClass_camelCase",
+			url:              "s3://mybucket/path?storageClass=GLACIER_IR",
+			wantStorageClass: "GLACIER_IR",
+		},
+		{
 			name:               "all_params_combined",
-			url:                "s3://mybucket/path?force-path-style=true&skip-verify=true&concurrency=4&part-size=8388608",
+			url:                "s3://mybucket/path?force-path-style=true&skip-verify=true&concurrency=4&part-size=8388608&storage-class=ONEZONE_IA",
 			wantForcePathStyle: true,
 			wantSkipVerify:     true,
 			wantConcurrency:    4,
 			wantPartSize:       8388608,
+			wantStorageClass:   "ONEZONE_IA",
 		},
 	}
 
@@ -2015,6 +2078,9 @@ func TestNewReplicaClientFromURL_QueryParamAliases(t *testing.T) {
 			}
 			if c.PartSize != tt.wantPartSize {
 				t.Errorf("PartSize = %d, want %d", c.PartSize, tt.wantPartSize)
+			}
+			if c.StorageClass != tt.wantStorageClass {
+				t.Errorf("StorageClass = %q, want %q", c.StorageClass, tt.wantStorageClass)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Adds an S3 storage class option that can be set from replica URLs or YAML config and is passed through to S3 uploads.

## Problem
Issue #1264 requests a way to choose the storage class for S3 buckets, specifically for S3-compatible providers where the default class may be more redundant than needed.

Investigation evidence:
- `rg "StorageClass|storage-class"` showed no existing S3 storage class plumbing before this change.
- `s3/replica_client.go` built `s3.PutObjectInput` without `StorageClass`, so uploads always used the provider default.
- Red tests initially failed to compile on the missing `StorageClass` field in `s3.ReplicaClient` and `cmd/litestream.ReplicaSettings`.

## Solution
The S3 replica client now carries a `StorageClass` string and sets `PutObjectInput.StorageClass` when configured. URL parsing accepts both `storageClass` and `storage-class`; YAML config uses `storage-class` and inherits from global replica defaults.

## Scope
**In scope:**
- S3 storage class pass-through for new uploads
- URL query parsing and YAML config/default propagation
- Unit tests for config parsing, URL aliases, and the emitted S3 upload header
- Provider compatibility docs entry

**Not in scope:**
- Provider-specific storage class validation
- Changes to existing objects or lifecycle policies
- Storage class defaults for any provider

## Test Plan
- `go test ./s3 -run 'TestNewReplicaClientFromURL_QueryParamAliases|TestReplicaClient_StorageClassHeader'`
- `go test ./cmd/litestream -run 'TestNewS3ReplicaClientFromConfig|TestGlobalDefaults'`
- `go test ./s3`
- `go test ./cmd/litestream`
- `go build ./...`
- `go test ./...`
- `go test -race -v ./...`
- `pre-commit run --all-files`
- `golangci-lint run --new-from-rev=0a2a39f1823b17df057b368e2beb9b21a984304f`

Note: plain `golangci-lint run` reports existing repo-wide `errcheck` findings unrelated to this diff; the new-only lint check reports `0 issues`.

## Related
Fixes #1264