### PR TITLE
Add a new target to Makefile for building litestream locally along wi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,15 @@ MACOSX_MIN_VERSION := 11.0
 DARWIN_LDFLAGS := -framework CoreFoundation -framework Security -lresolv -mmacosx-version-min=$(MACOSX_MIN_VERSION)
 LINUX_LDFLAGS := -lpthread -ldl -lm
 
+# Build metadata for -ldflags
+VERSION     := $(shell git describe --tags --always --dirty 2>/dev/null || echo "(development build)")
+LDFLAGS := -X 'main.Version=$(VERSION)'
+
+.PHONY: build
+build:
+	mkdir -p dist
+	go build -ldflags "$(LDFLAGS)" -o dist/litestream ./cmd/litestream
+
 .PHONY: vfs
 vfs:
 	mkdir -p dist
@@ -68,4 +77,4 @@ mcp-inspect:
 	fly mcp proxy -i --url http://localhost:8080/ --bearer-token=$(FLY_MCP_BEARER_TOKEN)
 
 
-.PHONY: default clean mcp-wrap mcp-inspect
+.PHONY: default clean build mcp-wrap mcp-inspect


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I want to propose a patch to the Makefile that will make the binary print version string as follows,

Instead of using `go build` use `make` to build the litestream binary. In this PR, I introduce a new `make` target named `build` that builds `litestream` binary and puts it in `dist/`,

```
$ make build
mkdir -p dist
go build -ldflags "-X 'main.Version=v0.5.13-6-g2b34013-dirty'" -o dist/litestream ./cmd/litestream
```
```
$ ./dist/litestream version
v0.5.13-6-g2b34013-dirty
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to issue if applicable: -->
Fixes #1335 

## How Has This Been Tested?
<!--- Describe how you tested your changes -->
<!--- Include details of your testing environment if relevant -->

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] My code follows the code style of this project (`go fmt`, `go vet`)
- [ ] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
