### PR TITLE
fix(replica): drain limited sync batches

### DIFF
--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -460,6 +460,80 @@ func TestReplica_SyncOnceLimitsLTXFiles(t *testing.T) {
 	}
 }
 
+func TestReplicaMonitor_DrainsLimitedBacklogWithoutWaitingForInterval(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	client := &testReplicaClient{dir: t.TempDir()}
+	r := NewReplicaWithClient(db, client)
+	r.MonitorEnabled = false
+	r.MaxSyncLTXFiles = 1
+	r.SyncInterval = time.Hour
+	db.Replica = r
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal;`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY);`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if _, err := sqldb.Exec(`INSERT INTO t DEFAULT VALUES;`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dpos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dpos.TXID <= ltx.TXID(r.MaxSyncLTXFiles) {
+		t.Fatalf("db txid=%s, want backlog larger than %d", dpos.TXID, r.MaxSyncLTXFiles)
+	}
+
+	r.MonitorEnabled = true
+	if err := r.Start(db.ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := r.Pos().TXID; got == dpos.TXID {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("replica txid=%s, want %s before next sync interval", r.Pos().TXID, dpos.TXID)
+		case <-ticker.C:
+		}
+	}
+}
+
 func TestDB_SyncDiagnostic(t *testing.T) {
 	db := NewDB(filepath.Join(t.TempDir(), "db"))
 

--- a/replica.go
+++ b/replica.go
@@ -53,8 +53,8 @@ type Replica struct {
 	// Time between syncs with the shadow WAL.
 	SyncInterval time.Duration
 
-	// Maximum L0 files to upload in a single monitor sync run.
-	// Set to zero to process all pending L0 files in one run.
+	// Maximum L0 files to upload in a single monitor sync batch.
+	// Set to zero to process all pending L0 files in one batch.
 	MaxSyncLTXFiles int
 
 	// If true, replica monitors database for changes automatically.
@@ -142,8 +142,18 @@ func (r *Replica) Stop(hard bool) (err error) {
 // Sync copies new WAL frames from the shadow WAL to the replica client.
 // Only one Sync can run at a time to prevent concurrent uploads of the same file.
 func (r *Replica) Sync(ctx context.Context) (err error) {
-	_, err = r.syncOnce(ctx, 0)
-	return err
+	return r.sync(ctx, 0)
+}
+
+func (r *Replica) sync(ctx context.Context, maxSyncLTXFiles int) error {
+	for {
+		result, err := r.syncOnce(ctx, maxSyncLTXFiles)
+		if err != nil {
+			return err
+		} else if !result.limited {
+			return nil
+		}
+	}
 }
 
 type replicaSyncResult struct {
@@ -427,7 +437,7 @@ func (r *Replica) monitor(ctx context.Context) {
 		notify = r.db.Notify()
 
 		// Synchronize the shadow wal into the replication directory.
-		if _, err := r.syncOnce(ctx, r.MaxSyncLTXFiles); err != nil {
+		if err := r.sync(ctx, r.MaxSyncLTXFiles); err != nil {
 			if errors.Is(err, errReplicaWaitForData) {
 				continue
 			}


### PR DESCRIPTION
## Description

The replica monitor now immediately drains additional bounded L0 batches while `syncOnce` reports that the batch limit was reached. Each batch still releases the sync semaphore, so explicit sync and shutdown callers can interleave without restoring the per-interval throughput cap.

The `MaxSyncLTXFiles` documentation now describes the value as a per-batch limit, and a regression test verifies that a backlog larger than the limit drains before the next monitor interval.

## Motivation and Context

The monitor previously discarded `replicaSyncResult.limited` after uploading `MaxSyncLTXFiles` and waited for the next `SyncInterval`. With the default values, replica drain throughput was capped near 256 L0 files per second, so a sustained producer above that rate could grow the unreplicated local backlog indefinitely.

The regression test creates three L0 files, sets `MaxSyncLTXFiles=1`, and sets a one-hour sync interval. Before the fix it failed after the first upload with:

```text
replica txid=0000000000000001, want 0000000000000003 before next sync interval
```

This mirrors the bounded-chunk catch-up behavior introduced for DB sync in #1290.

Fixes #1331

## Scope

In scope:

- Drain all currently pending replica L0 files through bounded batches.
- Release the replica sync semaphore between batches.
- Cover monitor behavior with a backlog larger than `MaxSyncLTXFiles`.

Out of scope:

- Changing the default batch size or sync interval.
- Adding an explicit replica throughput throttle.
- Changing DB-side WAL chunking.

This is stacked on `issue-1310-disk-full-staging-wedge` at `f2851b1`.

## How Has This Been Tested?

- Verified the new regression test failed before the production change.
- `go test . -run "^(TestReplica_Sync|TestReplica_SyncOnceLimitsLTXFiles|TestReplicaMonitor_DrainsLimitedBacklogWithoutWaitingForInterval|TestReplicaMonitor_IdleRecordsSyncHealth|TestReplicaMonitor_RecoversFromPositionError)$" -count=1 -v`
- `go test -race . -run "^(TestReplica_SyncOnceLimitsLTXFiles|TestReplicaMonitor_DrainsLimitedBacklogWithoutWaitingForInterval)$" -count=1`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `pre-commit run --all-files`
- `go build -o bin/litestream ./cmd/litestream`
- `go build -o bin/litestream-test ./cmd/litestream-test`
- `go test -tags "integration,soak" -run "^TestLTXBehavior$" -short -v -timeout 15m ./tests/integration/`

The LTX behavioral gate passed all low-volume, high-volume, and burst-volume profiles, including restore and integrity validation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)