### PR TITLE
chore(deps): bump sqlite3vfs upstream

### DIFF
--- a/docs/VFS.md
+++ b/docs/VFS.md
@@ -36,6 +36,7 @@ The VFS extension provides:
 
 ### Prerequisites
 
+- SQLite 3.31.0+ runtime
 - Go 1.21+
 - GCC (Linux) or Clang (macOS)
 - CGO enabled

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/nats-io/nats.go v1.44.0
 	github.com/pkg/sftp v1.13.6
 	github.com/prometheus/client_golang v1.17.0
-	github.com/psanford/sqlite3vfs v0.0.0-20251127171934-4e34e03a991a // direct
+	github.com/psanford/sqlite3vfs v0.0.0-20260519004904-f9180fa2acc9 // direct
 	github.com/studio-b12/gowebdav v0.11.0
 	github.com/superfly/ltx v0.5.1
 	golang.org/x/crypto v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/psanford/sqlite3vfs v0.0.0-20251127171934-4e34e03a991a h1:r4YWl0uVObCbBFvj1VsIlyHzgZwZOHvY1KdRaQjzzUc=
-github.com/psanford/sqlite3vfs v0.0.0-20251127171934-4e34e03a991a/go.mod h1:iW4cSew5PAb1sMZiTEkVJAIBNrepaB6jTYjeP47WtI0=
+github.com/psanford/sqlite3vfs v0.0.0-20260519004904-f9180fa2acc9 h1:9bBMbcwroL46feESdJWjRX0GV+k8o/P9gAg9UX6Vz7U=
+github.com/psanford/sqlite3vfs v0.0.0-20260519004904-f9180fa2acc9/go.mod h1:iW4cSew5PAb1sMZiTEkVJAIBNrepaB6jTYjeP47WtI0=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/src/litestream-vfs.c
+++ b/src/litestream-vfs.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define LITESTREAM_MIN_SQLITE_VERSION_NUMBER 3031000
+
 /* sqlite3vfs already called SQLITE_EXTENSION_INIT1 */
 extern const sqlite3_api_routines *sqlite3_api;
 
@@ -31,6 +33,13 @@ static void litestream_auto_extension(sqlite3* db, const char** pzErrMsg, const 
 int sqlite3_litestreamvfs_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
   int rc = SQLITE_OK;
   SQLITE_EXTENSION_INIT2(pApi);
+
+  if (sqlite3_libversion_number() < LITESTREAM_MIN_SQLITE_VERSION_NUMBER) {
+    if (pzErrMsg != NULL) {
+      *pzErrMsg = sqlite3_mprintf("litestream VFS requires SQLite 3.31.0 or later (found %s)", sqlite3_libversion());
+    }
+    return SQLITE_ERROR;
+  }
 
   /* Call into Go to register the VFS and check for errors. */
   char* err = LitestreamVFSRegister();


### PR DESCRIPTION
## Description

Bumps `github.com/psanford/sqlite3vfs` from `v0.0.0-20251127171934-4e34e03a991a` to upstream commit `f9180fa2acc9`, resolved as `v0.0.0-20260519004904-f9180fa2acc9`.

Upstream has no tag at this commit. The PR also enforces and documents SQLite 3.31.0 as the minimum runtime version for the loadable VFS extension.

## Motivation and Context

Upstream commit `f9180fa2acc9` adds URI opener support, so Litestream can consume the upstream implementation targeted by item 1 of #1355.

### SQLite runtime compatibility

The upstream implementation calls `uriParamsFromC(name)` before its `URIOpener` interface check. That function immediately calls `s3vfsURIKey()`, which unconditionally dereferences the loadable-extension table's `sqlite3_uri_key` entry for every non-null VFS open. The default VFS wrapper also implements `OpenURI`, so the interface check does not gate access to this API.

SQLite added `sqlite3_uri_key()` in 3.31.0. With SQLite 3.30.1, opening through the bumped VFS reproduced a `SIGBUS` at `uriParamsFromC -> s3vfsURIKey`. The extension entrypoint now checks `sqlite3_libversion_number()` before registering the VFS and returns a normal load error for older runtimes.

- Upstream implementation: https://github.com/psanford/sqlite3vfs/commit/f9180fa2acc9fc03941664f53464cf0b1c9f74ac
- SQLite 3.31.0 release notes: https://sqlite.org/changes.html#version_3_31_0

### Scope

**In scope:**
- Update the upstream `sqlite3vfs` dependency
- Tidy module metadata
- Reject SQLite runtimes older than 3.31.0 before VFS registration
- Document the minimum SQLite runtime version
- Verify the VFS-tagged test suite

**Not in scope:**
- Changes to PR #1157 or its branch
- Removing that branch's fork replacement
- Adapting that branch to the upstream opener API

Those are item 2 of #1355 and remain a separate follow-up.

## How Has This Been Tested?

- `go test -tags vfs -race ./cmd/litestream-vfs` — pass
- `make vfs` — pass
- SQLite 3.30.1 before the guard — reproducible `SIGBUS` at `uriParamsFromC -> s3vfsURIKey`
- SQLite 3.30.1 after the guard — clean load failure: `litestream VFS requires SQLite 3.31.0 or later (found 3.30.1)`
- SQLite 3.31.0 after the guard — extension loads successfully and reports SQLite `3.31.0`
- `go test -tags vfs -race ./cmd/litestream-vfs -run '^TestVFS_SortingLargeResultSet$' -count=1` — pass after one full-package rerun timed out in this existing test
- `go mod verify` — pass
- `pre-commit run --all-files` — pass
- `go test -tags vfs -race ./...` — all packages except the root package pass; the root package does not compile because VFS-only mocks in `vfs_test.go` are missing the existing `ReplicaClient.SetLogger` method. The identical failure reproduces on pristine `origin/main` with `go test -tags vfs -race .`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly

Related to #1355 (item 1).
