### PR TITLE
fix(db): retain truncate backstop at zero

### DIFF
--- a/db.go
+++ b/db.go
@@ -59,7 +59,7 @@ const (
 //
 //  3. TruncatePageN (TRUNCATE): Blocking checkpoint at ~121k pages (~500MB).
 //     Emergency brake for runaway WAL growth. Can block writes while waiting
-//     for long-lived read transactions. Configurable/disableable.
+//     for long-lived read transactions. Configurable with a default backstop.
 //
 // The RESTART checkpoint mode was permanently removed due to production issues
 // with indefinite write blocking (issue #724). All checkpoints now use either
@@ -132,8 +132,7 @@ type DB struct {
 	//
 	// Uses TRUNCATE checkpoint mode (blocking). Prevents unbounded WAL growth
 	// from long-lived read transactions. Default: 121359 pages (~500MB with 4KB
-	// page size). Set to 0 to disable forced truncation (use with caution as
-	// WAL can grow unbounded if read transactions prevent checkpointing).
+	// page size). Set to 0 to retain the default emergency threshold.
 	TruncatePageN int
 
 	// Time between automatic checkpoints in the WAL. This is done to allow
@@ -1410,7 +1409,7 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 	// Priority 1: Emergency truncate checkpoint (TRUNCATE mode, blocking)
 	// This prevents unbounded WAL growth from long-lived read transactions.
 	if db.exceedsTruncateThreshold(origWALSize) {
-		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
+		truncateThreshold := calcWALSize(uint32(db.pageSize), uint32(db.effectiveTruncatePageN()))
 
 		// Try a PASSIVE checkpoint first: if it restarts the WAL and brings
 		// the synced offset below the threshold, the blocking TRUNCATE and
@@ -1480,8 +1479,16 @@ func (db *DB) checkpointIfNeeded(ctx context.Context, exec *syncExecutor, origWA
 // exceedsTruncateThreshold returns true once walSize has grown past the
 // emergency truncate checkpoint threshold.
 func (db *DB) exceedsTruncateThreshold(walSize int64) bool {
-	return db.TruncatePageN > 0 && db.pageSize != 0 &&
-		walSize >= calcWALSize(uint32(db.pageSize), uint32(db.TruncatePageN))
+	truncatePageN := db.effectiveTruncatePageN()
+	return truncatePageN > 0 && db.pageSize != 0 &&
+		walSize >= calcWALSize(uint32(db.pageSize), uint32(truncatePageN))
+}
+
+func (db *DB) effectiveTruncatePageN() int {
+	if db.TruncatePageN == 0 {
+		return DefaultTruncatePageN
+	}
+	return db.TruncatePageN
 }
 
 // isSQLiteBusyError returns true if the error is an SQLITE_BUSY error.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -841,6 +841,45 @@ func TestDB_CheckpointTruncateFallsThroughWhenPassiveCannotRestart(t *testing.T)
 	}
 }
 
+func TestDB_ExceedsTruncateThreshold(t *testing.T) {
+	const pageSize = 4096
+
+	tests := []struct {
+		name          string
+		truncatePageN int
+		walSize       int64
+		want          bool
+	}{
+		{
+			name:          "configured threshold",
+			truncatePageN: 2,
+			walSize:       calcWALSize(pageSize, 2),
+			want:          true,
+		},
+		{
+			name:          "zero below default threshold",
+			truncatePageN: 0,
+			walSize:       calcWALSize(pageSize, DefaultTruncatePageN) - 1,
+			want:          false,
+		},
+		{
+			name:          "zero at default threshold",
+			truncatePageN: 0,
+			walSize:       calcWALSize(pageSize, DefaultTruncatePageN),
+			want:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &DB{pageSize: pageSize, TruncatePageN: tt.truncatePageN}
+			if got := db.exceedsTruncateThreshold(tt.walSize); got != tt.want {
+				t.Fatalf("exceedsTruncateThreshold(%d)=%t, want %t", tt.walSize, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWALReaderPageMapLimitStopsAtCommittedFrame(t *testing.T) {
 	b, err := os.ReadFile("testdata/wal-reader/ok/wal")
 	if err != nil {


### PR DESCRIPTION
## Summary

Retain `DefaultTruncatePageN` as the emergency WAL-growth backstop when `TruncatePageN` is configured as zero.

## Problem

Bounded WAL syncs only enter the emergency checkpoint path during chunked catch-up when `exceedsTruncateThreshold()` returns true. With `TruncatePageN=0`, that helper always returned false, so sustained writes faster than the chunk drain could defer every checkpoint and grow the WAL without bound.

The regression test reproduced this at the default 4KB-page boundary:

```text
exceedsTruncateThreshold(499999112)=false, want true
```

## Solution

Resolve zero to `DefaultTruncatePageN` before evaluating or reporting the emergency threshold. Explicit positive thresholds remain unchanged, and the DB field documentation now describes zero as retaining the default safety threshold.

## Behavior Change

| `TruncatePageN` | Before | After |
|---|---|---|
| Positive | Uses the configured threshold | Uses the configured threshold |
| Zero | Disables the emergency threshold | Uses `DefaultTruncatePageN` |

## Scope

**In scope:**
- Emergency truncate threshold resolution
- Regression coverage at configured and default boundaries

**Not in scope:**
- Changes to bounded sync chunk sizing
- Changes to PASSIVE/TRUNCATE checkpoint sequencing
- Changes to negative threshold handling

## Test Plan

- `go test . -run "TestDB_(ExceedsTruncateThreshold|SyncTruncateCheckpointFiresDuringChunkedCatchUp|CheckpointPassiveRestartSkipsTruncate|CheckpointTruncateFallsThroughWhenPassiveCannotRestart)$" -count=1`
- `go test -race -v ./...`
- `pre-commit run --all-files`
- `go test -tags "integration,soak" -run "^TestLTXBehavior$" -short -v -timeout 15m ./tests/integration/`
- `go test -tags "integration,soak" -run "^TestLTXBehavior_NoExcessiveSnapshots$" -short -v -timeout 20m ./tests/integration/`

## Related

- Fixes #1343
- Stacked on #1322
- Related to #1290