### PR TITLE
fix(mcp): report the running instance version, not a PATH binary

### DIFF
--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -30,7 +30,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 
 	mcpServer := server.NewMCPServer(
 		"Litestream MCP Server",
-		"1.0.0",
+		Version,
 		server.WithToolCapabilities(false),
 		server.WithRecovery(),
 		server.WithLogging(),
@@ -243,16 +243,11 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 
 func VersionTool() (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_version",
-		mcp.WithDescription("Print the Litestream binary version."),
+		mcp.WithDescription("Print the running Litestream instance's version."),
 	)
 
-	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		cmd := exec.CommandContext(ctx, "litestream", "version")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
-		}
-		return mcp.NewToolResultText(string(output)), nil
+	return tool, func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText(Version + "\n"), nil
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestMCPServerInitializeVersion(t *testing.T) {
+	server, err := NewMCP(t.Context(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	body := strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"clientInfo\":{\"name\":\"test-client\",\"version\":\"1.0.0\"}}}")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, httpServer.URL, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpServer.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var result struct {
+		Result mcp.InitializeResult `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := result.Result.ServerInfo.Version, Version; got != want {
+		t.Fatalf("server version=%q, want %q", got, want)
+	}
+}
+
+func TestVersionTool(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, handler := VersionTool()
+	result, err := handler(t.Context(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result.Content)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("content length=%d, want 1", len(result.Content))
+	}
+	content, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content type=%T, want mcp.TextContent", result.Content[0])
+	}
+	if got, want := content.Text, Version+"\n"; got != want {
+		t.Fatalf("version=%q, want %q", got, want)
+	}
+}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestMCPServerInitializeVersion(t *testing.T) {
+	const version = "v1.2.3-handshake-test"
+	setVersion(t, version)
+
 	server, err := NewMCP(t.Context(), "")
 	if err != nil {
 		t.Fatal(err)
@@ -41,12 +44,14 @@ func TestMCPServerInitializeVersion(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatal(err)
 	}
-	if got, want := result.Result.ServerInfo.Version, Version; got != want {
+	if got, want := result.Result.ServerInfo.Version, version; got != want {
 		t.Fatalf("server version=%q, want %q", got, want)
 	}
 }
 
 func TestVersionTool(t *testing.T) {
+	const version = "v1.2.3-instance-test"
+	setVersion(t, version)
 	t.Setenv("PATH", t.TempDir())
 
 	_, handler := VersionTool()
@@ -64,7 +69,15 @@ func TestVersionTool(t *testing.T) {
 	if !ok {
 		t.Fatalf("content type=%T, want mcp.TextContent", result.Content[0])
 	}
-	if got, want := content.Text, Version+"\n"; got != want {
+	if got, want := content.Text, version+"\n"; got != want {
 		t.Fatalf("version=%q, want %q", got, want)
 	}
+}
+
+func setVersion(t *testing.T, version string) {
+	t.Helper()
+
+	previous := Version
+	Version = version
+	t.Cleanup(func() { Version = previous })
 }


### PR DESCRIPTION
## Description
The MCP version tool now reports the in-process build version for the running embedded daemon instead of launching whichever `litestream` binary `$PATH` resolves. The MCP initialize response also advertises the real build version rather than the static `1.0.0` identity.

This change is limited to embedded MCP version reporting and handshake identity. Standalone or remote connected-daemon version sourcing remains out of scope.

## Motivation and Context
A daemon started from a source build, container, or versioned install path could report the version of an unrelated `litestream` executable. The regression reproduced this by removing `litestream` from `$PATH`, which returned an executable-not-found tool error, while initialization independently advertised `1.0.0` instead of the running development build.

Closes #1365

## How Has This Been Tested?
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test ./cmd/litestream -run "Test(MCPServerInitializeVersion|VersionTool)$" -count=1 -ldflags "-X main.Version=v1365-test"`
- `pre-commit run --all-files`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)