### PR TITLE
fix(mcp): correct optional parameter handling

### DIFF
--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,12 +3,12 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os/exec"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -135,7 +135,9 @@ func DatabasesTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[databasesIn
 		if input.Config != nil {
 			config = *input.Config
 		}
-		args = append(args, "-config", config)
+		if config != "" {
+			args = append(args, "-config", config)
+		}
 		cmd := exec.CommandContext(ctx, "litestream", args...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
@@ -166,14 +168,9 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 		var summary strings.Builder
 		summary.WriteString("=== Litestream Status Report ===\n\n")
 
-		versionCmd := exec.CommandContext(ctx, "litestream", "version")
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			return nil, infoOutput{}, fmt.Errorf("get version info: %w", commandError(versionOutput, err))
-		}
 		summary.WriteString("Version Information:\n")
-		summary.WriteString(string(versionOutput))
-		summary.WriteString("\n")
+		summary.WriteString(Version)
+		summary.WriteString("\n\n")
 
 		args := []string{"databases"}
 		config := configPath
@@ -183,7 +180,9 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 		summary.WriteString("Current Config Path:\n")
 		summary.WriteString(config + "\n\n")
 
-		args = append(args, "-config", config)
+		if config != "" {
+			args = append(args, "-config", config)
+		}
 		dbCmd := exec.CommandContext(ctx, "litestream", args...)
 		dbOutput, err := dbCmd.CombinedOutput()
 		if err != nil {
@@ -231,13 +230,13 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 
 type restoreInput struct {
 	Path            string  `json:"path" jsonschema:"Database path or replica URL."`
-	Output          *string `json:"o,omitempty" jsonschema:"Output path for the restored database. Optional."`
+	Output          *string `json:"output,omitempty" jsonschema:"Output path for the restored database. Required for replica URLs; optional for configured databases, where it defaults to the database path."`
 	Config          *string `json:"config,omitempty" jsonschema:"Path to the Litestream config file. Optional."`
 	TXID            *string `json:"txid,omitempty" jsonschema:"Restore up to a specific transaction ID. Optional."`
 	Timestamp       *string `json:"timestamp,omitempty" jsonschema:"Restore to a specific point-in-time (RFC3339). Optional."`
 	Parallelism     *string `json:"parallelism,omitempty" jsonschema:"Number of WAL files to download in parallel. Optional."`
-	IfDBNotExists   *bool   `json:"if_db_not_exists,omitempty" jsonschema:"Return 0 if the database already exists. Optional."`
-	IfReplicaExists *bool   `json:"if_replica_exists,omitempty" jsonschema:"Return 0 if no backups are found. Optional."`
+	IfDBNotExists   *bool   `json:"if_db_not_exists,omitempty" jsonschema:"Skip restore if the database already exists. Optional."`
+	IfReplicaExists *bool   `json:"if_replica_exists,omitempty" jsonschema:"Skip restore if no backups are found. Optional."`
 }
 
 type restoreOutput struct {
@@ -245,17 +244,23 @@ type restoreOutput struct {
 }
 
 func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput, restoreOutput]) {
+	inputSchema := nonNullableInputSchema[restoreInput]()
+	inputSchema.PatternProperties = map[string]*jsonschema.Schema{"^o$": {Type: "string"}}
 	tool := &mcp.Tool{
 		Name:        "litestream_restore",
 		Description: "Restore a database from a Litestream replica.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
-		InputSchema: nonNullableInputSchema[restoreInput](),
+		InputSchema: inputSchema,
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input restoreInput) (*mcp.CallToolResult, restoreOutput, error) {
+	return tool, func(ctx context.Context, request *mcp.CallToolRequest, input restoreInput) (*mcp.CallToolResult, restoreOutput, error) {
 		args := []string{"restore"}
-		if input.Output != nil {
-			args = append(args, "-o", *input.Output)
+		outputPath, err := restoreOutputPath(request, input)
+		if err != nil {
+			return nil, restoreOutput{}, err
+		}
+		if outputPath != "" {
+			args = append(args, "-o", outputPath)
 		}
 
 		if !isReplicaURL(input.Path) {
@@ -268,20 +273,20 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 			}
 		}
 
-		if input.TXID != nil {
+		if input.TXID != nil && *input.TXID != "" {
 			args = append(args, "-txid", *input.TXID)
 		}
-		if input.Timestamp != nil {
+		if input.Timestamp != nil && *input.Timestamp != "" {
 			args = append(args, "-timestamp", *input.Timestamp)
 		}
-		if input.Parallelism != nil {
+		if input.Parallelism != nil && *input.Parallelism != "" {
 			args = append(args, "-parallelism", *input.Parallelism)
 		}
-		if input.IfDBNotExists != nil {
-			args = append(args, "-if-db-not-exists", strconv.FormatBool(*input.IfDBNotExists))
+		if input.IfDBNotExists != nil && *input.IfDBNotExists {
+			args = append(args, "-if-db-not-exists")
 		}
-		if input.IfReplicaExists != nil {
-			args = append(args, "-if-replica-exists", strconv.FormatBool(*input.IfReplicaExists))
+		if input.IfReplicaExists != nil && *input.IfReplicaExists {
+			args = append(args, "-if-replica-exists")
 		}
 		if input.Path != "" {
 			args = append(args, input.Path)
@@ -294,6 +299,26 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 		text := string(output)
 		return textResult(text), restoreOutput{Text: text}, nil
 	}
+}
+
+func restoreOutputPath(request *mcp.CallToolRequest, input restoreInput) (string, error) {
+	if input.Output != nil && *input.Output != "" {
+		return *input.Output, nil
+	}
+	if request == nil || len(request.Params.Arguments) == 0 {
+		return "", nil
+	}
+
+	var legacy struct {
+		Output *string `json:"o"`
+	}
+	if err := json.Unmarshal(request.Params.Arguments, &legacy); err != nil {
+		return "", fmt.Errorf("decode legacy restore output: %w", err)
+	}
+	if legacy.Output == nil {
+		return "", nil
+	}
+	return *legacy.Output, nil
 }
 
 type versionInput struct{}
@@ -381,8 +406,10 @@ func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, s
 		if input.Config != nil {
 			config = *input.Config
 		}
-		args = append(args, "-config", config)
-		if input.Path != nil {
+		if config != "" {
+			args = append(args, "-config", config)
+		}
+		if input.Path != nil && *input.Path != "" {
 			args = append(args, *input.Path)
 		}
 		cmd := exec.CommandContext(ctx, "litestream", args...)
@@ -418,7 +445,9 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 		if input.Config != nil {
 			config = *input.Config
 		}
-		args = append(args, "-config", config)
+		if config != "" {
+			args = append(args, "-config", config)
+		}
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,7 +11,6 @@ import (
 	"net/http"
 	"os/exec"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -206,7 +206,9 @@ func DatabasesTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[databasesIn
 		if input.Config != nil {
 			config = *input.Config
 		}
-		args = append(args, "-config", config)
+		if config != "" {
+			args = append(args, "-config", config)
+		}
 		cmd := exec.CommandContext(ctx, "litestream", args...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
@@ -237,14 +239,9 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 		var summary strings.Builder
 		summary.WriteString("=== Litestream Status Report ===\n\n")
 
-		versionCmd := exec.CommandContext(ctx, "litestream", "version")
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			return nil, infoOutput{}, fmt.Errorf("get version info: %w", commandError(versionOutput, err))
-		}
 		summary.WriteString("Version Information:\n")
-		summary.WriteString(string(versionOutput))
-		summary.WriteString("\n")
+		summary.WriteString(Version)
+		summary.WriteString("\n\n")
 
 		args := []string{"databases"}
 		config := configPath
@@ -254,7 +251,9 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 		summary.WriteString("Current Config Path:\n")
 		summary.WriteString(config + "\n\n")
 
-		args = append(args, "-config", config)
+		if config != "" {
+			args = append(args, "-config", config)
+		}
 		dbCmd := exec.CommandContext(ctx, "litestream", args...)
 		dbOutput, err := dbCmd.CombinedOutput()
 		if err != nil {
@@ -302,13 +301,13 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 
 type restoreInput struct {
 	Path            string  `json:"path" jsonschema:"Database path or replica URL."`
-	Output          *string `json:"o,omitempty" jsonschema:"Output path for the restored database. Optional."`
+	Output          *string `json:"output,omitempty" jsonschema:"Output path for the restored database. Required for replica URLs; optional for configured databases, where it defaults to the database path."`
 	Config          *string `json:"config,omitempty" jsonschema:"Path to the Litestream config file. Optional."`
 	TXID            *string `json:"txid,omitempty" jsonschema:"Restore up to a specific transaction ID. Optional."`
 	Timestamp       *string `json:"timestamp,omitempty" jsonschema:"Restore to a specific point-in-time (RFC3339). Optional."`
 	Parallelism     *string `json:"parallelism,omitempty" jsonschema:"Number of WAL files to download in parallel. Optional."`
-	IfDBNotExists   *bool   `json:"if_db_not_exists,omitempty" jsonschema:"Return 0 if the database already exists. Optional."`
-	IfReplicaExists *bool   `json:"if_replica_exists,omitempty" jsonschema:"Return 0 if no backups are found. Optional."`
+	IfDBNotExists   *bool   `json:"if_db_not_exists,omitempty" jsonschema:"Skip restore if the database already exists. Optional."`
+	IfReplicaExists *bool   `json:"if_replica_exists,omitempty" jsonschema:"Skip restore if no backups are found. Optional."`
 }
 
 type restoreOutput struct {
@@ -316,17 +315,23 @@ type restoreOutput struct {
 }
 
 func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput, restoreOutput]) {
+	inputSchema := nonNullableInputSchema[restoreInput]()
+	inputSchema.PatternProperties = map[string]*jsonschema.Schema{"^o$": {Type: "string"}}
 	tool := &mcp.Tool{
 		Name:        "litestream_restore",
 		Description: "Restore a database from a Litestream replica.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
-		InputSchema: nonNullableInputSchema[restoreInput](),
+		InputSchema: inputSchema,
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input restoreInput) (*mcp.CallToolResult, restoreOutput, error) {
+	return tool, func(ctx context.Context, request *mcp.CallToolRequest, input restoreInput) (*mcp.CallToolResult, restoreOutput, error) {
 		args := []string{"restore"}
-		if input.Output != nil {
-			args = append(args, "-o", *input.Output)
+		outputPath, err := restoreOutputPath(request, input)
+		if err != nil {
+			return nil, restoreOutput{}, err
+		}
+		if outputPath != "" {
+			args = append(args, "-o", outputPath)
 		}
 
 		if !isReplicaURL(input.Path) {
@@ -339,20 +344,20 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 			}
 		}
 
-		if input.TXID != nil {
+		if input.TXID != nil && *input.TXID != "" {
 			args = append(args, "-txid", *input.TXID)
 		}
-		if input.Timestamp != nil {
+		if input.Timestamp != nil && *input.Timestamp != "" {
 			args = append(args, "-timestamp", *input.Timestamp)
 		}
-		if input.Parallelism != nil {
+		if input.Parallelism != nil && *input.Parallelism != "" {
 			args = append(args, "-parallelism", *input.Parallelism)
 		}
-		if input.IfDBNotExists != nil {
-			args = append(args, "-if-db-not-exists", strconv.FormatBool(*input.IfDBNotExists))
+		if input.IfDBNotExists != nil && *input.IfDBNotExists {
+			args = append(args, "-if-db-not-exists")
 		}
-		if input.IfReplicaExists != nil {
-			args = append(args, "-if-replica-exists", strconv.FormatBool(*input.IfReplicaExists))
+		if input.IfReplicaExists != nil && *input.IfReplicaExists {
+			args = append(args, "-if-replica-exists")
 		}
 		if input.Path != "" {
 			args = append(args, input.Path)
@@ -365,6 +370,26 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 		text := string(output)
 		return textResult(text), restoreOutput{Text: text}, nil
 	}
+}
+
+func restoreOutputPath(request *mcp.CallToolRequest, input restoreInput) (string, error) {
+	if input.Output != nil && *input.Output != "" {
+		return *input.Output, nil
+	}
+	if request == nil || len(request.Params.Arguments) == 0 {
+		return "", nil
+	}
+
+	var legacy struct {
+		Output *string `json:"o"`
+	}
+	if err := json.Unmarshal(request.Params.Arguments, &legacy); err != nil {
+		return "", fmt.Errorf("decode legacy restore output: %w", err)
+	}
+	if legacy.Output == nil {
+		return "", nil
+	}
+	return *legacy.Output, nil
 }
 
 type versionInput struct{}
@@ -452,8 +477,10 @@ func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, s
 		if input.Config != nil {
 			config = *input.Config
 		}
-		args = append(args, "-config", config)
-		if input.Path != nil {
+		if config != "" {
+			args = append(args, "-config", config)
+		}
+		if input.Path != nil && *input.Path != "" {
 			args = append(args, *input.Path)
 		}
 		cmd := exec.CommandContext(ctx, "litestream", args...)
@@ -489,7 +516,9 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 		if input.Config != nil {
 			config = *input.Config
 		}
-		args = append(args, "-config", config)
+		if config != "" {
+			args = append(args, "-config", config)
+		}
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +22,39 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func TestMain(m *testing.M) {
+	if filepath.Base(os.Args[0]) == mcpTestExecutableName(runtime.GOOS) && os.Getenv("LITESTREAM_MCP_TEST") == "1" {
+		os.Exit(runMCPTestCommand())
+	}
+	os.Exit(m.Run())
+}
+
+func mcpTestExecutableName(goos string) string {
+	if goos == "windows" {
+		return "litestream.exe"
+	}
+	return "litestream"
+}
+
+func TestMCPTestExecutableName(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{goos: "linux", want: "litestream"},
+		{goos: "darwin", want: "litestream"},
+		{goos: "windows", want: "litestream.exe"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.goos, func(t *testing.T) {
+			if got := mcpTestExecutableName(test.goos); got != test.want {
+				t.Fatalf("executable name=%q, want %q", got, test.want)
+			}
+		})
+	}
+}
 
 func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
@@ -89,7 +124,7 @@ func TestMCPServerTools(t *testing.T) {
 				"config":            "string",
 				"if_db_not_exists":  "boolean",
 				"if_replica_exists": "boolean",
-				"o":                 "string",
+				"output":            "string",
 				"parallelism":       "string",
 				"path":              "string",
 				"timestamp":         "string",
@@ -447,7 +482,7 @@ func TestMCPToolBehavior(t *testing.T) {
 		{
 			name:      "litestream_databases",
 			arguments: map[string]any{"config": ""},
-			want:      "<databases><-config><>\n",
+			want:      "<databases>\n",
 		},
 		{
 			name: "litestream_restore",
@@ -461,7 +496,7 @@ func TestMCPToolBehavior(t *testing.T) {
 				"if_db_not_exists":  false,
 				"if_replica_exists": true,
 			},
-			want: "<restore><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
+			want: "<restore><-if-replica-exists></data/db>\n",
 		},
 		{
 			name:      "litestream_ltx",
@@ -471,12 +506,12 @@ func TestMCPToolBehavior(t *testing.T) {
 		{
 			name:      "litestream_status",
 			arguments: map[string]any{"config": "", "path": ""},
-			want:      "<status><-config><><>\n",
+			want:      "<status>\n",
 		},
 		{
 			name:      "litestream_reset",
 			arguments: map[string]any{"path": "/data/db", "config": ""},
-			want:      "<reset><-config><></data/db>\n",
+			want:      "<reset></data/db>\n",
 		},
 	}
 
@@ -510,7 +545,7 @@ func TestMCPToolBehavior(t *testing.T) {
 		t.Fatalf("info tool error: %#v", result.Content)
 	}
 	for _, want := range []string{
-		"Litestream test-version",
+		"v1.2.3-mcp-test",
 		"Current Config Path:\n/custom/litestream.yml",
 		"Database: /data/db",
 		"<ltx><-config></custom/litestream.yml></data/db>",
@@ -536,6 +571,177 @@ func TestMCPToolBehavior(t *testing.T) {
 			t.Errorf("info error does not contain %q: %q", want, got)
 		}
 	}
+}
+
+func TestMCPToolsOmitEmptyConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		arguments   map[string]any
+		invocations []string
+	}{
+		{name: "litestream_databases", invocations: []string{"databases"}},
+		{name: "litestream_info", invocations: []string{"databases"}},
+		{name: "litestream_restore", arguments: map[string]any{"path": "/tmp/db"}, invocations: []string{"restore\x1f/tmp/db"}},
+		{name: "litestream_ltx", arguments: map[string]any{"path": "/tmp/db"}, invocations: []string{"ltx\x1f/tmp/db"}},
+		{name: "litestream_status", invocations: []string{"status"}},
+		{name: "litestream_reset", arguments: map[string]any{"path": "/tmp/db"}, invocations: []string{"reset\x1f/tmp/db"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			argsPath := useMCPTestCommand(t)
+			session := newMCPTestSession(t, "")
+			callMCPTool(t, session, test.name, test.arguments)
+			assertMCPInvocations(t, argsPath, test.invocations)
+		})
+	}
+}
+
+func TestRestoreToolArguments(t *testing.T) {
+	tests := []struct {
+		name       string
+		configPath string
+		arguments  map[string]any
+		invocation string
+	}{
+		{
+			name:       "all optional arguments",
+			configPath: "/default.yml",
+			arguments: map[string]any{
+				"path":              "/tmp/db",
+				"output":            "/tmp/restored.db",
+				"config":            "/custom.yml",
+				"txid":              "0000000000000001",
+				"timestamp":         "2026-07-16T12:00:00Z",
+				"parallelism":       "4",
+				"if_db_not_exists":  true,
+				"if_replica_exists": true,
+			},
+			invocation: strings.Join([]string{
+				"restore",
+				"-o", "/tmp/restored.db",
+				"-config", "/custom.yml",
+				"-txid", "0000000000000001",
+				"-timestamp", "2026-07-16T12:00:00Z",
+				"-parallelism", "4",
+				"-if-db-not-exists",
+				"-if-replica-exists",
+				"/tmp/db",
+			}, "\x1f"),
+		},
+		{
+			name:       "configured database path defaults output",
+			configPath: "/default.yml",
+			arguments:  map[string]any{"path": "/tmp/db"},
+			invocation: "restore\x1f-config\x1f/default.yml\x1f/tmp/db",
+		},
+		{
+			name:       "replica URL requires output",
+			configPath: "/default.yml",
+			arguments: map[string]any{
+				"path":   "s3://bucket/db",
+				"output": "/tmp/restored.db",
+				"config": "/custom.yml",
+			},
+			invocation: "restore\x1f-o\x1f/tmp/restored.db\x1fs3://bucket/db",
+		},
+		{
+			name: "legacy output alias",
+			arguments: map[string]any{
+				"path": "/tmp/db",
+				"o":    "/tmp/restored.db",
+			},
+			invocation: "restore\x1f-o\x1f/tmp/restored.db\x1f/tmp/db",
+		},
+		{
+			name:       "if database does not exist true",
+			arguments:  map[string]any{"path": "/tmp/db", "if_db_not_exists": true},
+			invocation: "restore\x1f-if-db-not-exists\x1f/tmp/db",
+		},
+		{
+			name:       "if database does not exist false",
+			arguments:  map[string]any{"path": "/tmp/db", "if_db_not_exists": false},
+			invocation: "restore\x1f/tmp/db",
+		},
+		{
+			name:       "if replica exists true",
+			arguments:  map[string]any{"path": "/tmp/db", "if_replica_exists": true},
+			invocation: "restore\x1f-if-replica-exists\x1f/tmp/db",
+		},
+		{
+			name:       "if replica exists false",
+			arguments:  map[string]any{"path": "/tmp/db", "if_replica_exists": false},
+			invocation: "restore\x1f/tmp/db",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			argsPath := useMCPTestCommand(t)
+			session := newMCPTestSession(t, test.configPath)
+			callMCPTool(t, session, "litestream_restore", test.arguments)
+			assertMCPInvocations(t, argsPath, []string{test.invocation})
+		})
+	}
+}
+
+func TestRestoreToolSchema(t *testing.T) {
+	tool, _ := RestoreTool("")
+	properties := schemaProperties(t, jsonObject(t, tool.InputSchema))
+
+	if _, ok := properties["output"]; !ok {
+		t.Fatal("output property is missing")
+	}
+	if _, ok := properties["o"]; ok {
+		t.Fatal("legacy o property is published")
+	}
+
+	descriptions := map[string]string{
+		"if_db_not_exists":  "Skip restore if the database already exists. Optional.",
+		"if_replica_exists": "Skip restore if no backups are found. Optional.",
+		"output":            "Output path for the restored database. Required for replica URLs; optional for configured databases, where it defaults to the database path.",
+	}
+	for name, want := range descriptions {
+		property := jsonObject(t, properties[name])
+		if got := property["description"]; got != want {
+			t.Fatalf("%s description=%q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestMCPToolsRequirePath(t *testing.T) {
+	tools := []string{"litestream_restore", "litestream_ltx", "litestream_reset"}
+	tests := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{name: "missing", arguments: map[string]any{}},
+		{name: "wrong type", arguments: map[string]any{"path": true}},
+	}
+
+	for _, tool := range tools {
+		for _, test := range tests {
+			t.Run(tool+"/"+test.name, func(t *testing.T) {
+				argsPath := useMCPTestCommand(t)
+				session := newMCPTestSession(t, "")
+				callMCPToolError(t, session, tool, test.arguments, "path")
+				assertNoMCPInvocations(t, argsPath)
+			})
+		}
+	}
+}
+
+func TestInfoToolUsesRunningVersion(t *testing.T) {
+	const version = "v1.2.3-running"
+	setVersion(t, version)
+	argsPath := useMCPTestCommand(t)
+	session := newMCPTestSession(t, "")
+
+	result := callMCPTool(t, session, "litestream_info", nil)
+	if got := textContent(t, result); !strings.Contains(got, "Version Information:\n"+version+"\n") {
+		t.Fatalf("info output does not contain running version %q: %q", version, got)
+	}
+	assertMCPInvocations(t, argsPath, []string{"databases"})
 }
 
 func TestMCPToolContextCancellation(t *testing.T) {
@@ -609,6 +815,133 @@ func schemaRequired(schema map[string]any) []string {
 	}
 	slices.Sort(required)
 	return required
+}
+
+func newMCPTestSession(t *testing.T, configPath string) *mcp.ClientSession {
+	t.Helper()
+
+	server, err := NewMCP(t.Context(), configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.mcpServer.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := serverSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	clientSession, err := client.Connect(t.Context(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := clientSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return clientSession
+}
+
+func callMCPTool(t *testing.T, session *mcp.ClientSession, name string, arguments map[string]any) *mcp.CallToolResult {
+	t.Helper()
+
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: name, Arguments: arguments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result.Content)
+	}
+	return result
+}
+
+func callMCPToolError(t *testing.T, session *mcp.ClientSession, name string, arguments map[string]any, want string) {
+	t.Helper()
+
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: name, Arguments: arguments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatalf("tool succeeded: %#v", result.Content)
+	}
+	if got := textContent(t, result); !strings.Contains(got, want) {
+		t.Fatalf("tool error does not contain %q: %q", want, got)
+	}
+}
+
+func useMCPTestCommand(t *testing.T) string {
+	t.Helper()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	commandPath := filepath.Join(dir, mcpTestExecutableName(runtime.GOOS))
+	var linkErr error
+	if runtime.GOOS == "windows" {
+		linkErr = os.Link(executable, commandPath)
+	} else {
+		linkErr = os.Symlink(executable, commandPath)
+	}
+	if linkErr != nil {
+		t.Fatal(linkErr)
+	}
+	argsPath := filepath.Join(dir, "args")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("LITESTREAM_MCP_TEST", "1")
+	t.Setenv("LITESTREAM_MCP_ARGS_PATH", argsPath)
+	return argsPath
+}
+
+func runMCPTestCommand() int {
+	f, err := os.OpenFile(os.Getenv("LITESTREAM_MCP_ARGS_PATH"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if _, err := fmt.Fprintln(f, strings.Join(os.Args[1:], "\x1f")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := f.Close(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(os.Args) > 1 && os.Args[1] == "databases" {
+		fmt.Println("path\treplicas")
+	} else {
+		fmt.Println("ok")
+	}
+	return 0
+}
+
+func assertMCPInvocations(t *testing.T, argsPath string, want []string) {
+	t.Helper()
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invocations=%q, want %q", got, want)
+	}
+}
+
+func assertNoMCPInvocations(t *testing.T, argsPath string) {
+	t.Helper()
+
+	if _, err := os.Stat(argsPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected no invocation, stat error: %v", err)
+	}
 }
 
 func installFakeLitestream(t *testing.T) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net"
 	"net/http"
@@ -21,6 +23,39 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func TestMain(m *testing.M) {
+	if filepath.Base(os.Args[0]) == mcpTestExecutableName(runtime.GOOS) && os.Getenv("LITESTREAM_MCP_TEST") == "1" {
+		os.Exit(runMCPTestCommand())
+	}
+	os.Exit(m.Run())
+}
+
+func mcpTestExecutableName(goos string) string {
+	if goos == "windows" {
+		return "litestream.exe"
+	}
+	return "litestream"
+}
+
+func TestMCPTestExecutableName(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{goos: "linux", want: "litestream"},
+		{goos: "darwin", want: "litestream"},
+		{goos: "windows", want: "litestream.exe"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.goos, func(t *testing.T) {
+			if got := mcpTestExecutableName(test.goos); got != test.want {
+				t.Fatalf("executable name=%q, want %q", got, test.want)
+			}
+		})
+	}
+}
 
 func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
@@ -90,7 +125,7 @@ func TestMCPServerTools(t *testing.T) {
 				"config":            "string",
 				"if_db_not_exists":  "boolean",
 				"if_replica_exists": "boolean",
-				"o":                 "string",
+				"output":            "string",
 				"parallelism":       "string",
 				"path":              "string",
 				"timestamp":         "string",
@@ -448,7 +483,7 @@ func TestMCPToolBehavior(t *testing.T) {
 		{
 			name:      "litestream_databases",
 			arguments: map[string]any{"config": ""},
-			want:      "<databases><-config><>\n",
+			want:      "<databases>\n",
 		},
 		{
 			name: "litestream_restore",
@@ -462,7 +497,7 @@ func TestMCPToolBehavior(t *testing.T) {
 				"if_db_not_exists":  false,
 				"if_replica_exists": true,
 			},
-			want: "<restore><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
+			want: "<restore><-if-replica-exists></data/db>\n",
 		},
 		{
 			name:      "litestream_ltx",
@@ -472,12 +507,12 @@ func TestMCPToolBehavior(t *testing.T) {
 		{
 			name:      "litestream_status",
 			arguments: map[string]any{"config": "", "path": ""},
-			want:      "<status><-config><><>\n",
+			want:      "<status>\n",
 		},
 		{
 			name:      "litestream_reset",
 			arguments: map[string]any{"path": "/data/db", "config": ""},
-			want:      "<reset><-config><></data/db>\n",
+			want:      "<reset></data/db>\n",
 		},
 	}
 
@@ -511,7 +546,7 @@ func TestMCPToolBehavior(t *testing.T) {
 		t.Fatalf("info tool error: %#v", result.Content)
 	}
 	for _, want := range []string{
-		"Litestream test-version",
+		"v1.2.3-mcp-test",
 		"Current Config Path:\n/custom/litestream.yml",
 		"Database: /data/db",
 		"<ltx><-config></custom/litestream.yml></data/db>",
@@ -537,6 +572,177 @@ func TestMCPToolBehavior(t *testing.T) {
 			t.Errorf("info error does not contain %q: %q", want, got)
 		}
 	}
+}
+
+func TestMCPToolsOmitEmptyConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		arguments   map[string]any
+		invocations []string
+	}{
+		{name: "litestream_databases", invocations: []string{"databases"}},
+		{name: "litestream_info", invocations: []string{"databases"}},
+		{name: "litestream_restore", arguments: map[string]any{"path": "/tmp/db"}, invocations: []string{"restore\x1f/tmp/db"}},
+		{name: "litestream_ltx", arguments: map[string]any{"path": "/tmp/db"}, invocations: []string{"ltx\x1f/tmp/db"}},
+		{name: "litestream_status", invocations: []string{"status"}},
+		{name: "litestream_reset", arguments: map[string]any{"path": "/tmp/db"}, invocations: []string{"reset\x1f/tmp/db"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			argsPath := useMCPTestCommand(t)
+			session := newMCPTestSession(t, "")
+			callMCPTool(t, session, test.name, test.arguments)
+			assertMCPInvocations(t, argsPath, test.invocations)
+		})
+	}
+}
+
+func TestRestoreToolArguments(t *testing.T) {
+	tests := []struct {
+		name       string
+		configPath string
+		arguments  map[string]any
+		invocation string
+	}{
+		{
+			name:       "all optional arguments",
+			configPath: "/default.yml",
+			arguments: map[string]any{
+				"path":              "/tmp/db",
+				"output":            "/tmp/restored.db",
+				"config":            "/custom.yml",
+				"txid":              "0000000000000001",
+				"timestamp":         "2026-07-16T12:00:00Z",
+				"parallelism":       "4",
+				"if_db_not_exists":  true,
+				"if_replica_exists": true,
+			},
+			invocation: strings.Join([]string{
+				"restore",
+				"-o", "/tmp/restored.db",
+				"-config", "/custom.yml",
+				"-txid", "0000000000000001",
+				"-timestamp", "2026-07-16T12:00:00Z",
+				"-parallelism", "4",
+				"-if-db-not-exists",
+				"-if-replica-exists",
+				"/tmp/db",
+			}, "\x1f"),
+		},
+		{
+			name:       "configured database path defaults output",
+			configPath: "/default.yml",
+			arguments:  map[string]any{"path": "/tmp/db"},
+			invocation: "restore\x1f-config\x1f/default.yml\x1f/tmp/db",
+		},
+		{
+			name:       "replica URL requires output",
+			configPath: "/default.yml",
+			arguments: map[string]any{
+				"path":   "s3://bucket/db",
+				"output": "/tmp/restored.db",
+				"config": "/custom.yml",
+			},
+			invocation: "restore\x1f-o\x1f/tmp/restored.db\x1fs3://bucket/db",
+		},
+		{
+			name: "legacy output alias",
+			arguments: map[string]any{
+				"path": "/tmp/db",
+				"o":    "/tmp/restored.db",
+			},
+			invocation: "restore\x1f-o\x1f/tmp/restored.db\x1f/tmp/db",
+		},
+		{
+			name:       "if database does not exist true",
+			arguments:  map[string]any{"path": "/tmp/db", "if_db_not_exists": true},
+			invocation: "restore\x1f-if-db-not-exists\x1f/tmp/db",
+		},
+		{
+			name:       "if database does not exist false",
+			arguments:  map[string]any{"path": "/tmp/db", "if_db_not_exists": false},
+			invocation: "restore\x1f/tmp/db",
+		},
+		{
+			name:       "if replica exists true",
+			arguments:  map[string]any{"path": "/tmp/db", "if_replica_exists": true},
+			invocation: "restore\x1f-if-replica-exists\x1f/tmp/db",
+		},
+		{
+			name:       "if replica exists false",
+			arguments:  map[string]any{"path": "/tmp/db", "if_replica_exists": false},
+			invocation: "restore\x1f/tmp/db",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			argsPath := useMCPTestCommand(t)
+			session := newMCPTestSession(t, test.configPath)
+			callMCPTool(t, session, "litestream_restore", test.arguments)
+			assertMCPInvocations(t, argsPath, []string{test.invocation})
+		})
+	}
+}
+
+func TestRestoreToolSchema(t *testing.T) {
+	tool, _ := RestoreTool("")
+	properties := schemaProperties(t, jsonObject(t, tool.InputSchema))
+
+	if _, ok := properties["output"]; !ok {
+		t.Fatal("output property is missing")
+	}
+	if _, ok := properties["o"]; ok {
+		t.Fatal("legacy o property is published")
+	}
+
+	descriptions := map[string]string{
+		"if_db_not_exists":  "Skip restore if the database already exists. Optional.",
+		"if_replica_exists": "Skip restore if no backups are found. Optional.",
+		"output":            "Output path for the restored database. Required for replica URLs; optional for configured databases, where it defaults to the database path.",
+	}
+	for name, want := range descriptions {
+		property := jsonObject(t, properties[name])
+		if got := property["description"]; got != want {
+			t.Fatalf("%s description=%q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestMCPToolsRequirePath(t *testing.T) {
+	tools := []string{"litestream_restore", "litestream_ltx", "litestream_reset"}
+	tests := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{name: "missing", arguments: map[string]any{}},
+		{name: "wrong type", arguments: map[string]any{"path": true}},
+	}
+
+	for _, tool := range tools {
+		for _, test := range tests {
+			t.Run(tool+"/"+test.name, func(t *testing.T) {
+				argsPath := useMCPTestCommand(t)
+				session := newMCPTestSession(t, "")
+				callMCPToolError(t, session, tool, test.arguments, "path")
+				assertNoMCPInvocations(t, argsPath)
+			})
+		}
+	}
+}
+
+func TestInfoToolUsesRunningVersion(t *testing.T) {
+	const version = "v1.2.3-running"
+	setVersion(t, version)
+	argsPath := useMCPTestCommand(t)
+	session := newMCPTestSession(t, "")
+
+	result := callMCPTool(t, session, "litestream_info", nil)
+	if got := textContent(t, result); !strings.Contains(got, "Version Information:\n"+version+"\n") {
+		t.Fatalf("info output does not contain running version %q: %q", version, got)
+	}
+	assertMCPInvocations(t, argsPath, []string{"databases"})
 }
 
 func TestMCPToolContextCancellation(t *testing.T) {
@@ -610,6 +816,133 @@ func schemaRequired(schema map[string]any) []string {
 	}
 	slices.Sort(required)
 	return required
+}
+
+func newMCPTestSession(t *testing.T, configPath string) *mcp.ClientSession {
+	t.Helper()
+
+	server, err := NewMCP(t.Context(), configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.mcpServer.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := serverSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	clientSession, err := client.Connect(t.Context(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := clientSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return clientSession
+}
+
+func callMCPTool(t *testing.T, session *mcp.ClientSession, name string, arguments map[string]any) *mcp.CallToolResult {
+	t.Helper()
+
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: name, Arguments: arguments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result.Content)
+	}
+	return result
+}
+
+func callMCPToolError(t *testing.T, session *mcp.ClientSession, name string, arguments map[string]any, want string) {
+	t.Helper()
+
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: name, Arguments: arguments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatalf("tool succeeded: %#v", result.Content)
+	}
+	if got := textContent(t, result); !strings.Contains(got, want) {
+		t.Fatalf("tool error does not contain %q: %q", want, got)
+	}
+}
+
+func useMCPTestCommand(t *testing.T) string {
+	t.Helper()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	commandPath := filepath.Join(dir, mcpTestExecutableName(runtime.GOOS))
+	var linkErr error
+	if runtime.GOOS == "windows" {
+		linkErr = os.Link(executable, commandPath)
+	} else {
+		linkErr = os.Symlink(executable, commandPath)
+	}
+	if linkErr != nil {
+		t.Fatal(linkErr)
+	}
+	argsPath := filepath.Join(dir, "args")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("LITESTREAM_MCP_TEST", "1")
+	t.Setenv("LITESTREAM_MCP_ARGS_PATH", argsPath)
+	return argsPath
+}
+
+func runMCPTestCommand() int {
+	f, err := os.OpenFile(os.Getenv("LITESTREAM_MCP_ARGS_PATH"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if _, err := fmt.Fprintln(f, strings.Join(os.Args[1:], "\x1f")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := f.Close(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(os.Args) > 1 && os.Args[1] == "databases" {
+		fmt.Println("path\treplicas")
+	} else {
+		fmt.Println("ok")
+	}
+	return 0
+}
+
+func assertMCPInvocations(t *testing.T, argsPath string, want []string) {
+	t.Helper()
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invocations=%q, want %q", got, want)
+	}
+}
+
+func assertNoMCPInvocations(t *testing.T, argsPath string) {
+	t.Helper()
+
+	if _, err := os.Stat(argsPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected no invocation, stat error: %v", err)
+	}
 }
 
 func installFakeLitestream(t *testing.T) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -654,6 +654,17 @@ func TestRestoreToolArguments(t *testing.T) {
 			},
 			invocation: "restore\x1f-o\x1f/tmp/restored.db\x1f/tmp/db",
 		},
+
+		{
+			name:       "canonical output takes precedence",
+			arguments:  map[string]any{"path": "/tmp/db", "output": "/tmp/canonical.db", "o": "/tmp/legacy.db"},
+			invocation: "restore\x1f-o\x1f/tmp/canonical.db\x1f/tmp/db",
+		},
+		{
+			name:       "empty canonical output uses alias",
+			arguments:  map[string]any{"path": "/tmp/db", "output": "", "o": "/tmp/legacy.db"},
+			invocation: "restore\x1f-o\x1f/tmp/legacy.db\x1f/tmp/db",
+		},
 		{
 			name:       "if database does not exist true",
 			arguments:  map[string]any{"path": "/tmp/db", "if_db_not_exists": true},
@@ -1090,5 +1101,16 @@ func TestMCPServerLifecycle(t *testing.T) {
 	}
 	if err := listener.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRestoreToolRejectsInvalidAlias(t *testing.T) {
+	for _, value := range []any{true, 42, nil} {
+		t.Run(fmt.Sprint(value), func(t *testing.T) {
+			argsPath := useMCPTestCommand(t)
+			session := newMCPTestSession(t, "")
+			callMCPToolError(t, session, "litestream_restore", map[string]any{"path": "/tmp/db", "o": value}, "o")
+			assertNoMCPInvocations(t, argsPath)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Rebuilds the MCP optional-argument fixes on PR #1378's official `github.com/modelcontextprotocol/go-sdk` implementation. Restore now emits valid CLI boolean flags, empty optional values are omitted, the public restore output parameter is `output` with legacy `o` compatibility, and `litestream_info` reports the running process version.

## Problem

The official-SDK restore handler emitted boolean options as `-if-db-not-exists true` and `-if-replica-exists true`. Go's `flag.Bool` consumes the bare flag, so the following boolean literal became the first positional argument and displaced the requested database path.

Several config-aware tools also emitted `-config ""`, restore exposed the CLI shorthand `o`, and `litestream_info` still executed a PATH-resolved `litestream version` binary.

## Solution

- Emit bare restore boolean flags only when their typed values are true.
- Omit false booleans and empty optional string values.
- Omit `-config` when no config path resolves for databases, info, status, reset, restore, and LTX.
- Publish `output` in the restore schema while accepting legacy `o` input.
- Port the improved restore parameter descriptions to `jsonschema` tags.
- Use the in-process `Version` in both the version tool and info report.
- Port the original handler-level regression intent to the official SDK without dropping #1378's tests.

The `litestream_info` version change is a separate, related fix, not part of #1365. #1365 scopes itself to the `litestream_version` tool and the handshake identity, both of which #1378 already delivers. `InfoTool` was a distinct occurrence of the same PATH-version smell, found while auditing this file, and is fixed here because it touches the same handlers.

## Scope

**In scope:**
- MCP command construction and schema descriptions
- Official-SDK typed input compatibility
- Exact argument-vector and behavioral regression tests

**Not in scope:**
- Changes to the underlying Litestream CLI flag definitions
- Merging or enabling auto-merge for either PR

## Test Plan

```bash
go test ./cmd/litestream -run 'TestMCPServerTools|TestMCPToolBehavior|TestMCPToolsOmitEmptyConfig|TestRestoreToolArguments|TestRestoreToolSchema|TestMCPToolsRequirePath|TestInfoToolUsesRunningVersion' -count=1
go build ./...
go vet ./...
staticcheck ./...
go test -race -count=1 ./...
pre-commit run --all-files
```

## Related

- Fixes #1366
- Fixes a separate PATH-version occurrence in `litestream_info` (not #1365 scope; see above)
- Built on #1378

