### PR TITLE
fix(cli): show one replica URL in usage

### DIFF
--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -527,7 +527,7 @@ Usage:
 
 	litestream replicate [arguments]
 
-	litestream replicate [arguments] DB_PATH REPLICA_URL [REPLICA_URL...]
+	litestream replicate [arguments] DB_PATH REPLICA_URL
 
 Arguments:
 


### PR DESCRIPTION
## Description
Updates the replicate command usage to show a single REPLICA_URL, matching the supported command-line behavior. No parsing or runtime behavior changes.

## Motivation and Context
The help output advertised optional additional replica URLs even though multiple replicas on one database are rejected at runtime. The rendered usage now shows DB_PATH REPLICA_URL without the repeatable argument.

Fixes #1350

## How Has This Been Tested?
- go run ./cmd/litestream replicate -h
- go test -race ./...
- pre-commit run --all-files

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (go fmt, go vet)
- [x] I have tested my changes (go test ./...)
- [x] I have updated the documentation accordingly (if needed)