### PR TITLE
fix(nats): propagate object store init errors

### DIFF
--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -130,12 +130,14 @@ func (c *ReplicaClient) Init(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.nc != nil {
+	if c.objectStore != nil {
 		return nil
 	}
 
-	if err := c.connect(ctx); err != nil {
-		return fmt.Errorf("nats: failed to connect: %w", err)
+	if c.nc == nil {
+		if err := c.connect(ctx); err != nil {
+			return fmt.Errorf("nats: failed to connect: %w", err)
+		}
 	}
 
 	if err := c.initObjectStore(ctx); err != nil {

--- a/nats/replica_client_test.go
+++ b/nats/replica_client_test.go
@@ -1,9 +1,13 @@
 package nats
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/superfly/ltx"
 )
 
@@ -11,6 +15,17 @@ func TestReplicaClient_Type(t *testing.T) {
 	client := NewReplicaClient()
 	if got, want := client.Type(), "nats"; got != want {
 		t.Fatalf("Type()=%s, want %s", got, want)
+	}
+}
+
+func TestReplicaClient_LTXFiles_InitError(t *testing.T) {
+	client := NewReplicaClient()
+	client.BucketName = "missing-bucket"
+	client.nc = &natsgo.Conn{}
+	client.js = &objectStoreErrorJetStream{err: jetstream.ErrBucketNotFound}
+
+	if _, err := client.LTXFiles(t.Context(), 0, 0, false); !errors.Is(err, jetstream.ErrBucketNotFound) {
+		t.Fatalf("LTXFiles() error = %v, want %v", err, jetstream.ErrBucketNotFound)
 	}
 }
 
@@ -193,6 +208,15 @@ type mockOtherError struct{}
 
 func (e *mockOtherError) Error() string {
 	return "some other error"
+}
+
+type objectStoreErrorJetStream struct {
+	jetstream.JetStream
+	err error
+}
+
+func (js *objectStoreErrorJetStream) ObjectStore(context.Context, string) (jetstream.ObjectStore, error) {
+	return nil, js.err
 }
 
 func TestReplicaClientDefaults(t *testing.T) {

--- a/store.go
+++ b/store.go
@@ -169,26 +169,43 @@ func (s *Store) Open(ctx context.Context) error {
 		return err
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(50)
+	initGroup, initCtx := errgroup.WithContext(ctx)
+	initGroup.SetLimit(50)
 	for _, db := range s.dbs {
 		db := db
-		g.Go(func() error {
+		initGroup.Go(func() error {
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-initCtx.Done():
+				return initCtx.Err()
 			default:
 			}
 
 			if db.Replica != nil && db.Replica.Client != nil {
-				if err := db.Replica.Client.Init(ctx); err != nil {
+				if err := db.Replica.Client.Init(initCtx); err != nil {
 					return fmt.Errorf("initialize replica client for %q: %w", db.Path(), err)
 				}
+			}
+			return nil
+		})
+	}
+	if err := initGroup.Wait(); err != nil {
+		return err
+	}
+
+	openGroup, openCtx := errgroup.WithContext(ctx)
+	openGroup.SetLimit(50)
+	for _, db := range s.dbs {
+		db := db
+		openGroup.Go(func() error {
+			select {
+			case <-openCtx.Done():
+				return openCtx.Err()
+			default:
 			}
 			return db.Open()
 		})
 	}
-	if err := g.Wait(); err != nil {
+	if err := openGroup.Wait(); err != nil {
 		return err
 	}
 

--- a/store.go
+++ b/store.go
@@ -178,8 +178,14 @@ func (s *Store) Open(ctx context.Context) error {
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				return db.Open()
 			}
+
+			if db.Replica != nil && db.Replica.Client != nil {
+				if err := db.Replica.Client.Init(ctx); err != nil {
+					return fmt.Errorf("initialize replica client for %q: %w", db.Path(), err)
+				}
+			}
+			return db.Open()
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/store_test.go
+++ b/store_test.go
@@ -31,6 +31,51 @@ func TestStore_Open_InitError(t *testing.T) {
 	}
 }
 
+func TestStore_Open_InitErrorDoesNotOpenDBs(t *testing.T) {
+	want := errors.New("init error")
+	initStarted := make(chan struct{})
+	allowFailure := make(chan struct{})
+
+	db0 := litestream.NewDB(filepath.Join(t.TempDir(), "db0"))
+	db0.MonitorInterval = 0
+	db0.Replica = litestream.NewReplicaWithClient(db0, &mock.ReplicaClient{
+		InitFunc: func(context.Context) error {
+			close(initStarted)
+			<-allowFailure
+			return nil
+		},
+	})
+	t.Cleanup(func() {
+		if db0.IsOpen() {
+			if err := db0.Close(context.Background()); err != nil {
+				t.Errorf("close db0: %v", err)
+			}
+		}
+	})
+
+	db1 := litestream.NewDB(filepath.Join(t.TempDir(), "db1"))
+	db1.MonitorInterval = 0
+	db1.Replica = litestream.NewReplicaWithClient(db1, &mock.ReplicaClient{
+		InitFunc: func(context.Context) error {
+			<-initStarted
+			close(allowFailure)
+			return want
+		},
+	})
+
+	store := litestream.NewStore([]*litestream.DB{db0, db1}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	if err := store.Open(t.Context()); !errors.Is(err, want) {
+		t.Fatalf("Open() error = %v, want %v", err, want)
+	}
+	if db0.IsOpen() {
+		t.Fatal("db0 opened before all replica clients initialized")
+	}
+	if db1.IsOpen() {
+		t.Fatal("db1 opened before all replica clients initialized")
+	}
+}
+
 func TestStore_CompactDB(t *testing.T) {
 	t.Run("L1", func(t *testing.T) {
 		db0, sqldb0 := testingutil.MustOpenDBs(t)

--- a/store_test.go
+++ b/store_test.go
@@ -1,6 +1,7 @@
 package litestream_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -13,7 +14,22 @@ import (
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/internal/testingutil"
+	"github.com/benbjohnson/litestream/mock"
 )
+
+func TestStore_Open_InitError(t *testing.T) {
+	want := errors.New("init error")
+	db := litestream.NewDB(filepath.Join(t.TempDir(), "db"))
+	db.Replica = litestream.NewReplicaWithClient(db, &mock.ReplicaClient{
+		InitFunc: func(context.Context) error { return want },
+	})
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	if err := store.Open(t.Context()); !errors.Is(err, want) {
+		t.Fatalf("Open() error = %v, want %v", err, want)
+	}
+}
 
 func TestStore_CompactDB(t *testing.T) {
 	t.Run("L1", func(t *testing.T) {


### PR DESCRIPTION
## Description

Propagates replica client initialization failures from `Store.Open()` before any database or compaction monitors start. All replica clients complete initialization as a separate pass before any database opens. NATS initialization now considers the object store, rather than only the NATS connection, to be the completed initialization state and reuses an existing connection when retrying object store access.

## Motivation and Context

With `origin/main` at c96c0f4 and a local `nats:latest -js` server that did not contain the configured object store, this command reproduced issue #1349:

    litestream replicate /tmp/test.db nats://127.0.0.1:4222/missing-bucket

Before this change, the first access returned `nats: bucket not found` after setting `ReplicaClient.nc` and `ReplicaClient.js`. A concurrent startup access then saw the non-nil connection, treated initialization as complete, and called `objectStore.List()` on a nil object store:

    panic: runtime error: invalid memory address or nil pointer dereference
    nats.(*ReplicaClient).LTXFiles
    nats/replica_client.go:285

The focused regression test reproduced the same partial state and panicked before the fix. After the fix, the CLI returns the initialization error once and exits with status 1:

    Error: cannot open store: initialize replica client for "/tmp/test.db": nats: failed to initialize object store: failed to access object store bucket "missing-bucket" (bucket must be created beforehand): nats: bucket not found

Fixes #1349

## Scope

In scope:

- Initialize replica clients before `Store` starts database and maintenance monitors.
- Require the complete client initialization pass to succeed before opening any database.
- Return initialization failures to the caller.
- Keep NATS clients retryable after object store initialization fails.
- Cover partial NATS initialization, Store error propagation, and multi-database startup atomicity.

Not in scope:

- Creating NATS object store buckets automatically.
- Changing NATS authentication or TLS configuration.
- Changing background retry behavior after successful startup.

## Behavior Change

| Scenario | Before | After |
| --- | --- | --- |
| NATS bucket is missing | Logs an initialization error, then panics | Returns the initialization error and exits 1 |
| Replica client initialization fails | Starts background work that encounters the error | `Store.Open()` returns the error before monitors start |
| NATS connection exists but object store init failed | Treats the client as initialized | Retries object store initialization on the existing connection |

## How Has This Been Tested?

- `go test ./nats -run TestReplicaClient_LTXFiles_InitError -count=1 -v`
- `go test . -run TestStore_Open_InitError -count=1 -v`
- `go test -race . -run TestStore_Open_InitErrorDoesNotOpenDBs -count=20`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `pre-commit run --all-files`
- Docker NATS JetStream reproduction with a missing bucket; verified one initialization error, no panic, and exit status 1.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
