### PR TITLE
fix(db): skip repeated passive before truncate

### DIFF
--- a/db.go
+++ b/db.go
@@ -221,11 +221,12 @@ type syncState struct {
 }
 
 type syncExecutor struct {
-	state      syncState
-	pos        ltx.Pos
-	posChanged bool
-	l0FileInfo *ltx.FileInfo
-	synced     bool
+	state               syncState
+	pos                 ltx.Pos
+	posChanged          bool
+	l0FileInfo          *ltx.FileInfo
+	synced              bool
+	checkpointAttempted bool
 }
 
 type diagOp string
@@ -1435,7 +1436,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 						"threshold", truncateThreshold)
 					return nil
 				}
-			} else {
+			} else if exec.checkpointAttempted {
 				exec.state.truncatePassiveFailed = true
 			}
 		}
@@ -1703,6 +1704,8 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 	if fi, err := os.Stat(db.WALPath()); err != nil {
 		return info, fmt.Errorf("open wal file: %w", err)
 	} else if info.offset > fi.Size() {
+		exec.state.truncatePassiveFailed = false
+
 		// If we previously synced to the exact end of the WAL, this truncation
 		// is expected (normal checkpoint behavior). Reset position and continue
 		// incrementally rather than triggering a full snapshot. See issue #927.
@@ -1739,6 +1742,9 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 	salt1 := binary.BigEndian.Uint32(hdr0[16:])
 	salt2 := binary.BigEndian.Uint32(hdr0[20:])
 	saltMatch := salt1 == dec.Header().WALSalt1 && salt2 == dec.Header().WALSalt2
+	if !saltMatch {
+		exec.state.truncatePassiveFailed = false
+	}
 
 	// Handle edge case where we're at WAL header (WALOffset=32, WALSize=0).
 	// This can happen when an LTX file represents a state at the beginning of the WAL
@@ -2426,6 +2432,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 // whether the checkpoint restarted the WAL. It returns false without
 // checkpointing when the checkpoint lock is held by an in-progress snapshot.
 func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syncExecutor) (walRestarted bool, err error) {
+	exec.checkpointAttempted = false
 	db.setSyncDiagPhase(diagPhaseCheckpointLock,
 		func(s *diagState) {
 			s.checkpointMode = mode
@@ -2442,6 +2449,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		return false, nil
 	}
 	defer db.chkMu.Unlock()
+	exec.checkpointAttempted = true
 
 	// Read WAL header before checkpoint to check if it has been restarted.
 	db.setSyncDiagPhase(diagPhaseCheckpointReadWALHeader,
@@ -2531,6 +2539,7 @@ func (db *DB) checkpointWithExecutor(ctx context.Context, mode string, exec *syn
 		exec.state.syncedSinceCheckpoint = false
 		return false, nil
 	}
+	exec.state.truncatePassiveFailed = false
 
 	if mode == CheckpointModePassive {
 		result, err = db.verifyAndSyncWithExecutor(ctx, true, exec, 0)

--- a/db.go
+++ b/db.go
@@ -195,6 +195,8 @@ type DB struct {
 // syncState holds mutable sync-tracking fields extracted from DB.
 // These fields are threaded through sync/checkpoint methods via pointer.
 type syncState struct {
+	truncatePassiveFailed bool
+
 	// syncedSinceCheckpoint tracks whether any data has been synced since
 	// the last checkpoint. Used to prevent time-based checkpoints from
 	// triggering when there are no actual database changes, which would
@@ -1406,31 +1408,45 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	if db.pageSize == 0 {
 		return nil
 	}
+	if !db.exceedsTruncateThreshold(exec.state.lastSyncedWALOffset) {
+		exec.state.truncatePassiveFailed = false
+	}
 
 	// Priority 1: Emergency truncate checkpoint (TRUNCATE mode, blocking)
 	// This prevents unbounded WAL growth from long-lived read transactions.
 	if db.exceedsTruncateThreshold(origWALSize) {
 		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
 
-		// Try a PASSIVE checkpoint first: if it restarts the WAL and brings
-		// the synced offset below the threshold, the blocking TRUNCATE and
-		// its mandatory boundary snapshot are skipped.
-		if restarted, err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
-			if !isSQLiteBusyError(err) {
-				return err
+		if !exec.state.truncatePassiveFailed {
+			// Try a PASSIVE checkpoint first: if it restarts the WAL and brings
+			// the synced offset below the threshold, the blocking TRUNCATE and
+			// its mandatory boundary snapshot are skipped.
+			if restarted, err := db.checkpointWithExecutor(ctx, CheckpointModePassive, exec); err != nil {
+				if !isSQLiteBusyError(err) {
+					return err
+				}
+				exec.state.truncatePassiveFailed = true
+				db.Logger.Log(ctx, internal.LevelTrace, "passive checkpoint skipped", "reason", "database busy")
+			} else if restarted {
+				exec.state.truncatePassiveFailed = false
+				if !db.exceedsTruncateThreshold(exec.state.lastSyncedWALOffset) {
+					db.Logger.Info("wal restarted by passive checkpoint, skipping truncate checkpoint",
+						"wal_size", origWALSize,
+						"threshold", truncateThreshold)
+					return nil
+				}
+			} else {
+				exec.state.truncatePassiveFailed = true
 			}
-			db.Logger.Log(ctx, internal.LevelTrace, "passive checkpoint skipped", "reason", "database busy")
-		} else if restarted && !db.exceedsTruncateThreshold(exec.state.lastSyncedWALOffset) {
-			db.Logger.Info("wal restarted by passive checkpoint, skipping truncate checkpoint",
-				"wal_size", origWALSize,
-				"threshold", truncateThreshold)
-			return nil
 		}
 
 		db.Logger.Info("forcing truncate checkpoint",
 			"wal_size", origWALSize,
 			"threshold", truncateThreshold)
-		_, err := db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
+		restarted, err := db.checkpointWithExecutor(ctx, CheckpointModeTruncate, exec)
+		if restarted || !db.exceedsTruncateThreshold(exec.state.lastSyncedWALOffset) {
+			exec.state.truncatePassiveFailed = false
+		}
 		return err
 	}
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -744,6 +744,13 @@ func TestDB_CheckpointPassiveRestartSkipsTruncate(t *testing.T) {
 	passiveBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive))
 	truncateBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate))
 
+	db.chkMu.RLock()
+	err = db.Sync(t.Context())
+	db.chkMu.RUnlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := db.Sync(t.Context()); err != nil {
 		t.Fatal(err)
 	}
@@ -866,33 +873,27 @@ func TestDB_CheckpointTruncateSkipsRepeatedPassiveWithoutProgress(t *testing.T) 
 	if err := tx.Rollback(); err != nil {
 		t.Fatal(err)
 	}
+	db.TruncatePageN = 1
+	if err := db.Checkpoint(t.Context(), CheckpointModePassive); err != nil {
+		t.Fatal(err)
+	}
+
+	db.mu.RLock()
+	restartedOffset := db.syncState.lastSyncedWALOffset
+	db.mu.RUnlock()
+	if !db.exceedsTruncateThreshold(restartedOffset) {
+		t.Fatalf("precondition: restarted wal offset %d must meet the truncate threshold", restartedOffset)
+	}
+
 	if err := db.Sync(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 2 {
-		t.Fatalf("passive checkpoints=%v, want 2 until wal restart", got)
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 4 {
+		t.Fatalf("passive checkpoints=%v, want 4 after wal restart", got)
 	}
 	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 4 {
 		t.Fatalf("truncate checkpoints=%v, want 4 after wal restart", got)
-	}
-
-	for range 5 {
-		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for range 2 {
-		if err := db.Sync(t.Context()); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 3 {
-		t.Fatalf("passive checkpoints=%v, want 3 after wal restart", got)
-	}
-	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 4 {
-		t.Fatalf("truncate checkpoints=%v, want 4 after passive restarted wal", got)
 	}
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -763,7 +763,7 @@ func TestDB_CheckpointPassiveRestartSkipsTruncate(t *testing.T) {
 	}
 }
 
-func TestDB_CheckpointTruncateFallsThroughWhenPassiveCannotRestart(t *testing.T) {
+func TestDB_CheckpointTruncateSkipsRepeatedPassiveWithoutProgress(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "db")
 
@@ -823,14 +823,21 @@ func TestDB_CheckpointTruncateFallsThroughWhenPassiveCannotRestart(t *testing.T)
 		t.Fatalf("precondition: synced WAL offset %d must exceed the truncate threshold", lastSyncedWALOffset)
 	}
 
+	passiveBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive))
 	truncateBaseline := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate))
 
-	if err := db.Sync(t.Context()); err != nil {
-		t.Fatal(err)
+	for range 2 {
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got == 0 {
-		t.Fatal("expected fall-through to a truncate checkpoint attempt when passive cannot restart the wal")
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 1 {
+		t.Fatalf("passive checkpoints=%v, want 1 across repeated blocked syncs", got)
+	}
+
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 2 {
+		t.Fatalf("truncate checkpoints=%v, want 2 across repeated blocked syncs", got)
 	}
 
 	db.mu.RLock()
@@ -838,6 +845,54 @@ func TestDB_CheckpointTruncateFallsThroughWhenPassiveCannotRestart(t *testing.T)
 	db.mu.RUnlock()
 	if !db.exceedsTruncateThreshold(blockedOffset) {
 		t.Fatalf("expected wal to remain unrestarted while reader is open: offset=%d", blockedOffset)
+	}
+
+	db.TruncatePageN = DefaultTruncatePageN
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	db.TruncatePageN = 2
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 2 {
+		t.Fatalf("passive checkpoints=%v, want 2 after threshold cleared", got)
+	}
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 3 {
+		t.Fatalf("truncate checkpoints=%v, want 3 after threshold cleared", got)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 2 {
+		t.Fatalf("passive checkpoints=%v, want 2 until wal restart", got)
+	}
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 4 {
+		t.Fatalf("truncate checkpoints=%v, want 4 after wal restart", got)
+	}
+
+	for range 5 {
+		if _, err := sqldb.Exec(`INSERT INTO t(data) VALUES (zeroblob(3000));`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for range 2 {
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModePassive)) - passiveBaseline; got != 3 {
+		t.Fatalf("passive checkpoints=%v, want 3 after wal restart", got)
+	}
+	if got := testutil.ToFloat64(checkpointNCounterVec.WithLabelValues(db.Path(), CheckpointModeTruncate)) - truncateBaseline; got != 4 {
+		t.Fatalf("truncate checkpoints=%v, want 4 after passive restarted wal", got)
 	}
 }
 


### PR DESCRIPTION
## Description
Persist a no-progress result from the emergency PASSIVE checkpoint attempt. While the logical WAL remains above the truncate threshold, later sync cycles go directly to TRUNCATE; the PASSIVE attempt is re-armed when the threshold clears or the WAL restarts.

This is intentionally limited to emergency checkpoint selection and its regression coverage. It is stacked on #1322 and targets `issue-1310-disk-full-staging-wedge`.

## Motivation and Context
A pinned reader reproduced the issue: before the fix, two blocked sync cycles executed two PASSIVE checkpoints and two TRUNCATE checkpoints. After the fix, those same cycles execute one PASSIVE checkpoint and two TRUNCATE checkpoints, avoiding the repeated write-lock barrier, sequence bump, and bookkeeping L0 file while still attempting TRUNCATE every cycle.

The regression test also verifies that PASSIVE is retried after the truncate threshold clears and after the WAL restarts.

Fixes #1339

## How Has This Been Tested?
- `go test -race . -run 'TestDB_(SyncTruncateCheckpointFiresDuringChunkedCatchUp|CheckpointPassiveRestartSkipsTruncate|CheckpointTruncateSkipsRepeatedPassiveWithoutProgress)$' -count=5`
- `go test -race -v ./...`
- `pre-commit run --all-files`
- `go build -o bin/litestream ./cmd/litestream`
- `go build -o bin/litestream-test ./cmd/litestream-test`
- All low-volume, high-volume, and burst-volume `TestLTXBehavior` soak profiles passed their behavioral, restore, and integrity checks.
- `go test -tags 'integration,soak' -run '^TestLTXBehavior_NoExcessiveSnapshots$' -short -v -timeout 5m ./tests/integration/`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
