### PR TITLE
fix(db): make SnapshotReader closeable

### DIFF
--- a/db.go
+++ b/db.go
@@ -2645,13 +2645,21 @@ type snapshotReadPosition struct {
 	pageSize     int
 	walEndOffset int64
 	db           *DB
+	closeOnce    sync.Once
 }
 
 func (p *snapshotReadPosition) close() {
-	if p.db != nil {
-		p.db.chkMu.RUnlock()
-		p.db = nil
-	}
+	p.closeOnce.Do(func() { p.db.chkMu.RUnlock() })
+}
+
+type snapshotReadCloser struct {
+	*io.PipeReader
+	pos *snapshotReadPosition
+}
+
+func (r *snapshotReadCloser) Close() error {
+	defer r.pos.close()
+	return r.PipeReader.Close()
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
@@ -2846,7 +2854,7 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 		_ = pw.Close()
 	}()
 
-	return pr, nil
+	return &snapshotReadCloser{PipeReader: pr, pos: pos}, nil
 }
 
 func snapshotHeaderWALRange(maxOffset, frameSize int64) (offset, size int64) {

--- a/db.go
+++ b/db.go
@@ -2655,10 +2655,10 @@ func (p *snapshotReadPosition) close() {
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
-// Internal checkpoints are disabled until the reader is fully drained or
-// closed (it implements io.Closer). An abandoned reader blocks checkpoints
-// for the life of the process.
-func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.Reader, error) {
+// Internal checkpoints remain disabled until the reader reaches EOF or is
+// closed. Callers must close readers they do not fully consume; abandoning a
+// reader blocks checkpoints indefinitely.
+func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.ReadCloser, error) {
 	pos, err := db.snapshotPosition(ctx)
 	if err != nil {
 		return ltx.Pos{}, nil, err
@@ -2752,7 +2752,7 @@ func (db *DB) snapshotWALEndOffset(pos ltx.Pos) (int64, error) {
 	return dec.Header().WALOffset + dec.Header().WALSize, nil
 }
 
-func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io.Reader, error) {
+func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io.ReadCloser, error) {
 	db.Logger.Debug("snapshot", "txid", pos.pos.TXID.String(), "walEndOffset", pos.walEndOffset)
 
 	// TODO(ltx): Read database size from database header.
@@ -2888,12 +2888,10 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = r.Close() }()
 
 	info, err := db.Replica.Client.WriteLTXFile(ctx, SnapshotLevel, 1, pos.TXID, r)
 	if err != nil {
-		if closer, ok := r.(io.Closer); ok {
-			_ = closer.Close()
-		}
 		return info, err
 	}
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -31,6 +31,14 @@ type testReplicaClient struct {
 	dir string
 }
 
+type earlyReturnSnapshotClient struct {
+	*testReplicaClient
+}
+
+func (c *earlyReturnSnapshotClient) WriteLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, _ io.Reader) (*ltx.FileInfo, error) {
+	return &ltx.FileInfo{Level: level, MinTXID: minTXID, MaxTXID: maxTXID}, nil
+}
+
 func (c *testReplicaClient) Init(_ context.Context) error { return nil }
 
 func (c *testReplicaClient) SetLogger(_ *slog.Logger) {}
@@ -4197,6 +4205,57 @@ func TestSyncRestoreIntegrity_WithCheckpoints(t *testing.T) {
 	}
 }
 
+func TestDB_SnapshotClosesReaderWhenReplicaReturnsEarly(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplica(db)
+	db.Replica.Client = &earlyReturnSnapshotClient{testReplicaClient: &testReplicaClient{dir: t.TempDir()}}
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close(context.Background()) }()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Snapshot(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if db.chkMu.TryLock() {
+			db.chkMu.Unlock()
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("checkpoint lock remains held after Snapshot returns")
+		case <-ticker.C:
+		}
+	}
+}
+
 // TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints verifies that a
 // snapshot's content matches its advertised position while checkpoints and
 // writes run concurrently. The position capture and chkMu read lock must be
@@ -4361,8 +4420,8 @@ func TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints(t *testing.T) {
 		if err := rf.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if closer, ok := r.(io.Closer); ok {
-			_ = closer.Close()
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
 		}
 
 		restoredDB, err := sql.Open("sqlite", restorePath)

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -4239,21 +4239,10 @@ func TestDB_SnapshotClosesReaderWhenReplicaReturnsEarly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.NewTimer(time.Second)
-	defer deadline.Stop()
-	ticker := time.NewTicker(time.Millisecond)
-	defer ticker.Stop()
-	for {
-		if db.chkMu.TryLock() {
-			db.chkMu.Unlock()
-			return
-		}
-		select {
-		case <-deadline.C:
-			t.Fatal("checkpoint lock remains held after Snapshot returns")
-		case <-ticker.C:
-		}
+	if !db.chkMu.TryLock() {
+		t.Fatal("checkpoint lock remains held after Snapshot returns")
 	}
+	db.chkMu.Unlock()
 }
 
 // TestDB_SnapshotReaderConsistentDuringConcurrentCheckpoints verifies that a


### PR DESCRIPTION
## Description

- Return `io.ReadCloser` from `DB.SnapshotReader` so checkpoint-lock cleanup is part of the public API.
- Close snapshot readers on every `DB.Snapshot` return path, including a successful replica write that stops before EOF.
- Document the checkpoint-lock lifetime and abandoned-reader contract.
- Add a regression test with a replica client that returns success without consuming the snapshot.

## Motivation and Context

`SnapshotReader` holds `chkMu.RLock` while its encoder streams through an `io.Pipe`. The old `io.Reader` return type did not expose cleanup structurally, and `DB.Snapshot` only closed the reader after upload errors. A replica client that returned success without reading to EOF left the encoder blocked in the pipe while holding the checkpoint lock, so every later checkpoint was skipped and the WAL could grow without bound.

Before the fix, the focused reproduction failed with:

```text
--- FAIL: TestDB_SnapshotClosesReaderWhenReplicaReturnsEarly
checkpoint lock remains held after Snapshot returns
```

This PR is stacked on #1322 and targets `issue-1310-disk-full-staging-wedge`.

## Scope

**In scope:**
- Structural `io.ReadCloser` API contract
- Snapshot cleanup on early replica returns
- SnapshotReader godoc contract
- Regression coverage

**Not in scope:**
- A watchdog or timeout for abandoned readers

## How Has This Been Tested?

```bash
go test -race -count=1 ./...
go test -race . -run '^TestDB_SnapshotClosesReaderWhenReplicaReturnsEarly$' -count=20 -timeout=60s
pre-commit run --all-files
go build -o bin/litestream ./cmd/litestream
go build -o bin/litestream-test ./cmd/litestream-test
LOG_LEVEL=DEBUG go test -tags 'integration,soak' -run '^TestLTXBehavior$' -short -v -timeout 15m ./tests/integration/
```

The short LTX behavioral gate passed all three profiles, including bounded WAL checks, checkpoint observation, restoration, and integrity validation.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Public API signature change

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly

## Related

- Fixes #1340
- Fixes #1334
