### PR TITLE
fix(retention): retain prior snapshot txid

### DIFF
--- a/db.go
+++ b/db.go
@@ -2491,9 +2491,11 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 	defer itr.Close()
 
 	var deleted []*ltx.FileInfo
+	var snapshots []*ltx.FileInfo
 	var lastInfo *ltx.FileInfo
 	for itr.Next() {
 		info := itr.Item()
+		snapshots = append(snapshots, info)
 		lastInfo = info
 
 		// If this snapshot is before the retention timestamp, mark it for deletion.
@@ -2501,17 +2503,23 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 			deleted = append(deleted, info)
 			continue
 		}
-
-		// Track the lowest snapshot TXID so we can enforce retention in lower levels.
-		// This is only tracked for snapshots not marked for deletion.
-		if minSnapshotTXID == 0 || info.MaxTXID < minSnapshotTXID {
-			minSnapshotTXID = info.MaxTXID
-		}
 	}
 
 	// If this is the snapshot level, we need to ensure that at least one snapshot exists.
 	if len(deleted) > 0 && deleted[len(deleted)-1] == lastInfo {
 		deleted = deleted[:len(deleted)-1]
+	}
+
+	for i, info := range snapshots {
+		if slices.Contains(deleted, info) {
+			continue
+		}
+		if i > 0 {
+			minSnapshotTXID = snapshots[i-1].MaxTXID
+		} else {
+			minSnapshotTXID = info.MaxTXID
+		}
+		break
 	}
 
 	// Remove files marked for deletion from remote storage (unless retention disabled).

--- a/db.go
+++ b/db.go
@@ -2516,8 +2516,6 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 		}
 		if i > 0 {
 			minSnapshotTXID = snapshots[i-1].MaxTXID
-		} else {
-			minSnapshotTXID = info.MaxTXID
 		}
 		break
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -622,6 +622,23 @@ func TestDB_EnforceRetention(t *testing.T) {
 	}
 }
 
+func TestDB_EnforceSnapshotRetention_ReturnsZeroWithoutPriorSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	db := testingutil.NewDB(t, filepath.Join(dir, "db"))
+	client := file.NewReplicaClient(filepath.Join(dir, "replica"))
+	db.Replica = litestream.NewReplicaWithClient(db, client)
+
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 5, time.Now().Add(-time.Hour))
+
+	minSnapshotTXID, err := db.EnforceSnapshotRetention(t.Context(), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := minSnapshotTXID, ltx.TXID(0); got != want {
+		t.Fatalf("MinSnapshotTXID=%s, want %s", got, want)
+	}
+}
+
 func TestDB_EnforceSnapshotRetention_RetentionDisabled(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)

--- a/db_test.go
+++ b/db_test.go
@@ -596,7 +596,7 @@ func TestDB_EnforceRetention(t *testing.T) {
 	retentionTime := time.Now().Add(-150 * time.Millisecond)
 	if minSnapshotTXID, err := db.EnforceSnapshotRetention(t.Context(), retentionTime); err != nil {
 		t.Fatal(err)
-	} else if got, want := minSnapshotTXID, ltx.TXID(4); got != want {
+	} else if got, want := minSnapshotTXID, ltx.TXID(3); got != want {
 		t.Fatalf("MinSnapshotTXID=%s, want %s", got, want)
 	}
 
@@ -679,6 +679,62 @@ func TestDB_EnforceSnapshotRetention_RetentionDisabled(t *testing.T) {
 	afterCount := countFiles()
 	if afterCount != beforeCount {
 		t.Fatalf("expected %d remote snapshots (no remote deletion), got %d", beforeCount, afterCount)
+	}
+}
+
+func TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db := testingutil.NewDB(t, filepath.Join(dir, "db"))
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	client := file.NewReplicaClient(filepath.Join(dir, "replica"))
+	db.Replica = litestream.NewReplicaWithClient(db, client)
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer testingutil.MustCloseDB(t, db)
+
+	oldTime := time.Now().Add(-2 * time.Hour)
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 5, oldTime)
+	createTestLTXFileWithTimestamp(t, client, 1, 6, 10, oldTime.Add(time.Minute))
+
+	plan, err := litestream.CalcRestorePlan(ctx, client, 10, time.Time{}, db.Logger)
+	if err != nil {
+		t.Fatalf("calc restore plan: %v", err)
+	}
+
+	var plannedInfo *ltx.FileInfo
+	for _, info := range plan {
+		if info.Level == 1 && info.MinTXID == 6 && info.MaxTXID == 10 {
+			plannedInfo = info
+			break
+		}
+	}
+	if plannedInfo == nil {
+		t.Fatalf("restore plan does not include L1 6-10: %#v", plan)
+	}
+
+	createTestLTXFileWithTimestamp(t, client, litestream.SnapshotLevel, 1, 11, time.Now())
+	createTestLTXFileWithTimestamp(t, client, 1, 11, 11, time.Now())
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{
+		{Level: 0},
+		{Level: 1, Interval: time.Hour},
+	})
+	store.SnapshotRetention = time.Hour
+
+	if err := store.EnforceSnapshotRetention(ctx, db); err != nil {
+		t.Fatalf("enforce snapshot retention: %v", err)
+	}
+
+	rc, err := client.OpenLTXFile(ctx, plannedInfo.Level, plannedInfo.MinTXID, plannedInfo.MaxTXID, 0, 0)
+	if err != nil {
+		t.Fatalf("planned LTX file was deleted by retention: level=%d min=%s max=%s: %v", plannedInfo.Level, plannedInfo.MinTXID, plannedInfo.MaxTXID, err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close planned LTX file: %v", err)
 	}
 }
 


### PR DESCRIPTION
Standalone extraction of the retention fix (originally commit `06052c9`, also in stacked PR #1312) so it can be reviewed and merged independently of the larger corruption stack.

**What:** retention now preserves lower-level files back to the prior retained snapshot TXID, so an in-flight restore plan can't lose files it still needs.

**Independence:** clean cherry-pick onto current `main`; touches only `db.go` (+ `db_test.go`). `go build ./...` and `TestStore_EnforceSnapshotRetention*` pass.

**Validation:** this fix is part of the soak-validated integration branch (#1324) that passes the full general fleet + all S3 fault scenarios.