### PR TITLE
fix(cli): honor part-size and concurrency replica URL params

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1464,6 +1464,10 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 		urequireContentMD5    bool
 		urequireContentMD5Set bool
 		ustorageClass         string
+		upartSize             int64
+		upartSizeSet          bool
+		uconcurrency          int64
+		uconcurrencySet       bool
 	)
 	if endpoint != "" {
 		endpointWasSet = true
@@ -1521,6 +1525,18 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 			ustorageClass = v
 		} else if v := query.Get("storage-class"); v != "" {
 			ustorageClass = v
+		}
+		if v, ok, err := litestream.IntQueryValue(query, "partSize", "part-size"); err != nil {
+			return nil, err
+		} else if ok {
+			upartSize = v
+			upartSizeSet = true
+		}
+		if v, ok, err := litestream.IntQueryValue(query, "concurrency"); err != nil {
+			return nil, err
+		} else if ok {
+			uconcurrency = v
+			uconcurrencySet = true
 		}
 
 		// Only apply URL parts to field that have not been overridden.
@@ -1609,7 +1625,13 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 		client.Concurrency = s3.DefaultR2Concurrency
 	}
 
-	// Apply upload configuration if specified.
+	// Apply upload configuration from URL query, then config overrides.
+	if upartSizeSet {
+		client.PartSize = upartSize
+	}
+	if uconcurrencySet {
+		client.Concurrency = int(uconcurrency)
+	}
 	if c.PartSize != nil {
 		client.PartSize = int64(*c.PartSize)
 	}

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -3224,6 +3224,139 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 			t.Error("expected explicit SignPayload=false to override R2 default")
 		}
 	})
+
+	t.Run("URLWithUploadParams", func(t *testing.T) {
+		config := &main.ReplicaConfig{
+			URL: "s3://mybucket/path?part-size=10485760&concurrency=4",
+		}
+
+		client, err := main.NewS3ReplicaClientFromConfig(config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if client.PartSize != 10485760 {
+			t.Errorf("expected PartSize 10485760, got %d", client.PartSize)
+		}
+		if client.Concurrency != 4 {
+			t.Errorf("expected Concurrency 4, got %d", client.Concurrency)
+		}
+	})
+
+	t.Run("URLWithUploadParamsCamelCase", func(t *testing.T) {
+		config := &main.ReplicaConfig{
+			URL: "s3://mybucket/path?partSize=8388608",
+		}
+
+		client, err := main.NewS3ReplicaClientFromConfig(config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if client.PartSize != 8388608 {
+			t.Errorf("expected PartSize 8388608, got %d", client.PartSize)
+		}
+
+		config = &main.ReplicaConfig{
+			URL: "s3://mybucket/path?partSize=8388608&part-size=1048576",
+		}
+
+		client, err = main.NewS3ReplicaClientFromConfig(config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if client.PartSize != 8388608 {
+			t.Errorf("expected camelCase partSize to win, got %d", client.PartSize)
+		}
+	})
+
+	t.Run("ConfigOverridesQueryUploadParams", func(t *testing.T) {
+		partSize := main.ByteSize(5 * 1024 * 1024)
+		concurrency := 8
+		config := &main.ReplicaConfig{
+			URL: "s3://mybucket/path?part-size=1048576&concurrency=2",
+			ReplicaSettings: main.ReplicaSettings{
+				PartSize:    &partSize,
+				Concurrency: &concurrency,
+			},
+		}
+
+		client, err := main.NewS3ReplicaClientFromConfig(config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if client.PartSize != int64(5*1024*1024) {
+			t.Errorf("expected config PartSize %d to override query, got %d", int64(5*1024*1024), client.PartSize)
+		}
+		if client.Concurrency != 8 {
+			t.Errorf("expected config Concurrency 8 to override query, got %d", client.Concurrency)
+		}
+	})
+
+	t.Run("InvalidUploadParams", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			url   string
+			param string
+		}{
+			{"part-size_non_numeric", "s3://mybucket/path?part-size=abc", "part-size"},
+			{"part-size_zero", "s3://mybucket/path?part-size=0", "part-size"},
+			{"part-size_negative", "s3://mybucket/path?part-size=-1", "part-size"},
+			{"concurrency_non_numeric", "s3://mybucket/path?concurrency=abc", "concurrency"},
+			{"concurrency_zero", "s3://mybucket/path?concurrency=0", "concurrency"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := main.NewS3ReplicaClientFromConfig(&main.ReplicaConfig{URL: tt.url}, nil)
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.url)
+				}
+				if !strings.Contains(err.Error(), tt.param) {
+					t.Errorf("expected error to name parameter %q, got %q", tt.param, err.Error())
+				}
+			})
+		}
+	})
+
+	t.Run("R2QueryConcurrencyOverride", func(t *testing.T) {
+		config := &main.ReplicaConfig{
+			URL: "s3://bucket/db?endpoint=https://accountid.r2.cloudflarestorage.com&concurrency=5",
+		}
+
+		client, err := main.NewS3ReplicaClientFromConfig(config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if client.Concurrency != 5 {
+			t.Errorf("expected query concurrency 5 to override R2 default, got %d", client.Concurrency)
+		}
+	})
+
+	t.Run("UploadParamsParity", func(t *testing.T) {
+		url := "s3://mybucket/path?endpoint=http://localhost:9000&part-size=8388608&concurrency=4"
+
+		urlClient, err := litestream.NewReplicaClientFromURL(url)
+		if err != nil {
+			t.Fatalf("URL factory error: %v", err)
+		}
+		uc := urlClient.(*s3.ReplicaClient)
+
+		cc, err := main.NewS3ReplicaClientFromConfig(&main.ReplicaConfig{URL: url}, nil)
+		if err != nil {
+			t.Fatalf("Config factory error: %v", err)
+		}
+
+		if uc.PartSize != cc.PartSize {
+			t.Errorf("PartSize: URL=%d, Config=%d", uc.PartSize, cc.PartSize)
+		}
+		if uc.Concurrency != cc.Concurrency {
+			t.Errorf("Concurrency: URL=%d, Config=%d", uc.Concurrency, cc.Concurrency)
+		}
+	})
 }
 
 func TestGlobalDefaults(t *testing.T) {

--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -320,7 +320,7 @@ Parameters with an alias accept both camelCase and hyphenated forms
 | `signPayload` | `sign-payload` | Sign request payloads | `true` |
 | `requireContentMD5` | `require-content-md5` | Require Content-MD5 header | `true` |
 | `concurrency` | | Multipart upload concurrency | `5` |
-| `partSize` | `part-size` | Multipart upload part size | `5MB` |
+| `partSize` | `part-size` | Multipart upload part size in bytes | `5242880` (5MB) |
 | `storageClass` | `storage-class` | Storage class for uploaded objects | None |
 | `sseCustomerAlgorithm` | `sse-customer-algorithm` | SSE-C encryption algorithm | None |
 | `sseCustomerKey` | `sse-customer-key` | SSE-C encryption key | None |

--- a/replica_url.go
+++ b/replica_url.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -205,6 +206,25 @@ func BoolQueryValue(query url.Values, keys ...string) (value bool, ok bool) {
 		}
 	}
 	return false, false
+}
+
+// IntQueryValue returns a positive integer value from URL query parameters.
+// It checks keys in order and returns the value and whether it was set.
+// Returns an error if a present value is not a positive integer.
+func IntQueryValue(query url.Values, keys ...string) (value int64, ok bool, err error) {
+	if query == nil {
+		return 0, false, nil
+	}
+	for _, key := range keys {
+		if raw := query.Get(key); raw != "" {
+			n, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil || n <= 0 {
+				return 0, false, fmt.Errorf("invalid value for query parameter %q: %q (must be a positive integer)", key, raw)
+			}
+			return n, true, nil
+		}
+	}
+	return 0, false, nil
 }
 
 // IsHetznerEndpoint returns true if the endpoint is Hetzner object storage service.

--- a/replica_url_test.go
+++ b/replica_url_test.go
@@ -574,6 +574,119 @@ func TestBoolQueryValue(t *testing.T) {
 	})
 }
 
+func TestIntQueryValue(t *testing.T) {
+	t.Run("Key present", func(t *testing.T) {
+		query := make(map[string][]string)
+		query["key"] = []string{"1048576"}
+		value, ok, err := litestream.IntQueryValue(query, "key")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if !ok {
+			t.Error("IntQueryValue with present key should be ok")
+		}
+		if value != 1048576 {
+			t.Errorf("IntQueryValue = %d, want 1048576", value)
+		}
+	})
+
+	t.Run("Missing key", func(t *testing.T) {
+		query := make(map[string][]string)
+		value, ok, err := litestream.IntQueryValue(query, "key")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if ok {
+			t.Error("IntQueryValue with missing key should not be ok")
+		}
+		if value != 0 {
+			t.Errorf("IntQueryValue = %d, want 0", value)
+		}
+	})
+
+	t.Run("Alias order", func(t *testing.T) {
+		query := make(map[string][]string)
+		query["key1"] = []string{"100"}
+		query["key2"] = []string{"200"}
+		value, ok, err := litestream.IntQueryValue(query, "key1", "key2")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if !ok {
+			t.Error("IntQueryValue should find first key")
+		}
+		if value != 100 {
+			t.Errorf("IntQueryValue = %d, want 100 (first key wins)", value)
+		}
+	})
+
+	t.Run("Second key used when first absent", func(t *testing.T) {
+		query := make(map[string][]string)
+		query["key2"] = []string{"200"}
+		value, ok, err := litestream.IntQueryValue(query, "key1", "key2")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if !ok {
+			t.Error("IntQueryValue should find second key")
+		}
+		if value != 200 {
+			t.Errorf("IntQueryValue = %d, want 200", value)
+		}
+	})
+
+	t.Run("Nil query", func(t *testing.T) {
+		value, ok, err := litestream.IntQueryValue(nil, "key")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if ok {
+			t.Error("IntQueryValue with nil query should not be ok")
+		}
+		if value != 0 {
+			t.Errorf("IntQueryValue = %d, want 0", value)
+		}
+	})
+
+	t.Run("Empty value not set", func(t *testing.T) {
+		query := make(map[string][]string)
+		query["key"] = []string{""}
+		_, ok, err := litestream.IntQueryValue(query, "key")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if ok {
+			t.Error("IntQueryValue with empty value should not be ok")
+		}
+	})
+
+	t.Run("Invalid values return error", func(t *testing.T) {
+		for _, v := range []string{"abc", "0", "-5"} {
+			query := make(map[string][]string)
+			query["key"] = []string{v}
+			_, _, err := litestream.IntQueryValue(query, "key")
+			if err == nil {
+				t.Errorf("IntQueryValue with %q should return error", v)
+			}
+		}
+	})
+
+	t.Run("Large value", func(t *testing.T) {
+		query := make(map[string][]string)
+		query["key"] = []string{"10737418240"}
+		value, ok, err := litestream.IntQueryValue(query, "key")
+		if err != nil {
+			t.Fatalf("IntQueryValue returned error: %v", err)
+		}
+		if !ok {
+			t.Error("IntQueryValue with large value should be ok")
+		}
+		if value != 10737418240 {
+			t.Errorf("IntQueryValue = %d, want 10737418240", value)
+		}
+	})
+}
+
 func TestIsTigrisEndpoint(t *testing.T) {
 	tests := []struct {
 		endpoint string

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -187,20 +186,16 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 		requireMD5 = v
 		requireMD5Set = true
 	}
-	if v := query.Get("concurrency"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			concurrency = n
-			concurrencySet = true
-		}
+	if v, ok, err := litestream.IntQueryValue(query, "concurrency"); err != nil {
+		return nil, err
+	} else if ok {
+		concurrency = int(v)
+		concurrencySet = true
 	}
-	if v := query.Get("partSize"); v != "" {
-		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
-			partSize = n
-		}
-	} else if v := query.Get("part-size"); v != "" {
-		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
-			partSize = n
-		}
+	if v, ok, err := litestream.IntQueryValue(query, "partSize", "part-size"); err != nil {
+		return nil, err
+	} else if ok {
+		partSize = v
 	}
 	if v := query.Get("storageClass"); v != "" {
 		storageClass = v

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2094,6 +2094,38 @@ func TestNewReplicaClientFromURL_QueryParamAliases(t *testing.T) {
 	}
 }
 
+func TestNewReplicaClientFromURL_InvalidUploadParams(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "part-size_non_numeric",
+			url:  "s3://mybucket/path?part-size=abc",
+		},
+		{
+			name: "part-size_zero",
+			url:  "s3://mybucket/path?part-size=0",
+		},
+		{
+			name: "concurrency_negative",
+			url:  "s3://mybucket/path?concurrency=-1",
+		},
+		{
+			name: "concurrency_non_numeric",
+			url:  "s3://mybucket/path?concurrency=abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := litestream.NewReplicaClientFromURL(tt.url); err == nil {
+				t.Fatalf("NewReplicaClientFromURL(%q) expected error, got nil", tt.url)
+			}
+		})
+	}
+}
+
 func TestNewReplicaClientFromURL_EndpointEnvVar(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
## Description

The CLI's S3 replica builder (`NewS3ReplicaClientFromConfig`) parses `endpoint`, `region`, `forcePathStyle`, `skipVerify`, `signPayload`, `requireContentMD5`, and `storageClass` from replica URL query parameters but silently dropped `part-size`/`partSize` and `concurrency`, while the registered URL factory (`s3.NewReplicaClientFromURL`) honored them — so the same URL behaved differently depending on which code path built the client.

This change:

- Adds a shared `litestream.IntQueryValue(query, keys...)` helper (sibling of the existing `BoolQueryValue`) that parses positive-integer query params and returns an error for invalid or non-positive values.
- Uses the helper in **both** the s3 URL factory and the CLI builder so query-parameter support cannot drift again, with an anti-drift parity test asserting both paths produce identical `PartSize`/`Concurrency` for the same URL.
- Invalid values (`?part-size=abc`, `0`, negative) now return a hard error naming the parameter in both paths. Previously the factory silently ignored them; this is a small deliberate behavior change for library consumers, in line with the project's "always return errors" rule.
- Precedence in the CLI builder: R2 provider default < URL query param < YAML config field (YAML wins, matching the existing config-overrides-query convention).
- Spelling support matches the factory exactly: `partSize` (camelCase, takes precedence) and `part-size`; `concurrency` single spelling. Values are raw bytes — `?part-size=5MiB` now errors loudly instead of being silently dropped (human-readable sizes remain YAML-only; adding them to URLs is a possible follow-up inside the single helper).
- Updates the `partSize` row in `docs/PROVIDER_COMPATIBILITY.md` to clarify the value is bytes.

Known non-blocking review note: `concurrency` is validated as int64 then narrowed to `int`; on 32-bit builds an absurdly large value (> 2^31) would wrap rather than error. Flagged as low priority in review; can harden in a follow-up.

Out of scope (pre-existing drift, not touched): CLI builder's `forcePathStyle`/`skipVerify` not accepting hyphenated aliases; `BoolQueryValue` coercing invalid booleans to false; other backends discarding URL queries entirely.

## Motivation and Context

Users setting `?part-size=` on a `litestream replicate`/`restore` URL silently got the default 5 MiB parts with no warning, while the same setting via YAML was honored. Found while verifying #1327 / #1328 — the small-object fast path's part-size floor validation was reachable via YAML but not via URL.

Fixes #1329

## How Has This Been Tested?

- TDD: all new tests written first and verified to fail for the right reason (params dropped / silently ignored), then implementation made them pass.
- New tests: `TestIntQueryValue` (root, 8 subtests: aliases, nil query, empty, invalid, large values); `TestNewReplicaClientFromURL_InvalidUploadParams` (s3); six new subtests in `TestNewS3ReplicaClientFromConfig` (cmd/litestream) covering URL params, camelCase precedence, YAML-overrides-query, invalid values, R2-default override, and cross-path parity.
- `go build ./...`, `go vet ./...`, full `go test -race ./...` — all green.
- `golangci-lint run` — zero new issues vs main (verified by before/after diff of full lint output).
- Changed-file coverage: 60.2% aggregate on gated files (replica_url.go 93.1%, s3/replica_client.go 52.5%), above the 60% gate.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)