### PR TITLE
fix(replica): fsync directory after durable renames

### DIFF
--- a/db.go
+++ b/db.go
@@ -2236,6 +2236,13 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		db.invalidatePosCache()
 		return result, fmt.Errorf("rename ltx file: %w", err)
 	}
+	if err := internal.FsyncDir(filepath.Dir(filename)); err != nil {
+		db.maxLTXFileInfos.Lock()
+		delete(db.maxLTXFileInfos.m, 0) // clear cache if in unknown state
+		db.maxLTXFileInfos.Unlock()
+		db.invalidatePosCache()
+		return result, fmt.Errorf("sync ltx dir: %w", err)
+	}
 
 	result.synced = true
 	result.l0FileInfo = &ltx.FileInfo{

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -224,6 +224,9 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	if err := os.Rename(tmpFilename, filename); err != nil {
 		return nil, err
 	}
+	if err := internal.FsyncDir(filepath.Dir(filename)); err != nil {
+		return nil, err
+	}
 
 	// Set file ModTime to preserve original timestamp
 	if err := os.Chtimes(filename, timestamp, timestamp); err != nil {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -96,6 +96,19 @@ func CreateFile(filename string, fi os.FileInfo) (*os.File, error) {
 
 // MkdirAll is a copy of os.MkdirAll() except that it attempts to set the
 // mode/uid/gid to match fi for each created directory.
+// FsyncDir syncs a directory so a preceding rename within it is durable.
+func FsyncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		return err
+	}
+	return dir.Close()
+}
+
 func MkdirAll(path string, fi os.FileInfo) error {
 	uid, gid := Fileinfo(fi)
 

--- a/replica.go
+++ b/replica.go
@@ -763,6 +763,9 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	if err := os.Rename(tmpOutputPath, opt.OutputPath); err != nil {
 		return err
 	}
+	if err := internal.FsyncDir(filepath.Dir(opt.OutputPath)); err != nil {
+		return fmt.Errorf("sync restore output dir: %w", err)
+	}
 
 	if opt.IntegrityCheck != IntegrityCheckNone {
 		if err := checkIntegrity(ctx, opt.OutputPath, opt.IntegrityCheck); err != nil {
@@ -1152,6 +1155,9 @@ func (r *Replica) RestoreV3(ctx context.Context, opt RestoreOptions) error {
 	// Rename to final path.
 	if err := os.Rename(tmpPath, opt.OutputPath); err != nil {
 		return fmt.Errorf("rename to output path: %w", err)
+	}
+	if err := internal.FsyncDir(filepath.Dir(opt.OutputPath)); err != nil {
+		return fmt.Errorf("sync restore output dir: %w", err)
 	}
 
 	if opt.IntegrityCheck != IntegrityCheckNone {
@@ -1738,15 +1744,10 @@ func WriteTXIDFile(outputPath string, txid ltx.TXID) error {
 		return fmt.Errorf("rename txid file: %w", err)
 	}
 
-	dir, err := os.Open(filepath.Dir(txidPath))
-	if err != nil {
-		return fmt.Errorf("open txid dir for sync: %w", err)
-	}
-	if err := dir.Sync(); err != nil {
-		_ = dir.Close()
+	if err := internal.FsyncDir(filepath.Dir(txidPath)); err != nil {
 		return fmt.Errorf("sync txid dir: %w", err)
 	}
-	return dir.Close()
+	return nil
 }
 
 // ReadTXIDFile reads the TXID from a sidecar file at <outputPath>-txid.


### PR DESCRIPTION
## Description
Adds `internal.FsyncDir` and calls it after every rename that finalizes a durable file:
- both `Replica.Restore` output paths (main + V3),
- local L0 LTX staging in `db.go`,
- the `file` replica backend's `WriteLTXFile`.

`WriteTXIDFile`'s existing inline directory sync is refactored onto the same helper, so the crash-durability pattern (temp + fsync + rename + dir-sync) now lives in one place.

## Motivation and Context
Without a directory fsync, a crash shortly after a successful `os.Rename` can lose the directory entry — a restore that reported success can leave no database file, and the file backend can lose a replica LTX object it reported as written. `WriteTXIDFile` already did this correctly; the other rename sites did not. The two non-restore sites were found by review while fixing the restore path (same defect class).

Fixes #1342

## How Has This Been Tested?
`go build ./...`, `go vet ./...`, and `go test -race` for the root, `file`, and `internal` packages all pass. Durability-on-crash itself is not directly testable without fault injection; the change is the established `WriteTXIDFile` pattern applied to the remaining sites.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)