### PR TITLE
[DO NOT MERGE] soak integration: Stack A (corruption) + Stack B (S3 resilience)

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // Compactor handles compaction and retention for LTX files.
@@ -147,7 +149,7 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 		if err != nil {
 			return nil, fmt.Errorf("open ltx file: %w", err)
 		}
-		rdrs = append(rdrs, f)
+		rdrs = append(rdrs, internal.NewResumableReader(ctx, c.client, info.Level, info.MinTXID, info.MaxTXID, info.Size, f, c.logger))
 	}
 	if len(rdrs) == 0 {
 		return nil, ErrNoCompaction

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -119,6 +119,35 @@ func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
 	}
 }
 
+func TestCompactor_CompactResumesRemoteSourceAfterDisconnect(t *testing.T) {
+	client := newDisconnectingCompactionClient(t.TempDir(), 16)
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+
+	info, err := compactor.Compact(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Level != 1 {
+		t.Errorf("Level=%d, want 1", info.Level)
+	}
+	if info.MinTXID != 1 || info.MaxTXID != 1 {
+		t.Errorf("TXID range=%d-%d, want 1-1", info.MinTXID, info.MaxTXID)
+	}
+
+	var resumed bool
+	for _, offset := range client.openOffsets[1:] {
+		if offset > 0 {
+			resumed = true
+			break
+		}
+	}
+	if !resumed {
+		t.Fatalf("OpenLTXFile offsets=%v, want reopen at non-zero offset", client.openOffsets)
+	}
+}
+
 func TestCompactor_MaxLTXFileInfo(t *testing.T) {
 	t.Run("WithFiles", func(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
@@ -649,6 +678,58 @@ func (c *earlyReturnCompactionClient) WriteLTXFile(ctx context.Context, level in
 		return nil, fmt.Errorf("early write failure")
 	}
 	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+type disconnectingCompactionClient struct {
+	litestream.ReplicaClient
+	dropAfter   int64
+	dropped     bool
+	openOffsets []int64
+}
+
+func newDisconnectingCompactionClient(path string, dropAfter int64) *disconnectingCompactionClient {
+	return &disconnectingCompactionClient{
+		ReplicaClient: file.NewReplicaClient(path),
+		dropAfter:     dropAfter,
+	}
+}
+
+func (c *disconnectingCompactionClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	c.openOffsets = append(c.openOffsets, offset)
+
+	rc, err := c.ReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+	if err != nil {
+		return nil, err
+	}
+	if !c.dropped && offset == 0 {
+		c.dropped = true
+		return &disconnectingReadCloser{ReadCloser: rc, remaining: c.dropAfter}, nil
+	}
+	return rc, nil
+}
+
+type disconnectingReadCloser struct {
+	io.ReadCloser
+	remaining int64
+}
+
+func (r *disconnectingReadCloser) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:int(r.remaining)]
+	}
+
+	n, err := r.ReadCloser.Read(p)
+	r.remaining -= int64(n)
+	if err != nil {
+		return n, err
+	}
+	if r.remaining <= 0 {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
 func countCompactorPipeWriters() int {

--- a/db.go
+++ b/db.go
@@ -2382,8 +2382,16 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	// Try getting a checkpoint lock, will fail during snapshots.
+	// Try getting a checkpoint lock, will fail during snapshots. Skipping
+	// is safe (the next sync retries) but must be observable: a snapshot
+	// that never drains its reader would otherwise disable checkpoints
+	// silently and the WAL would grow without explanation.
 	if !db.chkMu.TryLock() {
+		level := slog.LevelDebug
+		if mode == CheckpointModeTruncate {
+			level = slog.LevelInfo
+		}
+		db.Logger.Log(ctx, level, "checkpoint skipped, snapshot in progress", "mode", mode)
 		return nil
 	}
 	defer db.chkMu.Unlock()
@@ -2487,7 +2495,13 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		return nil
 	}
 
-	if checkpointRow[1] <= preCheckpointFrameN {
+	// A successful TRUNCATE checkpoint always reports zero frames because
+	// the WAL is reset before the counters are read, so the comparison
+	// below can never prove that no commits landed between the sealed
+	// sync and the checkpoint taking the writer lock. Those commits are
+	// backfilled and truncated unseen, so TRUNCATE must take the boundary
+	// snapshot unconditionally.
+	if mode != CheckpointModeTruncate && checkpointRow[1] <= preCheckpointFrameN {
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 		if err != nil {
 			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
@@ -2811,18 +2825,13 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 }
 
 // Snapshot writes a snapshot to the replica for the current database position.
+// It always writes, even when a snapshot already exists at the current
+// position, so operators can force a re-upload (replicate -force-snapshot).
+// Callers that want to skip duplicates check first, as Store.CompactDB does.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
-	}
-	if info, ok, err := db.existingSnapshotInfo(ctx, pos.pos.TXID); err != nil {
-		pos.close()
-		return nil, err
-	} else if ok {
-		pos.close()
-		db.Logger.Debug("snapshot already exists", "txid", pos.pos.TXID.String(), "snapshot", info.MaxTXID.String())
-		return info, nil
 	}
 
 	r, err := db.snapshotReader(ctx, pos)
@@ -2844,17 +2853,6 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	db.maxLTXFileInfos.Unlock()
 
 	return info, nil
-}
-
-func (db *DB) existingSnapshotInfo(ctx context.Context, txID ltx.TXID) (*ltx.FileInfo, bool, error) {
-	info, err := db.MaxLTXFileInfo(ctx, SnapshotLevel)
-	if err != nil {
-		return nil, false, err
-	}
-	if info.MaxTXID == 0 || info.MaxTXID < txID {
-		return nil, false, nil
-	}
-	return &info, true, nil
 }
 
 // EnforceSnapshotRetention enforces retention of the snapshot level in the database by timestamp.

--- a/db.go
+++ b/db.go
@@ -1401,9 +1401,19 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	// Priority 1: Emergency truncate checkpoint (TRUNCATE mode, blocking)
 	// This prevents unbounded WAL growth from long-lived read transactions.
 	if db.TruncatePageN > 0 && origWALSize >= calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)) {
+		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
-			"threshold", calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN)))
+			"threshold", truncateThreshold)
+
+		if err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+			if !isSQLiteBusyError(err) {
+				return err
+			}
+		} else if exec.state.lastSyncedWALOffset < truncateThreshold {
+			return nil
+		}
+
 		return db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
 	}
 
@@ -2315,6 +2325,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	defer db.chkMu.Unlock()
 
+	const checkpointSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
+
 	// Read WAL header before checkpoint to check if it has been restarted.
 	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
 		func(s *diagState) {
@@ -2338,6 +2350,35 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	exec.applySyncResult(result)
 
+	var barrierTx *sql.Tx
+	if mode == CheckpointModePassive {
+		barrierTx, err = db.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin passive checkpoint barrier: %w", err)
+		}
+		defer func() {
+			if barrierTx != nil {
+				_ = rollback(barrierTx)
+			}
+		}()
+
+		if _, err := barrierTx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+			return fmt.Errorf("_litestream_lock: %w", err)
+		}
+
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+		if err != nil {
+			return fmt.Errorf("cannot seal wal before passive checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
+	}
+
+	frameSize := int64(db.pageSize + WALFrameHeaderSize)
+	preCheckpointFrameN := 0
+	if exec.state.lastSyncedWALOffset > WALHeaderSize {
+		preCheckpointFrameN = int((exec.state.lastSyncedWALOffset - WALHeaderSize) / frameSize)
+	}
+
 	// Execute checkpoint and immediately issue a write to the WAL to ensure
 	// a new page is written.
 	db.setSyncDiagPhase(diagPhaseCheckpointExec,
@@ -2345,9 +2386,21 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	if err := db.execCheckpoint(ctx, mode); err != nil {
+	checkpointRow, err := db.execCheckpoint(ctx, mode)
+	if err != nil {
 		return err
-	} else if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
+	}
+
+	if barrierTx != nil {
+		if _, err = barrierTx.ExecContext(ctx, checkpointSeqSQL); err != nil {
+			return err
+		} else if _, err = barrierTx.ExecContext(ctx, `DELETE FROM _litestream_lock`); err != nil {
+			return err
+		} else if err = barrierTx.Commit(); err != nil {
+			return err
+		}
+		barrierTx = nil
+	} else if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
 		return err
 	}
 
@@ -2361,6 +2414,26 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	if err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
+		exec.state.syncedSinceCheckpoint = false
+		return nil
+	}
+
+	if mode == CheckpointModePassive {
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+		if err != nil {
+			return fmt.Errorf("cannot copy wal after passive checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
+		exec.state.syncedSinceCheckpoint = false
+		return nil
+	}
+
+	if checkpointRow[1] <= preCheckpointFrameN {
+		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+		if err != nil {
+			return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+		}
+		exec.applySyncResult(result)
 		exec.state.syncedSinceCheckpoint = false
 		return nil
 	}
@@ -2415,10 +2488,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	return nil
 }
 
-func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
+func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err error) {
 	// Ignore if there is no underlying database.
 	if db.db == nil {
-		return nil
+		return row, nil
 	}
 
 	// Track checkpoint metrics.
@@ -2435,7 +2508,7 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// Ensure the read lock has been removed before issuing a checkpoint.
 	// We defer the re-acquire to ensure it occurs even on an early return.
 	if err := db.releaseReadLock(); err != nil {
-		return fmt.Errorf("release read lock: %w", err)
+		return row, fmt.Errorf("release read lock: %w", err)
 	}
 	defer func() { _ = db.acquireReadLock(ctx) }()
 
@@ -2447,18 +2520,17 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// See: https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
 	rawsql := `PRAGMA wal_checkpoint(` + mode + `);`
 
-	var row [3]int
 	if err := db.db.QueryRowContext(ctx, rawsql).Scan(&row[0], &row[1], &row[2]); err != nil {
-		return err
+		return row, err
 	}
 	db.Logger.Debug("checkpoint", "mode", mode, "result", fmt.Sprintf("%d,%d,%d", row[0], row[1], row[2]))
 
 	// Reacquire the read lock immediately after the checkpoint.
 	if err := db.acquireReadLock(ctx); err != nil {
-		return fmt.Errorf("reacquire read lock: %w", err)
+		return row, fmt.Errorf("reacquire read lock: %w", err)
 	}
 
-	return nil
+	return row, nil
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.

--- a/db.go
+++ b/db.go
@@ -1644,6 +1644,7 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
 	info.salt1 = dec.Header().WALSalt1
 	info.salt2 = dec.Header().WALSalt2
+	info.prevCommit = dec.Header().Commit
 
 	// If LTX WAL offset is larger than real WAL then the WAL has been truncated.
 	if fi, err := os.Stat(db.WALPath()); err != nil {
@@ -1829,6 +1830,7 @@ type syncInfo struct {
 	offset              int64 // end of the previous LTX read
 	salt1               uint32
 	salt2               uint32
+	prevCommit          uint32
 	snapshotting        bool   // if true, a full snapshot is required
 	reason              string // reason for snapshot
 	clearSyncedToWALEnd bool
@@ -2107,7 +2109,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 				s.snapshotting = false
 				s.reason = info.reason
 			})
-		if err := db.writeLTXFromWAL(ctx, enc, walFile, pageMap); err != nil {
+		if err := db.writeLTXFromWAL(ctx, enc, walFile, info.prevCommit, commit, pageMap); err != nil {
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
@@ -2234,11 +2236,23 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 	return nil
 }
 
-func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, pageMap map[uint32]int64) error {
+func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
+	}
+	lockPgno := ltx.LockPgno(uint32(db.pageSize))
+	if commit > prevCommit {
+		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if pgno == lockPgno {
+				continue
+			}
+			if _, ok := pageMap[pgno]; ok {
+				continue
+			}
+			pgnos = append(pgnos, pgno)
+		}
 	}
 	slices.Sort(pgnos)
 
@@ -2250,18 +2264,23 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		default:
 		}
 
-		offset := pageMap[pgno]
+		if offset, ok := pageMap[pgno]; ok {
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+			} else if n != len(data) {
+				return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			}
+		} else {
+			offset := int64(pgno-1) * int64(db.pageSize)
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
 
-		// Read source page using page map.
-		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-		} else if n != len(data) {
-			return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			if _, err := db.f.ReadAt(data, offset); err != nil {
+				return fmt.Errorf("read database page %d: %w", pgno, err)
+			}
 		}
 
-		// Write page to LTX encoder.
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {
 			return fmt.Errorf("encode ltx frame (pgno=%d): %w", pgno, err)
 		}

--- a/db.go
+++ b/db.go
@@ -1477,11 +1477,35 @@ func isDiskFullError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, ErrDiskFull) {
+		return true
+	}
 	errStr := strings.ToLower(err.Error())
 	return strings.Contains(errStr, "no space left on device") ||
 		strings.Contains(errStr, "disk quota exceeded") ||
 		strings.Contains(errStr, "enospc") ||
 		strings.Contains(errStr, "edquot")
+}
+
+type ltxStagingFile interface {
+	io.Writer
+	Sync() error
+	Close() error
+}
+
+var openLTXFile = func(name string, flag int, perm os.FileMode) (ltxStagingFile, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func newLTXStagingDiskFullError(op, path string, level int, minTXID, maxTXID ltx.TXID, err error) *LTXStagingDiskFullError {
+	return &LTXStagingDiskFullError{
+		Op:      op,
+		Path:    path,
+		Level:   level,
+		MinTXID: uint64(minTXID),
+		MaxTXID: uint64(maxTXID),
+		Err:     err,
+	}
 }
 
 // walFileSize returns the size of the WAL file in bytes.
@@ -2058,8 +2082,11 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		return result, err
 	}
 
-	ltxFile, err := os.OpenFile(tmpFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
+	ltxFile, err := openLTXFile(tmpFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
+		if isDiskFullError(err) {
+			return result, newLTXStagingDiskFullError("open", tmpFilename, 0, txID, txID, err)
+		}
 		return result, fmt.Errorf("open temp ltx file: %w", err)
 	}
 	defer func() { _ = os.Remove(tmpFilename) }()
@@ -2094,6 +2121,9 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		WALSalt1:  rd.salt1,
 		WALSalt2:  rd.salt2,
 	}); err != nil {
+		if isDiskFullError(err) {
+			return result, newLTXStagingDiskFullError("write", tmpFilename, 0, txID, txID, err)
+		}
 		return result, fmt.Errorf("encode ltx header: %w", err)
 	}
 
@@ -2108,6 +2138,9 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 				s.reason = info.reason
 			})
 		if err := db.writeLTXFromDB(ctx, enc, walFile, commit, pageMap); err != nil {
+			if isDiskFullError(err) {
+				return result, newLTXStagingDiskFullError("write", tmpFilename, 0, txID, txID, err)
+			}
 			return result, fmt.Errorf("write ltx from db: %w", err)
 		}
 	} else {
@@ -2119,6 +2152,9 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 				s.reason = info.reason
 			})
 		if err := db.writeLTXFromWAL(ctx, enc, walFile, info.prevCommit, commit, pageMap); err != nil {
+			if isDiskFullError(err) {
+				return result, newLTXStagingDiskFullError("write", tmpFilename, 0, txID, txID, err)
+			}
 			return result, fmt.Errorf("write ltx from wal: %w", err)
 		}
 	}
@@ -2129,6 +2165,9 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		s.walSize = sz
 	})
 	if err := enc.Close(); err != nil {
+		if isDiskFullError(err) {
+			return result, newLTXStagingDiskFullError("write", tmpFilename, 0, txID, txID, err)
+		}
 		return result, fmt.Errorf("close ltx encoder: %w", err)
 	}
 
@@ -2138,9 +2177,15 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		s.walSize = sz
 	})
 	if err := ltxFile.Sync(); err != nil {
+		if isDiskFullError(err) {
+			return result, newLTXStagingDiskFullError("sync", tmpFilename, 0, txID, txID, err)
+		}
 		return result, fmt.Errorf("sync ltx file: %w", err)
 	}
 	if err := ltxFile.Close(); err != nil {
+		if isDiskFullError(err) {
+			return result, newLTXStagingDiskFullError("close", tmpFilename, 0, txID, txID, err)
+		}
 		return result, fmt.Errorf("close ltx file: %w", err)
 	}
 
@@ -3079,6 +3124,18 @@ func (db *DB) monitor() {
 		// tick would cap drain throughput and starve the TruncatePageN
 		// emergency checkpoint while behind, growing the WAL unbounded.
 		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
+			var diskFullErr *LTXStagingDiskFullError
+			if errors.As(err, &diskFullErr) {
+				db.Logger.Error("sync stopped: disk full while staging ltx file",
+					"error", err,
+					"path", diskFullErr.Path,
+					"level", diskFullErr.Level,
+					"min_txid", diskFullErr.MinTXID,
+					"max_txid", diskFullErr.MaxTXID,
+					"hint", "free disk space and restart litestream")
+				return
+			}
+
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max

--- a/db.go
+++ b/db.go
@@ -2594,21 +2594,36 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	if err := db.lockExec(ctx); err != nil {
-		return ltx.Pos{}, nil, err
+	pos, pageSize, err := db.snapshotPosition(ctx)
+	if err != nil {
+		return pos, nil, err
 	}
+
+	r, err := db.snapshotReader(ctx, pos, pageSize)
+	return pos, r, err
+}
+
+func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, 0, err
+	}
+	defer db.execSem.Release(1)
+
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execSem.Release(1)
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
-		return ltx.Pos{}, nil, &DBNotReadyError{Reason: "page size not initialized"}
+		return ltx.Pos{}, 0, &DBNotReadyError{Reason: "page size not initialized"}
 	}
 	if err != nil {
-		return pos, nil, fmt.Errorf("pos: %w", err)
+		return pos, pageSize, fmt.Errorf("pos: %w", err)
 	}
 
+	return pos, pageSize, nil
+}
+
+func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io.Reader, error) {
 	db.Logger.Debug("snapshot", "txid", pos.TXID.String())
 
 	// Prevent internal checkpoints during sync.
@@ -2619,7 +2634,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 
 	fi, err := db.f.Stat()
 	if err != nil {
-		return pos, nil, err
+		return nil, err
 	}
 	commit := uint32(fi.Size() / int64(pageSize))
 
@@ -2696,7 +2711,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 		_ = pw.Close()
 	}()
 
-	return pos, pr, nil
+	return pr, nil
 }
 
 // Compact performs a compaction of the LTX file at the previous level into dstLevel.
@@ -2721,12 +2736,24 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 	return info, nil
 }
 
-// SnapshotDB writes a snapshot to the replica for the current position of the database.
+// Snapshot writes a snapshot to the replica for the current database position.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, r, err := db.SnapshotReader(ctx)
+	pos, pageSize, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
 	}
+	if info, ok, err := db.existingSnapshotInfo(ctx, pos.TXID); err != nil {
+		return nil, err
+	} else if ok {
+		db.Logger.Debug("snapshot already exists", "txid", pos.TXID.String(), "snapshot", info.MaxTXID.String())
+		return info, nil
+	}
+
+	r, err := db.snapshotReader(ctx, pos, pageSize)
+	if err != nil {
+		return nil, err
+	}
+
 	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
 	if err != nil {
 		return info, err
@@ -2737,6 +2764,17 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	db.maxLTXFileInfos.Unlock()
 
 	return info, nil
+}
+
+func (db *DB) existingSnapshotInfo(ctx context.Context, txID ltx.TXID) (*ltx.FileInfo, bool, error) {
+	info, err := db.MaxLTXFileInfo(ctx, SnapshotLevel)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.MaxTXID == 0 || info.MaxTXID < txID {
+		return nil, false, nil
+	}
+	return &info, true, nil
 }
 
 // EnforceSnapshotRetention enforces retention of the snapshot level in the database by timestamp.

--- a/db.go
+++ b/db.go
@@ -65,7 +65,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execGate  syncGate
+	execSem   *semaphore.Weighted
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -186,38 +186,6 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type syncGate struct {
-	once sync.Once
-	sem  *semaphore.Weighted
-}
-
-func (g *syncGate) init() {
-	g.once.Do(func() {
-		g.sem = semaphore.NewWeighted(1)
-	})
-}
-
-func (g *syncGate) Acquire(ctx context.Context) error {
-	g.init()
-	if err := g.sem.Acquire(ctx, 1); err != nil {
-		if cause := context.Cause(ctx); cause != nil {
-			return cause
-		}
-		return err
-	}
-	return nil
-}
-
-func (g *syncGate) TryAcquire() bool {
-	g.init()
-	return g.sem.TryAcquire(1)
-}
-
-func (g *syncGate) Release() {
-	g.init()
-	g.sem.Release(1)
-}
-
 // syncState holds mutable sync-tracking fields extracted from DB.
 // These fields are threaded through sync/checkpoint methods via pointer.
 type syncState struct {
@@ -327,6 +295,13 @@ type SyncDiagnostic struct {
 	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
 }
 
+func contextCause(ctx context.Context, err error) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return err
+}
+
 // NewDB returns a new instance of DB for a given path.
 func NewDB(path string) *DB {
 	dir, file := filepath.Split(path)
@@ -334,6 +309,7 @@ func NewDB(path string) *DB {
 	db := &DB{
 		path:     path,
 		metaPath: filepath.Join(dir, "."+file+MetaDirSuffix),
+		execSem:  semaphore.NewWeighted(1),
 		notify:   make(chan struct{}),
 
 		MinCheckpointPageN:   DefaultMinCheckpointPageN,
@@ -843,10 +819,10 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return err
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return contextCause(ctx, err)
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -1258,20 +1234,20 @@ func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, 
 	if err := db.lockExec(ctx); err != nil {
 		return syncResult{}, err
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
-	if db.execGate.TryAcquire() {
+	if db.execSem.TryAcquire(1) {
 		return nil
 	}
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return fmt.Errorf("wait for db sync executor: %w", err)
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("wait for db sync executor: %w", contextCause(ctx, err))
 	}
 	return nil
 }
@@ -2277,7 +2253,7 @@ func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
 	if err := db.lockExec(ctx); err != nil {
 		return err
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 	db.beginSyncDiag(diagOpCheckpoint)
 	defer func() { db.finishSyncDiag(err) }()
 
@@ -2479,7 +2455,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
 	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execGate.Release()
+	db.execSem.Release(1)
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
@@ -2891,10 +2867,10 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	if err := db.execGate.Acquire(ctx); err != nil {
-		return 0, ltx.Pos{}, err
+	if err := db.execSem.Acquire(ctx, 1); err != nil {
+		return 0, ltx.Pos{}, contextCause(ctx, err)
 	}
-	defer db.execGate.Release()
+	defer db.execSem.Release(1)
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -2392,15 +2392,13 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 
 	if barrierTx != nil {
-		if _, err = barrierTx.ExecContext(ctx, checkpointSeqSQL); err != nil {
-			return err
-		} else if _, err = barrierTx.ExecContext(ctx, `DELETE FROM _litestream_lock`); err != nil {
-			return err
-		} else if err = barrierTx.Commit(); err != nil {
-			return err
+		if err = rollback(barrierTx); err != nil {
+			return fmt.Errorf("rollback passive checkpoint barrier: %w", err)
 		}
 		barrierTx = nil
-	} else if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
+	}
+
+	if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
 		return err
 	}
 

--- a/db.go
+++ b/db.go
@@ -107,6 +107,7 @@ type DB struct {
 	syncNCounter                prometheus.Counter
 	syncErrorNCounter           prometheus.Counter
 	syncSecondsCounter          prometheus.Counter
+	diskFullGauge               prometheus.Gauge
 	checkpointNCounterVec       *prometheus.CounterVec
 	checkpointErrorNCounterVec  *prometheus.CounterVec
 	checkpointSecondsCounterVec *prometheus.CounterVec
@@ -333,6 +334,7 @@ func NewDB(path string) *DB {
 	db.syncNCounter = syncNCounterVec.WithLabelValues(db.path)
 	db.syncErrorNCounter = syncErrorNCounterVec.WithLabelValues(db.path)
 	db.syncSecondsCounter = syncSecondsCounterVec.WithLabelValues(db.path)
+	db.diskFullGauge = diskFullGaugeVec.WithLabelValues(db.path)
 	db.checkpointNCounterVec = checkpointNCounterVec.MustCurryWith(prometheus.Labels{"db": db.path})
 	db.checkpointErrorNCounterVec = checkpointErrorNCounterVec.MustCurryWith(prometheus.Labels{"db": db.path})
 	db.checkpointSecondsCounterVec = checkpointSecondsCounterVec.MustCurryWith(prometheus.Labels{"db": db.path})
@@ -1267,6 +1269,14 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 		db.syncNCounter.Inc()
 		if err != nil {
 			db.syncErrorNCounter.Inc()
+			var diskFullErr *LTXStagingDiskFullError
+			if errors.As(err, &diskFullErr) {
+				db.diskFullGauge.Set(1)
+			} else {
+				db.diskFullGauge.Set(0)
+			}
+		} else {
+			db.diskFullGauge.Set(0)
 		}
 		db.syncSecondsCounter.Add(float64(time.Since(t).Seconds()))
 	}()
@@ -3124,18 +3134,6 @@ func (db *DB) monitor() {
 		// tick would cap drain throughput and starve the TruncatePageN
 		// emergency checkpoint while behind, growing the WAL unbounded.
 		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
-			var diskFullErr *LTXStagingDiskFullError
-			if errors.As(err, &diskFullErr) {
-				db.Logger.Error("sync stopped: disk full while staging ltx file",
-					"error", err,
-					"path", diskFullErr.Path,
-					"level", diskFullErr.Level,
-					"min_txid", diskFullErr.MinTXID,
-					"max_txid", diskFullErr.MaxTXID,
-					"hint", "free disk space and restart litestream")
-				return
-			}
-
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max
@@ -3148,13 +3146,28 @@ func (db *DB) monitor() {
 				}
 			}
 
-			// Log with rate limiting to avoid log spam during persistent errors.
-			if time.Since(lastLogTime) >= SyncErrorLogInterval {
-				db.Logger.Error("sync error",
-					"error", err,
-					"consecutive_errors", consecutiveErrs,
-					"backoff", backoff)
-				lastLogTime = time.Now()
+			var diskFullErr *LTXStagingDiskFullError
+			if errors.As(err, &diskFullErr) {
+				if time.Since(lastLogTime) >= SyncErrorLogInterval {
+					db.Logger.Error(fmt.Sprintf("disk full while staging LTX file %s: replication paused, will resume automatically when space is freed", diskFullErr.Path),
+						"error", err,
+						"path", diskFullErr.Path,
+						"level", diskFullErr.Level,
+						"min_txid", diskFullErr.MinTXID,
+						"max_txid", diskFullErr.MaxTXID,
+						"consecutive_errors", consecutiveErrs,
+						"backoff", backoff)
+					lastLogTime = time.Now()
+				}
+			} else {
+				// Log with rate limiting to avoid log spam during persistent errors.
+				if time.Since(lastLogTime) >= SyncErrorLogInterval {
+					db.Logger.Error("sync error",
+						"error", err,
+						"consecutive_errors", consecutiveErrs,
+						"backoff", backoff)
+					lastLogTime = time.Now()
+				}
 			}
 
 			// Try to clean up stale temp files after persistent disk errors.
@@ -3319,6 +3332,11 @@ var (
 	syncSecondsCounterVec = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "litestream_sync_seconds",
 		Help: "Time spent syncing shadow WAL, in seconds",
+	}, []string{"db"})
+
+	diskFullGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "litestream_disk_full",
+		Help: "Whether replication is paused because the local disk is full",
 	}, []string{"db"})
 
 	checkpointNCounterVec = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/db.go
+++ b/db.go
@@ -141,7 +141,9 @@ type DB struct {
 	MonitorInterval time.Duration
 
 	// Maximum WAL bytes to process in a single sync executor run.
-	// Set to zero to process all committed WAL frames in one run.
+	// The limit is checked at commit boundaries so a single transaction
+	// larger than this may exceed it. Set to zero to process all
+	// committed WAL frames in one run.
 	MaxSyncWALBytes int64
 
 	// The timeout to wait for EBUSY from SQLite.
@@ -2774,8 +2776,13 @@ func (db *DB) monitor() {
 			}
 		}
 
-		// Sync the database to the shadow WAL.
-		if _, err := db.syncOnce(db.ctx, db.MaxSyncWALBytes); err != nil && !errors.Is(err, context.Canceled) {
+		// Sync the database to the shadow WAL. Sync() loops over bounded
+		// chunks, releasing the executor lock between each so checkpoints
+		// and snapshots can interleave, but always catches up to the WAL
+		// end so checkpointIfNeeded() runs. A single bounded chunk per
+		// tick would cap drain throughput and starve the TruncatePageN
+		// emergency checkpoint while behind, growing the WAL unbounded.
+		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max

--- a/db.go
+++ b/db.go
@@ -819,8 +819,13 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	if err := db.execSem.Acquire(ctx, 1); err != nil {
-		return contextCause(ctx, err)
+	// Acquire without honoring caller cancellation: the cleanup below
+	// (read lock release, handle closes, state reset) must always run or
+	// the DB is left half-closed with its read lock held. Semaphore
+	// acquisition fails immediately on an already-done context even when
+	// the semaphore is free.
+	if err := db.execSem.Acquire(context.WithoutCancel(ctx), 1); err != nil {
+		return err
 	}
 	defer db.execSem.Release(1)
 

--- a/db.go
+++ b/db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 	"modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -64,7 +65,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execMu    contextMutex
+	execGate  syncGate
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -185,56 +186,36 @@ type DB struct {
 	Logger *slog.Logger
 }
 
-type contextMutex struct {
+type syncGate struct {
 	once sync.Once
-	ch   chan struct{}
+	sem  *semaphore.Weighted
 }
 
-func (m *contextMutex) init() {
-	m.once.Do(func() {
-		m.ch = make(chan struct{}, 1)
+func (g *syncGate) init() {
+	g.once.Do(func() {
+		g.sem = semaphore.NewWeighted(1)
 	})
 }
 
-func (m *contextMutex) Lock() {
-	m.init()
-	m.ch <- struct{}{}
-}
-
-func (m *contextMutex) LockContext(ctx context.Context) error {
-	m.init()
-
-	select {
-	case m.ch <- struct{}{}:
-		return nil
-	case <-ctx.Done():
-		err := context.Cause(ctx)
-		if err == nil {
-			err = ctx.Err()
+func (g *syncGate) Acquire(ctx context.Context) error {
+	g.init()
+	if err := g.sem.Acquire(ctx, 1); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return cause
 		}
 		return err
 	}
+	return nil
 }
 
-func (m *contextMutex) TryLock() bool {
-	m.init()
-
-	select {
-	case m.ch <- struct{}{}:
-		return true
-	default:
-		return false
-	}
+func (g *syncGate) TryAcquire() bool {
+	g.init()
+	return g.sem.TryAcquire(1)
 }
 
-func (m *contextMutex) Unlock() {
-	m.init()
-
-	select {
-	case <-m.ch:
-	default:
-		panic("unlock of unlocked contextMutex")
-	}
+func (g *syncGate) Release() {
+	g.init()
+	g.sem.Release(1)
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -862,8 +843,10 @@ func (db *DB) Close(ctx context.Context) (err error) {
 	db.cancel()
 	db.wg.Wait()
 
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.execGate.Acquire(ctx); err != nil {
+		return err
+	}
+	defer db.execGate.Release()
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -1275,19 +1258,19 @@ func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, 
 	if err := db.lockExec(ctx); err != nil {
 		return syncResult{}, err
 	}
-	defer db.execMu.Unlock()
+	defer db.execGate.Release()
 
 	return db.syncLocked(ctx, maxSyncWALBytes)
 }
 
 func (db *DB) lockExec(ctx context.Context) error {
-	if db.execMu.TryLock() {
+	if db.execGate.TryAcquire() {
 		return nil
 	}
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	if err := db.execMu.LockContext(ctx); err != nil {
+	if err := db.execGate.Acquire(ctx); err != nil {
 		return fmt.Errorf("wait for db sync executor: %w", err)
 	}
 	return nil
@@ -2291,8 +2274,10 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 // Checkpoint performs a checkpoint on the WAL file.
 func (db *DB) Checkpoint(ctx context.Context, mode string) (err error) {
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.lockExec(ctx); err != nil {
+		return err
+	}
+	defer db.execGate.Release()
 	db.beginSyncDiag(diagOpCheckpoint)
 	defer func() { db.finishSyncDiag(err) }()
 
@@ -2489,10 +2474,12 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	db.execMu.Lock()
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, nil, err
+	}
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
-	db.execMu.Unlock()
+	db.execGate.Release()
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
@@ -2904,8 +2891,10 @@ func (db *DB) monitor() {
 //
 // If dst is set, the database file is copied to that location before checksum.
 func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	if err := db.execGate.Acquire(ctx); err != nil {
+		return 0, ltx.Pos{}, err
+	}
+	defer db.execGate.Release()
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -1869,14 +1869,6 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 		return
 	}
 
-	db.mu.Lock()
-	db.syncState = exec.state
-	if notify && exec.synced {
-		close(db.notify)
-		db.notify = make(chan struct{})
-	}
-	db.mu.Unlock()
-
 	// Only publish the position if this executor advanced it. Republishing
 	// the snapshot taken at executor start would clobber concurrent cache
 	// invalidation (e.g. ResetLocalState) with a stale position.
@@ -1893,6 +1885,14 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 		db.maxLTXFileInfos.m[0] = &info
 		db.maxLTXFileInfos.Unlock()
 	}
+
+	db.mu.Lock()
+	db.syncState = exec.state
+	if notify && exec.synced {
+		close(db.notify)
+		db.notify = make(chan struct{})
+	}
+	db.mu.Unlock()
 }
 
 func (exec *syncExecutor) applySyncResult(result syncResult) {
@@ -2357,7 +2357,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	if other, err := readWALHeader(db.WALPath()); err != nil {
+	other, err := readWALHeader(db.WALPath())
+	if err != nil {
 		return err
 	} else if bytes.Equal(hdr, other) {
 		exec.state.syncedSinceCheckpoint = false
@@ -2390,9 +2391,16 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
+	snapshotInfo := syncInfo{
+		offset:       WALHeaderSize,
+		salt1:        binary.BigEndian.Uint32(other[16:]),
+		salt2:        binary.BigEndian.Uint32(other[20:]),
+		snapshotting: true,
+		reason:       "checkpoint boundary snapshot",
+	}
+	result, err = db.sync(ctx, true, exec, snapshotInfo, 0)
 	if err != nil {
-		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
+		return fmt.Errorf("cannot snapshot after checkpoint: %w", err)
 	}
 	exec.applySyncResult(result)
 

--- a/db.go
+++ b/db.go
@@ -2021,9 +2021,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 	if !info.snapshotting {
 		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-			info.snapshotting = true
-			info.reason = fmt.Sprintf("missing WAL growth page %d, full LTX", pgno)
-			db.Logger.Info("missing WAL growth page, writing full LTX",
+			db.Logger.Info("missing WAL growth page, reading from database",
 				"txid", txID.String(),
 				"pgno", pgno,
 				"prev_commit", info.prevCommit,
@@ -2259,14 +2257,26 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 	if err := checkContext(); err != nil {
 		return err
 	}
-	if pgno, ok := missingGrowthPage(prevCommit, commit, uint32(db.pageSize), pageMap); ok {
-		return fmt.Errorf("missing WAL growth page %d between previous commit %d and commit %d", pgno, prevCommit, commit)
-	}
 
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
+	}
+	lockPgno := ltx.LockPgno(uint32(db.pageSize))
+	if commit > prevCommit {
+		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+			if err := checkContext(); err != nil {
+				return err
+			}
+			if pgno == lockPgno {
+				continue
+			}
+			if _, ok := pageMap[pgno]; ok {
+				continue
+			}
+			pgnos = append(pgnos, pgno)
+		}
 	}
 	slices.Sort(pgnos)
 
@@ -2275,13 +2285,21 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		if err := checkContext(); err != nil {
 			return err
 		}
-		offset := pageMap[pgno]
-		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
+		if offset, ok := pageMap[pgno]; ok {
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-		} else if n != len(data) {
-			return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+			} else if n != len(data) {
+				return fmt.Errorf("short read page %d @ %d", pgno, offset)
+			}
+		} else {
+			offset := int64(pgno-1) * int64(db.pageSize)
+			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
+
+			if _, err := db.f.ReadAt(data, offset); err != nil {
+				return fmt.Errorf("read database page %d: %w", pgno, err)
+			}
 		}
 
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {

--- a/db.go
+++ b/db.go
@@ -2922,9 +2922,11 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 	defer itr.Close()
 
 	var deleted []*ltx.FileInfo
+	var snapshots []*ltx.FileInfo
 	var lastInfo *ltx.FileInfo
 	for itr.Next() {
 		info := itr.Item()
+		snapshots = append(snapshots, info)
 		lastInfo = info
 
 		// If this snapshot is before the retention timestamp, mark it for deletion.
@@ -2932,17 +2934,23 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 			deleted = append(deleted, info)
 			continue
 		}
-
-		// Track the lowest snapshot TXID so we can enforce retention in lower levels.
-		// This is only tracked for snapshots not marked for deletion.
-		if minSnapshotTXID == 0 || info.MaxTXID < minSnapshotTXID {
-			minSnapshotTXID = info.MaxTXID
-		}
 	}
 
 	// If this is the snapshot level, we need to ensure that at least one snapshot exists.
 	if len(deleted) > 0 && deleted[len(deleted)-1] == lastInfo {
 		deleted = deleted[:len(deleted)-1]
+	}
+
+	for i, info := range snapshots {
+		if slices.Contains(deleted, info) {
+			continue
+		}
+		if i > 0 {
+			minSnapshotTXID = snapshots[i-1].MaxTXID
+		} else {
+			minSnapshotTXID = info.MaxTXID
+		}
+		break
 	}
 
 	// Remove files marked for deletion from remote storage (unless retention disabled).

--- a/db.go
+++ b/db.go
@@ -2592,20 +2592,38 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (row [3]int, err 
 	return row, nil
 }
 
-// SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
-func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
-	pos, pageSize, err := db.snapshotPosition(ctx)
-	if err != nil {
-		return pos, nil, err
-	}
-
-	r, err := db.snapshotReader(ctx, pos, pageSize)
-	return pos, r, err
+type snapshotReadPosition struct {
+	pos          ltx.Pos
+	pageSize     int
+	walEndOffset int64
+	db           *DB
 }
 
-func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
+func (p *snapshotReadPosition) close() {
+	if p.db != nil {
+		p.db.chkMu.RUnlock()
+		p.db = nil
+	}
+}
+
+// SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
+func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
+	pos, err := db.snapshotPosition(ctx)
+	if err != nil {
+		return ltx.Pos{}, nil, err
+	}
+
+	r, err := db.snapshotReader(ctx, pos)
+	if err != nil {
+		pos.close()
+		return pos.pos, nil, err
+	}
+	return pos.pos, r, nil
+}
+
+func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, error) {
 	if err := db.lockExec(ctx); err != nil {
-		return ltx.Pos{}, 0, err
+		return nil, err
 	}
 	defer db.execSem.Release(1)
 
@@ -2614,21 +2632,53 @@ func (db *DB) snapshotPosition(ctx context.Context) (ltx.Pos, int, error) {
 
 	if pageSize == 0 {
 		db.Logger.Debug("page size not initialized yet", "pageSize", 0)
-		return ltx.Pos{}, 0, &DBNotReadyError{Reason: "page size not initialized"}
+		return nil, &DBNotReadyError{Reason: "page size not initialized"}
 	}
 	if err != nil {
-		return pos, pageSize, fmt.Errorf("pos: %w", err)
+		return nil, fmt.Errorf("pos: %w", err)
 	}
 
-	return pos, pageSize, nil
+	walEndOffset, err := db.snapshotWALEndOffset(ctx, pos)
+	if err != nil {
+		return nil, err
+	}
+	if walEndOffset < WALHeaderSize {
+		walEndOffset = WALHeaderSize
+	}
+
+	db.chkMu.RLock()
+	return &snapshotReadPosition{
+		pos:          pos,
+		pageSize:     pageSize,
+		walEndOffset: walEndOffset,
+		db:           db,
+	}, nil
 }
 
-func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io.Reader, error) {
-	db.Logger.Debug("snapshot", "txid", pos.TXID.String())
+func (db *DB) snapshotWALEndOffset(ctx context.Context, pos ltx.Pos) (int64, error) {
+	if db.syncState.lastSyncedWALOffset > 0 {
+		return db.syncState.lastSyncedWALOffset, nil
+	}
+	if pos.TXID == 0 {
+		return WALHeaderSize, nil
+	}
 
-	// Prevent internal checkpoints during sync.
-	db.chkMu.RLock()
-	defer db.chkMu.RUnlock()
+	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
+	f, err := os.Open(ltxPath)
+	if err != nil {
+		return 0, NewLTXError("open", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), err)
+	}
+	defer func() { _ = f.Close() }()
+
+	dec := ltx.NewDecoder(f)
+	if err := dec.DecodeHeader(); err != nil {
+		return 0, NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+	}
+	return dec.Header().WALOffset + dec.Header().WALSize, nil
+}
+
+func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io.Reader, error) {
+	db.Logger.Debug("snapshot", "txid", pos.pos.TXID.String(), "walEndOffset", pos.walEndOffset)
 
 	// TODO(ltx): Read database size from database header.
 
@@ -2636,11 +2686,13 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 	if err != nil {
 		return nil, err
 	}
-	commit := uint32(fi.Size() / int64(pageSize))
+	commit := uint32(fi.Size() / int64(pos.pageSize))
 
 	// Execute encoding in a separate goroutine so the caller can initialize before reading.
 	pr, pw := io.Pipe()
 	go func() {
+		defer pos.close()
+
 		walFile, err := os.Open(db.WALPath())
 		if err != nil {
 			pw.CloseWithError(err)
@@ -2655,25 +2707,33 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 		}
 
 		// Build a mapping of changed page numbers and their latest content.
-		pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("page map: %w", err))
-			return
+		maxBytes := pos.walEndOffset - WALHeaderSize
+		pageMap := make(map[uint32]int64)
+		var maxOffset int64
+		var walCommit uint32
+		if maxBytes > 0 {
+			pageMap, maxOffset, walCommit, _, err = rd.pageMap(ctx, maxBytes)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("page map: %w", err))
+				return
+			}
 		}
 		if walCommit > 0 {
 			commit = walCommit
 		}
 
-		var sz int64
-		if maxOffset > 0 {
-			sz = maxOffset - rd.Offset()
+		walOffset, walSize := snapshotHeaderWALRange(pos.walEndOffset, maxOffset, int64(WALFrameHeaderSize+pos.pageSize))
+		if maxOffset > pos.walEndOffset {
+			pw.CloseWithError(fmt.Errorf("snapshot wal read exceeded bound: max offset %d > end offset %d", maxOffset, pos.walEndOffset))
+			return
 		}
 
 		db.Logger.Debug("encode snapshot header",
-			"txid", pos.TXID.String(),
+			"txid", pos.pos.TXID.String(),
 			"commit", commit,
-			"walOffset", rd.Offset(),
-			"walSize", sz,
+			"walOffset", walOffset,
+			"walSize", walSize,
+			"walEndOffset", pos.walEndOffset,
 			"salt1", rd.salt1,
 			"salt2", rd.salt2)
 
@@ -2685,13 +2745,13 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 		if err := enc.EncodeHeader(ltx.Header{
 			Version:   ltx.Version,
 			Flags:     ltx.HeaderFlagNoChecksum,
-			PageSize:  uint32(pageSize),
+			PageSize:  uint32(pos.pageSize),
 			Commit:    commit,
 			MinTXID:   1,
-			MaxTXID:   pos.TXID,
+			MaxTXID:   pos.pos.TXID,
 			Timestamp: time.Now().UnixMilli(),
-			WALOffset: rd.Offset(),
-			WALSize:   sz,
+			WALOffset: walOffset,
+			WALSize:   walSize,
 			WALSalt1:  rd.salt1,
 			WALSalt2:  rd.salt2,
 		}); err != nil {
@@ -2712,6 +2772,20 @@ func (db *DB) snapshotReader(ctx context.Context, pos ltx.Pos, pageSize int) (io
 	}()
 
 	return pr, nil
+}
+
+func snapshotHeaderWALRange(walEndOffset, maxOffset, frameSize int64) (offset, size int64) {
+	if maxOffset <= WALHeaderSize || frameSize <= 0 {
+		return WALHeaderSize, 0
+	}
+	offset = maxOffset - frameSize
+	if offset < WALHeaderSize {
+		offset = WALHeaderSize
+	}
+	if maxOffset > walEndOffset {
+		maxOffset = walEndOffset
+	}
+	return offset, maxOffset - offset
 }
 
 // Compact performs a compaction of the LTX file at the previous level into dstLevel.
@@ -2738,24 +2812,30 @@ func (db *DB) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, error) 
 
 // Snapshot writes a snapshot to the replica for the current database position.
 func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
-	pos, pageSize, err := db.snapshotPosition(ctx)
+	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if info, ok, err := db.existingSnapshotInfo(ctx, pos.TXID); err != nil {
+	if info, ok, err := db.existingSnapshotInfo(ctx, pos.pos.TXID); err != nil {
+		pos.close()
 		return nil, err
 	} else if ok {
-		db.Logger.Debug("snapshot already exists", "txid", pos.TXID.String(), "snapshot", info.MaxTXID.String())
+		pos.close()
+		db.Logger.Debug("snapshot already exists", "txid", pos.pos.TXID.String(), "snapshot", info.MaxTXID.String())
 		return info, nil
 	}
 
-	r, err := db.snapshotReader(ctx, pos, pageSize)
+	r, err := db.snapshotReader(ctx, pos)
 	if err != nil {
+		pos.close()
 		return nil, err
 	}
 
-	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
+	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.pos.TXID, r)
 	if err != nil {
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
 		return info, err
 	}
 

--- a/db.go
+++ b/db.go
@@ -1501,6 +1501,13 @@ func calcWALSize(pageSize uint32, pageN uint32) int64 {
 	return int64(WALHeaderSize) + (int64(WALFrameHeaderSize+pageSize) * int64(pageN))
 }
 
+const bumpLitestreamSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
+
+func (db *DB) bumpLitestreamSeq(ctx context.Context) error {
+	_, err := db.db.ExecContext(ctx, bumpLitestreamSeqSQL)
+	return err
+}
+
 // ensureWALExists checks that the real WAL exists and has a header.
 func (db *DB) ensureWALExists(ctx context.Context) (err error) {
 	// Exit early if WAL header exists.
@@ -1509,8 +1516,7 @@ func (db *DB) ensureWALExists(ctx context.Context) (err error) {
 	}
 
 	// Otherwise create transaction that updates the internal litestream table.
-	_, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`)
-	return err
+	return db.bumpLitestreamSeq(ctx)
 }
 
 // checkDatabaseBehindReplica detects when a database has been restored to an
@@ -2325,8 +2331,6 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	defer db.chkMu.Unlock()
 
-	const checkpointSeqSQL = `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`
-
 	// Read WAL header before checkpoint to check if it has been restarted.
 	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
 		func(s *diagState) {
@@ -2398,8 +2402,8 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		barrierTx = nil
 	}
 
-	if _, err = db.db.ExecContext(ctx, checkpointSeqSQL); err != nil {
-		return err
+	if err = db.bumpLitestreamSeq(ctx); err != nil {
+		return fmt.Errorf("bump litestream seq: %w", err)
 	}
 
 	// If WAL hasn't been restarted, exit.

--- a/db.go
+++ b/db.go
@@ -269,6 +269,8 @@ type diagState struct {
 	checkpointMode      string
 	reason              string
 	err                 string
+	executorWaiterCount int
+	executorWaitStarted time.Time
 }
 
 // SyncDiagnostic reports the latest DB sync/checkpoint activity.
@@ -287,6 +289,9 @@ type SyncDiagnostic struct {
 	CheckpointMode      string     `json:"checkpoint_mode,omitempty"`
 	Reason              string     `json:"reason,omitempty"`
 	Error               string     `json:"error,omitempty"`
+	ExecutorWaiterCount int        `json:"executor_waiter_count,omitempty"`
+	ExecutorWaitStarted *time.Time `json:"executor_wait_started_at,omitempty"`
+	ExecutorWaitSeconds float64    `json:"executor_wait_seconds,omitempty"`
 }
 
 // NewDB returns a new instance of DB for a given path.
@@ -386,6 +391,12 @@ func (db *DB) SyncDiagnostic() SyncDiagnostic {
 		CheckpointMode:      db.syncDiag.checkpointMode,
 		Reason:              db.syncDiag.reason,
 		Error:               db.syncDiag.err,
+		ExecutorWaiterCount: db.syncDiag.executorWaiterCount,
+	}
+	if !db.syncDiag.executorWaitStarted.IsZero() {
+		startedAt := db.syncDiag.executorWaitStarted
+		diag.ExecutorWaitStarted = &startedAt
+		diag.ExecutorWaitSeconds = time.Since(db.syncDiag.executorWaitStarted).Seconds()
 	}
 	if !db.syncDiag.startedAt.IsZero() {
 		startedAt := db.syncDiag.startedAt
@@ -448,6 +459,27 @@ func (db *DB) finishSyncDiag(err error) {
 	db.syncDiag.updatedAt = time.Now()
 	if err != nil {
 		db.syncDiag.err = err.Error()
+	}
+}
+
+func (db *DB) beginSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Now()
+	}
+	db.syncDiag.executorWaiterCount++
+}
+
+func (db *DB) finishSyncExecutorWait() {
+	db.syncDiag.Lock()
+	defer db.syncDiag.Unlock()
+	if db.syncDiag.executorWaiterCount == 0 {
+		return
+	}
+	db.syncDiag.executorWaiterCount--
+	if db.syncDiag.executorWaiterCount == 0 {
+		db.syncDiag.executorWaitStarted = time.Time{}
 	}
 }
 
@@ -1200,6 +1232,8 @@ func (db *DB) lockExec(ctx context.Context) error {
 	if db.execMu.TryLock() {
 		return nil
 	}
+	db.beginSyncExecutorWait()
+	defer db.finishSyncExecutorWait()
 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()

--- a/db.go
+++ b/db.go
@@ -33,6 +33,7 @@ const (
 	DefaultBusyTimeout          = 1 * time.Second
 	DefaultMinCheckpointPageN   = 1000
 	DefaultTruncatePageN        = 121359 // ~500MB with 4KB page size
+	DefaultMaxSyncWALBytes      = 64 << 20
 	DefaultShutdownSyncTimeout  = 30 * time.Second
 	DefaultShutdownSyncInterval = 500 * time.Millisecond
 
@@ -139,6 +140,10 @@ type DB struct {
 	// Frequency at which to perform db sync.
 	MonitorInterval time.Duration
 
+	// Maximum WAL bytes to process in a single sync executor run.
+	// Set to zero to process all committed WAL frames in one run.
+	MaxSyncWALBytes int64
+
 	// The timeout to wait for EBUSY from SQLite.
 	BusyTimeout time.Duration
 
@@ -227,7 +232,9 @@ const (
 	diagPhaseVerifyAndSync                  diagPhase = "verify_and_sync"
 	diagPhaseCheckpointIfNeeded             diagPhase = "checkpoint_if_needed"
 	diagPhaseUpdateMetrics                  diagPhase = "update_metrics"
+	diagPhaseStatWAL                        diagPhase = "stat_wal"
 	diagPhaseVerify                         diagPhase = "verify"
+	diagPhaseSyncLTX                        diagPhase = "sync_ltx"
 	diagPhaseSyncOpenLTX                    diagPhase = "sync_open_ltx"
 	diagPhaseSyncPageMap                    diagPhase = "sync_page_map"
 	diagPhaseSyncPrepareLTX                 diagPhase = "sync_prepare_ltx"
@@ -293,6 +300,7 @@ func NewDB(path string) *DB {
 		TruncatePageN:        DefaultTruncatePageN,
 		CheckpointInterval:   DefaultCheckpointInterval,
 		MonitorInterval:      DefaultMonitorInterval,
+		MaxSyncWALBytes:      DefaultMaxSyncWALBytes,
 		BusyTimeout:          DefaultBusyTimeout,
 		L0Retention:          DefaultL0Retention,
 		RetentionEnabled:     true,
@@ -773,7 +781,7 @@ func (db *DB) Close(ctx context.Context) (err error) {
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
-		if e := db.syncLocked(ctx); e != nil {
+		if _, e := db.syncLocked(ctx, 0); e != nil {
 			err = e
 		}
 	}
@@ -1162,16 +1170,58 @@ func (db *DB) releaseReadLock() error {
 }
 
 // Sync copies pending data from the WAL to the shadow WAL.
-func (db *DB) Sync(ctx context.Context) (err error) {
-	db.execMu.Lock()
+func (db *DB) Sync(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
+
+		result, err := db.syncOnce(ctx, db.MaxSyncWALBytes)
+		if err != nil {
+			return err
+		} else if !result.synced || !result.limited || result.syncedToWALEnd {
+			return nil
+		}
+	}
+}
+
+func (db *DB) syncOnce(ctx context.Context, maxSyncWALBytes int64) (syncResult, error) {
+	if err := db.lockExec(ctx); err != nil {
+		return syncResult{}, err
+	}
 	defer db.execMu.Unlock()
+
+	return db.syncLocked(ctx, maxSyncWALBytes)
+}
+
+func (db *DB) lockExec(ctx context.Context) error {
+	if db.execMu.TryLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			err := context.Cause(ctx)
+			if err == nil {
+				err = ctx.Err()
+			}
+			return fmt.Errorf("wait for db sync executor: %w", err)
+		case <-ticker.C:
+			if db.execMu.TryLock() {
+				return nil
+			}
+		}
+	}
+}
+
+func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {
 	db.beginSyncDiag(diagOpSync)
 	defer func() { db.finishSyncDiag(err) }()
 
-	return db.syncLocked(ctx)
-}
-
-func (db *DB) syncLocked(ctx context.Context) (err error) {
 	// Track total sync metrics.
 	t := time.Now()
 	defer func() {
@@ -1184,10 +1234,10 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 
 	exec, err := db.newSyncExecutor(ctx)
 	if err != nil {
-		return err
+		return result, err
 	} else if exec == nil {
 		db.Logger.Debug("sync: no database found")
-		return nil
+		return result, nil
 	}
 	defer db.applySyncExecutor(exec, true)
 
@@ -1196,13 +1246,15 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 	})
 	if err := db.ensureWALExists(ctx); err != nil {
-		return fmt.Errorf("ensure wal exists: %w", err)
+		return result, fmt.Errorf("ensure wal exists: %w", err)
 	}
 
-	db.setSyncDiagPhase(diagPhaseVerifyAndSync)
-	result, err := db.verifyAndSyncWithExecutor(ctx, false, exec)
+	db.setSyncDiagPhase(diagPhaseVerifyAndSync, func(s *diagState) {
+		s.txID = exec.pos.TXID + 1
+	})
+	result, err = db.verifyAndSyncWithExecutor(ctx, false, exec, maxSyncWALBytes)
 	if err != nil {
-		return err
+		return result, err
 	}
 	exec.applySyncResult(result)
 
@@ -1211,14 +1263,18 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 		exec.state.syncedSinceCheckpoint = true
 	}
 
-	db.setSyncDiagPhase(diagPhaseCheckpointIfNeeded, func(s *diagState) {
-		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
-	})
-	if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
-		return fmt.Errorf("checkpoint: %w", err)
+	if !result.limited || result.syncedToWALEnd {
+		db.setSyncDiagPhase(diagPhaseCheckpointIfNeeded, func(s *diagState) {
+			s.txID = exec.pos.TXID
+			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+		})
+		if err := db.checkpointIfNeeded(ctx, exec, result.origWALSize, result.newWALSize); err != nil {
+			return result, fmt.Errorf("checkpoint: %w", err)
+		}
 	}
 
 	db.setSyncDiagPhase(diagPhaseUpdateMetrics, func(s *diagState) {
+		s.txID = exec.pos.TXID
 		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 	})
 
@@ -1231,7 +1287,7 @@ func (db *DB) syncLocked(ctx context.Context) (err error) {
 	}
 	db.walSizeGauge.Set(float64(exec.state.lastSyncedWALOffset))
 
-	return nil
+	return result, nil
 }
 
 func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *syncState) (syncResult, error) {
@@ -1243,10 +1299,15 @@ func (db *DB) verifyAndSync(ctx context.Context, checkpointing bool, state *sync
 	return db.verifyAndSyncWithExecutor(ctx, checkpointing, &syncExecutor{
 		state: *state,
 		pos:   pos,
-	})
+	}, 0)
 }
 
-func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor) (syncResult, error) {
+func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool, exec *syncExecutor, maxSyncWALBytes int64) (syncResult, error) {
+	db.setSyncDiagPhase(diagPhaseStatWAL, func(s *diagState) {
+		s.txID = exec.pos.TXID + 1
+		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+	})
+
 	// Use the last synced WAL offset as the logical size for checkpoint decisions.
 	// This avoids using file size which may include stale frames with old salt
 	// values after a checkpoint. See issue #997.
@@ -1269,7 +1330,13 @@ func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool,
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
-	result, err := db.sync(ctx, checkpointing, exec, info)
+	db.setSyncDiagPhase(diagPhaseSyncLTX, func(s *diagState) {
+		s.txID = exec.pos.TXID + 1
+		s.snapshotting = info.snapshotting
+		s.reason = info.reason
+		s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+	})
+	result, err := db.sync(ctx, checkpointing, exec, info, maxSyncWALBytes)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
 	}
@@ -1716,6 +1783,7 @@ type syncResult struct {
 	origWALSize    int64
 	newWALSize     int64
 	synced         bool
+	limited        bool
 	syncedToWALEnd bool
 	pos            *ltx.Pos
 	l0FileInfo     *ltx.FileInfo
@@ -1804,7 +1872,7 @@ func (exec *syncExecutor) applySyncResult(result syncResult) {
 
 // sync copies pending bytes from the real WAL to LTX.
 // Returns synced=true if an LTX file was created (i.e., there were new pages to sync).
-func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo) (result syncResult, err error) {
+func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, info syncInfo, maxSyncWALBytes int64) (result syncResult, err error) {
 	result.newWALSize = exec.state.lastSyncedWALOffset
 	result.syncedToWALEnd = exec.state.syncedToWALEnd
 	if info.clearSyncedToWALEnd {
@@ -1883,10 +1951,14 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 			s.snapshotting = info.snapshotting
 			s.reason = info.reason
 		})
-	pageMap, maxOffset, walCommit, err := rd.PageMap(ctx)
+	if info.snapshotting {
+		maxSyncWALBytes = 0
+	}
+	pageMap, maxOffset, walCommit, limited, err := rd.pageMap(ctx, maxSyncWALBytes)
 	if err != nil {
 		return result, fmt.Errorf("page map: %w", err)
 	}
+	result.limited = limited
 	if walCommit > 0 {
 		commit = walCommit
 	}
@@ -2117,6 +2189,12 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
+		}
+
 		offset := pageMap[pgno]
 
 		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
@@ -2213,7 +2291,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec)
+	result, err := db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal before checkpoint: %w", err)
 	}
@@ -2271,7 +2349,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec)
+	result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)
 	if err != nil {
 		return fmt.Errorf("cannot copy wal after checkpoint: %w", err)
 	}
@@ -2697,7 +2775,7 @@ func (db *DB) monitor() {
 		}
 
 		// Sync the database to the shadow WAL.
-		if err := db.Sync(db.ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if _, err := db.syncOnce(db.ctx, db.MaxSyncWALBytes); err != nil && !errors.Is(err, context.Canceled) {
 			consecutiveErrs++
 
 			// Exponential backoff: MonitorInterval -> 2x -> 4x -> ... -> max

--- a/db.go
+++ b/db.go
@@ -2019,6 +2019,17 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	if walCommit > 0 {
 		commit = walCommit
 	}
+	if !info.snapshotting {
+		if pgno, ok := missingGrowthPage(info.prevCommit, commit, uint32(db.pageSize), pageMap); ok {
+			info.snapshotting = true
+			info.reason = fmt.Sprintf("missing WAL growth page %d, full LTX", pgno)
+			db.Logger.Info("missing WAL growth page, writing full LTX",
+				"txid", txID.String(),
+				"pgno", pgno,
+				"prev_commit", info.prevCommit,
+				"commit", commit)
+		}
+	}
 
 	var sz int64
 	if maxOffset > 0 {
@@ -2237,48 +2248,40 @@ func (db *DB) writeLTXFromDB(ctx context.Context, enc *ltx.Encoder, walFile *os.
 }
 
 func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os.File, prevCommit, commit uint32, pageMap map[uint32]int64) error {
+	checkContext := func() error {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
+			return nil
+		}
+	}
+	if err := checkContext(); err != nil {
+		return err
+	}
+	if pgno, ok := missingGrowthPage(prevCommit, commit, uint32(db.pageSize), pageMap); ok {
+		return fmt.Errorf("missing WAL growth page %d between previous commit %d and commit %d", pgno, prevCommit, commit)
+	}
+
 	// Create an ordered list of page numbers since the LTX encoder requires it.
 	pgnos := make([]uint32, 0, len(pageMap))
 	for pgno := range pageMap {
 		pgnos = append(pgnos, pgno)
 	}
-	lockPgno := ltx.LockPgno(uint32(db.pageSize))
-	if commit > prevCommit {
-		for pgno := prevCommit + 1; pgno <= commit; pgno++ {
-			if pgno == lockPgno {
-				continue
-			}
-			if _, ok := pageMap[pgno]; ok {
-				continue
-			}
-			pgnos = append(pgnos, pgno)
-		}
-	}
 	slices.Sort(pgnos)
 
 	data := make([]byte, db.pageSize)
 	for _, pgno := range pgnos {
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		default:
+		if err := checkContext(); err != nil {
+			return err
 		}
+		offset := pageMap[pgno]
+		db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
 
-		if offset, ok := pageMap[pgno]; ok {
-			db.Logger.Log(ctx, internal.LevelTrace, "encode page from wal", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walonly")
-
-			if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
-				return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
-			} else if n != len(data) {
-				return fmt.Errorf("short read page %d @ %d", pgno, offset)
-			}
-		} else {
-			offset := int64(pgno-1) * int64(db.pageSize)
-			db.Logger.Log(ctx, internal.LevelTrace, "encode page from database", "txid", enc.Header().MinTXID, "offset", offset, "pgno", pgno, "type", "walgrowth")
-
-			if _, err := db.f.ReadAt(data, offset); err != nil {
-				return fmt.Errorf("read database page %d: %w", pgno, err)
-			}
+		if n, err := walFile.ReadAt(data, offset+WALFrameHeaderSize); err != nil {
+			return fmt.Errorf("read page %d @ %d: %w", pgno, offset, err)
+		} else if n != len(data) {
+			return fmt.Errorf("short read page %d @ %d", pgno, offset)
 		}
 
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, data); err != nil {
@@ -2286,6 +2289,23 @@ func (db *DB) writeLTXFromWAL(ctx context.Context, enc *ltx.Encoder, walFile *os
 		}
 	}
 	return nil
+}
+
+func missingGrowthPage(prevCommit, commit, pageSize uint32, pageMap map[uint32]int64) (uint32, bool) {
+	if commit <= prevCommit {
+		return 0, false
+	}
+
+	lockPgno := ltx.LockPgno(pageSize)
+	for pgno := prevCommit + 1; pgno <= commit; pgno++ {
+		if pgno == lockPgno {
+			continue
+		}
+		if _, ok := pageMap[pgno]; !ok {
+			return pgno, true
+		}
+	}
+	return 0, false
 }
 
 // Checkpoint performs a checkpoint on the WAL file.

--- a/db.go
+++ b/db.go
@@ -64,7 +64,7 @@ const (
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
 	mu        sync.RWMutex
-	execMu    sync.Mutex
+	execMu    contextMutex
 	path      string        // part to database
 	metaPath  string        // Path to the database metadata.
 	db        *sql.DB       // target database
@@ -183,6 +183,58 @@ type DB struct {
 
 	// Where to send log messages, defaults to global slog with database epath.
 	Logger *slog.Logger
+}
+
+type contextMutex struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+func (m *contextMutex) init() {
+	m.once.Do(func() {
+		m.ch = make(chan struct{}, 1)
+	})
+}
+
+func (m *contextMutex) Lock() {
+	m.init()
+	m.ch <- struct{}{}
+}
+
+func (m *contextMutex) LockContext(ctx context.Context) error {
+	m.init()
+
+	select {
+	case m.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		err := context.Cause(ctx)
+		if err == nil {
+			err = ctx.Err()
+		}
+		return err
+	}
+}
+
+func (m *contextMutex) TryLock() bool {
+	m.init()
+
+	select {
+	case m.ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *contextMutex) Unlock() {
+	m.init()
+
+	select {
+	case <-m.ch:
+	default:
+		panic("unlock of unlocked contextMutex")
+	}
 }
 
 // syncState holds mutable sync-tracking fields extracted from DB.
@@ -1235,23 +1287,10 @@ func (db *DB) lockExec(ctx context.Context) error {
 	db.beginSyncExecutorWait()
 	defer db.finishSyncExecutorWait()
 
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if err == nil {
-				err = ctx.Err()
-			}
-			return fmt.Errorf("wait for db sync executor: %w", err)
-		case <-ticker.C:
-			if db.execMu.TryLock() {
-				return nil
-			}
-		}
+	if err := db.execMu.LockContext(ctx); err != nil {
+		return fmt.Errorf("wait for db sync executor: %w", err)
 	}
+	return nil
 }
 
 func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2088,7 +2087,7 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 	}
 }
 
-func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
+func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 	walPath := filepath.Join(dir, "db-wal")
@@ -2148,82 +2147,12 @@ func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
-		t.Fatal(err)
+	err = db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap)
+	if err == nil {
+		t.Fatal("expected missing growth page error")
 	}
-	if err := enc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
-	if err := dec.DecodeHeader(); err != nil {
-		t.Fatal(err)
-	}
-
-	var pgnos []uint32
-	got := make(map[uint32][]byte)
-	pageBuf := make([]byte, pageSize)
-	for {
-		var phdr ltx.PageHeader
-		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
-			break
-		} else if err != nil {
-			t.Fatal(err)
-		}
-		pgnos = append(pgnos, phdr.Pgno)
-		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
-	}
-
-	if !reflect.DeepEqual([]uint32{3, 4, 5}, pgnos) {
-		t.Fatalf("page numbers mismatch: got=%v", pgnos)
-	}
-	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
-		t.Fatal("expected page 3 to come from WAL")
-	}
-	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
-		t.Fatal("expected page 4 to come from database")
-	}
-	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
-		t.Fatal("expected page 5 to come from WAL")
-	}
-
-	snapshot := new(bytes.Buffer)
-	snapshotEnc, err := ltx.NewEncoder(snapshot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := snapshotEnc.EncodeHeader(ltx.Header{
-		Version:   ltx.Version,
-		Flags:     ltx.HeaderFlagNoChecksum,
-		PageSize:  pageSize,
-		Commit:    2,
-		MinTXID:   1,
-		MaxTXID:   1,
-		Timestamp: time.Now().UnixMilli(),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	for _, pgno := range []uint32{1, 2} {
-		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
-		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := snapshotEnc.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	compacted := new(bytes.Buffer)
-	c, err := ltx.NewCompactor(compacted, []io.Reader{
-		bytes.NewReader(snapshot.Bytes()),
-		bytes.NewReader(buf.Bytes()),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.HeaderFlags = ltx.HeaderFlagNoChecksum
-	if err := c.Compact(context.Background()); err != nil {
-		t.Fatalf("compaction failed: %v", err)
+	if !strings.Contains(err.Error(), "missing WAL growth page 4") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2274,13 +2274,47 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 	// Verify a snapshot L0 was created during checkpoint.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
 	newL0Count := 0
+	newCoverageCount := 0
 	for _, entry := range l0AfterEntries {
 		if !l0BeforeNames[entry.Name()] {
 			newL0Count++
+
+			f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			dec := ltx.NewDecoder(f)
+			if err := dec.DecodeHeader(); err != nil {
+				_ = f.Close()
+				t.Fatal(err)
+			}
+			hdr := dec.Header()
+			buf := make([]byte, hdr.PageSize)
+			pageCount := 0
+			for {
+				var pageHdr ltx.PageHeader
+				if err := dec.DecodePage(&pageHdr, buf); err == io.EOF {
+					break
+				} else if err != nil {
+					_ = f.Close()
+					t.Fatal(err)
+				}
+				pageCount++
+			}
+			if pageCount > 1 {
+				newCoverageCount++
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
+	}
+	if newCoverageCount == 0 {
+		t.Fatal("expected checkpoint to create an L0 file with more than one page")
 	}
 }
 
@@ -2404,10 +2438,18 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	case err := <-writerDone:
 		t.Fatalf("writer exited before starting: %v", err)
 	}
-	if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil {
-		cancelWriter()
-		<-writerDone
-		t.Fatal(err)
+	checkpointDeadline := time.Now().Add(5 * time.Second)
+	for {
+		err := db.Checkpoint(ctx, CheckpointModeTruncate)
+		if err == nil {
+			break
+		}
+		if !isSQLiteBusyError(err) || time.Now().After(checkpointDeadline) {
+			cancelWriter()
+			<-writerDone
+			t.Fatal(err)
+		}
+		time.Sleep(time.Millisecond)
 	}
 	cancelWriter()
 	if err := <-writerDone; err != nil {
@@ -2526,6 +2568,55 @@ func TestDB_CheckpointPageGapWithConcurrentWrites(t *testing.T) {
 	}
 
 	t.Logf("all %d pages present across L0 files (commit=%d)", len(allPages), maxCommit)
+
+	replicaDir := t.TempDir()
+	replicaL0Dir := filepath.Join(replicaDir, "l0")
+	if err := os.Mkdir(replicaL0Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l0Entries, err := os.ReadDir(db.LTXLevelDir(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range l0Entries {
+		srcPath := filepath.Join(db.LTXLevelDir(0), entry.Name())
+		dstPath := filepath.Join(replicaL0Dir, entry.Name())
+
+		src, err := os.Open(srcPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			_ = src.Close()
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			_ = src.Close()
+			_ = dst.Close()
+			t.Fatal(err)
+		}
+		if err := src.Close(); err != nil {
+			_ = dst.Close()
+			t.Fatal(err)
+		}
+		if err := dst.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	restorePath := filepath.Join(dir, "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreReplica := NewReplica(restoreDB)
+	restoreReplica.Client = &testReplicaClient{dir: replicaDir}
+
+	restoreOpt := NewRestoreOptions()
+	restoreOpt.OutputPath = restorePath
+	restoreOpt.IntegrityCheck = IntegrityCheckFull
+
+	if err := restoreReplica.Restore(ctx, restoreOpt); err != nil {
+		t.Fatalf("restore from local ltx chain: %v", err)
+	}
 }
 
 // TestDB_Sync_InitErrorMetrics verifies that sync error counter is incremented

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -958,6 +959,106 @@ func TestDB_Sync_ErrorMetrics(t *testing.T) {
 	syncErrorValue := testutil.ToFloat64(syncErrorNCounterVec.WithLabelValues(db.Path()))
 	if syncErrorValue <= baselineErrors {
 		t.Fatalf("litestream_sync_error_count=%v, want > %v", syncErrorValue, baselineErrors)
+	}
+}
+
+type enospcLTXStagingFile struct {
+	failOp string
+}
+
+func (f *enospcLTXStagingFile) Write(p []byte) (int, error) {
+	if f.failOp == "write" {
+		return 0, syscall.ENOSPC
+	}
+	return len(p), nil
+}
+
+func (f *enospcLTXStagingFile) Sync() error {
+	if f.failOp == "sync" {
+		return syscall.ENOSPC
+	}
+	return nil
+}
+
+func (f *enospcLTXStagingFile) Close() error {
+	return nil
+}
+
+func TestDB_SyncReturnsDiskFullErrorForLTXStaging(t *testing.T) {
+	tests := []struct {
+		name   string
+		failOp string
+	}{
+		{name: "Write", failOp: "write"},
+		{name: "Sync", failOp: "sync"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "db")
+
+			db := NewDB(dbPath)
+			db.MonitorInterval = 0
+			db.ShutdownSyncTimeout = 0
+			db.Replica = NewReplica(db)
+			db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+			db.Replica.MonitorEnabled = false
+			if err := db.Open(); err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = db.Close(context.Background()) }()
+
+			sqldb, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer sqldb.Close()
+
+			if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES ('initial snapshot')`); err != nil {
+				t.Fatal(err)
+			}
+
+			origOpenLTXFile := openLTXFile
+			openLTXFile = func(name string, flag int, perm os.FileMode) (ltxStagingFile, error) {
+				if strings.HasSuffix(name, ".tmp") && strings.Contains(name, string(filepath.Separator)+"ltx"+string(filepath.Separator)+"0"+string(filepath.Separator)) {
+					return &enospcLTXStagingFile{failOp: tt.failOp}, nil
+				}
+				return origOpenLTXFile(name, flag, perm)
+			}
+			defer func() { openLTXFile = origOpenLTXFile }()
+
+			err = db.Sync(context.Background())
+			if err == nil {
+				t.Fatal("expected disk full error")
+			}
+
+			var diskFullErr *LTXStagingDiskFullError
+			if !errors.As(err, &diskFullErr) {
+				t.Fatalf("expected *LTXStagingDiskFullError, got %T: %v", err, err)
+			}
+			if !errors.Is(err, ErrDiskFull) {
+				t.Fatalf("expected ErrDiskFull, got %v", err)
+			}
+			if !errors.Is(err, syscall.ENOSPC) {
+				t.Fatalf("expected ENOSPC in error chain, got %v", err)
+			}
+			if diskFullErr.Path == "" {
+				t.Fatal("expected staging path")
+			}
+			if diskFullErr.Level != 0 || diskFullErr.MinTXID != 1 || diskFullErr.MaxTXID != 1 {
+				t.Fatalf("unexpected LTX identity: level=%d min=%d max=%d", diskFullErr.Level, diskFullErr.MinTXID, diskFullErr.MaxTXID)
+			}
+			if !strings.Contains(err.Error(), "staging") || !strings.Contains(err.Error(), "disk full") {
+				t.Fatalf("error message %q should identify disk-full staging failure", err.Error())
+			}
+		})
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -159,6 +159,139 @@ func TestDB_SyncDiagnostic(t *testing.T) {
 	}
 }
 
+func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	walPath := filepath.Join(dir, "db-wal")
+
+	walFile, err := os.OpenFile(walPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer walFile.Close()
+
+	db := NewDB(dbPath)
+	db.pageSize = 1024
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:  ltx.Version,
+		Flags:    ltx.HeaderFlagNoChecksum,
+		PageSize: 1024,
+		Commit:   1,
+		MinTXID:  1,
+		MaxTXID:  1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = db.writeLTXFromWAL(ctx, enc, walFile, map[uint32]int64{1: 0})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+}
+
+func TestDB_SyncChunksWALAtCommitBoundary(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.MaxSyncWALBytes = int64(WALFrameHeaderSize + 4096)
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data BLOB);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := db.syncOnce(context.Background(), db.MaxSyncWALBytes)
+	if err != nil {
+		t.Fatal(err)
+	} else if !result.synced {
+		t.Fatal("expected sync to create an LTX file")
+	} else if !result.limited {
+		t.Fatal("expected sync to stop at WAL byte limit")
+	} else if result.syncedToWALEnd {
+		t.Fatal("expected first bounded sync to leave pending WAL frames")
+	}
+
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	syncedToWALEnd := db.syncState.syncedToWALEnd
+	db.mu.RUnlock()
+	if !syncedToWALEnd {
+		t.Fatal("expected public Sync to finish remaining WAL chunks")
+	}
+}
+
+func TestWALReaderPageMapLimitStopsAtCommittedFrame(t *testing.T) {
+	b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewWALReader(bytes.NewReader(b), slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pageMap, maxOffset, commit, limited, err := r.pageMap(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !limited {
+		t.Fatal("expected page map to stop at limit")
+	}
+	if got, want := maxOffset, int64(8272); got != want {
+		t.Fatalf("maxOffset=%d, want %d", got, want)
+	}
+	if got, want := commit, uint32(2); got != want {
+		t.Fatalf("commit=%d, want %d", got, want)
+	}
+	if got, want := len(pageMap), 2; got != want {
+		t.Fatalf("len(pageMap)=%d, want %d", got, want)
+	}
+}
+
 // TestCalcWALSize ensures calcWALSize doesn't overflow with large page sizes.
 // Regression test for uint32 overflow bug where large page sizes (>=16KB)
 // caused incorrect WAL size calculations, triggering checkpoints too early.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3383,3 +3383,244 @@ func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
 		t.Fatal("read lock not released after Close with canceled context")
 	}
 }
+
+func TestSyncRestoreIntegrity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.MinCheckpointPageN = 50
+	db.CheckpointInterval = 100 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close(context.Background()) })
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+
+	schema := `
+		CREATE TABLE IF NOT EXISTS data (
+			ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+			_uid TEXT NOT NULL,
+			_resource_version INTEGER NOT NULL,
+			_updated_at DATETIME NOT NULL,
+			name TEXT,
+			data_json BLOB,
+			is_active INTEGER,
+			UNIQUE (_uid, _resource_version)
+		);
+		CREATE INDEX IF NOT EXISTS data_uid_idx ON data (_uid);
+		CREATE INDEX IF NOT EXISTS data_name_idx ON data (name);
+	`
+	if _, err := sqldb.Exec(schema); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		for j := 0; j < 10; j++ {
+			uid := fmt.Sprintf("uid-%d-%d", i, j)
+			_, err := sqldb.ExecContext(ctx,
+				`INSERT INTO data (_uid, _resource_version, _updated_at, name, data_json, is_active)
+				 VALUES (?, 1, datetime('now'), ?, ?, ?)`,
+				uid, fmt.Sprintf("item-%d-%d", i, j),
+				[]byte(fmt.Sprintf(`{"key":"k%d","value":%d}`, j, j)),
+				j%2,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatalf("sync iteration %d: %v", i, err)
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatalf("close sqlite db: %v", err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreDB.Replica = NewReplica(restoreDB)
+	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
+	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatalf("open restored db: %v", err)
+	}
+	defer func() { _ = restoredDB.Close() }()
+
+	rows, err := restoredDB.QueryContext(ctx, `PRAGMA integrity_check`)
+	if err != nil {
+		t.Fatalf("integrity check: %v", err)
+	}
+	defer rows.Close()
+
+	var results []string
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			t.Fatal(err)
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("integrity check returned no results")
+	}
+	if results[0] != "ok" {
+		t.Fatalf("integrity check failed on restored database: %v", results)
+	}
+
+	var count int
+	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM data`).Scan(&count); err != nil {
+		t.Fatalf("count data: %v", err)
+	}
+	expectedRows := iterations * 10
+	if count != expectedRows {
+		t.Fatalf("restored row count=%d, want %d", count, expectedRows)
+	}
+}
+
+func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.MinCheckpointPageN = 20
+	db.TruncatePageN = 200
+	db.CheckpointInterval = 50 * time.Millisecond
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close(context.Background()) })
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT, extra BLOB)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	for i := 0; i < 30; i++ {
+		for j := 0; j < 20; j++ {
+			_, err := sqldb.ExecContext(ctx,
+				`INSERT INTO t (val, extra) VALUES (?, ?)`,
+				fmt.Sprintf("val-%d-%d", i, j),
+				bytes.Repeat([]byte{byte(i)}, 512),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := db.Sync(ctx); err != nil {
+			t.Fatalf("sync %d: %v", i, err)
+		}
+
+		if i%5 == 4 {
+			if _, err := sqldb.ExecContext(ctx, `PRAGMA wal_checkpoint(PASSIVE)`); err != nil {
+				t.Logf("passive checkpoint %d: %v", i, err)
+			}
+		}
+	}
+
+	if err := db.Sync(ctx); err != nil {
+		t.Fatalf("final sync: %v", err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatalf("close sqlite db: %v", err)
+	}
+	if err := db.Close(ctx); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	restorePath := filepath.Join(t.TempDir(), "restored.db")
+	restoreDB := NewDB(restorePath)
+	restoreDB.Replica = NewReplica(restoreDB)
+	restoreDB.Replica.Client = &testReplicaClient{dir: replicaDir}
+	restoreDB.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := restoreDB.Replica.Restore(ctx, RestoreOptions{OutputPath: restorePath}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = restoredDB.Close() }()
+
+	var result string
+	if err := restoredDB.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result != "ok" {
+		t.Fatalf("integrity check failed: %s", result)
+	}
+
+	var count int
+	if err := restoredDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM t`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 30*20 {
+		t.Fatalf("row count=%d, want %d", count, 30*20)
+	}
+}

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -169,6 +169,71 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	}
 }
 
+func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		err := db.lockExec(ctx)
+		if err == nil {
+			db.execMu.Unlock()
+		}
+		done <- err
+	}()
+
+	deadline := time.After(100 * time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if db.SyncDiagnostic().ExecutorWaiterCount == 1 {
+			break
+		}
+
+		select {
+		case err := <-done:
+			t.Fatalf("lockExec returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("lockExec did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+
+	hogReady := make(chan struct{})
+	hogAcquired := make(chan struct{})
+	hogDone := make(chan struct{})
+	go func() {
+		close(hogReady)
+		db.execMu.Lock()
+		close(hogAcquired)
+		time.Sleep(150 * time.Millisecond)
+		db.execMu.Unlock()
+		close(hogDone)
+	}()
+	<-hogReady
+	time.Sleep(5 * time.Millisecond)
+
+	db.execMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lockExec returned error: %v", err)
+		}
+	case <-hogAcquired:
+		<-hogDone
+		err := <-done
+		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+	case <-ctx.Done():
+		err := <-done
+		t.Fatalf("lockExec timed out waiting behind later lock attempt: %v", err)
+	}
+}
+
 func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 	_ "modernc.org/sqlite"
 
 	"github.com/benbjohnson/litestream/internal"
@@ -105,16 +106,16 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
-func mustAcquireGate(g *syncGate) {
-	if err := g.Acquire(context.Background()); err != nil {
+func mustAcquireSemaphore(s *semaphore.Weighted) {
+	if err := s.Acquire(context.Background(), 1); err != nil {
 		panic(err)
 	}
 }
 
 func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
-	defer db.execGate.Release()
+	mustAcquireSemaphore(db.execSem)
+	defer db.execSem.Release(1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -130,8 +131,8 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 
 func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
-	defer db.execGate.Release()
+	mustAcquireSemaphore(db.execSem)
+	defer db.execSem.Release(1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -177,7 +178,7 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 
 func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	mustAcquireGate(&db.execGate)
+	mustAcquireSemaphore(db.execSem)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -186,7 +187,7 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := db.lockExec(ctx)
 		if err == nil {
-			db.execGate.Release()
+			db.execSem.Release(1)
 		}
 		done <- err
 	}()
@@ -214,16 +215,16 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		mustAcquireGate(&db.execGate)
+		mustAcquireSemaphore(db.execSem)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		db.execGate.Release()
+		db.execSem.Release(1)
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	db.execGate.Release()
+	db.execSem.Release(1)
 
 	select {
 	case err := <-done:
@@ -244,7 +245,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
 
-	mustAcquireGate(&r.syncGate)
+	mustAcquireSemaphore(r.syncSem)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
@@ -253,7 +254,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("err=%v, want context deadline exceeded", err)
 		}
@@ -261,7 +262,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 			t.Fatalf("err=%q, want replica sync context", err)
 		}
 	case <-time.After(100 * time.Millisecond):
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		select {
 		case <-done:
 		case <-time.After(time.Second):
@@ -274,7 +275,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
-	mustAcquireGate(&r.syncGate)
+	mustAcquireSemaphore(r.syncSem)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -283,7 +284,7 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := r.lockSync(ctx)
 		if err == nil {
-			r.syncGate.Release()
+			r.syncSem.Release(1)
 		}
 		done <- err
 	}()
@@ -295,16 +296,16 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		mustAcquireGate(&r.syncGate)
+		mustAcquireSemaphore(r.syncSem)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		r.syncGate.Release()
+		r.syncSem.Release(1)
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	r.syncGate.Release()
+	r.syncSem.Release(1)
 
 	select {
 	case err := <-done:

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -984,6 +984,27 @@ func (f *enospcLTXStagingFile) Close() error {
 	return nil
 }
 
+func isLTXStagingPath(name string) bool {
+	return strings.HasSuffix(name, ".tmp") && strings.Contains(name, string(filepath.Separator)+"ltx"+string(filepath.Separator)+"0"+string(filepath.Separator))
+}
+
+type lockedLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 func TestDB_SyncReturnsDiskFullErrorForLTXStaging(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1027,7 +1048,7 @@ func TestDB_SyncReturnsDiskFullErrorForLTXStaging(t *testing.T) {
 
 			origOpenLTXFile := openLTXFile
 			openLTXFile = func(name string, flag int, perm os.FileMode) (ltxStagingFile, error) {
-				if strings.HasSuffix(name, ".tmp") && strings.Contains(name, string(filepath.Separator)+"ltx"+string(filepath.Separator)+"0"+string(filepath.Separator)) {
+				if isLTXStagingPath(name) {
 					return &enospcLTXStagingFile{failOp: tt.failOp}, nil
 				}
 				return origOpenLTXFile(name, flag, perm)
@@ -1058,8 +1079,144 @@ func TestDB_SyncReturnsDiskFullErrorForLTXStaging(t *testing.T) {
 			if !strings.Contains(err.Error(), "staging") || !strings.Contains(err.Error(), "disk full") {
 				t.Fatalf("error message %q should identify disk-full staging failure", err.Error())
 			}
+			if got := testutil.ToFloat64(diskFullGaugeVec.WithLabelValues(db.Path())); got != 1 {
+				t.Fatalf("litestream_disk_full=%v, want 1", got)
+			}
 		})
 	}
+}
+
+func TestDB_MonitorRetriesAndRecoversFromLTXStagingDiskFull(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	replicaDir := t.TempDir()
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: replicaDir}
+	db.Replica.SyncInterval = 5 * time.Millisecond
+
+	var logs lockedLogBuffer
+	db.Logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES ('initial snapshot')`); err != nil {
+		t.Fatal(err)
+	}
+
+	var stagingAttempts atomic.Int64
+	var diskFull atomic.Bool
+	diskFull.Store(true)
+
+	origOpenLTXFile := openLTXFile
+	openLTXFile = func(name string, flag int, perm os.FileMode) (ltxStagingFile, error) {
+		if isLTXStagingPath(name) {
+			stagingAttempts.Add(1)
+			if diskFull.Load() {
+				return &enospcLTXStagingFile{failOp: "write"}, nil
+			}
+		}
+		return origOpenLTXFile(name, flag, perm)
+	}
+
+	done := make(chan struct{})
+	db.MonitorInterval = 5 * time.Millisecond
+	go func() {
+		defer close(done)
+		db.monitor()
+	}()
+
+	defer func() {
+		db.cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("monitor did not stop")
+		}
+		openLTXFile = origOpenLTXFile
+		if err := sqldb.Close(); err != nil {
+			t.Errorf("close sql db: %v", err)
+		}
+		if err := db.Close(context.Background()); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	}()
+
+	waitFor := func(name string, fn func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if fn() {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %s", name)
+	}
+
+	waitFor("disk-full signal", func() bool {
+		s := logs.String()
+		return stagingAttempts.Load() >= 1 &&
+			testutil.ToFloat64(diskFullGaugeVec.WithLabelValues(db.Path())) == 1 &&
+			strings.Contains(s, "disk full while staging LTX file") &&
+			strings.Contains(s, "replication paused, will resume automatically when space is freed")
+	})
+
+	s := logs.String()
+	if strings.Contains(s, `msg="sync error"`) {
+		t.Fatalf("disk-full staging error should not use generic sync error log: %s", s)
+	}
+	if !strings.Contains(s, ".tmp") {
+		t.Fatalf("disk-full log should include staging path: %s", s)
+	}
+
+	diskFull.Store(false)
+
+	remoteLTXCount := func() int {
+		entries, err := os.ReadDir(filepath.Join(replicaDir, "l0"))
+		if os.IsNotExist(err) {
+			return 0
+		} else if err != nil {
+			t.Fatalf("read replica ltx dir: %v", err)
+		}
+		return len(entries)
+	}
+
+	waitFor("automatic recovery", func() bool {
+		pos, err := db.Pos()
+		return stagingAttempts.Load() >= 2 &&
+			err == nil &&
+			pos.TXID >= 1 &&
+			remoteLTXCount() >= 1 &&
+			testutil.ToFloat64(diskFullGaugeVec.WithLabelValues(db.Path())) == 0
+	})
+
+	if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES ('after recovery')`); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor("continued monitor sync after recovery", func() bool {
+		pos, err := db.Pos()
+		return stagingAttempts.Load() >= 3 &&
+			err == nil &&
+			pos.TXID >= 2 &&
+			remoteLTXCount() >= 2
+	})
 }
 
 // TestDB_Checkpoint_ErrorMetrics verifies that checkpoint error counter is incremented on failure.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -186,10 +186,10 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		err := db.lockExec(ctx)
+		done <- err
 		if err == nil {
 			db.execSem.Release(1)
 		}
-		done <- err
 	}()
 
 	deadline := time.After(100 * time.Millisecond)
@@ -232,9 +232,18 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 			t.Fatalf("lockExec returned error: %v", err)
 		}
 	case <-hogAcquired:
-		<-hogDone
-		err := <-done
-		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		// The hog legitimately acquires right after the queued waiter
+		// releases, so only fail if the waiter had not already succeeded.
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("lockExec returned error: %v", err)
+			}
+		default:
+			<-hogDone
+			err := <-done
+			t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		}
 	case <-ctx.Done():
 		err := <-done
 		t.Fatalf("lockExec timed out waiting behind later lock attempt: %v", err)
@@ -283,10 +292,10 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		err := r.lockSync(ctx)
+		done <- err
 		if err == nil {
 			r.syncSem.Release(1)
 		}
-		done <- err
 	}()
 
 	time.Sleep(5 * time.Millisecond)
@@ -313,9 +322,18 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 			t.Fatalf("lockSync returned error: %v", err)
 		}
 	case <-hogAcquired:
-		<-hogDone
-		err := <-done
-		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		// The hog legitimately acquires right after the queued waiter
+		// releases, so only fail if the waiter had not already succeeded.
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("lockSync returned error: %v", err)
+			}
+		default:
+			<-hogDone
+			err := <-done
+			t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+		}
 	case <-ctx.Done():
 		err := <-done
 		t.Fatalf("lockSync timed out waiting behind later lock attempt: %v", err)
@@ -386,8 +404,8 @@ func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
 	if got, want := r.Pos().TXID, dpos.TXID-1; got != want {
 		t.Fatalf("replica txid=%s, want %s", got, want)
 	}
-	if !db.LastSuccessfulSyncAt().IsZero() {
-		t.Fatal("limited replica sync should not record full sync success")
+	if db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("limited replica sync with successful uploads should record sync health")
 	}
 
 	result, err = r.syncOnce(context.Background(), 10)
@@ -3068,5 +3086,61 @@ func TestReplicaMonitor_RecoversFromPositionError(t *testing.T) {
 			t.Fatal("replication did not resume after auto-recovery")
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestDB_CloseWithCanceledContextStillCleansUp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A canceled context may fail the final sync, but cleanup (read lock
+	// release, handle closes, state reset) must always run.
+	_ = db.Close(ctx)
+
+	db.mu.Lock()
+	opened, sqlDB, f, rtx := db.opened, db.db, db.f, db.rtx
+	db.mu.Unlock()
+
+	if opened {
+		t.Fatal("db still marked open after Close with canceled context")
+	}
+	if sqlDB != nil {
+		t.Fatal("sql handle not released after Close with canceled context")
+	}
+	if f != nil {
+		t.Fatal("file handle not released after Close with canceled context")
+	}
+	if rtx != nil {
+		t.Fatal("read lock not released after Close with canceled context")
 	}
 }

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2416,16 +2416,53 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify a snapshot L0 was created during checkpoint.
+	// Verify a snapshot L0 was created during checkpoint. A TRUNCATE
+	// checkpoint reports zero frame counts, so it cannot prove that no
+	// commits landed between the pre-checkpoint sync and the checkpoint;
+	// it must take the boundary snapshot unconditionally. An incremental
+	// (non-snapshot) L0 here would silently drop those commits.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
-	newL0Count := 0
+	newL0Count, newSnapshotCount := 0, 0
 	for _, entry := range l0AfterEntries {
-		if !l0BeforeNames[entry.Name()] {
-			newL0Count++
+		if l0BeforeNames[entry.Name()] {
+			continue
+		}
+		newL0Count++
+
+		f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		dec := ltx.NewDecoder(f)
+		if err := dec.DecodeHeader(); err != nil {
+			f.Close()
+			t.Fatalf("decode header %s: %v", entry.Name(), err)
+		}
+		hdr := dec.Header()
+		pageCount := 0
+		pageData := make([]byte, hdr.PageSize)
+		for {
+			var phdr ltx.PageHeader
+			if err := dec.DecodePage(&phdr, pageData); err == io.EOF {
+				break
+			} else if err != nil {
+				f.Close()
+				t.Fatalf("decode page %s: %v", entry.Name(), err)
+			}
+			pageCount++
+		}
+		f.Close()
+
+		// A boundary snapshot contains every page up to the commit.
+		if uint32(pageCount) == hdr.Commit {
+			newSnapshotCount++
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
+	}
+	if newSnapshotCount == 0 {
+		t.Fatal("expected TRUNCATE checkpoint to create a boundary snapshot L0")
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -514,7 +515,7 @@ func TestDB_WriteLTXFromWALHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err = db.writeLTXFromWAL(ctx, enc, walFile, map[uint32]int64{1: 0})
+	err = db.writeLTXFromWAL(ctx, enc, walFile, 0, 1, map[uint32]int64{1: 0})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v, want context canceled", err)
 	}
@@ -2084,6 +2085,145 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 		last := missing[len(missing)-1]
 		t.Errorf("pages missing from incremental LTX: %d total (first=%d, last=%d, prevCommit=%d, newCommit=%d)",
 			len(missing), first, last, prevCommit, newCommit)
+	}
+}
+
+func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	walPath := filepath.Join(dir, "db-wal")
+
+	const pageSize = 1024
+
+	dbFile, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbFile.Close()
+
+	for pgno := 1; pgno <= 5; pgno++ {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if _, err := dbFile.WriteAt(page, int64(pgno-1)*pageSize); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	walFile, err := os.OpenFile(walPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer walFile.Close()
+
+	frameSize := int64(WALFrameHeaderSize + pageSize)
+	pageMap := map[uint32]int64{
+		3: 0,
+		5: frameSize,
+	}
+	for _, pgno := range []uint32{3, 5} {
+		offset := pageMap[pgno] + WALFrameHeaderSize
+		page := bytes.Repeat([]byte{byte(pgno + 10)}, pageSize)
+		if _, err := walFile.WriteAt(page, offset); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	db := NewDB(dbPath)
+	db.pageSize = pageSize
+	db.f = dbFile
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    5,
+		MinTXID:   2,
+		MaxTXID:   2,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pgnos []uint32
+	got := make(map[uint32][]byte)
+	pageBuf := make([]byte, pageSize)
+	for {
+		var phdr ltx.PageHeader
+		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		pgnos = append(pgnos, phdr.Pgno)
+		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
+	}
+
+	if !reflect.DeepEqual([]uint32{3, 4, 5}, pgnos) {
+		t.Fatalf("page numbers mismatch: got=%v", pgnos)
+	}
+	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
+		t.Fatal("expected page 3 to come from WAL")
+	}
+	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
+		t.Fatal("expected page 4 to come from database")
+	}
+	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
+		t.Fatal("expected page 5 to come from WAL")
+	}
+
+	snapshot := new(bytes.Buffer)
+	snapshotEnc, err := ltx.NewEncoder(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotEnc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, pgno := range []uint32{1, 2} {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := snapshotEnc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := new(bytes.Buffer)
+	c, err := ltx.NewCompactor(compacted, []io.Reader{
+		bytes.NewReader(snapshot.Bytes()),
+		bytes.NewReader(buf.Bytes()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	if err := c.Compact(context.Background()); err != nil {
+		t.Fatalf("compaction failed: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -2087,7 +2087,7 @@ func TestDB_WriteLTXFromWAL_PageGrowthCoverage(t *testing.T) {
 	}
 }
 
-func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
+func TestDB_WriteLTXFromWAL_FillsMissingGrowthPagesFromDB(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 	walPath := filepath.Join(dir, "db-wal")
@@ -2147,12 +2147,88 @@ func TestDB_WriteLTXFromWAL_RejectsMissingGrowthPages(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	err = db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap)
-	if err == nil {
-		t.Fatal("expected missing growth page error")
+	if err := db.writeLTXFromWAL(context.Background(), enc, walFile, 2, 5, pageMap); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "missing WAL growth page 4") {
-		t.Fatalf("unexpected error: %v", err)
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	}
+
+	var pgnos []uint32
+	got := make(map[uint32][]byte)
+	pageBuf := make([]byte, pageSize)
+	for {
+		var phdr ltx.PageHeader
+		if err := dec.DecodePage(&phdr, pageBuf); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		pgnos = append(pgnos, phdr.Pgno)
+		got[phdr.Pgno] = append([]byte(nil), pageBuf...)
+	}
+
+	wantPgnos := []uint32{3, 4, 5}
+	if len(pgnos) != len(wantPgnos) {
+		t.Fatalf("page numbers mismatch: got=%v want=%v", pgnos, wantPgnos)
+	}
+	for i := range wantPgnos {
+		if pgnos[i] != wantPgnos[i] {
+			t.Fatalf("page numbers mismatch: got=%v want=%v", pgnos, wantPgnos)
+		}
+	}
+	if !bytes.Equal(got[3], bytes.Repeat([]byte{13}, pageSize)) {
+		t.Fatal("expected page 3 to come from WAL")
+	}
+	if !bytes.Equal(got[4], bytes.Repeat([]byte{4}, pageSize)) {
+		t.Fatal("expected page 4 to come from database")
+	}
+	if !bytes.Equal(got[5], bytes.Repeat([]byte{15}, pageSize)) {
+		t.Fatal("expected page 5 to come from WAL")
+	}
+
+	snapshot := new(bytes.Buffer)
+	snapshotEnc, err := ltx.NewEncoder(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotEnc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, pgno := range []uint32{1, 2} {
+		page := bytes.Repeat([]byte{byte(pgno)}, pageSize)
+		if err := snapshotEnc.EncodePage(ltx.PageHeader{Pgno: uint32(pgno)}, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := snapshotEnc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := new(bytes.Buffer)
+	c, err := ltx.NewCompactor(compacted, []io.Reader{
+		bytes.NewReader(snapshot.Bytes()),
+		bytes.NewReader(buf.Bytes()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	if err := c.Compact(context.Background()); err != nil {
+		t.Fatalf("compaction failed: %v", err)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -996,7 +996,7 @@ func TestDB_Checkpoint_ErrorMetrics(t *testing.T) {
 
 	db.db.Close()
 
-	if err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
+	if _, err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
 		t.Fatal("expected error from checkpoint with closed db")
 	}
 
@@ -2274,47 +2274,13 @@ func TestDB_CheckpointCreatesSnapshotL0(t *testing.T) {
 	// Verify a snapshot L0 was created during checkpoint.
 	l0AfterEntries, _ := os.ReadDir(l0Dir)
 	newL0Count := 0
-	newCoverageCount := 0
 	for _, entry := range l0AfterEntries {
 		if !l0BeforeNames[entry.Name()] {
 			newL0Count++
-
-			f, err := os.Open(filepath.Join(l0Dir, entry.Name()))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			dec := ltx.NewDecoder(f)
-			if err := dec.DecodeHeader(); err != nil {
-				_ = f.Close()
-				t.Fatal(err)
-			}
-			hdr := dec.Header()
-			buf := make([]byte, hdr.PageSize)
-			pageCount := 0
-			for {
-				var pageHdr ltx.PageHeader
-				if err := dec.DecodePage(&pageHdr, buf); err == io.EOF {
-					break
-				} else if err != nil {
-					_ = f.Close()
-					t.Fatal(err)
-				}
-				pageCount++
-			}
-			if pageCount > 1 {
-				newCoverageCount++
-			}
-			if err := f.Close(); err != nil {
-				t.Fatal(err)
-			}
 		}
 	}
 	if newL0Count == 0 {
 		t.Fatal("expected checkpoint to create at least one new L0 file")
-	}
-	if newCoverageCount == 0 {
-		t.Fatal("expected checkpoint to create an L0 file with more than one page")
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -3622,5 +3623,220 @@ func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
 	}
 	if count != 30*20 {
 		t.Fatalf("row count=%d, want %d", count, 30*20)
+	}
+}
+
+// TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints verifies that a
+// snapshot's content matches its advertised position while checkpoints and
+// writes run concurrently. The position capture and chkMu read lock must be
+// atomic with respect to checkpoints: if a checkpoint can run between them,
+// the snapshot reads post-position pages from the database file while its
+// header still claims the earlier transaction — the #1164 corruption class.
+func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.CheckpointInterval = 0
+	db.MinCheckpointPageN = 1000000
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &testReplicaClient{dir: t.TempDir()}
+	db.Replica.MonitorEnabled = false
+	db.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE kv (id INTEGER PRIMARY KEY, v INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`INSERT INTO kv VALUES (1, 0)`); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// valueAt records which kv value was current at each synced position so
+	// snapshots can be checked against the state their header advertises.
+	var valueMu sync.Mutex
+	valueAt := map[ltx.TXID]int64{}
+	recordPos := func(v int64) error {
+		pos, err := db.Pos()
+		if err != nil {
+			return err
+		}
+		valueMu.Lock()
+		valueAt[pos.TXID] = v
+		valueMu.Unlock()
+		return nil
+	}
+	if err := recordPos(0); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for v := int64(1); ; v++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := sqldb.Exec(`UPDATE kv SET v = ? WHERE id = 1`, v); err != nil {
+				errCh <- err
+				return
+			}
+			if err := db.Sync(ctx); err != nil {
+				errCh <- err
+				return
+			}
+			if err := recordPos(v); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// TRUNCATE resets the WAL so subsequent snapshots must read
+			// cold pages from the database file — the path that exposes
+			// a checkpoint racing the position capture.
+			if err := db.Checkpoint(ctx, CheckpointModeTruncate); err != nil && !isSQLiteBusyError(err) {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 15; i++ {
+		select {
+		case err := <-errCh:
+			t.Fatal(err)
+		default:
+		}
+
+		pos, r, err := db.SnapshotReader(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dec := ltx.NewDecoder(r)
+		if err := dec.DecodeHeader(); err != nil {
+			t.Fatal(err)
+		}
+		hdr := dec.Header()
+		if hdr.MaxTXID != pos.TXID {
+			t.Fatalf("snapshot header txid=%s, want advertised position %s", hdr.MaxTXID, pos.TXID)
+		}
+
+		restorePath := filepath.Join(t.TempDir(), fmt.Sprintf("restore-%d.db", i))
+		rf, err := os.Create(restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pageData := make([]byte, hdr.PageSize)
+		for {
+			var phdr ltx.PageHeader
+			if err := dec.DecodePage(&phdr, pageData); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := rf.WriteAt(pageData, int64(phdr.Pgno-1)*int64(hdr.PageSize)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := dec.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := rf.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
+
+		restoredDB, err := sql.Open("sqlite", restorePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var integrity string
+		if err := restoredDB.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+			t.Fatal(err)
+		}
+		var got int64
+		if err := restoredDB.QueryRow(`SELECT v FROM kv WHERE id = 1`).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		restoredDB.Close()
+		if integrity != "ok" {
+			t.Fatalf("snapshot %d integrity check failed: %s", i, integrity)
+		}
+
+		// Find the kv value recorded at the greatest synced position at or
+		// before the snapshot position. Skip if recording lags behind the
+		// snapshot position; intermediate unmapped TXIDs (checkpoint
+		// bookkeeping) never change kv.
+		valueMu.Lock()
+		var want int64
+		var bestTXID, maxTXID ltx.TXID
+		for txid, val := range valueAt {
+			if txid > maxTXID {
+				maxTXID = txid
+			}
+			if txid <= pos.TXID && txid >= bestTXID {
+				bestTXID, want = txid, val
+			}
+		}
+		valueMu.Unlock()
+		if pos.TXID > maxTXID {
+			continue
+		}
+		if got != want {
+			t.Fatalf("snapshot at txid %s contains v=%d, want %d (recorded at txid %s): content inconsistent with advertised position",
+				pos.TXID, got, want, bestTXID)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
 	}
 }

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -105,6 +105,187 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	err := db.Sync(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v, want context deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), "wait for db sync executor") {
+		t.Fatalf("err=%q, want sync executor context", err)
+	}
+}
+
+func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.execMu.Lock()
+	defer db.execMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- db.Sync(ctx) }()
+
+	deadline := time.After(100 * time.Millisecond)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	var diag SyncDiagnostic
+	for {
+		diag = db.SyncDiagnostic()
+		if diag.ExecutorWaiterCount == 1 {
+			break
+		}
+
+		select {
+		case err := <-done:
+			t.Fatalf("sync returned before reporting executor wait: %v", err)
+		case <-deadline:
+			t.Fatal("sync diagnostic did not report executor wait")
+		case <-ticker.C:
+		}
+	}
+
+	if diag.ExecutorWaitStarted == nil {
+		t.Fatal("expected executor wait start time")
+	}
+	if diag.ExecutorWaitSeconds <= 0 {
+		t.Fatalf("executor_wait_seconds=%f, want positive", diag.ExecutorWaitSeconds)
+	}
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+	if got := db.SyncDiagnostic().ExecutorWaiterCount; got != 0 {
+		t.Fatalf("executor_waiter_count=%d, want 0", got)
+	}
+}
+
+func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+
+	r.syncMu.Lock()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- r.Sync(ctx) }()
+
+	select {
+	case err := <-done:
+		r.syncMu.Unlock()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err=%v, want context deadline exceeded", err)
+		}
+		if !strings.Contains(err.Error(), "wait for replica sync") {
+			t.Fatalf("err=%q, want replica sync context", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		r.syncMu.Unlock()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("replica sync did not return after lock release")
+		}
+		t.Fatal("replica sync did not honor context while waiting for sync lock")
+	}
+}
+
+func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	client := &testReplicaClient{dir: t.TempDir()}
+	r := NewReplicaWithClient(db, client)
+	r.MonitorEnabled = false
+	db.Replica = r
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := sqldb.Exec(`INSERT INTO t DEFAULT VALUES;`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dpos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dpos.TXID < 2 {
+		t.Fatalf("db txid=%s, want at least 2", dpos.TXID)
+	}
+	r.SetPos(ltx.Pos{TXID: dpos.TXID - 2})
+
+	result, err := r.syncOnce(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("expected limited replica sync to upload one file")
+	}
+	if !result.limited {
+		t.Fatal("expected limited replica sync to stop before catching up")
+	}
+	if got, want := r.Pos().TXID, dpos.TXID-1; got != want {
+		t.Fatalf("replica txid=%s, want %s", got, want)
+	}
+	if !db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("limited replica sync should not record full sync success")
+	}
+
+	result, err = r.syncOnce(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.synced {
+		t.Fatal("expected final replica sync to upload remaining files")
+	}
+	if result.limited {
+		t.Fatal("expected final replica sync to catch up")
+	}
+	if got, want := r.Pos().TXID, dpos.TXID; got != want {
+		t.Fatalf("replica txid=%s, want %s", got, want)
+	}
+	if db.LastSuccessfulSyncAt().IsZero() {
+		t.Fatal("full replica sync should record sync success")
+	}
+}
+
 func TestDB_SyncDiagnostic(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -265,6 +265,56 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	}
 }
 
+func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+	r.syncMu.Lock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		err := r.lockSync(ctx)
+		if err == nil {
+			r.syncMu.Unlock()
+		}
+		done <- err
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	hogReady := make(chan struct{})
+	hogAcquired := make(chan struct{})
+	hogDone := make(chan struct{})
+	go func() {
+		close(hogReady)
+		r.syncMu.Lock()
+		close(hogAcquired)
+		time.Sleep(150 * time.Millisecond)
+		r.syncMu.Unlock()
+		close(hogDone)
+	}()
+	<-hogReady
+	time.Sleep(5 * time.Millisecond)
+
+	r.syncMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lockSync returned error: %v", err)
+		}
+	case <-hogAcquired:
+		<-hogDone
+		err := <-done
+		t.Fatalf("later lock acquired before queued waiter; err=%v", err)
+	case <-ctx.Done():
+		err := <-done
+		t.Fatalf("lockSync timed out waiting behind later lock attempt: %v", err)
+	}
+}
+
 func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -105,10 +105,16 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 	return nil
 }
 
+func mustAcquireGate(g *syncGate) {
+	if err := g.Acquire(context.Background()); err != nil {
+		panic(err)
+	}
+}
+
 func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	mustAcquireGate(&db.execGate)
+	defer db.execGate.Release()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -124,8 +130,8 @@ func TestDB_SyncHonorsContextWaitingForExecLock(t *testing.T) {
 
 func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
-	defer db.execMu.Unlock()
+	mustAcquireGate(&db.execGate)
+	defer db.execGate.Release()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -171,7 +177,7 @@ func TestDB_SyncDiagnosticReportsExecutorWait(t *testing.T) {
 
 func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.execMu.Lock()
+	mustAcquireGate(&db.execGate)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -180,7 +186,7 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := db.lockExec(ctx)
 		if err == nil {
-			db.execMu.Unlock()
+			db.execGate.Release()
 		}
 		done <- err
 	}()
@@ -208,16 +214,16 @@ func TestDB_LockExecDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		db.execMu.Lock()
+		mustAcquireGate(&db.execGate)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		db.execMu.Unlock()
+		db.execGate.Release()
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	db.execMu.Unlock()
+	db.execGate.Release()
 
 	select {
 	case err := <-done:
@@ -238,7 +244,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
 
-	r.syncMu.Lock()
+	mustAcquireGate(&r.syncGate)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
@@ -247,7 +253,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 
 	select {
 	case err := <-done:
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("err=%v, want context deadline exceeded", err)
 		}
@@ -255,7 +261,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 			t.Fatalf("err=%q, want replica sync context", err)
 		}
 	case <-time.After(100 * time.Millisecond):
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		select {
 		case <-done:
 		case <-time.After(time.Second):
@@ -268,7 +274,7 @@ func TestReplica_SyncHonorsContextWaitingForSyncLock(t *testing.T) {
 func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 	r := NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
-	r.syncMu.Lock()
+	mustAcquireGate(&r.syncGate)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -277,7 +283,7 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	go func() {
 		err := r.lockSync(ctx)
 		if err == nil {
-			r.syncMu.Unlock()
+			r.syncGate.Release()
 		}
 		done <- err
 	}()
@@ -289,16 +295,16 @@ func TestReplica_LockSyncDoesNotStarveQueuedWaiter(t *testing.T) {
 	hogDone := make(chan struct{})
 	go func() {
 		close(hogReady)
-		r.syncMu.Lock()
+		mustAcquireGate(&r.syncGate)
 		close(hogAcquired)
 		time.Sleep(150 * time.Millisecond)
-		r.syncMu.Unlock()
+		r.syncGate.Release()
 		close(hogDone)
 	}()
 	<-hogReady
 	time.Sleep(5 * time.Millisecond)
 
-	r.syncMu.Unlock()
+	r.syncGate.Release()
 
 	select {
 	case err := <-done:

--- a/db_test.go
+++ b/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/crc64"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,27 @@ import (
 	"github.com/benbjohnson/litestream/internal/testingutil"
 	"github.com/benbjohnson/litestream/mock"
 )
+
+type snapshotCountingClient struct {
+	litestream.ReplicaClient
+	mu sync.Mutex
+	n  int
+}
+
+func (c *snapshotCountingClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if level == litestream.SnapshotLevel {
+		c.mu.Lock()
+		c.n++
+		c.mu.Unlock()
+	}
+	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+}
+
+func (c *snapshotCountingClient) writeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
 
 func TestDB_Path(t *testing.T) {
 	db := testingutil.NewDB(t, "/tmp/db")
@@ -547,6 +569,42 @@ func TestDB_Snapshot(t *testing.T) {
 		t.Fatal(err)
 	} else if got, want := h.Sum64(), chksum0; got != want {
 		t.Fatal("snapshot checksum mismatch")
+	}
+}
+
+func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	client := &snapshotCountingClient{ReplicaClient: db.Replica.Client}
+	db.Replica.Client = client
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+		t.Fatal(err)
+	} else if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+		t.Fatal(err)
+	} else if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	info0, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	info1, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := ltx.FormatFilename(info1.MinTXID, info1.MaxTXID), ltx.FormatFilename(info0.MinTXID, info0.MaxTXID); got != want {
+		t.Fatalf("Filename=%s, want %s", got, want)
+	}
+	if got, want := client.writeCount(), 1; got != want {
+		t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
 	}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -718,7 +718,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 	retentionTime := time.Now().Add(-150 * time.Millisecond)
 	if minSnapshotTXID, err := db.EnforceSnapshotRetention(t.Context(), retentionTime); err != nil {
 		t.Fatal(err)
-	} else if got, want := minSnapshotTXID, ltx.TXID(4); got != want {
+	} else if got, want := minSnapshotTXID, ltx.TXID(3); got != want {
 		t.Fatalf("MinSnapshotTXID=%s, want %s", got, want)
 	}
 
@@ -801,6 +801,62 @@ func TestDB_EnforceSnapshotRetention_RetentionDisabled(t *testing.T) {
 	afterCount := countFiles()
 	if afterCount != beforeCount {
 		t.Fatalf("expected %d remote snapshots (no remote deletion), got %d", beforeCount, afterCount)
+	}
+}
+
+func TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db := testingutil.NewDB(t, filepath.Join(dir, "db"))
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	client := file.NewReplicaClient(filepath.Join(dir, "replica"))
+	db.Replica = litestream.NewReplicaWithClient(db, client)
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer testingutil.MustCloseDB(t, db)
+
+	oldTime := time.Now().Add(-2 * time.Hour)
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 5, oldTime)
+	createTestLTXFileWithTimestamp(t, client, 1, 6, 10, oldTime.Add(time.Minute))
+
+	plan, err := litestream.CalcRestorePlan(ctx, client, 10, time.Time{}, db.Logger)
+	if err != nil {
+		t.Fatalf("calc restore plan: %v", err)
+	}
+
+	var plannedInfo *ltx.FileInfo
+	for _, info := range plan {
+		if info.Level == 1 && info.MinTXID == 6 && info.MaxTXID == 10 {
+			plannedInfo = info
+			break
+		}
+	}
+	if plannedInfo == nil {
+		t.Fatalf("restore plan does not include L1 6-10: %#v", plan)
+	}
+
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 11, time.Now())
+	createTestLTXFileWithTimestamp(t, client, 1, 11, 11, time.Now())
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{
+		{Level: 0},
+		{Level: 1, Interval: time.Hour},
+	})
+	store.SnapshotRetention = time.Hour
+
+	if err := store.EnforceSnapshotRetention(ctx, db); err != nil {
+		t.Fatalf("enforce snapshot retention: %v", err)
+	}
+
+	rc, err := client.OpenLTXFile(ctx, plannedInfo.Level, plannedInfo.MinTXID, plannedInfo.MaxTXID, 0, 0)
+	if err != nil {
+		t.Fatalf("planned LTX file was deleted by retention: level=%d min=%s max=%s: %v", plannedInfo.Level, plannedInfo.MinTXID, plannedInfo.MaxTXID, err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close planned LTX file: %v", err)
 	}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -633,7 +633,7 @@ func TestDB_SnapshotExcludesUnsyncedWALFrames(t *testing.T) {
 	}
 }
 
-func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
+func TestDB_SnapshotAlwaysWrites(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)
 
@@ -652,6 +652,9 @@ func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Snapshot is a primitive that always writes, even at the same
+	// position, so -force-snapshot can re-upload a suspect snapshot.
+	// Duplicate skipping belongs to callers like Store.CompactDB.
 	info0, err := db.Snapshot(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -664,7 +667,7 @@ func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 	if got, want := ltx.FormatFilename(info1.MinTXID, info1.MaxTXID), ltx.FormatFilename(info0.MinTXID, info0.MaxTXID); got != want {
 		t.Fatalf("Filename=%s, want %s", got, want)
 	}
-	if got, want := client.writeCount(), 1; got != want {
+	if got, want := client.writeCount(), 2; got != want {
 		t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
 	}
 }

--- a/db_test.go
+++ b/db_test.go
@@ -572,6 +572,67 @@ func TestDB_Snapshot(t *testing.T) {
 	}
 }
 
+func TestDB_SnapshotExcludesUnsyncedWALFrames(t *testing.T) {
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (1);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (2);`); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := db.Snapshot(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.MaxTXID != pos.TXID {
+		t.Fatalf("snapshot txid=%s, want %s", info.MaxTXID, pos.TXID)
+	}
+
+	rc, err := db.Replica.Client.OpenLTXFile(t.Context(), litestream.SnapshotLevel, 1, pos.TXID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	restorePath := filepath.Join(t.TempDir(), "snapshot.db")
+	f, err := os.Create(restorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ltx.NewDecoder(rc).DecodeDatabaseTo(f); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := testingutil.MustOpenSQLDB(t, restorePath)
+	defer testingutil.MustCloseSQLDB(t, restored)
+
+	var count int
+	if err := restored.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM t;`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("restored row count=%d, want 1", count)
+	}
+}
+
 func TestDB_SnapshotSkipsExistingTXID(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -63,9 +64,21 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 
 const resumableReaderMaxRetries = 3
 
+// resumableReaderBackoff is the base delay between retry attempts, doubling
+// per attempt. Zero-delay retries land every attempt inside the same provider
+// throttle window (e.g. Tigris 408 load shedding), guaranteeing exhaustion.
+const resumableReaderBackoff = 250 * time.Millisecond
+
 func (r *ResumableReader) Read(p []byte) (int, error) {
 	var lastErr error
 	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-r.ctx.Done():
+				return 0, r.ctx.Err()
+			case <-time.After(resumableReaderBackoff << (attempt - 1)):
+			}
+		}
 		// Reopen the stream from the current offset if the previous
 		// connection was closed (rc is nil after a retry).
 		if r.rc == nil {

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -309,4 +310,58 @@ func (r *errorAfterN) Read(p []byte) (int, error) {
 	n := copy(p, r.data[r.pos:r.pos+len(p)])
 	r.pos += n
 	return n, nil
+}
+
+func TestResumableReader_BackoffBetweenReopens(t *testing.T) {
+	// Burst-retrying a throttling provider (e.g. Tigris load-shedding with
+	// 408 RequestCanceled) lands every reopen attempt inside the same
+	// throttle window. Reopens must back off between attempts.
+	data := []byte("hello world")
+	var callTimes []time.Time
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			callTimes = append(callTimes, time.Now())
+			if len(callTimes) <= 2 {
+				return nil, fmt.Errorf("operation error S3: GetObject, api error RequestCanceled: Request is canceled.")
+			}
+			return io.NopCloser(bytes.NewReader(data[offset:])), nil
+		},
+	}
+
+	r := NewResumableReader(context.Background(), client, 2, 1, 2, int64(len(data)), nil, slog.Default())
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q, want %q", got, data)
+	}
+	if len(callTimes) != 3 {
+		t.Fatalf("expected 3 OpenLTXFile calls, got %d", len(callTimes))
+	}
+	for i := 1; i < len(callTimes); i++ {
+		if gap := callTimes[i].Sub(callTimes[i-1]); gap < 100*time.Millisecond {
+			t.Fatalf("reopen attempt %d fired %v after attempt %d; want >= 100ms backoff", i+1, gap, i)
+		}
+	}
+}
+
+func TestResumableReader_ContextCancelAbortsBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			cancel()
+			return nil, fmt.Errorf("connection reset")
+		},
+	}
+
+	r := NewResumableReader(ctx, client, 2, 1, 2, 11, nil, slog.Default())
+	start := time.Now()
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("read blocked %v after cancellation; backoff must abort on ctx.Done", elapsed)
+	}
 }

--- a/litestream.go
+++ b/litestream.go
@@ -34,6 +34,7 @@ var (
 	ErrChecksumMismatch = errors.New("invalid replica, checksum mismatch")
 	ErrLTXCorrupted     = errors.New("ltx file corrupted")
 	ErrLTXMissing       = errors.New("ltx file missing")
+	ErrDiskFull         = errors.New("disk full")
 )
 
 // LTXError provides detailed context for LTX file errors with recovery hints.
@@ -55,6 +56,31 @@ func (e *LTXError) Error() string {
 }
 
 func (e *LTXError) Unwrap() error { return e.Err }
+
+type LTXStagingDiskFullError struct {
+	Op      string
+	Path    string
+	Level   int
+	MinTXID uint64
+	MaxTXID uint64
+	Err     error
+}
+
+func (e *LTXStagingDiskFullError) Error() string {
+	msg := e.Op + " ltx staging file"
+	if e.Path != "" {
+		msg += " " + e.Path
+	}
+	msg += ": disk full"
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *LTXStagingDiskFullError) Unwrap() error { return e.Err }
+
+func (e *LTXStagingDiskFullError) Is(target error) bool { return target == ErrDiskFull }
 
 // IsAutoRecoverable reports whether the underlying error indicates local state
 // corruption that can be fixed by resetting and re-downloading from remote.

--- a/replica.go
+++ b/replica.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/superfly/ltx"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/benbjohnson/litestream/internal"
 )
@@ -36,7 +37,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncGate syncGate
+	syncSem *semaphore.Weighted
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -67,8 +68,9 @@ type Replica struct {
 
 func NewReplica(db *DB) *Replica {
 	r := &Replica{
-		db:     db,
-		cancel: func() {},
+		db:      db,
+		syncSem: semaphore.NewWeighted(1),
+		cancel:  func() {},
 
 		SyncInterval:    DefaultSyncInterval,
 		MaxSyncLTXFiles: DefaultMaxSyncLTXFiles,
@@ -151,7 +153,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	if err := r.lockSync(ctx); err != nil {
 		return result, err
 	}
-	defer r.syncGate.Release()
+	defer r.syncSem.Release(1)
 
 	// Clear last position if if an error occurs during sync.
 	defer func() {
@@ -213,11 +215,11 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 }
 
 func (r *Replica) lockSync(ctx context.Context) error {
-	if r.syncGate.TryAcquire() {
+	if r.syncSem.TryAcquire(1) {
 		return nil
 	}
-	if err := r.syncGate.Acquire(ctx); err != nil {
-		return fmt.Errorf("wait for replica sync: %w", err)
+	if err := r.syncSem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("wait for replica sync: %w", contextCause(ctx, err))
 	}
 	return nil
 }

--- a/replica.go
+++ b/replica.go
@@ -36,7 +36,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncMu contextMutex // protects Sync() from concurrent calls
+	syncGate syncGate
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -151,7 +151,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	if err := r.lockSync(ctx); err != nil {
 		return result, err
 	}
-	defer r.syncMu.Unlock()
+	defer r.syncGate.Release()
 
 	// Clear last position if if an error occurs during sync.
 	defer func() {
@@ -213,10 +213,10 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 }
 
 func (r *Replica) lockSync(ctx context.Context) error {
-	if r.syncMu.TryLock() {
+	if r.syncGate.TryAcquire() {
 		return nil
 	}
-	if err := r.syncMu.LockContext(ctx); err != nil {
+	if err := r.syncGate.Acquire(ctx); err != nil {
 		return fmt.Errorf("wait for replica sync: %w", err)
 	}
 	return nil

--- a/replica.go
+++ b/replica.go
@@ -966,6 +966,9 @@ func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileIn
 	}
 
 	if hdr.Commit > 0 {
+		if err := f.Sync(); err != nil {
+			return fmt.Errorf("sync before truncate: %w", err)
+		}
 		newSize := int64(hdr.Commit) * int64(pageSize)
 		if err := f.Truncate(newSize); err != nil {
 			return fmt.Errorf("truncate: %w", err)

--- a/replica.go
+++ b/replica.go
@@ -195,6 +195,13 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 	for txID, syncedFileN := r.Pos().TXID+1, 0; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
 		if maxSyncLTXFiles > 0 && syncedFileN >= maxSyncLTXFiles {
 			result.limited = true
+			// Uploads succeeded, so record sync health; otherwise a
+			// sustained backlog reads as unhealthy while progressing.
+			r.db.RecordSuccessfulSync()
+			r.Logger().Debug("replica sync limited",
+				"synced_files", syncedFileN,
+				"db_txid", dpos.TXID.String(),
+				"replica_txid", r.Pos().TXID.String())
 			return result, nil
 		}
 		if err := ctx.Err(); err != nil {

--- a/replica.go
+++ b/replica.go
@@ -21,7 +21,8 @@ import (
 
 // Default replica settings.
 const (
-	DefaultSyncInterval = 1 * time.Second
+	DefaultSyncInterval    = 1 * time.Second
+	DefaultMaxSyncLTXFiles = 256
 )
 
 var errReplicaWaitForData = errors.New("no position, waiting for data")
@@ -49,6 +50,10 @@ type Replica struct {
 	// Time between syncs with the shadow WAL.
 	SyncInterval time.Duration
 
+	// Maximum L0 files to upload in a single monitor sync run.
+	// Set to zero to process all pending L0 files in one run.
+	MaxSyncLTXFiles int
+
 	// If true, replica monitors database for changes automatically.
 	// Set to false if replica is being used synchronously (such as in tests).
 	MonitorEnabled bool
@@ -65,8 +70,9 @@ func NewReplica(db *DB) *Replica {
 		db:     db,
 		cancel: func() {},
 
-		SyncInterval:   DefaultSyncInterval,
-		MonitorEnabled: true,
+		SyncInterval:    DefaultSyncInterval,
+		MaxSyncLTXFiles: DefaultMaxSyncLTXFiles,
+		MonitorEnabled:  true,
 	}
 
 	return r
@@ -132,7 +138,19 @@ func (r *Replica) Stop(hard bool) (err error) {
 // Sync copies new WAL frames from the shadow WAL to the replica client.
 // Only one Sync can run at a time to prevent concurrent uploads of the same file.
 func (r *Replica) Sync(ctx context.Context) (err error) {
-	r.syncMu.Lock()
+	_, err = r.syncOnce(ctx, 0)
+	return err
+}
+
+type replicaSyncResult struct {
+	synced  bool
+	limited bool
+}
+
+func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result replicaSyncResult, err error) {
+	if err := r.lockSync(ctx); err != nil {
+		return result, err
+	}
 	defer r.syncMu.Unlock()
 
 	// Clear last position if if an error occurs during sync.
@@ -144,11 +162,15 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		}
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return result, context.Cause(ctx)
+	}
+
 	// Calculate current replica position, if unknown.
 	if r.Pos().IsZero() {
 		pos, err := r.calcPos(ctx)
 		if err != nil {
-			return fmt.Errorf("calc pos: %w", err)
+			return result, fmt.Errorf("calc pos: %w", err)
 		}
 		r.SetPos(pos)
 	}
@@ -156,9 +178,9 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 	// Find current position of database.
 	dpos, err := r.db.Pos()
 	if err != nil {
-		return fmt.Errorf("cannot determine current position: %w", err)
+		return result, fmt.Errorf("cannot determine current position: %w", err)
 	} else if dpos.IsZero() {
-		return errReplicaWaitForData
+		return result, errReplicaWaitForData
 	}
 
 	r.Logger().Info("replica sync",
@@ -168,17 +190,50 @@ func (r *Replica) Sync(ctx context.Context) (err error) {
 		))
 
 	// Replicate all L0 LTX files since last replica position.
-	for txID := r.Pos().TXID + 1; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+	for txID, syncedFileN := r.Pos().TXID+1, 0; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+		if maxSyncLTXFiles > 0 && syncedFileN >= maxSyncLTXFiles {
+			result.limited = true
+			return result, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return result, context.Cause(ctx)
+		}
 		if err := r.uploadLTXFile(ctx, 0, txID, txID); err != nil {
-			return err
+			return result, err
 		}
 		r.SetPos(ltx.Pos{TXID: txID})
+		result.synced = true
+		syncedFileN++
 	}
 
 	// Record successful sync for heartbeat monitoring.
 	r.db.RecordSuccessfulSync()
 
-	return nil
+	return result, nil
+}
+
+func (r *Replica) lockSync(ctx context.Context) error {
+	if r.syncMu.TryLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			err := context.Cause(ctx)
+			if err == nil {
+				err = ctx.Err()
+			}
+			return fmt.Errorf("wait for replica sync: %w", err)
+		case <-ticker.C:
+			if r.syncMu.TryLock() {
+				return nil
+			}
+		}
+	}
 }
 
 func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {
@@ -373,7 +428,7 @@ func (r *Replica) monitor(ctx context.Context) {
 		notify = r.db.Notify()
 
 		// Synchronize the shadow wal into the replication directory.
-		if err := r.Sync(ctx); err != nil {
+		if _, err := r.syncOnce(ctx, r.MaxSyncLTXFiles); err != nil {
 			if errors.Is(err, errReplicaWaitForData) {
 				continue
 			}

--- a/replica.go
+++ b/replica.go
@@ -36,7 +36,7 @@ type Replica struct {
 	mu  sync.RWMutex
 	pos ltx.Pos // current replicated position
 
-	syncMu sync.Mutex // protects Sync() from concurrent calls
+	syncMu contextMutex // protects Sync() from concurrent calls
 
 	muf sync.Mutex
 	f   *os.File // long-running file descriptor to avoid non-OFD lock issues
@@ -216,24 +216,10 @@ func (r *Replica) lockSync(ctx context.Context) error {
 	if r.syncMu.TryLock() {
 		return nil
 	}
-
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			err := context.Cause(ctx)
-			if err == nil {
-				err = ctx.Err()
-			}
-			return fmt.Errorf("wait for replica sync: %w", err)
-		case <-ticker.C:
-			if r.syncMu.TryLock() {
-				return nil
-			}
-		}
+	if err := r.syncMu.LockContext(ctx); err != nil {
+		return fmt.Errorf("wait for replica sync: %w", err)
 	}
+	return nil
 }
 
 func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -410,5 +411,147 @@ func TestCheckIntegrity_CorruptDB(t *testing.T) {
 	err = checkIntegrity(context.Background(), dbPath, IntegrityCheckFull)
 	if err == nil {
 		t.Fatal("expected integrity check to fail on corrupt database")
+	}
+}
+
+func TestApplyLTXFile_TruncatesAfterWrite(t *testing.T) {
+	const pageSize = 4096
+
+	info := &ltx.FileInfo{Level: 0, MinTXID: 10, MaxTXID: 10}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    2,
+		MinTXID:   info.MinTXID,
+		MaxTXID:   info.MaxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	page1 := make([]byte, pageSize)
+	copy(page1, []byte("SQLite format 3\000"))
+	page1[18], page1[19] = 0x01, 0x01
+	binary.BigEndian.PutUint16(page1[16:18], pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1); err != nil {
+		t.Fatal(err)
+	}
+	page2 := bytes.Repeat([]byte{0xAB}, pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, page2); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ltxData := buf.Bytes()
+	client := &followTestReplicaClient{}
+	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(ltxData)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	if err := r.applyLTXFile(context.Background(), f, info, pageSize); err != nil {
+		t.Fatalf("applyLTXFile: %v", err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSize := int64(2) * int64(pageSize)
+	if fi.Size() != expectedSize {
+		t.Fatalf("file size=%d, want %d", fi.Size(), expectedSize)
+	}
+
+	readBuf := make([]byte, pageSize)
+	if _, err := f.ReadAt(readBuf, int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(readBuf, page2) {
+		t.Fatal("page 2 data mismatch after applyLTXFile")
+	}
+}
+
+func TestApplyLTXFile_MultiplePages(t *testing.T) {
+	const pageSize = 4096
+	const numPages = 5
+
+	info := &ltx.FileInfo{Level: 0, MinTXID: 1, MaxTXID: 1}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  pageSize,
+		Commit:    numPages,
+		MinTXID:   info.MinTXID,
+		MaxTXID:   info.MaxTXID,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := make([][]byte, numPages)
+	for i := uint32(0); i < numPages; i++ {
+		pages[i] = bytes.Repeat([]byte{byte(0x10 + i)}, pageSize)
+		if i == 0 {
+			copy(pages[i], []byte("SQLite format 3\000"))
+			pages[i][18], pages[i][19] = 0x01, 0x01
+		}
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: i + 1}, pages[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ltxData := buf.Bytes()
+	client := &followTestReplicaClient{}
+	client.OpenLTXFileFunc = func(context.Context, int, ltx.TXID, ltx.TXID, int64, int64) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(ltxData)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	if err := r.applyLTXFile(context.Background(), f, info, pageSize); err != nil {
+		t.Fatalf("applyLTXFile: %v", err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSize := int64(numPages) * int64(pageSize)
+	if fi.Size() != expectedSize {
+		t.Fatalf("file size=%d, want %d", fi.Size(), expectedSize)
+	}
+
+	readBuf := make([]byte, pageSize)
+	for i := uint32(0); i < numPages; i++ {
+		if _, err := f.ReadAt(readBuf, int64(i)*int64(pageSize)); err != nil {
+			t.Fatalf("read page %d: %v", i+1, err)
+		}
+		if i > 0 && !bytes.Equal(readBuf, pages[i]) {
+			t.Fatalf("page %d data mismatch", i+1)
+		}
 	}
 }

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -567,6 +567,19 @@ func newTransportRetryer() aws.Retryer {
 	return retry.NewStandard(func(o *retry.StandardOptions) {
 		o.MaxAttempts = transportRetryMaxAttempts
 		o.RateLimiter = ratelimit.None
+		// S3-compatible providers (observed: Tigris) load-shed with HTTP 408
+		// and api error code "RequestCanceled", neither of which the SDK
+		// classifies as retryable by default. Genuine client-side context
+		// cancellation stays non-retryable via the standard retryer's
+		// canceled-context check, which runs before these.
+		o.Retryables = append(o.Retryables,
+			retry.RetryableHTTPStatusCode{Codes: map[int]struct{}{
+				http.StatusRequestTimeout: {},
+			}},
+			retry.RetryableErrorCode{Codes: map[string]struct{}{
+				"RequestCanceled": {},
+			}},
+		)
 	})
 }
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -382,10 +384,7 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// Build configuration options
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithRegion(region),
-		// Use adaptive retry mode for better resilience with 24 hour timeout
-		// This matches Azure's approach for long-running operations
-		config.WithRetryMode(aws.RetryModeAdaptive),
-		config.WithRetryMaxAttempts(10), // Increase retry attempts for resilience
+		config.WithRetryer(newTransportRetryer),
 	}
 
 	// Add HTTP client with proper timeout
@@ -554,10 +553,29 @@ func (c *ReplicaClient) validateSSEConfig() error {
 	return nil
 }
 
+// transportRetryMaxAttempts caps total attempts per operation; exponential
+// backoff between attempts still bounds request rate during outages.
+const transportRetryMaxAttempts = 10
+
+// newTransportRetryer returns a retryer that keeps retrying through sustained
+// object-store transport flaps. The SDK's default token bucket (and the
+// adaptive mode previously configured here) only refills retry quota on
+// successful responses, so a sustained provider flap drains it to zero and
+// every subsequent operation fails fast ("retry quota exceeded, 0 available")
+// precisely when retrying matters most for a replication tool.
+func newTransportRetryer() aws.Retryer {
+	return retry.NewStandard(func(o *retry.StandardOptions) {
+		o.MaxAttempts = transportRetryMaxAttempts
+		o.RateLimiter = ratelimit.None
+	})
+}
+
 // findBucketRegion looks up the AWS region for a bucket. Returns blank if non-S3.
 func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (string, error) {
 	// Build a config with credentials but no region
-	configOpts := []func(*config.LoadOptions) error{}
+	configOpts := []func(*config.LoadOptions) error{
+		config.WithRetryer(newTransportRetryer),
+	}
 
 	// Add static credentials if provided
 	if c.AccessKeyID != "" && c.SecretAccessKey != "" {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2084,3 +2084,57 @@ func TestNewReplicaClientFromURL_EndpointEnvVar(t *testing.T) {
 		})
 	}
 }
+
+// TestTransportRetryer_SurvivesSustainedFailures reproduces the soak finding where
+// sustained S3 transport flaps (e.g. Tigris returning unexpected EOF) exhausted the
+// SDK retryer's client-side token bucket ("retry quota exceeded, 0 available,
+// 5 requested") and Litestream stopped retrying exactly when retries mattered.
+// The bucket only refills on success, so 100+ consecutive failures starve it.
+func TestTransportRetryer_SurvivesSustainedFailures(t *testing.T) {
+	retryer := newTransportRetryer()
+
+	if got := retryer.MaxAttempts(); got != transportRetryMaxAttempts {
+		t.Fatalf("MaxAttempts() = %d, want %d", got, transportRetryMaxAttempts)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 200; i++ {
+		release, err := retryer.GetRetryToken(ctx, io.ErrUnexpectedEOF)
+		if err != nil {
+			t.Fatalf("retry token denied after %d consecutive transport failures: %v", i, err)
+		}
+		if err := release(io.ErrUnexpectedEOF); err != nil {
+			t.Fatalf("release after failure %d: %v", i, err)
+		}
+	}
+}
+
+// TestReplicaClient_RetryerSurvivesSustainedFailures verifies the configured S3
+// client actually carries the starvation-proof retryer (guards the config wiring,
+// not just the constructor).
+func TestReplicaClient_RetryerSurvivesSustainedFailures(t *testing.T) {
+	client := NewReplicaClient()
+	client.Bucket = "test-bucket"
+	client.Path = "replica"
+	client.Region = "us-east-1"
+	client.Endpoint = "http://localhost:1"
+	client.ForcePathStyle = true
+	client.AccessKeyID = "test-access-key"
+	client.SecretAccessKey = "test-secret-key"
+
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	retryer := client.s3.Options().Retryer
+	for i := 0; i < 200; i++ {
+		release, err := retryer.GetRetryToken(ctx, io.ErrUnexpectedEOF)
+		if err != nil {
+			t.Fatalf("configured client denied retry token after %d consecutive failures: %v", i, err)
+		}
+		if err := release(io.ErrUnexpectedEOF); err != nil {
+			t.Fatalf("release after failure %d: %v", i, err)
+		}
+	}
+}

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2138,3 +2138,25 @@ func TestReplicaClient_RetryerSurvivesSustainedFailures(t *testing.T) {
 		}
 	}
 }
+
+// TestTransportRetryer_RetriesProviderThrottleResponses covers S3-compatible
+// providers that load-shed with HTTP 408 / api error "RequestCanceled"
+// (observed from Tigris during soak testing). The SDK defaults treat neither
+// as retryable, so restores failed after effectively zero patience.
+func TestTransportRetryer_RetriesProviderThrottleResponses(t *testing.T) {
+	retryer := newTransportRetryer()
+
+	status408 := &smithyhttp.ResponseError{Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusRequestTimeout}}, Err: fmt.Errorf("request timeout")}
+	if !retryer.IsErrorRetryable(status408) {
+		t.Fatal("HTTP 408 must be retryable for S3-compatible providers")
+	}
+
+	canceledCode := &smithy.GenericAPIError{Code: "RequestCanceled", Message: "Request is canceled."}
+	if !retryer.IsErrorRetryable(canceledCode) {
+		t.Fatal(`api error code "RequestCanceled" (server-side load shed) must be retryable`)
+	}
+
+	if retryer.IsErrorRetryable(fmt.Errorf("wrapped: %w", context.Canceled)) {
+		t.Fatal("genuine client-side context cancellation must NOT be retryable")
+	}
+}

--- a/store.go
+++ b/store.go
@@ -761,6 +761,14 @@ func (s *Store) CompactDB(ctx context.Context, db *DB, lvl *CompactionLevel) (*l
 
 	// Shortcut if this is a snapshot since we are not pulling from a previous level.
 	if dstLevel == SnapshotLevel {
+		pos, err := db.Pos()
+		if err != nil {
+			return nil, fmt.Errorf("fetch db position: %w", err)
+		}
+		if dstInfo.MaxTXID != 0 && dstInfo.MaxTXID >= pos.TXID {
+			return nil, ErrNoCompaction
+		}
+
 		info, err := db.Snapshot(ctx)
 		if err != nil {
 			return info, err

--- a/store_test.go
+++ b/store_test.go
@@ -102,6 +102,43 @@ func TestStore_CompactDB(t *testing.T) {
 		}
 	})
 
+	t.Run("SnapshotNoProgress", func(t *testing.T) {
+		db0, sqldb0 := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db0, sqldb0)
+
+		client := &snapshotCountingClient{ReplicaClient: db0.Replica.Client}
+		db0.Replica.Client = client
+
+		s := litestream.NewStore([]*litestream.DB{db0}, litestream.CompactionLevels{{Level: 0}})
+		s.SnapshotInterval = time.Nanosecond
+		s.CompactionMonitorEnabled = false
+		if err := s.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close(t.Context())
+
+		if _, err := sqldb0.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrNoCompaction) {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got, want := client.writeCount(), 1; got != want {
+			t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
+		}
+	})
+
 	// Regression test for GitHub issue #877: level 9 compaction fails with
 	// "page size not initialized yet" error when attempted before DB initialization.
 	t.Run("DBNotReady", func(t *testing.T) {

--- a/tests/integration/soak_replicate_restore_test.go
+++ b/tests/integration/soak_replicate_restore_test.go
@@ -1,0 +1,373 @@
+//go:build integration && soak && docker
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestSoakReplicateRestore reproduces issue #1164: intermittent database corruption
+// ("wrong # of entries in index") after restoring from S3-compatible replicas.
+//
+// This test mirrors fuchstim's exact setup:
+// - SQLite DB in WAL mode with tables + indexes
+// - Litestream replication to MinIO (S3)
+// - ~100 rows/sec concurrent writes
+// - Periodic stop→restore→integrity_check cycles
+//
+// Default duration: 5 minutes (override with SOAK_DURATION env var)
+// Can be shortened with: go test -test.short (runs for 1 minute)
+//
+// Requirements:
+// - Docker must be running
+// - Binaries must be built: go build -o bin/litestream ./cmd/litestream
+func TestSoakReplicateRestore(t *testing.T) {
+	RequireBinaries(t)
+	RequireDocker(t)
+
+	duration := parseSoakDuration(t, 5*time.Minute)
+	if testing.Short() {
+		duration = 1 * time.Minute
+	}
+	restoreInterval := 30 * time.Second
+	writeRate := 100
+
+	t.Logf("================================================")
+	t.Logf("Issue #1164 Reproduction: Replicate+Restore Soak")
+	t.Logf("================================================")
+	t.Logf("Duration:          %v", duration)
+	t.Logf("Restore interval:  %v", restoreInterval)
+	t.Logf("Write rate:        %d rows/sec", writeRate)
+	t.Logf("Start time:        %s", time.Now().Format(time.RFC3339))
+	t.Log("")
+
+	containerID, endpoint, dataVolume := StartMinIOContainer(t)
+	defer StopMinIOContainer(t, containerID, dataVolume)
+
+	bucket := "litestream-test"
+	CreateMinIOBucket(t, containerID, bucket)
+
+	db := SetupTestDB(t, "replicate-restore")
+	defer db.Cleanup()
+
+	if err := db.Create(); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	sqlDB, err := sql.Open("sqlite3", db.Path)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer sqlDB.Close()
+
+	if _, err := sqlDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("set WAL mode: %v", err)
+	}
+
+	// Create schema matching fuchstim's setup: table with indexes
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE IF NOT EXISTS resources (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			_uid TEXT NOT NULL,
+			_resource_version INTEGER NOT NULL DEFAULT 0,
+			name TEXT NOT NULL,
+			data TEXT,
+			created_at INTEGER NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_uid ON resources(_uid);
+		CREATE INDEX IF NOT EXISTS idx_resources_rv ON resources(_resource_version);
+		CREATE INDEX IF NOT EXISTS idx_resources_name ON resources(name);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	s3Path := fmt.Sprintf("replicate-restore-%d", time.Now().Unix())
+	s3URL := fmt.Sprintf("s3://%s/%s", bucket, s3Path)
+	db.ReplicaURL = s3URL
+
+	configPath := writeReplicateRestoreConfig(t, db.Path, s3URL, endpoint)
+	db.ConfigPath = configPath
+
+	if err := db.StartLitestreamWithConfig(configPath); err != nil {
+		t.Fatalf("start litestream: %v", err)
+	}
+	t.Logf("Litestream running (PID: %d)", db.LitestreamPID)
+
+	// Wait for initial sync
+	time.Sleep(3 * time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	// Performance tracking
+	var (
+		latencies   latencyTracker
+		totalWrites atomic.Int64
+		writeErrs   atomic.Int64
+	)
+
+	// Writer goroutine: ~writeRate rows/sec
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(time.Second / time.Duration(writeRate))
+		defer ticker.Stop()
+
+		rv := int64(0)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				rv++
+				start := time.Now()
+				_, err := sqlDB.ExecContext(ctx, `
+					INSERT INTO resources (_uid, _resource_version, name, data, created_at)
+					VALUES (?, ?, ?, ?, ?)`,
+					fmt.Sprintf("uid-%d-%d", time.Now().UnixNano(), rv),
+					rv,
+					fmt.Sprintf("resource-%d", rv%1000),
+					fmt.Sprintf("payload data for resource version %d with some padding to simulate real workload size", rv),
+					time.Now().Unix(),
+				)
+				elapsed := time.Since(start)
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					writeErrs.Add(1)
+					continue
+				}
+				totalWrites.Add(1)
+				latencies.record(elapsed)
+			}
+		}
+	}()
+
+	// Periodic restore+integrity check loop
+	var (
+		restoreCount    int
+		corruptionCount int
+		restoreErrors   []string
+	)
+
+	restoreTicker := time.NewTicker(restoreInterval)
+	defer restoreTicker.Stop()
+
+	t.Log("Running replicate+restore cycles...")
+	t.Log("")
+
+	startTime := time.Now()
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+		case <-restoreTicker.C:
+			restoreCount++
+			elapsed := time.Since(startTime)
+			sourceRows := countRowsSafe(sqlDB)
+
+			t.Logf("[%v] Restore cycle #%d (source rows: %d, writes: %d, write errors: %d)",
+				elapsed.Round(time.Second), restoreCount, sourceRows, totalWrites.Load(), writeErrs.Load())
+
+			// Stop litestream for clean restore
+			if err := db.StopLitestream(); err != nil {
+				t.Logf("  Warning: stop litestream: %v", err)
+			}
+			time.Sleep(1 * time.Second)
+
+			// Restore to new path
+			restoredPath := filepath.Join(db.TempDir, fmt.Sprintf("restored-%d.db", restoreCount))
+			if err := db.Restore(restoredPath); err != nil {
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restore: %v", restoreCount, err))
+				t.Logf("  RESTORE FAILED: %v", err)
+				// Restart litestream and continue
+				if err := db.StartLitestreamWithConfig(configPath); err != nil {
+					t.Fatalf("restart litestream after failed restore: %v", err)
+				}
+				continue
+			}
+
+			// Integrity check on restored DB
+			restoredDB, err := sql.Open("sqlite3", restoredPath)
+			if err != nil {
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: open restored: %v", restoreCount, err))
+				t.Logf("  OPEN FAILED: %v", err)
+			} else {
+				var result string
+				if err := restoredDB.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil {
+					restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: integrity_check query: %v", restoreCount, err))
+					t.Logf("  INTEGRITY CHECK QUERY FAILED: %v", err)
+				} else if result != "ok" {
+					corruptionCount++
+					restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: CORRUPTION: %s", restoreCount, result))
+					t.Errorf("  CORRUPTION DETECTED: %s", result)
+				} else {
+					// Verify row count is reasonable (restored may lag behind source)
+					var restoredRows int
+					restoredDB.QueryRow("SELECT COUNT(*) FROM resources").Scan(&restoredRows)
+					t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
+				}
+				restoredDB.Close()
+			}
+
+			// Clean up restored DB
+			os.Remove(restoredPath)
+			os.Remove(restoredPath + "-wal")
+			os.Remove(restoredPath + "-shm")
+
+			// Restart litestream
+			if err := db.StartLitestreamWithConfig(configPath); err != nil {
+				t.Fatalf("restart litestream: %v", err)
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	cancel()
+	wg.Wait()
+
+	// Final report
+	t.Log("")
+	t.Log("================================================")
+	t.Log("Results")
+	t.Log("================================================")
+	t.Logf("Duration:          %v", time.Since(startTime).Round(time.Second))
+	t.Logf("Total writes:      %d", totalWrites.Load())
+	t.Logf("Write errors:      %d", writeErrs.Load())
+	t.Logf("Restore cycles:    %d", restoreCount)
+	t.Logf("Corruptions:       %d", corruptionCount)
+
+	stats := latencies.stats()
+	t.Logf("Write latency P50: %v", stats.p50)
+	t.Logf("Write latency P95: %v", stats.p95)
+	t.Logf("Write latency P99: %v", stats.p99)
+	t.Logf("Write latency max: %v", stats.max)
+
+	if len(restoreErrors) > 0 {
+		t.Log("")
+		t.Log("Restore errors:")
+		for _, e := range restoreErrors {
+			t.Logf("  %s", e)
+		}
+	}
+
+	t.Log("================================================")
+
+	if corruptionCount > 0 {
+		t.Fatalf("FAILED: %d corruption(s) detected in %d restore cycles", corruptionCount, restoreCount)
+	}
+
+	if stats.p99 > 500*time.Millisecond {
+		t.Errorf("P99 write latency %v exceeds 500ms threshold", stats.p99)
+	}
+
+	t.Log("PASSED: no corruption detected")
+}
+
+func writeReplicateRestoreConfig(t *testing.T, dbPath, s3URL, endpoint string) string {
+	t.Helper()
+	configPath := filepath.Join(filepath.Dir(dbPath), "litestream.yml")
+	config := fmt.Sprintf(`access-key-id: minioadmin
+secret-access-key: minioadmin
+
+dbs:
+  - path: %s
+    checkpoint-interval: 1m
+    min-checkpoint-page-count: 100
+    replicas:
+      - url: %s
+        endpoint: %s
+        region: us-east-1
+        force-path-style: true
+        skip-verify: true
+        sync-interval: 1s
+        snapshot-interval: 30s
+`, filepath.ToSlash(dbPath), s3URL, endpoint)
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func parseSoakDuration(t *testing.T, defaultDuration time.Duration) time.Duration {
+	t.Helper()
+	if v := os.Getenv("SOAK_DURATION"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		if mins, err := strconv.Atoi(v); err == nil {
+			return time.Duration(mins) * time.Minute
+		}
+		t.Logf("Warning: invalid SOAK_DURATION %q, using default %v", v, defaultDuration)
+	}
+	return defaultDuration
+}
+
+func countRowsSafe(db *sql.DB) int {
+	var count int
+	db.QueryRow("SELECT COUNT(*) FROM resources").Scan(&count)
+	return count
+}
+
+type latencyTracker struct {
+	mu      sync.Mutex
+	samples []time.Duration
+}
+
+func (lt *latencyTracker) record(d time.Duration) {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	lt.samples = append(lt.samples, d)
+}
+
+type latencyStats struct {
+	p50, p95, p99, max time.Duration
+}
+
+func (lt *latencyTracker) stats() latencyStats {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+
+	if len(lt.samples) == 0 {
+		return latencyStats{}
+	}
+
+	sorted := make([]time.Duration, len(lt.samples))
+	copy(sorted, lt.samples)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	percentile := func(p float64) time.Duration {
+		idx := int(math.Ceil(p/100*float64(len(sorted)))) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(sorted) {
+			idx = len(sorted) - 1
+		}
+		return sorted[idx]
+	}
+
+	return latencyStats{
+		p50: percentile(50),
+		p95: percentile(95),
+		p99: percentile(99),
+		max: sorted[len(sorted)-1],
+	}
+}

--- a/tests/integration/soak_replicate_restore_test.go
+++ b/tests/integration/soak_replicate_restore_test.go
@@ -38,10 +38,12 @@ func TestSoakReplicateRestore(t *testing.T) {
 	RequireBinaries(t)
 	RequireDocker(t)
 
-	duration := parseSoakDuration(t, 5*time.Minute)
+	// An explicit SOAK_DURATION wins over the -short default.
+	defaultDuration := 5 * time.Minute
 	if testing.Short() {
-		duration = 1 * time.Minute
+		defaultDuration = 1 * time.Minute
 	}
+	duration := parseSoakDuration(t, defaultDuration)
 	restoreInterval := 30 * time.Second
 	writeRate := 100
 
@@ -109,6 +111,11 @@ func TestSoakReplicateRestore(t *testing.T) {
 	// Wait for initial sync
 	time.Sleep(3 * time.Second)
 
+	// Register before cancel so the deferred cancel stops the writer
+	// before wg.Wait runs, even on t.Fatalf paths.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
@@ -120,7 +127,6 @@ func TestSoakReplicateRestore(t *testing.T) {
 	)
 
 	// Writer goroutine: ~writeRate rows/sec
-	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -160,9 +166,10 @@ func TestSoakReplicateRestore(t *testing.T) {
 
 	// Periodic restore+integrity check loop
 	var (
-		restoreCount    int
-		corruptionCount int
-		restoreErrors   []string
+		restoreCount     int
+		corruptionCount  int
+		restoreErrors    []string
+		lastRestoredRows int
 	)
 
 	restoreTicker := time.NewTicker(restoreInterval)
@@ -186,9 +193,11 @@ loop:
 			t.Logf("[%v] Restore cycle #%d (source rows: %d, writes: %d, write errors: %d)",
 				elapsed.Round(time.Second), restoreCount, sourceRows, totalWrites.Load(), writeErrs.Load())
 
-			// Stop litestream for clean restore
+			// Stop litestream for clean restore. A failed stop usually
+			// means the process died mid-soak, which is itself a failure.
 			if err := db.StopLitestream(); err != nil {
-				t.Logf("  Warning: stop litestream: %v", err)
+				restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: stop litestream: %v", restoreCount, err))
+				t.Errorf("  STOP LITESTREAM FAILED: %v", err)
 			}
 			time.Sleep(1 * time.Second)
 
@@ -219,10 +228,26 @@ loop:
 					restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: CORRUPTION: %s", restoreCount, result))
 					t.Errorf("  CORRUPTION DETECTED: %s", result)
 				} else {
-					// Verify row count is reasonable (restored may lag behind source)
+					// The restore may lag behind the source, but row count
+					// must never be zero with data written nor shrink
+					// between cycles — either means lost data that passes
+					// integrity_check.
 					var restoredRows int
-					restoredDB.QueryRow("SELECT COUNT(*) FROM resources").Scan(&restoredRows)
-					t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
+					if err := restoredDB.QueryRow("SELECT COUNT(*) FROM resources").Scan(&restoredRows); err != nil {
+						restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: count restored rows: %v", restoreCount, err))
+						t.Errorf("  COUNT RESTORED ROWS FAILED: %v", err)
+					} else {
+						if restoredRows == 0 && sourceRows > 0 {
+							restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restored 0 rows, source has %d", restoreCount, sourceRows))
+							t.Errorf("  EMPTY RESTORE: source has %d rows", sourceRows)
+						}
+						if restoredRows < lastRestoredRows {
+							restoreErrors = append(restoreErrors, fmt.Sprintf("cycle %d: restored rows shrank %d -> %d", restoreCount, lastRestoredRows, restoredRows))
+							t.Errorf("  RESTORED ROWS SHRANK: %d -> %d", lastRestoredRows, restoredRows)
+						}
+						lastRestoredRows = restoredRows
+						t.Logf("  OK: integrity=ok, restored_rows=%d", restoredRows)
+					}
 				}
 				restoredDB.Close()
 			}
@@ -274,11 +299,32 @@ loop:
 		t.Fatalf("FAILED: %d corruption(s) detected in %d restore cycles", corruptionCount, restoreCount)
 	}
 
-	if stats.p99 > 500*time.Millisecond {
-		t.Errorf("P99 write latency %v exceeds 500ms threshold", stats.p99)
+	// The test exists to prove restores work; a failed restore, open, or
+	// verification is a failure even when no corruption was detected.
+	if len(restoreErrors) > 0 {
+		t.Fatalf("FAILED: %d restore error(s) in %d restore cycles", len(restoreErrors), restoreCount)
+	}
+
+	if totalWrites.Load() == 0 {
+		t.Fatal("FAILED: no writes succeeded; soak applied no load")
+	}
+
+	if threshold := parseSoakP99Threshold(t, 500*time.Millisecond); stats.p99 > threshold {
+		t.Errorf("P99 write latency %v exceeds %v threshold", stats.p99, threshold)
 	}
 
 	t.Log("PASSED: no corruption detected")
+}
+
+func parseSoakP99Threshold(t *testing.T, defaultThreshold time.Duration) time.Duration {
+	t.Helper()
+	if v := os.Getenv("SOAK_P99_THRESHOLD"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		t.Logf("Warning: invalid SOAK_P99_THRESHOLD %q, using default %v", v, defaultThreshold)
+	}
+	return defaultThreshold
 }
 
 func writeReplicateRestoreConfig(t *testing.T, dbPath, s3URL, endpoint string) string {

--- a/wal_reader.go
+++ b/wal_reader.go
@@ -134,7 +134,13 @@ func (r *WALReader) ReadFrame(ctx context.Context, data []byte) (pgno, commit ui
 	return r.readFrame(ctx, data, true)
 }
 
-func (r *WALReader) readFrame(_ context.Context, data []byte, verifyChecksum bool) (pgno, commit uint32, err error) {
+func (r *WALReader) readFrame(ctx context.Context, data []byte, verifyChecksum bool) (pgno, commit uint32, err error) {
+	select {
+	case <-ctx.Done():
+		return 0, 0, context.Cause(ctx)
+	default:
+	}
+
 	if len(data) != int(r.pageSize) {
 		return 0, 0, fmt.Errorf("WALReader.ReadFrame(): buffer size (%d) must match page size (%d)", len(data), r.pageSize)
 	}
@@ -190,15 +196,22 @@ func (r *WALReader) readFrame(_ context.Context, data []byte, verifyChecksum boo
 // map of pgno to offset of the latest version of each page. Also returns the
 // max offset of the wal segment read, and the final database size, in pages.
 func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset int64, commit uint32, err error) {
+	m, maxOffset, commit, _, err = r.pageMap(ctx, 0)
+	return m, maxOffset, commit, err
+}
+
+func (r *WALReader) pageMap(ctx context.Context, maxBytes int64) (m map[uint32]int64, maxOffset int64, commit uint32, limited bool, err error) {
 	m = make(map[uint32]int64)
 	txMap := make(map[uint32]int64)
 	data := make([]byte, r.pageSize)
-	for i := 0; ; i++ {
+	frameSize := int64(WALFrameHeaderSize + r.pageSize)
+	startOffset := WALHeaderSize + int64(r.frameN)*frameSize
+	for {
 		pgno, fcommit, err := r.ReadFrame(ctx, data)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
-			return nil, 0, 0, err
+			return nil, 0, 0, false, err
 		}
 
 		// Update latest offset for the page for this transaction.
@@ -211,7 +224,13 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 			for pgno, offset := range txMap {
 				m[pgno] = offset
 			}
+			txMap = make(map[uint32]int64)
 			commit = fcommit
+
+			if maxBytes > 0 && r.Offset()+frameSize-startOffset >= maxBytes {
+				limited = true
+				break
+			}
 		}
 	}
 
@@ -225,7 +244,7 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 
 	// If full transactions available, return the original offset.
 	if len(m) == 0 {
-		return m, 0, 0, nil
+		return m, 0, 0, limited, nil
 	}
 
 	// Compute the highest page offsets.
@@ -240,7 +259,7 @@ func (r *WALReader) PageMap(ctx context.Context) (m map[uint32]int64, maxOffset 
 	end += WALFrameHeaderSize + int64(r.pageSize)
 
 	r.logger.Log(ctx, internal.LevelTrace, "page map complete", "n", len(m), "end", end, "commit", commit)
-	return m, end, commit, nil
+	return m, end, commit, limited, nil
 }
 
 // FrameSaltsUntil returns a set of all unique frame salts in the WAL file.

--- a/wal_reader_test.go
+++ b/wal_reader_test.go
@@ -244,6 +244,24 @@ func TestWALReader(t *testing.T) {
 			t.Fatalf("unexpected error: %#v", err)
 		}
 	})
+
+	t.Run("ErrContextCanceled", func(t *testing.T) {
+		b, err := os.ReadFile("testdata/wal-reader/ok/wal")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r, err := litestream.NewWALReader(bytes.NewReader(b), slog.Default())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, _, err := r.ReadFrame(ctx, make([]byte, 4096)); !errors.Is(err, context.Canceled) {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	})
 }
 
 func TestWALReader_FrameSaltsUntil(t *testing.T) {


### PR DESCRIPTION
**Soak-validation branch only — do NOT merge.**

This combines the two independent in-flight fix stacks so the litestream-soak system can validate them together (no single existing PR head contains both, so every individual PR soaks red on the half it's missing):

- **Stack A — corruption / checkpoint hardening:** #1290 → #1291 → #1292 → #1166 → #1302, plus both sibling leaves #1312 (retention: retain prior snapshot txid, cherry-picked) and #1322 (disk-full staging).
- **Stack B — S3 fault resilience:** #1305 (retry through transport flaps) → #1306 (retry through provider throttle) → #1311 (resume remote compaction reads).

The two stacks touch disjoint files and combine cleanly. Local `go build`, `go vet`, and `go test . ./s3 ./internal` all pass.

Purpose: produce a single branch that should pass the full soak fleet (general + fault scenarios), as a green reference for the stacked-PR release. Intended to be soaked, reviewed, and then have its constituent stacks merged piecemeal — this integration branch itself is not a merge target.