### PR TITLE
WAL increment can drop newly-allocated pages → restore-fatal 'nonsequential page numbers' (repro + candidate fix, #1199)

### DIFF
--- a/db.go
+++ b/db.go
@@ -176,6 +176,15 @@ type DB struct {
 
 	// Where to send log messages, defaults to global slog with database epath.
 	Logger *slog.Logger
+
+	// Test seam: when non-nil, called with the freshly-built incremental WAL
+	// page map in sync() so tests can simulate an incomplete WAL view (the
+	// #1198 condition). Never set in production.
+	corruptPageMapForTest func(pageMap map[uint32]int64, prevCommit, commit uint32)
+
+	// Test seam: when true, skips the missing-newly-allocated-page guard so a
+	// test can reproduce the pre-fix corruption. Never set in production.
+	disableMissingPageGuardForTest bool
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -1522,6 +1531,7 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
 	info.salt1 = dec.Header().WALSalt1
 	info.salt2 = dec.Header().WALSalt2
+	info.prevCommit = dec.Header().Commit
 
 	// If LTX WAL offset is larger than real WAL then the WAL has been truncated.
 	if fi, err := os.Stat(db.WALPath()); err != nil {
@@ -1710,6 +1720,7 @@ type syncInfo struct {
 	snapshotting        bool   // if true, a full snapshot is required
 	reason              string // reason for snapshot
 	clearSyncedToWALEnd bool
+	prevCommit          uint32 // commit (page count) of the previous LTX, 0 if unknown
 }
 
 type syncResult struct {
@@ -1802,6 +1813,25 @@ func (exec *syncExecutor) applySyncResult(result syncResult) {
 	exec.synced = exec.synced || result.synced
 }
 
+// missingNewlyAllocatedPage reports whether the page map is missing any page
+// in the range (prevCommit, commit] that the database grew into. Those pages
+// are newly allocated by this transaction and therefore must be present in the
+// WAL view; an absent one means the incremental sync captured an incomplete
+// view of the transaction (see #1198) and a snapshot must be taken instead so
+// the replica does not gain a silently-corrupt increment (see #1199). The lock
+// page never carries data and is skipped.
+func missingNewlyAllocatedPage(pageMap map[uint32]int64, prevCommit, commit, lockPgno uint32) (uint32, bool) {
+	for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+		if pgno == lockPgno {
+			continue
+		}
+		if _, ok := pageMap[pgno]; !ok {
+			return pgno, true
+		}
+	}
+	return 0, false
+}
+
 // sync copies pending bytes from the real WAL to LTX.
 // Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
 func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo) (result syncResult, err error) {
@@ -1891,6 +1921,10 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		commit = walCommit
 	}
 
+	if db.corruptPageMapForTest != nil && !info.snapshotting {
+		db.corruptPageMapForTest(pageMap, info.prevCommit, commit)
+	}
+
 	var sz int64
 	if maxOffset > 0 {
 		sz = maxOffset - info.offset
@@ -1913,6 +1947,49 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	if !info.snapshotting && sz == 0 {
 		db.Logger.Log(ctx, internal.LevelTrace, "sync: skip", "reason", "no new wal pages")
 		return result, nil
+	}
+
+	// Guard against writing an incremental LTX that grows the database past
+	// pages it does not contain. When commit increases, the newly allocated
+	// pages (prevCommit+1 .. commit) exist nowhere but this transaction, so
+	// every one of them MUST be present in the page map. If any is absent the
+	// WAL view is incomplete (e.g. frames skipped after a concurrent
+	// checkpoint, see #1198): the incremental encoder does not enforce page
+	// contiguity, so such a file replicates and compacts without error and
+	// only fails later when restore re-encodes it as a snapshot with
+	// "nonsequential page numbers in snapshot transaction" (see #1199).
+	// Fall back to a full snapshot, which is always self-consistent, rather
+	// than persisting a silently-corrupt increment.
+	if !db.disableMissingPageGuardForTest && !info.snapshotting && info.prevCommit != 0 && commit > info.prevCommit {
+		if pgno, ok := missingNewlyAllocatedPage(pageMap, info.prevCommit, commit, ltx.LockPgno(uint32(db.pageSize))); ok {
+			db.Logger.Warn("incremental sync missing newly-allocated page; forcing snapshot",
+				"pgno", pgno, "prevCommit", info.prevCommit, "commit", commit)
+			info.snapshotting = true
+			info.reason = "incremental wal view missing newly-allocated pages"
+
+			// Re-read from the start of the WAL so the snapshot captures the
+			// latest version of every page changed anywhere in the WAL, not
+			// just this partial view from info.offset. writeLTXFromDB reads any
+			// page absent from pageMap out of the main db file, but with
+			// litestream-owned checkpointing the main file does not yet contain
+			// pages changed in earlier un-checkpointed WAL frames; reusing the
+			// partial map would read those stale. This mirrors verify()'s other
+			// snapshot paths, which reset the offset to the WAL header.
+			info.offset = WALHeaderSize
+			if rd, err = NewWALReader(walFile, walReaderLogger); err != nil {
+				return result, fmt.Errorf("new wal reader, snapshot fallback: %w", err)
+			}
+			if pageMap, maxOffset, walCommit, err = rd.PageMap(ctx); err != nil {
+				return result, fmt.Errorf("page map, snapshot fallback: %w", err)
+			}
+			if walCommit > 0 {
+				commit = walCommit
+			}
+			sz = 0
+			if maxOffset > 0 {
+				sz = maxOffset - info.offset
+			}
+		}
 	}
 
 	tmpFilename := filename + ".tmp"

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2634,3 +2634,271 @@ func TestReplicaMonitor_RecoversFromPositionError(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 }
+
+// TestMissingNewlyAllocatedPage covers the guard that prevents litestream from
+// writing an incremental LTX that grows the database past pages it does not
+// contain. See #1198 (incomplete WAL view after a concurrent checkpoint) and
+// #1199 (the resulting "nonsequential page numbers in snapshot transaction"
+// failure surfaced only at restore time).
+func TestMissingNewlyAllocatedPage(t *testing.T) {
+	const lockPgno = uint32(0) // 0 = no lock page in range for these cases
+
+	t.Run("AllNewPagesPresent", func(t *testing.T) {
+		pm := map[uint32]int64{7: 0, 8: 0, 9: 0}
+		if pgno, ok := missingNewlyAllocatedPage(pm, 6, 9, lockPgno); ok {
+			t.Fatalf("expected no missing page, got pgno=%d", pgno)
+		}
+	})
+
+	t.Run("GapInNewPages", func(t *testing.T) {
+		// Grew 6 -> 9 but only captured page 9 (the production shape: 28251,28281).
+		pm := map[uint32]int64{9: 0}
+		pgno, ok := missingNewlyAllocatedPage(pm, 6, 9, lockPgno)
+		if !ok {
+			t.Fatal("expected a missing newly-allocated page, got none")
+		}
+		if pgno != 7 {
+			t.Fatalf("expected first missing pgno=7, got %d", pgno)
+		}
+	})
+
+	t.Run("SparseLowPagesAllowed", func(t *testing.T) {
+		// Pages at/below prevCommit may be sparse (they exist in earlier LTX);
+		// only the grown range must be complete.
+		pm := map[uint32]int64{7: 0} // prevCommit=6, commit=7: only new page present
+		if pgno, ok := missingNewlyAllocatedPage(pm, 6, 7, lockPgno); ok {
+			t.Fatalf("expected no missing page for sparse low pages, got pgno=%d", pgno)
+		}
+	})
+
+	t.Run("NoGrowth", func(t *testing.T) {
+		// commit == prevCommit: loop body never runs, nothing required.
+		if pgno, ok := missingNewlyAllocatedPage(map[uint32]int64{}, 6, 6, lockPgno); ok {
+			t.Fatalf("expected no missing page when DB did not grow, got pgno=%d", pgno)
+		}
+	})
+
+	t.Run("LockPageSkipped", func(t *testing.T) {
+		// The lock page never carries data and must not be required.
+		pm := map[uint32]int64{6: 0, 8: 0} // 7 is the lock page, absent on purpose
+		if pgno, ok := missingNewlyAllocatedPage(pm, 5, 8, 7); ok {
+			t.Fatalf("expected lock page to be skipped, got missing pgno=%d", pgno)
+		}
+	})
+}
+
+// TestDB_Verify_PrevCommitFromLTXHeader verifies the wiring the missing-page
+// guard depends on: verify() reports prevCommit equal to the Commit recorded in
+// the previous LTX header. Without this, the guard in sync() could never fire.
+func TestDB_Verify_PrevCommitFromLTXHeader(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close(context.Background())
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 40; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t VALUES (?, ?)`, i, make([]byte, 3000)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(db.LTXPath(0, pos.TXID, pos.TXID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	dec := ltx.NewDecoder(f)
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+	wantCommit := dec.Header().Commit
+	if wantCommit == 0 {
+		t.Fatal("previous LTX header Commit is 0; test setup did not grow the db")
+	}
+
+	info, err := db.verify(ctx, &db.syncState)
+	if err != nil {
+		t.Fatalf("verify() returned error: %v", err)
+	}
+	if info.prevCommit != wantCommit {
+		t.Fatalf("info.prevCommit=%d, want %d (from previous LTX header)", info.prevCommit, wantCommit)
+	}
+}
+
+// TestDB_RestoreSurvivesIncompleteWALView is the end-to-end regression for the
+// production outage (#1198/#1199).
+//
+// HONESTY NOTE: this does NOT trigger the #1198 race naturally. It injects the
+// *symptom* — an incremental sync whose WAL page map is missing a newly-
+// allocated page — via the corruptPageMapForTest seam, then drives a real
+// Replica.Restore and asserts the guard's effect. The natural reproducer
+// (concurrent writer + TRUNCATE checkpoint) does not produce the gap, because
+// the existing post-checkpoint-snapshot logic already covers that path; the
+// only natural occurrence on record is the production incident. So this proves
+// the guard converts the corruption into a clean restore, NOT that #1198 fires
+// on its own. The subtests discriminate: with the guard disabled the injected
+// gap makes restore fail with the production error; with it enabled, restore
+// succeeds with integrity_check=ok and every row present.
+func TestDB_RestoreSurvivesIncompleteWALView(t *testing.T) {
+	run := func(t *testing.T, disableGuard bool) (restoreErr error, integrity string, rows int) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "db")
+
+		db := NewDB(dbPath)
+		db.MonitorInterval = 0
+		db.CheckpointInterval = 0
+		db.MinCheckpointPageN = 1000000
+		db.Replica = NewReplica(db)
+		db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+		db.Replica.MonitorEnabled = false
+		db.disableMissingPageGuardForTest = disableGuard
+
+		// Drop exactly one newly-allocated page from the first growing
+		// incremental sync's WAL view — the #1198 incomplete-view condition.
+		// With the guard disabled this gap reaches the replica (pre-fix
+		// corruption); with the guard enabled it forces a snapshot (the fix).
+		var injected bool
+		db.corruptPageMapForTest = func(pageMap map[uint32]int64, prevCommit, commit uint32) {
+			if injected || commit <= prevCommit {
+				return
+			}
+			lockPgno := ltx.LockPgno(uint32(db.pageSize))
+			for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+				if pgno == lockPgno {
+					continue
+				}
+				if _, ok := pageMap[pgno]; ok {
+					delete(pageMap, pgno)
+					injected = true
+					return
+				}
+			}
+		}
+
+		if err := db.Open(); err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close(context.Background())
+
+		sqldb, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sqldb.Close()
+		if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB)`); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		if err := db.Sync(ctx); err != nil { // initial snapshot
+			t.Fatal(err)
+		}
+		// Grow the DB so the next sync is a growing incremental.
+		for i := 0; i < 200; i++ {
+			if _, err := sqldb.Exec(`INSERT INTO t VALUES (?, ?)`, i, make([]byte, 4000)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := db.Sync(ctx); err != nil { // guard/injection happens here
+			t.Fatal(err)
+		}
+		if !injected {
+			t.Fatal("page-map injection never fired; test did not exercise the condition")
+		}
+		// A couple more growth+sync rounds for good measure.
+		for round := 0; round < 2; round++ {
+			for i := 0; i < 100; i++ {
+				if _, err := sqldb.Exec(`INSERT INTO t VALUES (?, ?)`, 1000+round*1000+i, make([]byte, 4000)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := db.Sync(ctx); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Replica.Sync(ctx); err != nil {
+			t.Fatalf("replica sync: %v", err)
+		}
+		var liveCount int
+		if err := sqldb.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&liveCount); err != nil {
+			t.Fatal(err)
+		}
+
+		restorePath := filepath.Join(t.TempDir(), "restored.db")
+		restoreErr = db.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath})
+		if restoreErr != nil {
+			return restoreErr, "", 0
+		}
+
+		restored, err := sql.Open("sqlite", restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer restored.Close()
+		if err := restored.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+			t.Fatal(err)
+		}
+		if err := restored.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&rows); err != nil {
+			t.Fatal(err)
+		}
+		if rows != liveCount {
+			t.Fatalf("restored row count=%d, want %d", rows, liveCount)
+		}
+		return nil, integrity, rows
+	}
+
+	t.Run("WithoutGuard_RestoreFails", func(t *testing.T) {
+		restoreErr, _, _ := run(t, true)
+		if restoreErr == nil {
+			t.Fatal("expected restore to fail without the guard, but it succeeded")
+		}
+		if !strings.Contains(restoreErr.Error(), "nonsequential page numbers") {
+			t.Fatalf("expected 'nonsequential page numbers' error, got: %v", restoreErr)
+		}
+		t.Logf("without guard, restore failed as expected: %v", restoreErr)
+	})
+
+	t.Run("WithGuard_RestoreSucceeds", func(t *testing.T) {
+		restoreErr, integrity, rows := run(t, false)
+		if restoreErr != nil {
+			t.Fatalf("restore failed with guard active: %v", restoreErr)
+		}
+		if integrity != "ok" {
+			t.Fatalf("restored db failed integrity_check: %q", integrity)
+		}
+		t.Logf("with guard, restore ok: integrity_check=ok, rows=%d", rows)
+	})
+}


### PR DESCRIPTION
> **Drive-by, AI-assisted, draft.** I hit this in production and used an AI assistant to investigate and write the fix; I haven't independently audited Litestream's sync internals, so I can't vouch it's the right fix or the right layer. It reproduces the bug, the fix makes it pass, suite + soak stay green — but the design call is yours. Take it, rework it, or just use it as a reproducer.

## The bug

Litestream 0.5.11, S3, `wal_autocheckpoint=0`. A transaction grew the DB 28250 → 28281 pages. Replication logged only routine INFO and the replica looked healthy — but a later cold-start restore failed, total loss:

```
decode database: decode page 28252: copy page 28281 header:
nonsequential page numbers in snapshot transaction: 28251,28281
```

Page 28281 was captured; 28252..28280 were not, yet the increment's `Commit` was 28281.

**Cause:** under a concurrent checkpoint the incremental sync's WAL page map can miss pages the transaction allocated (#1198). `writeLTXFromWAL` writes only the pages in that map but stamps `Commit` = new DB size, and the incremental LTX encoder checks page *ordering* but not *contiguity* — so the gapped increment replicates and compacts with no error. The gap only becomes fatal at restore, where files are re-encoded as a snapshot (`MinTXID==1`) and contiguity *is* enforced. Latent until cold start.

## The fix (containment, not root cause)

In `sync()`, when `commit > prevCommit`, every page in `prevCommit+1..commit` is newly allocated and must be in the page map. If any is missing, fall back to a full snapshot instead of writing the gapped increment (resetting `info.offset` to the WAL header so it's a true full snapshot, not the partial mid-WAL view). `prevCommit` comes from the previous LTX header via `verify()`. Lock page skipped; gated on growth, so the normal path and VACUUM/shrink are untouched.

**This is a write-side guard, not a root-cause fix.** It does not touch the `verify()`/`syncedToWALEnd` checkpoint race that produces the incomplete map (#1198). It catches the **loud** failure (missing *newly-allocated* page → the #1199 restore error); it would **not** catch a dropped update to an *existing* page (≤ prevCommit), which would be silent wrong data — I haven't confirmed whether that variant can occur.

## Reproduction (first principles, on `main`)

#1198 reproduces naturally on current `main`, not just 0.5.11. A stress harness (concurrent writers + **PASSIVE** checkpoints) observing the *real, unmodified* page map saw **6 and 8** natural gaps across ~400–500 growing syncs in two ~90s runs. It's checkpoint-mode-specific: **TRUNCATE-only → 0 gaps** (snapshot-on-truncate covers it), **PASSIVE under write load → gaps** — so `[no-snap-on-checkpoint]` passing doesn't mean it's gone.

That harness isn't committed (concurrent `database/sql` is timing-dependent / lock-order-flaky as a unit test). The committed e2e `TestDB_RestoreSurvivesIncompleteWALView` injects the same gap deterministically via a nil-by-default seam, then does a real `Replica.Restore`: it fails with the production error when the guard is off, and restores with `integrity_check=ok` when on.

## Tests

```bash
go test -run 'TestMissingNewlyAllocatedPage|TestDB_Verify_PrevCommitFromLTXHeader|TestDB_RestoreSurvivesIncompleteWALView' -v .
go test .            # full package: ok
go vet . && gofmt -l db.go db_internal_test.go   # clean
# soak (touches WAL handling): all profiles pass
go build -o bin/litestream ./cmd/litestream && go build -o bin/litestream-test ./cmd/litestream-test
go test -timeout 30m -tags 'integration,soak' -run TestLTXBehavior -short ./tests/integration/
```

Fixes #1199. Related: #1198.

---

🤖 AI-assisted per CONTRIBUTING.md: investigation and code are AI-generated; I reproduced the bug and ran the tests but have not independently audited the sync internals.
