### PR TITLE
fix(config): detect Hetzner endpoints

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1557,6 +1557,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 
 	// Detect S3-compatible provider endpoints for applying appropriate defaults.
 	// These providers require specific settings to work correctly with AWS SDK v2.
+	isHetzner := litestream.IsHetznerEndpoint(endpoint)
 	isTigris := litestream.IsTigrisEndpoint(endpoint)
 	if !isTigris && !endpointWasSet && litestream.IsTigrisEndpoint(c.Endpoint) {
 		isTigris = true
@@ -1579,7 +1580,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 		signSetting.ApplyDefault(true)
 		requireSetting.ApplyDefault(false)
 	}
-	if isDigitalOcean || isBackblaze || isFilebase || isScaleway || isCloudflareR2 || isMinIO || isSupabase {
+	if isHetzner || isDigitalOcean || isBackblaze || isFilebase || isScaleway || isCloudflareR2 || isMinIO || isSupabase {
 		// All these providers require signed payloads (don't support UNSIGNED-PAYLOAD)
 		signSetting.ApplyDefault(true)
 	}

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -3164,6 +3164,7 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 			{"CloudflareR2", "https://accountid.r2.cloudflarestorage.com"},
 			{"MinIO", "http://localhost:9000"},
 			{"Supabase", "https://myproject.supabase.co/storage/v1/s3"},
+			{"Hetzner", "https://fsn1.your-objectstorage.com"},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
## Description
Apply Hetzner Object Storage provider defaults when constructing an S3 replica from configuration fields. Extend the URL/config provider parity coverage with a Hetzner endpoint so both construction paths remain aligned.

## Motivation and Context
Issue #1351 identified that the URL factory calls `IsHetznerEndpoint` and includes Hetzner in the signed-payload provider set, while `NewS3ReplicaClientFromConfig` omitted both checks.

On `main` at c96c0f4, the base S3 client already defaults `SignPayload` to `true`, so the new parity case passes before the fix and masks the missing config branch. Aligning the provider lists removes that source-level drift and prevents a future base-default change from making Hetzner configuration behavior depend on whether the endpoint came from a URL or configuration fields.

Fixes #1351

## How Has This Been Tested?
Investigation evidence:
- `s3/replica_client.go` detects `IsHetznerEndpoint` and applies the signed-payload provider default.
- `cmd/litestream/main.go` had the equivalent provider adjustment block without Hetzner.
- The existing URL/config parity table covered every other detected S3-compatible provider.

Verification:
- `go test ./cmd/litestream -run 'TestNewS3ReplicaClientFromConfig/ProviderDefaultsParity' -count=1 -v`
- `go test -race -v ./...`
- `pre-commit run --all-files`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
