### PR TITLE
fix(nats): apply TLS replica options

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1930,6 +1930,7 @@ func newNATSReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ 
 	client.Token = c.Token
 
 	// Set TLS options
+	client.TLS = c.TLS
 	client.RootCAs = c.RootCAs
 	client.ClientCert = c.ClientCert
 	client.ClientKey = c.ClientKey

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1158,7 +1158,7 @@ type ReplicaSettings struct {
 	NKey          string         `yaml:"nkey"`
 	Username      string         `yaml:"username"`
 	Token         string         `yaml:"token"`
-	TLS           bool           `yaml:"tls"`
+	TLS           *bool          `yaml:"tls"`
 	RootCAs       []string       `yaml:"root-cas"`
 	ClientCert    string         `yaml:"client-cert"`
 	ClientKey     string         `yaml:"client-key"`
@@ -1289,7 +1289,7 @@ func (rs *ReplicaSettings) SetDefaults(src *ReplicaSettings) {
 	if rs.Token == "" {
 		rs.Token = src.Token
 	}
-	if !rs.TLS {
+	if rs.TLS == nil {
 		rs.TLS = src.TLS
 	}
 	if len(rs.RootCAs) == 0 {
@@ -1930,7 +1930,9 @@ func newNATSReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ 
 	client.Token = c.Token
 
 	// Set TLS options
-	client.TLS = c.TLS
+	if c.TLS != nil {
+		client.TLS = *c.TLS
+	}
 	client.RootCAs = c.RootCAs
 	client.ClientCert = c.ClientCert
 	client.ClientKey = c.ClientKey

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	main "github.com/benbjohnson/litestream/cmd/litestream"
 	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/gs"
+	"github.com/benbjohnson/litestream/nats"
 	"github.com/benbjohnson/litestream/s3"
 	"github.com/benbjohnson/litestream/sftp"
 )
@@ -421,6 +423,44 @@ func TestNewGSReplicaFromConfig(t *testing.T) {
 		t.Fatalf("Bucket=%s, want %s", got, want)
 	} else if got, want := client.Path, "bar"; got != want {
 		t.Fatalf("Path=%s, want %s", got, want)
+	}
+}
+
+func TestNewNATSReplicaFromConfig_TLS(t *testing.T) {
+	config, err := main.ParseConfig(strings.NewReader(`
+dbs:
+  - path: /tmp/db
+    replica:
+      type: nats
+      bucket: bucket
+      tls: true
+      root-cas: [ca.pem]
+      client-cert: client.pem
+      client-key: client-key.pem
+`), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := main.NewReplicaFromConfig(config.DBs[0].Replica, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, ok := r.Client.(*nats.ReplicaClient)
+	if !ok {
+		t.Fatal("unexpected replica type")
+	}
+	if !client.TLS {
+		t.Fatal("TLS=false, want true")
+	}
+	if got, want := client.RootCAs, []string{"ca.pem"}; !slices.Equal(got, want) {
+		t.Fatalf("RootCAs=%v, want %v", got, want)
+	}
+	if got, want := client.ClientCert, "client.pem"; got != want {
+		t.Fatalf("ClientCert=%q, want %q", got, want)
+	}
+	if got, want := client.ClientKey, "client-key.pem"; got != want {
+		t.Fatalf("ClientKey=%q, want %q", got, want)
 	}
 }
 

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -464,6 +464,49 @@ dbs:
 	}
 }
 
+func TestNewNATSReplicaFromConfig_TLSOverridesGlobalDefault(t *testing.T) {
+	config, err := main.ParseConfig(strings.NewReader(`
+tls: true
+dbs:
+  - path: /tmp/db
+    replica:
+      type: nats
+      bucket: bucket
+      tls: false
+  - path: /tmp/db-inherits
+    replica:
+      type: nats
+      bucket: bucket
+`), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		index int
+		want  bool
+	}{
+		{name: "ExplicitFalse", index: 0, want: false},
+		{name: "InheritedTrue", index: 1, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := main.NewReplicaFromConfig(config.DBs[test.index].Replica, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client, ok := r.Client.(*nats.ReplicaClient)
+			if !ok {
+				t.Fatal("unexpected replica type")
+			}
+			if client.TLS != test.want {
+				t.Fatalf("TLS=%v, want %v", client.TLS, test.want)
+			}
+		})
+	}
+}
+
 func TestNewSFTPReplicaFromConfig(t *testing.T) {
 	hostKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAnK0+GdwOelXlAXdqLx/qvS7WHMr3rH7zW2+0DtmK5r"
 	r, err := main.NewReplicaFromConfig(&main.ReplicaConfig{

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -149,6 +149,28 @@ func (c *ReplicaClient) Init(ctx context.Context) error {
 
 // connect establishes a connection to NATS server with proper configuration.
 func (c *ReplicaClient) connect(_ context.Context) error {
+	url := c.URL
+	if url == "" {
+		url = nats.DefaultURL
+	}
+
+	nc, err := nats.Connect(url, c.options()...)
+	if err != nil {
+		return fmt.Errorf("failed to connect to NATS server: %w", err)
+	}
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return fmt.Errorf("failed to create JetStream context: %w", err)
+	}
+
+	c.nc = nc
+	c.js = js
+	return nil
+}
+
+func (c *ReplicaClient) options() []nats.Option {
 	opts := []nats.Option{
 		nats.MaxReconnects(c.MaxReconnects),
 		nats.ReconnectWait(c.ReconnectWait),
@@ -178,6 +200,10 @@ func (c *ReplicaClient) connect(_ context.Context) error {
 	}
 
 	// TLS configuration
+	if c.TLS {
+		opts = append(opts, nats.Secure())
+	}
+
 	if c.ClientCert != "" && c.ClientKey != "" {
 		opts = append(opts, nats.ClientCert(c.ClientCert, c.ClientKey))
 	}
@@ -186,28 +212,7 @@ func (c *ReplicaClient) connect(_ context.Context) error {
 		opts = append(opts, nats.RootCAs(c.RootCAs...))
 	}
 
-	// Note: NATS Connect doesn't directly support context cancellation during connection
-	// The context parameter is preserved for potential future use
-
-	url := c.URL
-	if url == "" {
-		url = nats.DefaultURL
-	}
-
-	nc, err := nats.Connect(url, opts...)
-	if err != nil {
-		return fmt.Errorf("failed to connect to NATS server: %w", err)
-	}
-
-	js, err := jetstream.New(nc)
-	if err != nil {
-		nc.Close()
-		return fmt.Errorf("failed to create JetStream context: %w", err)
-	}
-
-	c.nc = nc
-	c.js = js
-	return nil
+	return opts
 }
 
 // initObjectStore retrieves the existing object store bucket.

--- a/nats/replica_client_test.go
+++ b/nats/replica_client_test.go
@@ -2,7 +2,13 @@ package nats
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -27,6 +33,116 @@ func TestReplicaClient_LTXFiles_InitError(t *testing.T) {
 	if _, err := client.LTXFiles(t.Context(), 0, 0, false); !errors.Is(err, jetstream.ErrBucketNotFound) {
 		t.Fatalf("LTXFiles() error = %v, want %v", err, jetstream.ErrBucketNotFound)
 	}
+}
+
+func TestReplicaClient_options_TLS(t *testing.T) {
+	t.Run("Disabled", func(t *testing.T) {
+		options := applyOptions(t, NewReplicaClient().options())
+		if options.Secure {
+			t.Fatal("Secure=true, want false")
+		}
+	})
+
+	t.Run("Explicit", func(t *testing.T) {
+		client := NewReplicaClient()
+		client.TLS = true
+
+		options := applyOptions(t, client.options())
+		if !options.Secure {
+			t.Fatal("Secure=false, want true")
+		}
+	})
+
+	t.Run("RootCAs", func(t *testing.T) {
+		rootCAPath, _, _ := writeTLSFiles(t)
+		client := NewReplicaClient()
+		client.RootCAs = []string{rootCAPath}
+
+		options := applyOptions(t, client.options())
+		if !options.Secure {
+			t.Fatal("Secure=false, want true")
+		}
+		if options.RootCAsCB == nil {
+			t.Fatal("RootCAsCB=nil")
+		}
+		pool, err := options.RootCAsCB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		rootPEM, err := os.ReadFile(rootCAPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := x509.NewCertPool()
+		if !want.AppendCertsFromPEM(rootPEM) {
+			t.Fatal("append root CA")
+		}
+		if !pool.Equal(want) {
+			t.Fatal("unexpected root CAs")
+		}
+	})
+
+	t.Run("ClientCertificate", func(t *testing.T) {
+		_, certPath, keyPath := writeTLSFiles(t)
+		client := NewReplicaClient()
+		client.ClientCert = certPath
+		client.ClientKey = keyPath
+
+		options := applyOptions(t, client.options())
+		if !options.Secure {
+			t.Fatal("Secure=false, want true")
+		}
+		if options.TLSCertCB == nil {
+			t.Fatal("TLSCertCB=nil")
+		}
+		cert, err := options.TLSCertCB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(cert.Certificate), 1; got != want {
+			t.Fatalf("Certificates=%d, want %d", got, want)
+		}
+	})
+}
+
+func applyOptions(t *testing.T, options []natsgo.Option) natsgo.Options {
+	t.Helper()
+
+	config := natsgo.GetDefaultOptions()
+	for _, option := range options {
+		if err := option(&config); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return config
+}
+
+func writeTLSFiles(t *testing.T) (rootCAPath, certPath, keyPath string) {
+	t.Helper()
+
+	server := httptest.NewTLSServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	rootCAPath = certPath
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(certPath, certPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(server.TLS.Certificates[0].PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	return rootCAPath, certPath, keyPath
 }
 
 func TestReplicaClient_ltxPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Apply every NATS replica TLS setting when constructing the NATS client options.

## Problem

The `tls:` YAML setting parsed successfully but was dropped by `newNATSReplicaClientFromConfig()`. The NATS client also no longer added `nats.Secure()` for explicit TLS after PR #720 replaced the original TLS branch with certificate helpers.

Before the fix, the regression test failed with:

```text
TestNewNATSReplicaFromConfig_TLS: TLS=false, want true
```

Root CA and client certificate settings still auto-enabled TLS, which masked the missing explicit TLS path.

## Solution

- Propagate the parsed TLS flag to the NATS replica client.
- Build connection options in a testable helper.
- Add `nats.Secure()` when explicit TLS is enabled.
- Verify explicit TLS, root CA, and client certificate options independently.

## Scope

**In scope:**
- NATS replica TLS option propagation
- Unit coverage for all supported NATS TLS settings

**Not in scope:**
- NATS server configuration changes
- New TLS configuration fields
- Changes to other replica backends

## Test Plan

```bash
go test -race ./cmd/litestream ./nats -run '^(TestNewNATSReplicaFromConfig_TLS|TestReplicaClient_options_TLS)$' -count=1
go test -race -v ./...
go vet ./...
pre-commit run --all-files
```

## Related

Fixes #1352
