### PR TITLE
perf(s3): single PutObject for small ltx objects

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -680,38 +680,156 @@ func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, max
 
 // WriteLTXFile writes an LTX file to the replica.
 // Extracts timestamp from LTX header and stores it in S3 metadata to preserve original creation time.
+// Objects smaller than the part size are written with a single PutObject call
+// to avoid the multipart upload manager's 5 MiB part buffers (issue #1327).
 func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
 	if err := c.Init(ctx); err != nil {
 		return nil, err
 	}
 
-	// Use TeeReader to peek at LTX header while preserving data for upload
-	var buf bytes.Buffer
-	teeReader := io.TeeReader(r, &buf)
-
-	// Extract timestamp from LTX header
-	hdr, _, err := ltx.PeekHeader(teeReader)
-	if err != nil {
-		return nil, fmt.Errorf("extract timestamp from LTX header: %w", err)
-	}
-	timestamp := time.UnixMilli(hdr.Timestamp).UTC()
-
-	// Combine buffered data with rest of reader
-	rc := internal.NewReadCounter(io.MultiReader(&buf, r))
-
 	filename := ltx.FormatFilename(minTXID, maxTXID)
 	key := c.Path + "/" + fmt.Sprintf("%04x/%s", level, filename)
 
-	// Store timestamp in S3 metadata for accurate timestamp retrieval
-	metadata := map[string]string{
-		MetadataKeyTimestamp: timestamp.Format(time.RFC3339Nano),
+	partSize := int64(manager.DefaultUploadPartSize)
+	if c.PartSize > 0 {
+		partSize = c.PartSize
 	}
 
+	// The uploader rejects part sizes below the SDK minimum on every upload.
+	// Fail identically here so the single-put path cannot mask the
+	// misconfiguration for small objects.
+	if partSize < manager.MinUploadPartSize {
+		return nil, fmt.Errorf("s3: upload to %s: part size must be at least %d bytes", key, manager.MinUploadPartSize)
+	}
+
+	size, timestamp, etag, err := c.uploadLTX(ctx, key, r, partSize)
+	if err != nil {
+		return nil, err
+	}
+
+	internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "PUT").Inc()
+	internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "PUT").Add(float64(size))
+
+	// ETag indicates successful upload
+	if etag == nil {
+		return nil, fmt.Errorf("s3: upload failed: no ETag returned")
+	}
+
+	return &ltx.FileInfo{
+		Level:     level,
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Size:      size,
+		CreatedAt: timestamp,
+	}, nil
+}
+
+// uploadLTX uploads LTX data from r to key, choosing between a single
+// PutObject and the multipart uploader based on the object size.
+func (c *ReplicaClient) uploadLTX(ctx context.Context, key string, r io.Reader, partSize int64) (int64, time.Time, *string, error) {
+	// The L0 replication path passes the local LTX file, so the size is
+	// known up front and the body stays seekable for SDK retries.
+	if rs, ok := r.(io.ReadSeeker); ok {
+		if start, err := rs.Seek(0, io.SeekCurrent); err == nil {
+			return c.uploadSizedLTX(ctx, key, rs, start, partSize)
+		}
+		// Reader does not support seeking (e.g. piped file descriptor);
+		// nothing has been consumed, so treat it as an unsized stream.
+	}
+	return c.uploadStreamedLTX(ctx, key, r, partSize)
+}
+
+// uploadSizedLTX uploads from a seekable reader whose size is known.
+func (c *ReplicaClient) uploadSizedLTX(ctx context.Context, key string, rs io.ReadSeeker, start, partSize int64) (int64, time.Time, *string, error) {
+	end, err := rs.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("s3: size ltx file %s: %w", key, err)
+	}
+	size := end - start
+	if _, err := rs.Seek(start, io.SeekStart); err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("s3: rewind ltx file %s: %w", key, err)
+	}
+
+	// Extract timestamp from LTX header, then rewind so the upload sees the
+	// full file.
+	hdr, _, err := ltx.PeekHeader(rs)
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("extract timestamp from LTX header: %w", err)
+	}
+	timestamp := time.UnixMilli(hdr.Timestamp).UTC()
+	if _, err := rs.Seek(start, io.SeekStart); err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("s3: rewind ltx file %s: %w", key, err)
+	}
+
+	input := c.putObjectInput(key, timestamp)
+	input.Body = rs
+
+	if size < partSize {
+		input.ContentLength = aws.Int64(size)
+		out, err := c.s3.PutObject(ctx, input)
+		if err != nil {
+			return 0, time.Time{}, nil, fmt.Errorf("s3: put object %s: %w", key, err)
+		}
+		return size, timestamp, out.ETag, nil
+	}
+
+	// At or above the part size the uploader splits the seekable body into
+	// section readers without copying it into part buffers.
+	out, err := c.uploader.Upload(ctx, input)
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("s3: upload to %s: %w", key, err)
+	}
+	return size, timestamp, out.ETag, nil
+}
+
+// uploadStreamedLTX uploads from a reader of unknown size, buffering up to
+// the part size to determine whether the object fits in a single PutObject.
+func (c *ReplicaClient) uploadStreamedLTX(ctx context.Context, key string, r io.Reader, partSize int64) (int64, time.Time, *string, error) {
+	// Use TeeReader to peek at LTX header while preserving data for upload
+	var buf bytes.Buffer
+	hdr, _, err := ltx.PeekHeader(io.TeeReader(r, &buf))
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("extract timestamp from LTX header: %w", err)
+	}
+	timestamp := time.UnixMilli(hdr.Timestamp).UTC()
+
+	if _, err := io.CopyN(&buf, r, partSize-int64(buf.Len())); err != nil && !errors.Is(err, io.EOF) {
+		return 0, time.Time{}, nil, fmt.Errorf("s3: buffer ltx stream %s: %w", key, err)
+	}
+
+	input := c.putObjectInput(key, timestamp)
+
+	// Reaching EOF before the part size means the whole object is buffered.
+	if size := int64(buf.Len()); size < partSize {
+		input.Body = bytes.NewReader(buf.Bytes())
+		input.ContentLength = aws.Int64(size)
+		out, err := c.s3.PutObject(ctx, input)
+		if err != nil {
+			return 0, time.Time{}, nil, fmt.Errorf("s3: put object %s: %w", key, err)
+		}
+		return size, timestamp, out.ETag, nil
+	}
+
+	// Combine buffered prefix with rest of reader so nothing is re-read.
+	rc := internal.NewReadCounter(io.MultiReader(bytes.NewReader(buf.Bytes()), r))
+	input.Body = rc
+	out, err := c.uploader.Upload(ctx, input)
+	if err != nil {
+		return 0, time.Time{}, nil, fmt.Errorf("s3: upload to %s: %w", key, err)
+	}
+	return rc.N(), timestamp, out.ETag, nil
+}
+
+// putObjectInput returns a PutObjectInput populated with the client's write
+// parameters so the single-put and multipart paths stay in parity.
+func (c *ReplicaClient) putObjectInput(key string, timestamp time.Time) *s3.PutObjectInput {
 	input := &s3.PutObjectInput{
-		Bucket:   aws.String(c.Bucket),
-		Key:      aws.String(key),
-		Body:     rc,
-		Metadata: metadata,
+		Bucket: aws.String(c.Bucket),
+		Key:    aws.String(key),
+		// Store timestamp in S3 metadata for accurate timestamp retrieval
+		Metadata: map[string]string{
+			MetadataKeyTimestamp: timestamp.Format(time.RFC3339Nano),
+		},
 	}
 	if c.StorageClass != "" {
 		input.StorageClass = types.StorageClass(c.StorageClass)
@@ -730,29 +848,7 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 		input.SSEKMSKeyId = aws.String(c.SSEKMSKeyID)
 	}
 
-	out, err := c.uploader.Upload(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("s3: upload to %s: %w", key, err)
-	}
-
-	// Build file info from the uploaded file
-	info := &ltx.FileInfo{
-		Level:     level,
-		MinTXID:   minTXID,
-		MaxTXID:   maxTXID,
-		Size:      rc.N(),
-		CreatedAt: timestamp,
-	}
-
-	internal.OperationTotalCounterVec.WithLabelValues(ReplicaClientType, "PUT").Inc()
-	internal.OperationBytesCounterVec.WithLabelValues(ReplicaClientType, "PUT").Add(float64(rc.N()))
-
-	// ETag indicates successful upload
-	if out.ETag == nil {
-		return nil, fmt.Errorf("s3: upload failed: no ETag returned")
-	}
-
-	return info, nil
+	return input
 }
 
 func (c *ReplicaClient) middlewareOption() func(*middleware.Stack) error {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -13,7 +13,13 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -357,7 +363,9 @@ func TestReplicaClient_MultipartUploadThreshold(t *testing.T) {
 		wantMultipart bool
 	}{
 		{"BelowThreshold_4MB", 4 * mb, false},
-		{"AtThreshold_5MB", 5 * mb, true},
+		// With a seekable body the uploader knows the total size, so an
+		// object of exactly one part is sent as a single PutObject.
+		{"AtThreshold_5MB", 5 * mb, false},
 		{"AboveThreshold_6MB", 6 * mb, true},
 	}
 
@@ -461,6 +469,559 @@ func TestReplicaClient_MultipartUploadThreshold(t *testing.T) {
 				t.Error("aws-chunked encoding detected; this is incompatible with S3-compatible providers")
 			}
 		})
+	}
+}
+
+// TestReplicaClient_WriteLTXFile_SmallUploadAllocations verifies that
+// sub-part-size uploads bypass the multipart upload manager, which allocates
+// a fresh 5 MiB part buffer per call even for tiny objects (issue #1327).
+// TotalAlloc is monotonic, so GC activity cannot skew the measurement.
+func TestReplicaClient_WriteLTXFile_SmallUploadAllocations(t *testing.T) {
+	const (
+		uploads         = 16
+		perUploadBudget = 1 << 20 // well below the 5 MiB part buffer, well above per-request overhead
+	)
+
+	run := func(t *testing.T, newBody func() io.Reader) {
+		t.Helper()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewReplicaClient()
+		client.Bucket = "test-bucket"
+		client.Path = "replica"
+		client.Region = "us-east-1"
+		client.Endpoint = server.URL
+		client.ForcePathStyle = true
+		client.AccessKeyID = "test-access-key"
+		client.SecretAccessKey = "test-secret-key"
+
+		ctx := context.Background()
+		if err := client.Init(ctx); err != nil {
+			t.Fatalf("Init() error: %v", err)
+		}
+
+		upload := func() {
+			if _, err := client.WriteLTXFile(ctx, 0, 2, 2, newBody()); err != nil {
+				t.Fatalf("WriteLTXFile() error: %v", err)
+			}
+		}
+
+		// Warm up one-time allocations (TLS session, middleware stacks, connection pool).
+		upload()
+		upload()
+
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		for range uploads {
+			upload()
+		}
+		runtime.ReadMemStats(&after)
+
+		allocated := after.TotalAlloc - before.TotalAlloc
+		t.Logf("allocated %.2f MiB per upload", float64(allocated)/uploads/(1<<20))
+		if allocated > uploads*perUploadBudget {
+			t.Errorf("allocated %.2f MiB per upload, want < %.2f MiB: small objects must not stream through multipart part buffers",
+				float64(allocated)/uploads/(1<<20), float64(perUploadBudget)/(1<<20))
+		}
+	}
+
+	data := mustLTXWithSize(t, 8192)
+
+	t.Run("KnownSizeFile", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "0000000000000002.ltx")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		var files []*os.File
+		t.Cleanup(func() {
+			for _, f := range files {
+				_ = f.Close()
+			}
+		})
+
+		run(t, func() io.Reader {
+			f, err := os.Open(path)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			files = append(files, f)
+			return f
+		})
+	})
+
+	t.Run("UnknownSizeStream", func(t *testing.T) {
+		run(t, func() io.Reader {
+			pr, pw := io.Pipe()
+			go func() {
+				_, _ = pw.Write(data)
+				_ = pw.Close()
+			}()
+			return pr
+		})
+	})
+}
+
+// newTestReplicaClient returns a ReplicaClient configured against server with
+// the same defaults the upload tests use.
+func newTestReplicaClient(t *testing.T, server *httptest.Server) *ReplicaClient {
+	t.Helper()
+
+	client := NewReplicaClient()
+	client.Bucket = "test-bucket"
+	client.Path = "replica"
+	client.Region = "us-east-1"
+	client.Endpoint = server.URL
+	client.ForcePathStyle = true
+	client.AccessKeyID = "test-access-key"
+	client.SecretAccessKey = "test-secret-key"
+	return client
+}
+
+// TestReplicaClient_WriteLTXFile_SinglePutKnownSize verifies the known-size
+// fast path sends one PutObject with an exact Content-Length and intact body.
+func TestReplicaClient_WriteLTXFile_SinglePutKnownSize(t *testing.T) {
+	data := mustLTXWithSize(t, 8192)
+
+	var (
+		mu            sync.Mutex
+		putCount      int
+		gotInitiate   bool
+		contentLength int64
+		gotBody       []byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.Method == http.MethodPost && r.URL.Query().Has("uploads") {
+			mu.Lock()
+			gotInitiate = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>test-bucket</Bucket><Key>test-key</Key><UploadId>test-upload-id</UploadId></InitiateMultipartUploadResult>`)
+			return
+		}
+
+		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			putCount++
+			contentLength = r.ContentLength
+			gotBody = body
+			mu.Unlock()
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestReplicaClient(t, server)
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "0000000000000002.ltx")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+
+	info, err := client.WriteLTXFile(ctx, 0, 2, 2, f)
+	if err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotInitiate {
+		t.Error("did not expect CreateMultipartUpload for small object")
+	}
+	if putCount != 1 {
+		t.Errorf("PUT count = %d, want 1", putCount)
+	}
+	if contentLength != int64(len(data)) {
+		t.Errorf("Content-Length = %d, want %d", contentLength, len(data))
+	}
+	if !bytes.Equal(gotBody, data) {
+		t.Errorf("uploaded body does not match source data (%d bytes vs %d bytes)", len(gotBody), len(data))
+	}
+	if info.Size != int64(len(data)) {
+		t.Errorf("info.Size = %d, want %d", info.Size, len(data))
+	}
+}
+
+// TestReplicaClient_WriteLTXFile_SinglePutRetries verifies the single-put body
+// stays seekable so the SDK can replay it after a transient server error.
+func TestReplicaClient_WriteLTXFile_SinglePutRetries(t *testing.T) {
+	data := mustLTXWithSize(t, 8192)
+
+	var (
+		mu        sync.Mutex
+		putBodies [][]byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		putBodies = append(putBodies, body)
+		attempt := len(putBodies)
+		mu.Unlock()
+
+		if attempt == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("ETag", `"test-etag"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestReplicaClient(t, server)
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "0000000000000002.ltx")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+
+	info, err := client.WriteLTXFile(ctx, 0, 2, 2, f)
+	if err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(putBodies) != 2 {
+		t.Fatalf("PUT count = %d, want 2 (initial attempt + retry)", len(putBodies))
+	}
+	if !bytes.Equal(putBodies[1], data) {
+		t.Errorf("retried body does not match source data (%d bytes vs %d bytes)", len(putBodies[1]), len(data))
+	}
+	if info.Size != int64(len(data)) {
+		t.Errorf("info.Size = %d, want %d", info.Size, len(data))
+	}
+}
+
+// TestReplicaClient_WriteLTXFile_StreamSmallSinglePut verifies unknown-size
+// readers below the part size are buffered and sent as a single PutObject
+// with an exact Content-Length.
+func TestReplicaClient_WriteLTXFile_StreamSmallSinglePut(t *testing.T) {
+	data := mustLTXWithSize(t, 8192)
+
+	var (
+		mu            sync.Mutex
+		putCount      int
+		gotInitiate   bool
+		contentLength int64
+		gotBody       []byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.Method == http.MethodPost && r.URL.Query().Has("uploads") {
+			mu.Lock()
+			gotInitiate = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>test-bucket</Bucket><Key>test-key</Key><UploadId>test-upload-id</UploadId></InitiateMultipartUploadResult>`)
+			return
+		}
+
+		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			putCount++
+			contentLength = r.ContentLength
+			gotBody = body
+			mu.Unlock()
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestReplicaClient(t, server)
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write(data)
+		_ = pw.Close()
+	}()
+
+	info, err := client.WriteLTXFile(ctx, 0, 2, 2, pr)
+	if err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotInitiate {
+		t.Error("did not expect CreateMultipartUpload for small streamed object")
+	}
+	if putCount != 1 {
+		t.Errorf("PUT count = %d, want 1", putCount)
+	}
+	if contentLength != int64(len(data)) {
+		t.Errorf("Content-Length = %d, want %d", contentLength, len(data))
+	}
+	if !bytes.Equal(gotBody, data) {
+		t.Errorf("uploaded body does not match source data (%d bytes vs %d bytes)", len(gotBody), len(data))
+	}
+	if info.Size != int64(len(data)) {
+		t.Errorf("info.Size = %d, want %d", info.Size, len(data))
+	}
+}
+
+// TestReplicaClient_WriteLTXFile_StreamLargeMultipartRoundTrip verifies
+// unknown-size readers above the part size fall back to multipart upload and
+// that the buffered prefix plus streamed remainder reassemble byte-for-byte.
+func TestReplicaClient_WriteLTXFile_StreamLargeMultipartRoundTrip(t *testing.T) {
+	const mb = 1024 * 1024
+	data := mustLTXWithSize(t, 12*mb)
+
+	var (
+		mu          sync.Mutex
+		parts       = make(map[int][]byte)
+		singlePuts  int
+		gotComplete bool
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		query := r.URL.Query()
+
+		if r.Method == http.MethodPost && query.Has("uploads") {
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>test-bucket</Bucket><Key>test-key</Key><UploadId>test-upload-id</UploadId></InitiateMultipartUploadResult>`)
+			return
+		}
+
+		if r.Method == http.MethodPut && query.Get("partNumber") != "" {
+			partNumber, err := strconv.Atoi(query.Get("partNumber"))
+			if err != nil {
+				t.Errorf("invalid partNumber %q: %v", query.Get("partNumber"), err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			parts[partNumber] = body
+			mu.Unlock()
+			w.Header().Set("ETag", fmt.Sprintf(`"part-etag-%d"`, partNumber))
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method == http.MethodPost && query.Get("uploadId") != "" {
+			mu.Lock()
+			gotComplete = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult><Location>http://test-bucket.s3.amazonaws.com/test-key</Location><Bucket>test-bucket</Bucket><Key>test-key</Key><ETag>"complete-etag"</ETag></CompleteMultipartUploadResult>`)
+			return
+		}
+
+		if r.Method == http.MethodPut {
+			mu.Lock()
+			singlePuts++
+			mu.Unlock()
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestReplicaClient(t, server)
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write(data)
+		_ = pw.Close()
+	}()
+
+	info, err := client.WriteLTXFile(ctx, 0, 2, 2, pr)
+	if err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !gotComplete {
+		t.Error("expected CompleteMultipartUpload but did not receive one")
+	}
+	if singlePuts != 0 {
+		t.Errorf("single PUT count = %d, want 0 for large streamed object", singlePuts)
+	}
+	if len(parts) < 2 {
+		t.Fatalf("part count = %d, want at least 2", len(parts))
+	}
+
+	var assembled []byte
+	for i := 1; i <= len(parts); i++ {
+		part, ok := parts[i]
+		if !ok {
+			t.Fatalf("missing part %d of %d", i, len(parts))
+		}
+		assembled = append(assembled, part...)
+	}
+	if !bytes.Equal(assembled, data) {
+		t.Errorf("reassembled body does not match source data (%d bytes vs %d bytes)", len(assembled), len(data))
+	}
+	if info.Size != int64(len(data)) {
+		t.Errorf("info.Size = %d, want %d", info.Size, len(data))
+	}
+}
+
+// TestReplicaClient_WriteLTXFile_PartSizeBelowMinimum verifies a part size
+// below the SDK minimum still fails for small objects instead of being
+// silently accepted by the single-put path.
+func TestReplicaClient_WriteLTXFile_PartSizeBelowMinimum(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestReplicaClient(t, server)
+	client.PartSize = 1024 * 1024 // below the SDK's 5 MiB minimum
+
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	_, err := client.WriteLTXFile(ctx, 0, 2, 2, bytes.NewReader(mustLTX(t)))
+	if err == nil {
+		t.Fatal("expected error for part size below minimum, got nil")
+	}
+	if !strings.Contains(err.Error(), "part size must be at least") {
+		t.Errorf("error = %q, want part size validation error", err)
+	}
+	if n := requests.Load(); n != 0 {
+		t.Errorf("request count = %d, want 0", n)
+	}
+}
+
+// TestReplicaClient_WriteLTXFile_MultipartParamParity verifies StorageClass,
+// SSE-C, and timestamp metadata reach the multipart initiate request just
+// like they do on single-put uploads.
+func TestReplicaClient_WriteLTXFile_MultipartParamParity(t *testing.T) {
+	const mb = 1024 * 1024
+
+	validKey := base64.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
+	keyBytes, _ := base64.StdEncoding.DecodeString(validKey)
+	keyMD5Sum := md5.Sum(keyBytes)
+	expectedMD5 := base64.StdEncoding.EncodeToString(keyMD5Sum[:])
+
+	data := mustLTXWithSize(t, 12*mb)
+
+	initiateHeaders := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		_, _ = io.Copy(io.Discard, r.Body)
+		query := r.URL.Query()
+
+		if r.Method == http.MethodPost && query.Has("uploads") {
+			select {
+			case initiateHeaders <- r.Header.Clone():
+			default:
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>test-bucket</Bucket><Key>test-key</Key><UploadId>test-upload-id</UploadId></InitiateMultipartUploadResult>`)
+			return
+		}
+
+		if r.Method == http.MethodPut && query.Get("partNumber") != "" {
+			w.Header().Set("ETag", fmt.Sprintf(`"part-etag-%s"`, query.Get("partNumber")))
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method == http.MethodPost && query.Get("uploadId") != "" {
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult><Location>http://test-bucket.s3.amazonaws.com/test-key</Location><Bucket>test-bucket</Bucket><Key>test-key</Key><ETag>"complete-etag"</ETag></CompleteMultipartUploadResult>`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestReplicaClient(t, server)
+	client.StorageClass = "STANDARD_IA"
+	client.SSECustomerKey = validKey
+
+	ctx := context.Background()
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	if _, err := client.WriteLTXFile(ctx, 0, 2, 2, bytes.NewReader(data)); err != nil {
+		t.Fatalf("WriteLTXFile() error: %v", err)
+	}
+
+	select {
+	case hdr := <-initiateHeaders:
+		if got := hdr.Get("x-amz-storage-class"); got != "STANDARD_IA" {
+			t.Errorf("storage class header = %q, want STANDARD_IA", got)
+		}
+		if got := hdr.Get("x-amz-server-side-encryption-customer-algorithm"); got != "AES256" {
+			t.Errorf("SSE-C algorithm header = %q, want AES256", got)
+		}
+		if got := hdr.Get("x-amz-server-side-encryption-customer-key"); got != validKey {
+			t.Errorf("SSE-C key header = %q, want %q", got, validKey)
+		}
+		if got := hdr.Get("x-amz-server-side-encryption-customer-key-md5"); got != expectedMD5 {
+			t.Errorf("SSE-C key MD5 header = %q, want %q", got, expectedMD5)
+		}
+		if got := hdr.Get("x-amz-meta-litestream-timestamp"); got == "" {
+			t.Error("timestamp metadata header missing on multipart initiate")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for CreateMultipartUpload request")
 	}
 }
 


### PR DESCRIPTION
## Description

`WriteLTXFile` wrapped every upload body in a non-seekable `ReadCounter(MultiReader(...))`, forcing the AWS upload manager down its part-buffer path — which allocates a fresh 5 MiB part buffer per call (the manager's pool returns its capacity when each `Upload` completes, so buffers never survive between calls), even for a 200-byte LTX file.

This PR routes uploads by size:

- **Known size** (seekable body — the L0 replication path passes the local `*os.File`, `replica.go:186-192`): size measured via `Seek`; below the effective part size → direct `c.s3.PutObject` with exact `ContentLength` and a seekable (retryable) body; at/above it → existing `c.uploader.Upload` with the raw seekable body, which the SDK slices into zero-copy `SectionReader`s instead of part buffers.
- **Unknown size** (compaction/snapshot pipes): grow-on-demand buffer up to the part size; EOF before that → `PutObject` from `bytes.NewReader(buf)`; otherwise fall back to `uploader.Upload` with `io.MultiReader(prefix, rest)` so nothing is re-read.
- **Parameter parity**: a shared `putObjectInput` helper builds the one `*s3.PutObjectInput` both paths use (timestamp metadata, `StorageClass` from #1321, SSE-C/SSE-KMS). No `ContentType` invented. The direct `PutObject` goes through the already-initialized `c.s3`, so the transport retryer (#1305), signing, checksum, and endpoint middleware all still apply.
- **Misconfiguration stays loud**: a configured `part-size` below the SDK's 5 MiB floor fails every upload with the SDK's own message (`part size must be at least 5242880 bytes`) instead of silently succeeding for small objects.

**Scope**: only `s3/replica_client.go` upload routing. No manifest/caching work (declined separately in the issue), no changes to other backends, no config surface changes.

**Deliberate wire change**: an object of *exactly* the part size is now one `PutObject` instead of a one-part multipart upload (the uploader sees the total size once the body is seekable) — 1 request instead of 3. `TestReplicaClient_MultipartUploadThreshold/AtThreshold_5MB` updated with a comment.

## Motivation and Context

Profiling the many-database tier (100 mostly-idle ~5 MB SQLite DBs in one process) showed the upload manager's 5 MiB part buffers as the dominant allocation traffic and `memclr` CPU cost, and the multipart floor means `part-size` config can't shrink them for tiny objects.

Measured by the new allocation regression test (TotalAlloc across 16 uploads of an 8 KiB LTX, mock S3 endpoint):

| Path | before | after |
|---|---|---|
| known-size `*os.File` | 5.08 MiB/upload | 0.09 MiB/upload |
| unknown-size pipe | 5.08 MiB/upload | 0.07 MiB/upload |

Fixes #1327

## How Has This Been Tested?

TDD: the allocation test was written first and failed at 5.08 MiB/upload on both paths before the change.

```bash
go test -race ./s3/                                  # unit + regression tests, all green
go test -race ./...                                  # full suite green
go test -race . -v -run TestReplicaClient -integration -replica-clients s3   # against MinIO
pre-commit run --all-files                           # gofmt/vet/staticcheck green
```

New tests: `TestReplicaClient_WriteLTXFile_SmallUploadAllocations` (the perf guard, logs measured MiB/upload), `_SinglePutKnownSize` (exact `Content-Length`, byte-for-byte body, no multipart), `_SinglePutRetries` (first PUT 500 → SDK replays the seekable body intact — guards the "don't wrap in ReadCounter" trap), `_StreamSmallSinglePut`, `_StreamLargeMultipartRoundTrip` (parts reassemble byte-for-byte across the buffered-prefix handoff), `_PartSizeBelowMinimum` (fails with zero requests on the wire), `_MultipartParamParity` (StorageClass/SSE-C/timestamp metadata on the multipart initiate).

End-to-end against real MinIO with server-side API tracing (`mc admin trace`):

- `litestream replicate` of a WAL-mode DB: small L0 files and small streamed L1/L9 compactions arrive as single `s3.PutObject`; a 12.1 MiB L0 file and a large streamed L1 compaction arrive as `NewMultipartUpload` + 3 `PutObjectPart` + `Complete` — all four routing paths observed on the wire.
- `litestream restore` round-trip: `PRAGMA integrity_check` ok, row content and 12,582,912 blob bytes identical to origin.
- `part-size: 1MB` via config: 46 loud errors across snapshot/compaction/monitor, zero write APIs reached the server.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)