### PR TITLE
Fix writable VFS database corruption under sustained writes

### DIFF
--- a/vfs.go
+++ b/vfs.go
@@ -2566,6 +2566,14 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 		return nil
 	}
 
+	// In write mode the local writer is authoritative: a polled commit at or
+	// below the local commit is the writer's own older upload (raced with sync),
+	// not a truncation. Replacing here would purge fresh pages and regress
+	// f.commit.
+	if f.writeEnabled && newCommit <= f.commit {
+		replaceIndex = false
+	}
+
 	// Apply updates and invalidate cache entries for updated pages
 	invalidateN := 0
 	target := f.index

--- a/vfs.go
+++ b/vfs.go
@@ -2173,6 +2173,12 @@ func (f *VFSFile) FileSize() (size int64, err error) {
 			size = v
 		}
 	}
+	// Honor the committed page count: after a sync clears f.dirty the synced
+	// pages live only in the cache (not the index), so without this the size
+	// would shrink below page 1's header and SQLite would report SQLITE_CORRUPT.
+	if v := int64(f.commit) * int64(pageSize); v > size {
+		size = v
+	}
 	f.mu.Unlock()
 
 	f.logger.Debug("file size", "size", size)

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -1399,3 +1399,6 @@ func TestVFSFile_Hydration_PersistentResumeOnReopen(t *testing.T) {
 		t.Fatalf("expected hydration file modtime unchanged on reopen resume")
 	}
 }
+
+func (c *mockReplicaClient) SetLogger(*slog.Logger)     {}
+func (c *countingReplicaClient) SetLogger(*slog.Logger) {}

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -1987,3 +1987,97 @@ func TestVFS_CloseReleasesWriteSlot(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestVFSFile_FileSizeStableAfterSyncExtendsDatabase is a regression test:
+// FileSize() must not shrink after a sync that extended the database.
+// syncToRemote() clears f.dirty and adds the synced pages to the cache (not the
+// index), so before the fix FileSize() dropped back to the old indexed size,
+// SQLite read past EOF, and reported SQLITE_CORRUPT.
+func TestVFSFile_FileSizeStableAfterSyncExtendsDatabase(t *testing.T) {
+	client := newWriteTestReplicaClient()
+
+	pageSize := uint32(4096)
+	initialPage := make([]byte, pageSize)
+	copy(initialPage, "initial data")
+	createTestLTXFile(t, client, 1, pageSize, 1, map[uint32][]byte{1: initialPage})
+
+	f := setupWriteableVFSFile(t, client)
+	f.PollInterval = time.Hour // suppress background poll for a deterministic test
+	if err := f.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Extend the database to 5 pages by writing page 5.
+	page5 := make([]byte, pageSize)
+	copy(page5, "page five")
+	if _, err := f.WriteAt(page5, int64(4)*int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+
+	want := int64(5) * int64(pageSize)
+	if size, err := f.FileSize(); err != nil {
+		t.Fatal(err)
+	} else if size != want {
+		t.Fatalf("before sync: FileSize()=%d, want %d", size, want)
+	}
+
+	if err := f.Sync(0); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.dirty) != 0 {
+		t.Fatalf("expected f.dirty cleared after sync, got %d pages", len(f.dirty))
+	}
+
+	if size, err := f.FileSize(); err != nil {
+		t.Fatal(err)
+	} else if size != want {
+		t.Fatalf("after sync: FileSize()=%d shrank below committed size %d", size, want)
+	}
+}
+
+// TestVFSFile_PollDoesNotRegressWriterCommit is a regression test: in write mode
+// the poll can re-fetch the writer's own just-uploaded LTX (via a stale pos
+// snapshot). Its header commit is below the writer's current commit; before the
+// fix that was misread as a truncation and regressed f.commit, shrinking
+// FileSize() and corrupting reads under sustained writes.
+func TestVFSFile_PollDoesNotRegressWriterCommit(t *testing.T) {
+	client := newWriteTestReplicaClient()
+
+	pageSize := uint32(4096)
+	page := make([]byte, pageSize)
+	copy(page, "p1")
+	createTestLTXFile(t, client, 1, pageSize, 3, map[uint32][]byte{1: page})
+
+	f := setupWriteableVFSFile(t, client)
+	f.PollInterval = time.Hour // drive the poll manually
+	if err := f.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Writer has advanced ahead of the replica: commit is 8, applied pos behind.
+	f.mu.Lock()
+	f.commit = 8
+	f.pos = ltx.Pos{TXID: 1}
+	f.mu.Unlock()
+
+	// A newer LTX (txid 2) whose header commit (5) is below the writer's current
+	// commit (8): the writer's own older upload observed via the poll.
+	updated := make([]byte, pageSize)
+	copy(updated, "p1'")
+	createTestLTXFile(t, client, 2, pageSize, 5, map[uint32][]byte{1: updated})
+
+	if err := f.pollReplicaClient(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	f.mu.Lock()
+	got := f.commit
+	f.mu.Unlock()
+	if got != 8 {
+		t.Fatalf("poll regressed f.commit to %d; want it to stay 8", got)
+	}
+}
+
+func (c *writeTestReplicaClient) SetLogger(*slog.Logger) {}


### PR DESCRIPTION
## Summary

Fixes two bugs in the writable VFS (`vfs.go`, built with `-tags vfs`, `WriteEnabled`) that corrupt the SQLite database under a sustained multi-page write workload — reads start failing with `SQLITE_CORRUPT` ("database disk image is malformed").

## Problem

Reproduced by driving JuiceFS's SQLite metadata engine over the VFS (`sqlite3://…?vfs=litestream&_journal=DELETE&max_open_conns=1`) and creating files in a loop. It corrupts after ~40–430 files on macOS/arm64, Linux/arm64, and Linux/x86_64. Debug logs pin each corruption to a page-count regression immediately after a sync:

**Bug 1 — `FileSize()` shrinks after a sync that extended the DB:**
```
write ... pgno=37 commit=37
file size size=151552          # 37 pages
synced to remote txid=5 pages=17   # clears f.dirty
file size size=131072          # 32 pages  <-- shrank
ERROR: database disk image is malformed
```

**Bug 2 — the write-mode poll re-ingests the writer's own upload and regresses `commit`:**
```
file size size=299008          # 73 pages
adding new page index ... MinTXID=MaxTXID=8   # poll re-fetches our own LTX 8
cache invalidated pages count=29
file size size=294912          # 72 pages  <-- regressed
ERROR: database disk image is malformed
```

## Root cause

**Bug 1:** `syncToRemoteWithLock()` clears `f.dirty` and adds the synced pages to the page cache, but not to `f.index`. `FileSize()` computes the size from `f.index`/`f.pending`/`f.dirty` and ignores `f.commit`, so once `f.dirty` is cleared a sync that had grown the DB makes the reported size drop below page 1's header → SQLite reads past EOF → `SQLITE_CORRUPT`.

**Bug 2:** `monitorReplicaClient` runs unconditionally in single-writer write mode. `pollReplicaClient` snapshots `pos` before a concurrent `syncToRemote` advances it, so it re-fetches the writer's own just-uploaded LTX whose header `commit` is at/below the writer's current `f.commit`. `pollLevel` reads `hdr.Commit < baseCommit` as a truncation (`replaceIndex`), so the apply step resets `f.index`, purges cache entries for freshly-written pages, and regresses `f.commit`.

## Solution

- `FileSize()`: honor `f.commit` (the authoritative committed page count).
- `pollReplicaClient()`: in write mode, a polled commit at/below the local commit is the writer's own older upload (raced with sync), not a truncation — merge its page index without replacing.

## Scope

**In scope:**
- The two corruption fixes above. They are separate root causes but the same symptom, and both are required for the writable VFS to survive sustained writes (the regression tests below cover both). Happy to split into two PRs if you'd prefer.
- Regression tests for each bug (fail on `main`, pass with this PR).
- No-op `ReplicaClient.SetLogger` on the vfs-tagged test mocks — the `-tags vfs` test suite did not compile at `main` without it.

**Not in scope:**
- The FUSE-layer errno noise seen only on macFUSE (`ENOSYS` / "device not configured") under heavy load — it does not reproduce on Linux FUSE and is unrelated to litestream.
- Any broader redesign of the write-mode poll / index reconciliation.

## Test Plan

```bash
# The two regression tests — fail on main, pass with this PR:
go test -tags vfs -race -run 'TestVFSFile_FileSizeStableAfterSyncExtendsDatabase|TestVFSFile_PollDoesNotRegressWriterCommit' .

# Full vfs-tagged package suite:
go test -tags vfs -race .        # ok (27s)

# Non-vfs suite + vet:
go test ./...                    # ok
go vet ./... && go vet -tags vfs .   # clean
```

On `main` the two tests fail with `FileSize()=4096 shrank below committed size 20480` and `poll regressed f.commit to 5; want it to stay 8`.

Integration: JuiceFS over the VFS with the default config (poll on, 1s sync), 2500 file creates → zero corruption on Linux.

## Static analysis

`gofmt`, `goimports`, and `go vet` (with and without `-tags vfs`) are clean on the changed files, and `staticcheck` 2026.1 reports no findings in the changed code. Two pre-existing findings are intentionally left out of scope: `syncToRemote` in `vfs.go` is unused (also reported on `main`), and `TestVFSFile_WriteAt` in `vfs_write_test.go` has an SA4006 (unused value) that only becomes visible because this PR makes the `-tags vfs` test suite compile.

## Related

No existing issue. This is a data-corruption fix in the writable VFS, so it likely warrants the `stability` label.
