### PR TITLE
fix(mcp): report running daemon version

### DIFF
--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -243,16 +243,11 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 
 func VersionTool() (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_version",
-		mcp.WithDescription("Print the Litestream binary version."),
+		mcp.WithDescription("Print the running Litestream daemon version."),
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		cmd := exec.CommandContext(ctx, "litestream", "version")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
-		}
-		return mcp.NewToolResultText(string(output)), nil
+		return mcp.NewToolResultText(Version + "\n"), nil
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestVersionTool(t *testing.T) {
+	prevVersion := Version
+	t.Cleanup(func() { Version = prevVersion })
+	Version = resolveVersion("v0.5.14-running", nil)
+	t.Setenv("PATH", t.TempDir())
+
+	_, handler := VersionTool()
+	result, err := handler(t.Context(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result.Content)
+	}
+	if got, want := len(result.Content), 1; got != want {
+		t.Fatalf("content length=%d, want %d", got, want)
+	}
+	content, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content type=%T, want mcp.TextContent", result.Content[0])
+	}
+	if got, want := content.Text, Version+"\n"; got != want {
+		t.Fatalf("content=%q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Description
The MCP `litestream_version` tool now returns the daemon's in-process `Version` value instead of launching whichever `litestream` executable appears first on `$PATH`. The response preserves the existing newline formatting, and the tool description now identifies the running daemon as the version source.

A regression test removes `litestream` from `$PATH`, resolves a distinct in-process version through the machinery added by #1338, and verifies that the MCP response still reports it.

**Scope:** This changes only `litestream_version`; other MCP tools that intentionally invoke CLI operations remain unchanged.

This PR is stacked on #1338 and uses its version-resolution machinery.

## Motivation and Context
The previous handler called `exec.CommandContext(ctx, "litestream", "version")`, so its answer described the PATH binary rather than the daemon serving the MCP request. If no PATH binary existed, the regression test failed with:

```text
exec: "litestream": executable file not found in $PATH
```

Returning the already-resolved process value makes the MCP result match the running daemon regardless of how it was launched or what is installed on `$PATH`.

Fixes #1353

## How Has This Been Tested?
- Verified `go test ./cmd/litestream -run '^TestVersionTool$' -count=1 -v` failed before the production change and passed afterward.
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `pre-commit run --all-files`
- `go build -o bin/litestream ./cmd/litestream`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality not to work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
