### PR TITLE
fix(db): hold write lock across checkpoint to prevent replica corruptio

### DIFF
--- a/db.go
+++ b/db.go
@@ -202,6 +202,15 @@ type syncState struct {
 	// a checkpoint. This prevents issue #997 where PASSIVE checkpoints
 	// trigger a feedback loop because stale file size exceeds threshold.
 	lastSyncedWALOffset int64
+
+	// snapshotPending forces the next sync to write a full snapshot from
+	// the database file instead of copying incrementally from the WAL. Set
+	// after a checkpoint that may have backfilled WAL frames into the
+	// database file before they were captured to an LTX file; the WAL alone
+	// can no longer reconstruct the database state. Cleared only once a
+	// snapshot has been written successfully so the repair survives
+	// transient sync failures.
+	snapshotPending bool
 }
 
 type syncExecutor struct {
@@ -239,6 +248,7 @@ const (
 	diagPhaseSyncComplete                   diagPhase = "sync_complete"
 	diagPhaseCheckpointLock                 diagPhase = "checkpoint_lock"
 	diagPhaseCheckpointReadWALHeader        diagPhase = "checkpoint_read_wal_header"
+	diagPhaseCheckpointCopyBeforeLock       diagPhase = "checkpoint_copy_before_lock"
 	diagPhaseCheckpointCopyBefore           diagPhase = "checkpoint_copy_before"
 	diagPhaseCheckpointExec                 diagPhase = "checkpoint_exec"
 	diagPhaseCheckpointVerifyRestart        diagPhase = "checkpoint_verify_restart"
@@ -1269,9 +1279,21 @@ func (db *DB) verifyAndSyncWithExecutor(ctx context.Context, checkpointing bool,
 		return syncResult{}, fmt.Errorf("cannot verify wal state: %w", err)
 	}
 
+	// Force a full snapshot if a checkpoint may have backfilled WAL frames
+	// into the database file before they were captured to an LTX file.
+	if exec.state.snapshotPending && !info.snapshotting {
+		info.snapshotting = true
+		info.reason = "checkpoint backfilled unsynced wal frames, snapshotting"
+	}
+
 	result, err := db.sync(ctx, checkpointing, exec, info)
 	if err != nil {
 		return syncResult{}, fmt.Errorf("sync: %w", err)
+	}
+
+	// The pending snapshot has been written; incremental sync is safe again.
+	if info.snapshotting {
+		exec.state.snapshotPending = false
 	}
 
 	result.origWALSize = origWALSize
@@ -2207,6 +2229,29 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		return err
 	}
 
+	// Acquire the database write lock before copying the end of the WAL so
+	// that no other connection can commit new frames between the copy and
+	// the checkpoint below. Frames committed in that window would be
+	// backfilled into the database file without ever being captured into an
+	// LTX file and then silently dropped when the WAL restarts, permanently
+	// corrupting the replica. The lock table insert never actually occurs
+	// because the transaction is always rolled back; it only grabs the
+	// write lock.
+	db.setSyncDiagPhase(diagPhaseCheckpointCopyBeforeLock,
+		func(s *diagState) {
+			s.checkpointMode = mode
+			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
+		})
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = rollback(tx) }()
+
+	if _, err := tx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+		return fmt.Errorf("_litestream_lock: %w", err)
+	}
+
 	// Copy end of WAL before checkpoint to copy as much as possible.
 	db.setSyncDiagPhase(diagPhaseCheckpointCopyBefore,
 		func(s *diagState) {
@@ -2219,20 +2264,57 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	}
 	exec.applySyncResult(result)
 
-	// Execute checkpoint and immediately issue a write to the WAL to ensure
-	// a new page is written.
+	// PASSIVE checkpoints never take SQLite's writer lock, so we keep holding
+	// the write lock while checkpointing to guarantee that every backfilled
+	// frame has been captured. FULL/RESTART/TRUNCATE checkpoints acquire the
+	// writer lock themselves, so the write lock must be released first; the
+	// snapshot fallback below covers frames that sneak in before they run.
+	if mode != CheckpointModePassive {
+		if err := rollback(tx); err != nil {
+			return fmt.Errorf("rollback pre-checkpoint tx: %w", err)
+		}
+	}
+
+	// Execute checkpoint.
 	db.setSyncDiagPhase(diagPhaseCheckpointExec,
 		func(s *diagState) {
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	if err := db.execCheckpoint(ctx, mode); err != nil {
-		return err
-	} else if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
+	nLog, nCkpt, err := db.execCheckpoint(ctx, mode)
+	if err != nil {
 		return err
 	}
 
-	// If WAL hasn't been restarted, exit.
+	// Release the write lock before writing to the WAL below.
+	if err := rollback(tx); err != nil {
+		return fmt.Errorf("rollback pre-checkpoint tx: %w", err)
+	}
+
+	// Determine whether the checkpoint may have backfilled WAL frames into
+	// the database file that were never captured into an LTX file. This
+	// should be impossible for PASSIVE mode now that the write lock is held
+	// across the copy & checkpoint, but it is kept as a safety net. RESTART
+	// & TRUNCATE reset the WAL and report zero frames, so they can never
+	// prove that nothing was missed and must always take the snapshot path.
+	capturedFrames := (exec.state.lastSyncedWALOffset - WALHeaderSize) / int64(db.pageSize+WALFrameHeaderSize)
+	if mode != CheckpointModePassive {
+		exec.state.snapshotPending = true
+	} else if int64(nCkpt) > capturedFrames {
+		exec.state.snapshotPending = true
+		db.Logger.Warn("checkpoint backfilled frames beyond last synced position, forcing snapshot",
+			"mode", mode,
+			"wal_frames", nLog,
+			"checkpointed_frames", nCkpt,
+			"synced_frames", capturedFrames)
+	}
+
+	// Issue a write to the WAL to ensure a new page is written.
+	if _, err = db.db.ExecContext(ctx, `INSERT INTO _litestream_seq (id, seq) VALUES (1, 1) ON CONFLICT (id) DO UPDATE SET seq = seq + 1`); err != nil {
+		return err
+	}
+
+	// If WAL hasn't been restarted and no snapshot is pending, exit.
 	db.setSyncDiagPhase(diagPhaseCheckpointVerifyRestart,
 		func(s *diagState) {
 			s.checkpointMode = mode
@@ -2240,7 +2322,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		})
 	if other, err := readWALHeader(db.WALPath()); err != nil {
 		return err
-	} else if bytes.Equal(hdr, other) {
+	} else if bytes.Equal(hdr, other) && !exec.state.snapshotPending {
 		exec.state.syncedSinceCheckpoint = false
 		return nil
 	}
@@ -2251,21 +2333,24 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 			s.checkpointMode = mode
 			s.lastSyncedWALOffset = exec.state.lastSyncedWALOffset
 		})
-	tx, err := db.db.BeginTx(ctx, nil)
+	tx2, err := db.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
 	}
-	defer func() { _ = rollback(tx) }()
+	defer func() { _ = rollback(tx2) }()
 
 	// Insert into the lock table to promote to a write tx. The lock table
 	// insert will never actually occur because our tx will be rolled back,
 	// however, it will ensure our tx grabs the write lock. Unfortunately,
 	// we can't call "BEGIN IMMEDIATE" as we are already in a transaction.
-	if _, err := tx.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
+	if _, err := tx2.ExecContext(ctx, `INSERT INTO _litestream_lock (id) VALUES (1);`); err != nil {
 		return fmt.Errorf("_litestream_lock: %w", err)
 	}
 
-	// Copy anything that may have occurred after the checkpoint.
+	// Copy anything that may have occurred after the checkpoint. If a
+	// snapshot is pending because the checkpoint backfilled frames that
+	// were never captured, this sync writes a full snapshot from the
+	// database file to repair the LTX chain.
 	db.setSyncDiagPhase(diagPhaseCheckpointSnapshotBoundary,
 		func(s *diagState) {
 			s.checkpointMode = mode
@@ -2280,7 +2365,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	// Release write lock before exiting.
 	// Use rollback() helper for consistency with releaseReadLock() and the
 	// defer above. See issue #934.
-	if err := rollback(tx); err != nil {
+	if err := rollback(tx2); err != nil {
 		return fmt.Errorf("rollback post-checkpoint tx: %w", err)
 	}
 
@@ -2288,10 +2373,10 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 	return nil
 }
 
-func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
+func (db *DB) execCheckpoint(ctx context.Context, mode string) (nLog, nCkpt int, err error) {
 	// Ignore if there is no underlying database.
 	if db.db == nil {
-		return nil
+		return 0, 0, nil
 	}
 
 	// Track checkpoint metrics.
@@ -2308,7 +2393,7 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 	// Ensure the read lock has been removed before issuing a checkpoint.
 	// We defer the re-acquire to ensure it occurs even on an early return.
 	if err := db.releaseReadLock(); err != nil {
-		return fmt.Errorf("release read lock: %w", err)
+		return 0, 0, fmt.Errorf("release read lock: %w", err)
 	}
 	defer func() { _ = db.acquireReadLock(ctx) }()
 
@@ -2322,16 +2407,16 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (err error) {
 
 	var row [3]int
 	if err := db.db.QueryRowContext(ctx, rawsql).Scan(&row[0], &row[1], &row[2]); err != nil {
-		return err
+		return 0, 0, err
 	}
 	db.Logger.Debug("checkpoint", "mode", mode, "result", fmt.Sprintf("%d,%d,%d", row[0], row[1], row[2]))
 
 	// Reacquire the read lock immediately after the checkpoint.
 	if err := db.acquireReadLock(ctx); err != nil {
-		return fmt.Errorf("reacquire read lock: %w", err)
+		return 0, 0, fmt.Errorf("reacquire read lock: %w", err)
 	}
 
-	return nil
+	return row[1], row[2], nil
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -542,7 +542,7 @@ func TestDB_Checkpoint_ErrorMetrics(t *testing.T) {
 
 	db.db.Close()
 
-	if err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
+	if _, _, err := db.execCheckpoint(context.Background(), "PASSIVE"); err == nil {
 		t.Fatal("expected error from checkpoint with closed db")
 	}
 

--- a/tests/integration/concurrent_replication_corruption_test.go
+++ b/tests/integration/concurrent_replication_corruption_test.go
@@ -1,0 +1,179 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestConcurrentWriteReplicationCorruption reproduces a silent data-loss bug in
+// the capture path.
+//
+// Under a concurrent writer and frequent checkpoints, a checkpoint can flush WAL
+// frames into the database file before litestream captures them into an LTX file.
+// Those page writes never reach the replica, so the replica's LTX chain claims a
+// database state it cannot actually reconstruct. The backup becomes permanently
+// unrestorable even though the live database passes integrity_check.
+//
+// No crash, restart, or restore/replicate loop is required - the corruption is
+// baked into the replica during ordinary continuous replication. This asserts the
+// core backup invariant: a replica of a healthy database must always restore to a
+// consistent database.
+//
+// It FAILS on the buggy code (reproduces within a few seconds) and should PASS
+// once the capture/checkpoint boundary is fixed.
+func TestConcurrentWriteReplicationCorruption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	RequireBinaries(t)
+
+	db := SetupTestDB(t, "replication-corruption")
+	defer db.Cleanup()
+
+	if err := db.Create(); err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+
+	// TEXT primary key: SQLite builds a unique auto-index whose btree overflows and
+	// rebalances as rows grow. That rebalance is the multi-page transaction whose
+	// pages get dropped at the checkpoint/capture boundary.
+	if _, err := execSQL(db.Path,
+		`CREATE TABLE editor_objects (id TEXT PRIMARY KEY NOT NULL, payload TEXT NOT NULL)`,
+		`INSERT INTO editor_objects VALUES ('seed','x')`,
+	); err != nil {
+		t.Fatalf("Failed to seed schema: %v", err)
+	}
+
+	// Aggressive checkpointing so the WAL is recycled constantly, maximizing the
+	// number of checkpoint/capture boundaries the race can land on.
+	configPath := filepath.Join(db.TempDir, "litestream.yml")
+	cfg := fmt.Sprintf(`dbs:
+  - path: %s
+    monitor-interval: 20ms
+    checkpoint-interval: 40ms
+    min-checkpoint-page-count: 8
+    replicas:
+      - type: file
+        path: %s
+`, filepath.ToSlash(db.Path), filepath.ToSlash(db.ReplicaPath))
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	t.Log("[1] Starting Litestream...")
+	if err := db.StartLitestreamWithConfig(configPath); err != nil {
+		t.Fatalf("Failed to start Litestream: %v", err)
+	}
+
+	t.Log("[2] Writing concurrently while the replica is periodically restored...")
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); writeCorruptionRows(ctx, db.Path) }()
+
+	// A healthy database's replica must always restore to a consistent database.
+	// Restore it repeatedly during replication; the first restore that fails
+	// integrity_check (or fails to decode) is the reproduced corruption.
+	var corruption error
+	deadline := time.Now().Add(30 * time.Second)
+	for i := 0; corruption == nil && time.Now().Before(deadline); i++ {
+		time.Sleep(400 * time.Millisecond)
+
+		restoredPath := filepath.Join(db.TempDir, fmt.Sprintf("restored-%d.db", i))
+		if err := db.Restore(restoredPath); err != nil {
+			// A structural decode error is real corruption. Other restore errors
+			// can happen transiently while litestream compacts the replica (a file
+			// it listed is removed mid-read), so retry those.
+			if strings.Contains(err.Error(), "nonsequential page numbers") ||
+				strings.Contains(err.Error(), "decode page") {
+				corruption = err
+			}
+			_ = os.Remove(restoredPath)
+			continue
+		}
+
+		restored := &TestDB{Path: restoredPath, t: t}
+		if err := restored.IntegrityCheck(); err != nil {
+			corruption = err
+		}
+		_ = os.Remove(restoredPath)
+	}
+
+	cancel()
+	wg.Wait()
+	db.StopLitestream()
+
+	if corruption != nil {
+		t.Fatalf("CORRUPTION: replica of a healthy database did not restore to a consistent database: %v", corruption)
+	}
+	t.Log("TEST PASSED: replica stayed restorable throughout replication")
+}
+
+// writeCorruptionRows inserts unique small rows until ctx is cancelled. Errors are
+// ignored - litestream holds locks and the writer is expected to contend with it.
+//
+// It follows Litestream's documented tips for high write loads
+// (https://litestream.io/tips/): busy_timeout=5000 and, crucially,
+// wal_autocheckpoint=0 so the application never checkpoints and Litestream is the
+// sole checkpointer. This proves the corruption is NOT the documented
+// "application checkpoints between Litestream's checkpoints" footgun - it happens
+// even when the app does everything the docs recommend.
+//
+// The connection is pinned (SetMaxOpenConns(1) + a single *sql.Conn) because
+// database/sql pools connections: a PRAGMA run on the pool only affects one
+// connection, so pooled inserts could still run with the default autocheckpoint.
+func writeCorruptionRows(ctx context.Context, path string) {
+	dsn := fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", filepath.ToSlash(path))
+	pool, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return
+	}
+	defer pool.Close()
+	pool.SetMaxOpenConns(1)
+
+	conn, err := pool.Conn(ctx)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `PRAGMA wal_autocheckpoint=0`); err != nil {
+		return
+	}
+
+	payload := strings.Repeat("x", 48)
+	for i := 0; ctx.Err() == nil; i++ {
+		_, _ = conn.ExecContext(ctx,
+			`INSERT INTO editor_objects (id,payload) VALUES (?,?)`,
+			fmt.Sprintf("obj-%08d", i), payload)
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// execSQL opens path, runs the given statements, and closes it.
+func execSQL(path string, stmts ...string) (sql.Result, error) {
+	sqldb, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return nil, err
+	}
+	defer sqldb.Close()
+
+	var res sql.Result
+	for _, stmt := range stmts {
+		if res, err = sqldb.Exec(stmt); err != nil {
+			return nil, fmt.Errorf("%s: %w", stmt, err)
+		}
+	}
+	return res, nil
+}


### PR DESCRIPTION
## Summary
In a system I operate, sometimes "litestream restore" will create an invalid database file. 

I've got a test case (tests/integration/concurrent_replication_corruption_test.go) in
this PR that reliably reproduces the error: one litestream process replicates a database
file to a file target while a concurrent writer inserts rows into that same database. The
test then restores from the target in a loop and checks integrity — and within a few
seconds hits a restore that produces an invalid database file (fails PRAGMA
integrity_check, or fails to decode).

The restore loop is only how the test *detects* the problem — the corruption is baked
into the replica during ordinary replication, before any restore. So this is a bug in the
capture/checkpoint path, not in restore.

This PR also includes a potential fix, which can be disregarded in favor of a more
appropriate one. AI was used to help reduce the bug to a reproducible test case and 
to write the fix.

## Problem
During continuous replication with a concurrent writer, replicas would
intermittently fail `PRAGMA integrity_check` after restore, with signatures like:

- `wrong # of entries in index ...`
- `Page N: never used`

`checkpointWithExecutor` did not hold the database write lock between (a) copying
the WAL tail into an LTX file and (b) running `PRAGMA wal_checkpoint`. A concurrent
writer could commit frames in that window; the checkpoint backfilled them into the
database file, and the subsequent WAL restart (triggered by litestream's own
`_litestream_seq` write) discarded them from the WAL. `verify()` then saw a
benign-looking single-generation salt change and continued incrementally on the new
WAL, so those pages never reached any LTX file.

Instrumentation confirmed the race: 32 events in a single 5s run where the
checkpoint backfilled more frames than litestream had captured (e.g. `nCkpt=17` vs
`captured=15`).

## Solution
Two complementary mechanisms in `db.go`:

1. **Close the race:** acquire the write lock (`BEGIN` + `_litestream_lock` insert,
   always rolled back — the same trick the post-checkpoint copy already used) before
   the pre-checkpoint WAL copy, and hold it through PASSIVE checkpoints (which never
   need SQLite's writer lock). No frame can be committed between capture and
   checkpoint.
2. **Safety net:** `execCheckpoint` now returns `(frames-in-WAL, frames-backfilled)`.
   If a checkpoint may have backfilled uncaptured frames (provable overrun for
   PASSIVE, always assumed for FULL/RESTART/TRUNCATE), a persistent `snapshotPending`
   flag forces the next sync to write a full snapshot from the database file,
   repairing the LTX chain. The flag survives transient sync failures and clears only
   after a snapshot is written.

## Scope
**In scope:**
- Checkpoint locking + safety-net snapshot in `db.go`
- Regression test in `tests/integration/`

**Not in scope:**
- No changes to compaction, restore, or storage backends

## Test Plan
```bash
# Regression test (fails pre-fix in ~5s, passes post-fix)
go test -tags integration -race -run TestConcurrentWriteReplicationCorruption ./tests/integration/

# Full race suite
go test -race ./...

Post-fix: the regression test passes the full window with zero safety-net triggers;
go test -race ./... passes.