### PR TITLE
feat(cli): print proper version string on dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 default:
 
+VERSION = $(shell git describe --tags --always --dirty 2>/dev/null)
+
+.PHONY: build
+build:
+	mkdir -p dist
+	go build -ldflags "-X 'main.Version=$(VERSION)'" -o dist/litestream ./cmd/litestream
+
 docker:
 	docker build -t litestream .
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -13,6 +13,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -35,10 +36,14 @@ import (
 	"github.com/benbjohnson/litestream/webdav"
 )
 
-// Build information.
-var (
-	Version = "(development build)"
-)
+// Version is set via -ldflags "-X main.Version=..." on release and Makefile
+// builds; otherwise it is resolved from embedded VCS build info at startup.
+var Version = defaultVersion
+
+func init() {
+	bi, _ := debug.ReadBuildInfo()
+	Version = resolveVersion(Version, bi)
+}
 
 // errStop is a terminal error for indicating program should quit.
 var errStop = errors.New("stop")

--- a/cmd/litestream/version.go
+++ b/cmd/litestream/version.go
@@ -4,7 +4,57 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"runtime"
+	"runtime/debug"
 )
+
+// defaultVersion is the placeholder used when no version was injected at
+// build time via -ldflags "-X main.Version=...".
+const defaultVersion = "(development build)"
+
+// resolveVersion returns the most descriptive version string available:
+// the ldflags-injected value, the VCS-stamped module version, the VCS
+// revision, or the development-build placeholder, in that order.
+func resolveVersion(injected string, bi *debug.BuildInfo) string {
+	if injected != "" && injected != defaultVersion {
+		return injected
+	}
+	if bi == nil {
+		return defaultVersion
+	}
+
+	if v := bi.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+
+	revision, modified, _ := vcsSettings(bi)
+	if revision == "" {
+		return defaultVersion
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	if modified {
+		revision += "-dirty"
+	}
+	return fmt.Sprintf("(development build %s)", revision)
+}
+
+// vcsSettings extracts VCS metadata from embedded build info settings.
+// The vcs.time value is the commit timestamp, not the build time.
+func vcsSettings(bi *debug.BuildInfo) (revision string, modified bool, commitTime string) {
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		case "vcs.time":
+			commitTime = s.Value
+		}
+	}
+	return revision, modified, commitTime
+}
 
 // VersionCommand represents a command to print the current version.
 type VersionCommand struct{}
@@ -12,12 +62,32 @@ type VersionCommand struct{}
 // Run executes the command.
 func (c *VersionCommand) Run(_ context.Context, args []string) (err error) {
 	fs := flag.NewFlagSet("litestream-version", flag.ContinueOnError)
+	verbose := fs.Bool("verbose", false, "print detailed build metadata")
 	fs.Usage = c.Usage
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	fmt.Println(Version)
+	if !*verbose {
+		fmt.Println(Version)
+		return nil
+	}
+
+	fmt.Printf("Version:     %s\n", Version)
+	fmt.Printf("Go Version:  %s\n", runtime.Version())
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		revision, modified, commitTime := vcsSettings(bi)
+		if revision != "" {
+			if modified {
+				revision += " (dirty)"
+			}
+			fmt.Printf("Git Commit:  %s\n", revision)
+		}
+		if commitTime != "" {
+			fmt.Printf("Commit Time: %s\n", commitTime)
+		}
+	}
+	fmt.Printf("OS/Arch:     %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
 	return nil
 }
@@ -29,6 +99,11 @@ Prints the version.
 
 Usage:
 
-	litestream version
+	litestream version [arguments]
+
+Arguments:
+
+	-verbose
+	    Print detailed build metadata (Go version, commit, build time, OS/arch).
 `[1:])
 }

--- a/cmd/litestream/version_cli_test.go
+++ b/cmd/litestream/version_cli_test.go
@@ -1,0 +1,34 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+
+	main "github.com/benbjohnson/litestream/cmd/litestream"
+)
+
+func TestVersionCommand_Default(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := (&main.VersionCommand{}).Run(t.Context(), nil); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if got, want := out, main.Version+"\n"; got != want {
+		t.Fatalf("output=%q, want %q", got, want)
+	}
+}
+
+func TestVersionCommand_Verbose(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := (&main.VersionCommand{}).Run(t.Context(), []string{"-verbose"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	for _, field := range []string{"Version:", "Go Version:", "OS/Arch:"} {
+		if !strings.Contains(out, field) {
+			t.Fatalf("verbose output missing %q:\n%s", field, out)
+		}
+	}
+}

--- a/cmd/litestream/version_test.go
+++ b/cmd/litestream/version_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveVersion(t *testing.T) {
+	buildInfo := func(mainVersion string, settings map[string]string) *debug.BuildInfo {
+		bi := &debug.BuildInfo{}
+		bi.Main.Version = mainVersion
+		for k, v := range settings {
+			bi.Settings = append(bi.Settings, debug.BuildSetting{Key: k, Value: v})
+		}
+		return bi
+	}
+
+	for _, tt := range []struct {
+		name     string
+		injected string
+		bi       *debug.BuildInfo
+		want     string
+	}{
+		{
+			name:     "InjectedVersionWins",
+			injected: "v0.5.13-6-g2b34013-dirty",
+			bi:       buildInfo("v0.5.14", nil),
+			want:     "v0.5.13-6-g2b34013-dirty",
+		},
+		{
+			name:     "ModuleVersionFromBuildInfo",
+			injected: defaultVersion,
+			bi:       buildInfo("v0.5.13+dirty", nil),
+			want:     "v0.5.13+dirty",
+		},
+		{
+			name:     "EmptyInjectedFallsBackToBuildInfo",
+			injected: "",
+			bi:       buildInfo("v0.5.13", nil),
+			want:     "v0.5.13",
+		},
+		{
+			name:     "DevelModuleVersionFallsBackToRevision",
+			injected: defaultVersion,
+			bi: buildInfo("(devel)", map[string]string{
+				"vcs.revision": "2b340139876543210fedcba9876543210fedcba9",
+				"vcs.modified": "false",
+			}),
+			want: "(development build 2b3401398765)",
+		},
+		{
+			name:     "DirtyRevisionMarked",
+			injected: defaultVersion,
+			bi: buildInfo("(devel)", map[string]string{
+				"vcs.revision": "2b340139876543210fedcba9876543210fedcba9",
+				"vcs.modified": "true",
+			}),
+			want: "(development build 2b3401398765-dirty)",
+		},
+		{
+			name:     "ShortRevisionNotTruncated",
+			injected: defaultVersion,
+			bi: buildInfo("(devel)", map[string]string{
+				"vcs.revision": "2b34013",
+				"vcs.modified": "false",
+			}),
+			want: "(development build 2b34013)",
+		},
+		{
+			name:     "NoBuildInfo",
+			injected: defaultVersion,
+			bi:       nil,
+			want:     defaultVersion,
+		},
+		{
+			name:     "NoVersionInfoAtAll",
+			injected: defaultVersion,
+			bi:       buildInfo("(devel)", nil),
+			want:     defaultVersion,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveVersion(tt.injected, tt.bi); got != tt.want {
+				t.Fatalf("resolveVersion()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Makes `litestream version` print a descriptive version string on dev builds instead of the bare `(development build)` placeholder.

- The version is resolved at startup with this precedence: ldflags-injected value → VCS-stamped module version from embedded build info (Go 1.24+ stamps this on plain `go build` in a git clone, e.g. `v0.5.13+dirty`) → VCS revision with a dirty marker, e.g. `(development build 2b3401398765-dirty)` → the `(development build)` placeholder.
- New `make build` target injects `git describe --tags --always --dirty` via ldflags and produces `dist/litestream`, giving a full `v0.5.13-6-g2b34013-dirty` style string even in git worktrees, where the Go toolchain skips VCS stamping.
- New `litestream version -verbose` flag prints Go version, git commit (with dirty marker), commit time, and OS/arch.
- The resolved version also flows into the startup log line, the HTTP server version, and the MCP version tool, which all read the same variable.

Release builds are unaffected: goreleaser and the Dockerfile inject `main.Version` via ldflags, which always wins.

## Motivation and Context
Dev builds printed only `(development build)`, which makes build traceability impossible when triaging reports from locally built binaries.

Fixes #1335

## How Has This Been Tested?
- Table-driven unit tests for the resolution precedence (injected / module version / revision+dirty / no info) and CLI output tests for default and verbose modes.
- `go test ./...` passes (full suite), `go test -race ./cmd/litestream` passes, `go vet` clean.
- Manually verified: `make build && ./dist/litestream version` prints `v0.5.13-6-g2b34013-dirty`; plain `go build` binary in a fresh clone gets the VCS-stamped fallback; verbose output verified on both.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)