### PR TITLE
fix(replica): bound resumable reader retries

### DIFF
--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -44,6 +44,8 @@ type ResumableReader struct {
 	size    int64 // expected total file size from FileInfo; 0 means unknown
 	offset  int64
 	rc      io.ReadCloser
+	retryN  int
+	err     error
 	logger  *slog.Logger
 }
 
@@ -64,8 +66,11 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 const resumableReaderMaxRetries = 3
 
 func (r *ResumableReader) Read(p []byte) (int, error) {
-	var lastErr error
-	for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++ {
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	for {
 		// Reopen the stream from the current offset if the previous
 		// connection was closed (rc is nil after a retry).
 		if r.rc == nil {
@@ -74,10 +79,12 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 				if errors.Is(err, os.ErrNotExist) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || r.ctx.Err() != nil {
 					return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
 				}
-				lastErr = fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				if retryErr := r.retry(fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)); retryErr != nil {
+					return 0, retryErr
+				}
 				r.logger.Debug("reopen ltx file failed, retrying",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
-					"offset", r.offset, "error", err, "attempt", attempt+1)
+					"offset", r.offset, "error", err, "attempt", r.retryN)
 				continue
 			}
 			r.rc = rc
@@ -97,9 +104,12 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 			if r.size > 0 && r.offset < r.size {
 				r.logger.Debug("premature EOF on ltx file, reconnecting",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
-					"offset", r.offset, "size", r.size, "attempt", attempt+1)
+					"offset", r.offset, "size", r.size, "attempt", r.retryN+1)
 				r.close()
 				r.rc = nil
+				if retryErr := r.retry(io.ErrUnexpectedEOF); retryErr != nil {
+					return n, retryErr
+				}
 				if n > 0 {
 					// Return the bytes we did get. The caller (e.g. io.ReadFull)
 					// will call Read again, which will trigger the reopen above.
@@ -114,21 +124,16 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		// stream so the next iteration reopens from the current offset.
 		r.logger.Debug("read error on ltx file, reconnecting",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
-			"error", err, "offset", r.offset, "attempt", attempt+1)
+			"error", err, "offset", r.offset, "attempt", r.retryN+1)
 		r.close()
 		r.rc = nil
+		if retryErr := r.retry(err); retryErr != nil {
+			return n, retryErr
+		}
 		if n > 0 {
 			return n, nil
 		}
-		continue
 	}
-
-	if lastErr != nil {
-		return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d): %w",
-			r.level, r.minTXID, r.maxTXID, r.offset, lastErr)
-	}
-	return 0, fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d)",
-		r.level, r.minTXID, r.maxTXID, r.offset)
 }
 
 func (r *ResumableReader) Close() error {
@@ -146,4 +151,14 @@ func (r *ResumableReader) close() {
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"offset", r.offset, "error", err)
 	}
+}
+
+func (r *ResumableReader) retry(err error) error {
+	r.retryN++
+	if r.retryN <= resumableReaderMaxRetries {
+		return nil
+	}
+	r.err = fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d): %w",
+		r.level, r.minTXID, r.maxTXID, r.offset, err)
+	return r.err
 }

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -6,7 +6,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/superfly/ltx"
@@ -262,6 +267,52 @@ func TestResumableReader(t *testing.T) {
 			t.Fatalf("reopen offset = %d, want 7", reopenOffset)
 		}
 	})
+}
+
+func TestResumableReader_BoundsConnectionsAcrossPartialReads(t *testing.T) {
+	data := []byte("0123456789abcdef")
+	var connectionN atomic.Int64
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offset, err := strconv.Atoi(r.URL.Query().Get("offset"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)-offset))
+		_, _ = w.Write(data[offset : offset+1])
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connectionN.Add(1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	client := server.Client()
+	opener := &testLTXFileOpener{
+		OpenLTXFileFunc: func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s?offset=%d", server.URL, offset), nil)
+			if err != nil {
+				return nil, err
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				return nil, err
+			}
+			return resp.Body, nil
+		},
+	}
+
+	r := newTestResumableReader(opener, int64(len(data)), data)
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Error("ReadAll() error=nil, want retry limit error")
+	}
+	if got, max := connectionN.Load(), int64(resumableReaderMaxRetries+1); got > max {
+		t.Errorf("connections=%d, want at most %d", got, max)
+	}
 }
 
 // newTestResumableReader creates a resumableReader for testing. The initial


### PR DESCRIPTION
## Description

Bounds reconnect attempts across the complete lifetime of a resumable LTX stream instead of restarting the retry budget on every caller read. Adds an HTTP regression test that truncates every response and counts accepted TCP connections.

**Scope:** This changes resumable-stream retry accounting only. It does not change the S3 transport configuration, AWS SDK retry policy, compaction scheduling, or retention behavior.

## Motivation and Context

The retry counter was local to each `Read` call. When a response returned bytes together with a premature EOF or transport error, the reader closed that body, suppressed the error so the caller could consume the bytes, and reopened on the next call. That next call started the retry counter at zero again, so a sufficiently large source could reconnect indefinitely without surfacing an error or entering replication backoff.

The release history explains the v0.5.14 regression shape:

- v0.5.12 used resumable streams for explicit restore operations.
- #1326 added resumable streams to ongoing remote compaction reads in v0.5.14, exposing the latent per-read retry reset during replication.
- #1305 did not create HTTP clients or transports, but its ten-attempt S3 operation retryer could multiply every unbounded reopen during a transport flap.

The S3 client caches one transport per replica, AWS SDK middleware drains and closes failed non-streaming responses, and the resumable reader closes the previous successful `GetObject` body before reopening. The unbounded cross-read retry reset was the resource-lifecycle defect.

The regression server declares the full remaining `Content-Length` but returns one byte per connection. Before the fix, a 16-byte read opened 16 TCP connections, returned all data, and produced no error. After the fix, it opens at most four connections (the initial connection plus three retries) and returns the retry-limit error so normal replication backoff can engage.

Fixes #1354

## How Has This Been Tested?

```bash
go test ./internal -run TestResumableReader_BoundsConnectionsAcrossPartialReads -count=1 -v
go test ./internal ./s3 -count=1
go test . -run 'TestCompactor_CompactResumesRemoteSource|TestReplica_Restore' -count=1 -v
go test ./... -count=1
go test -race ./... -count=1
go vet ./...
pre-commit run --all-files
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (no documentation change is needed)
