### PR TITLE
refactor(mcp): call Litestream in-process instead of exec-ing a PATH binary

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -41,6 +41,7 @@ const ReplicaClientType = "abs"
 const MetadataKeyTimestamp = "litestreamtimestamp"
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to Azure Blob Storage.
 type ReplicaClient struct {
@@ -200,6 +201,14 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	}
 
 	c.client = client
+	return nil
+}
+
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.client = nil
 	return nil
 }
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -599,18 +599,36 @@ func OpenConfigFile(filename string) (io.ReadCloser, error) {
 // ReadConfigFile unmarshals config from filename. Expands path if needed.
 // If expandEnv is true then environment variables are expanded in the config.
 func ReadConfigFile(filename string, expandEnv bool) (Config, error) {
+	config, err := readConfigFile(filename, expandEnv)
+	if err != nil {
+		return config, err
+	}
+	initConfigLog(config)
+	return config, nil
+}
+
+func readConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 	f, err := OpenConfigFile(filename)
 	if err != nil {
 		return DefaultConfig(), err
 	}
-	defer f.Close()
+	defer func() { err = errors.Join(err, f.Close()) }()
 
-	return ParseConfig(f, expandEnv)
+	return parseConfig(f, expandEnv)
 }
 
 // ParseConfig unmarshals config from a reader.
 // If expandEnv is true then environment variables are expanded in the config.
 func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
+	config, err := parseConfig(r, expandEnv)
+	if err != nil {
+		return config, err
+	}
+	initConfigLog(config)
+	return config, nil
+}
+
+func parseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	config := DefaultConfig()
 
 	// Read configuration.
@@ -683,17 +701,19 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 		return config, err
 	}
 
-	// Configure logging.
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		config.Logging.Level = v
+	}
+
+	return config, nil
+}
+
+func initConfigLog(config Config) {
 	logOutput := os.Stdout
 	if config.Logging.Stderr {
 		logOutput = os.Stderr
 	}
-	if v := os.Getenv("LOG_LEVEL"); v != "" {
-		config.Logging.Level = v
-	}
 	internal.InitLog(logOutput, config.Logging.Level, config.Logging.Type, config.Logging.Source)
-
-	return config, nil
 }
 
 // CompactionLevelConfig the configuration for a single level of compaction.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -616,18 +616,36 @@ func OpenConfigFile(filename string) (io.ReadCloser, error) {
 // ReadConfigFile unmarshals config from filename. Expands path if needed.
 // If expandEnv is true then environment variables are expanded in the config.
 func ReadConfigFile(filename string, expandEnv bool) (Config, error) {
+	config, err := readConfigFile(filename, expandEnv)
+	if err != nil {
+		return config, err
+	}
+	initConfigLog(config)
+	return config, nil
+}
+
+func readConfigFile(filename string, expandEnv bool) (_ Config, err error) {
 	f, err := OpenConfigFile(filename)
 	if err != nil {
 		return DefaultConfig(), err
 	}
-	defer f.Close()
+	defer func() { err = errors.Join(err, f.Close()) }()
 
-	return ParseConfig(f, expandEnv)
+	return parseConfig(f, expandEnv)
 }
 
 // ParseConfig unmarshals config from a reader.
 // If expandEnv is true then environment variables are expanded in the config.
 func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
+	config, err := parseConfig(r, expandEnv)
+	if err != nil {
+		return config, err
+	}
+	initConfigLog(config)
+	return config, nil
+}
+
+func parseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	config := DefaultConfig()
 
 	// Read configuration.
@@ -700,17 +718,19 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 		return config, err
 	}
 
-	// Configure logging.
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		config.Logging.Level = v
+	}
+
+	return config, nil
+}
+
+func initConfigLog(config Config) {
 	logOutput := os.Stdout
 	if config.Logging.Stderr {
 		logOutput = os.Stderr
 	}
-	if v := os.Getenv("LOG_LEVEL"); v != "" {
-		config.Logging.Level = v
-	}
 	internal.InitLog(logOutput, config.Logging.Level, config.Logging.Type, config.Logging.Source)
-
-	return config, nil
 }
 
 // CompactionLevelConfig the configuration for a single level of compaction.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -169,6 +169,15 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 			} else {
 				slog.Info("replication complete, litestream shutting down")
 			}
+		case err = <-c.mcpErrCh:
+			slog.Info("MCP server exited, litestream shutting down")
+			if c.cmd != nil {
+				if e := c.cmd.Process.Kill(); e != nil && !errors.Is(e, os.ErrProcessDone) {
+					err = errors.Join(err, fmt.Errorf("stop exec process: %w", e))
+				} else {
+					<-c.execCh
+				}
+			}
 		case sig := <-signalCh:
 			slog.Info("signal received, litestream shutting down", "signal", sig)
 
@@ -192,9 +201,7 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		}
 
 		// Gracefully close.
-		if e := c.Close(ctx); e != nil && err == nil {
-			err = e
-		}
+		err = errors.Join(err, c.Close(ctx))
 		slog.Info("litestream shut down")
 		return err
 

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -18,6 +20,8 @@ const defaultConfigPath = `C:\Litestream\litestream.yml`
 
 // serviceName is the Windows Service name.
 const serviceName = "Litestream"
+
+const windowsServiceCloseExitCode = 4
 
 // isWindowsService returns true if currently executing within a Windows service.
 func isWindowsService() (bool, error) {
@@ -51,7 +55,9 @@ func runWindowsService(ctx context.Context) error {
 
 // windowsService is an interface adapter for svc.Handler.
 type windowsService struct {
-	ctx context.Context
+	ctx          context.Context
+	command      *ReplicateCommand
+	closeCommand func(context.Context, *ReplicateCommand) error
 }
 
 func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, statusCh chan<- svc.Status) (svcSpecificEC bool, exitCode uint32) {
@@ -61,10 +67,13 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 	statusCh <- svc.Status{State: svc.StartPending}
 
 	// Instantiate replication command and load configuration.
-	c := NewReplicateCommand()
-	if c.Config, err = ReadConfigFile(DefaultConfigPath(), true); err != nil {
-		slog.Error("cannot load configuration", "error", err)
-		return true, 1
+	c := s.command
+	if c == nil {
+		c = NewReplicateCommand()
+		if c.Config, err = ReadConfigFile(DefaultConfigPath(), true); err != nil {
+			slog.Error("cannot load configuration", "error", err)
+			return true, 1
+		}
 	}
 
 	// Execute replication command.
@@ -79,10 +88,23 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 
 	for {
 		select {
+		case err := <-c.mcpErrCh:
+			if err != nil {
+				slog.Error("MCP server exited", "error", err)
+			}
+			if closeErr := s.close(c); closeErr != nil {
+				slog.Error("cannot close replication", "error", closeErr)
+			}
+			statusCh <- svc.Status{State: svc.StopPending}
+			return true, 3
 		case req := <-r:
 			switch req.Cmd {
 			case svc.Stop:
-				c.Close(s.ctx)
+				if err := s.close(c); err != nil {
+					slog.Error("cannot close replication", "error", err)
+					statusCh <- svc.Status{State: svc.StopPending}
+					return true, windowsServiceCloseExitCode
+				}
 				statusCh <- svc.Status{State: svc.StopPending}
 				return false, windows.NO_ERROR
 			case svc.Interrogate:
@@ -92,6 +114,21 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 			}
 		}
 	}
+}
+
+func (s *windowsService) close(c *ReplicateCommand) error {
+	var stopErr error
+	if c.cmd != nil && c.cmd.Process != nil {
+		if err := c.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			stopErr = fmt.Errorf("stop exec process: %w", err)
+		} else {
+			<-c.execCh
+		}
+	}
+	if s.closeCommand != nil {
+		return errors.Join(stopErr, s.closeCommand(s.ctx, c))
+	}
+	return errors.Join(stopErr, c.Close(s.ctx))
 }
 
 // Ensure implementation implements io.Writer interface.

--- a/cmd/litestream/main_windows_test.go
+++ b/cmd/litestream/main_windows_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"slices"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+func TestWindowsServiceExecuteStopCloseError(t *testing.T) {
+	closeErr := errors.New("test close error")
+	command := NewReplicateCommand()
+	command.Config = DefaultConfig()
+	service := &windowsService{
+		ctx:     t.Context(),
+		command: command,
+		closeCommand: func(ctx context.Context, command *ReplicateCommand) error {
+			return errors.Join(closeErr, command.Close(ctx))
+		},
+	}
+	requestCh := make(chan svc.ChangeRequest, 1)
+	requestCh <- svc.ChangeRequest{Cmd: svc.Stop}
+	statusCh := make(chan svc.Status, 3)
+
+	serviceSpecific, exitCode := service.Execute(nil, requestCh, statusCh)
+	if !serviceSpecific {
+		t.Fatal("serviceSpecific=false, want true")
+	}
+	if exitCode != windowsServiceCloseExitCode {
+		t.Fatalf("exitCode=%d, want %d", exitCode, windowsServiceCloseExitCode)
+	}
+
+	states := make([]svc.State, 0, len(statusCh))
+	close(statusCh)
+	for status := range statusCh {
+		states = append(states, status.State)
+	}
+	want := []svc.State{svc.StartPending, svc.Running, svc.StopPending}
+	if !slices.Equal(states, want) {
+		t.Fatalf("states=%v, want %v", states, want)
+	}
+}
+
+func TestWindowsServiceCloseStopsExec(t *testing.T) {
+	command := NewReplicateCommand()
+	command.cmd = exec.Command(os.Args[0], "-test.run=^TestWindowsServiceExecHelper$")
+	command.cmd.Env = append(os.Environ(), "LITESTREAM_TEST_SERVICE_EXEC=1")
+	command.execCh = make(chan error, 1)
+	if err := command.cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	go func() { command.execCh <- command.cmd.Wait() }()
+	service := &windowsService{ctx: t.Context()}
+	if err := service.close(command); err != nil {
+		t.Fatal(err)
+	}
+	if command.cmd.ProcessState == nil || command.cmd.ProcessState.Success() {
+		t.Fatal("exec child was not terminated and reaped")
+	}
+}
+
+func TestWindowsServiceExecHelper(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_SERVICE_EXEC") != "1" {
+		t.Skip("helper process only")
+	}
+	time.Sleep(time.Minute)
+}

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -37,7 +39,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 
 	mcpServer := server.NewMCPServer(
 		"Litestream MCP Server",
-		Version,
+		"1.0.0",
 		server.WithToolCapabilities(false),
 		server.WithRecovery(),
 		server.WithLogging(),
@@ -88,12 +90,12 @@ func DatabasesTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		_, dbs, err := loadMCPDatabases(req.GetString("config", configPath))
+		resources, err := loadMCPDatabases(req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-		output, err := formatMCPDatabases(dbs)
-		if err != nil {
+		output, opErr := formatMCPDatabases(resources.DBs)
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -107,43 +109,15 @@ func InfoTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		config, dbs, err := loadMCPDatabases(req.GetString("config", configPath))
+		resources, err := loadMCPDatabases(req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-
-		var summary strings.Builder
-		summary.WriteString("=== Litestream Status Report ===\n\n")
-		summary.WriteString("Version Information:\n")
-		summary.WriteString(Version)
-		summary.WriteString("\n\n")
-		summary.WriteString("Current Config Path:\n")
-		summary.WriteString(config + "\n\n")
-
-		dbOutput, err := formatMCPDatabases(dbs)
-		if err != nil {
+		output, opErr := formatMCPInfo(ctx, resources.ConfigPath, resources.DBs)
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
-		summary.WriteString("Databases:\n")
-		summary.WriteString(dbOutput)
-		summary.WriteString("\n")
-
-		summary.WriteString("LTX Files:\n")
-		for _, db := range dbs {
-			files, err := listMCPLTXFiles(ctx, db.Replica, 0)
-			if err != nil {
-				return mcpToolError(fmt.Errorf("list ltx files for %s: %w", db.Path(), err))
-			}
-			ltxOutput, err := formatMCPLTXFiles(files)
-			if err != nil {
-				return mcpToolError(err)
-			}
-			summary.WriteString("Database: " + db.Path() + "\n")
-			summary.WriteString(ltxOutput)
-			summary.WriteString("\n")
-		}
-
-		return mcp.NewToolResultText(summary.String()), nil
+		return mcp.NewToolResultText(output), nil
 	}
 }
 
@@ -193,61 +167,32 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			opt.Parallelism = parallelism
 		}
 
-		r, err := loadMCPRestoreReplica(path, req.GetString("config", configPath), &opt)
+		resources, err := loadMCPRestoreReplica(path, req.GetString("config", configPath), &opt)
 		if err != nil {
 			return mcpToolError(err)
 		}
 
-		ifReplicaExists := req.GetBool("if_replica_exists", false)
-		if req.GetBool("if_db_not_exists", false) {
-			if _, err := os.Stat(opt.OutputPath); err == nil {
-				return mcp.NewToolResultText("database already exists, skipping\n"), nil
-			} else if !os.IsNotExist(err) {
-				return mcpToolError(fmt.Errorf("access output path: %w", err))
-			}
-		}
-		if litestream.IsURL(path) && !ifReplicaExists {
-			if _, err := r.CalcRestoreTarget(ctx, opt); err != nil {
-				return mcpToolError(err)
-			}
-		}
-
-		cmd := &RestoreCommand{}
-		if err := cmd.prepareOutputPath(opt.OutputPath, false); err != nil {
+		output, opErr := restoreMCP(ctx, path, resources.Replica, opt,
+			req.GetBool("if_db_not_exists", false), req.GetBool("if_replica_exists", false))
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
-
-		txID := cmd.restoreTXID(ctx, r, opt)
-		start := time.Now()
-		if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) && ifReplicaExists {
-			return mcp.NewToolResultText("no matching backups found, skipping\n"), nil
-		} else if errors.Is(err, litestream.ErrTxNotAvailable) {
-			return mcpToolError(fmt.Errorf("no matching backup files available"))
-		} else if err != nil {
-			return mcpToolError(err)
-		}
-
-		output, err := json.MarshalIndent(RestoreResult{
-			DBPath:         opt.OutputPath,
-			Replica:        r.Client.Type(),
-			TXID:           txID,
-			DurationMS:     time.Since(start).Milliseconds(),
-			IntegrityCheck: "none",
-		}, "", "  ")
-		if err != nil {
-			return mcpToolError(fmt.Errorf("format response: %w", err))
-		}
-		return mcp.NewToolResultText(string(output) + "\n"), nil
+		return mcp.NewToolResultText(output), nil
 	}
 }
 
 func VersionTool() (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_version",
-		mcp.WithDescription("Print the running Litestream instance's version."),
+		mcp.WithDescription("Print the Litestream binary version."),
 	)
 
-	return tool, func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return mcp.NewToolResultText(Version + "\n"), nil
+	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		cmd := exec.CommandContext(ctx, "litestream", "version")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
+		}
+		return mcp.NewToolResultText(string(output)), nil
 	}
 }
 
@@ -264,16 +209,16 @@ func LTXTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			return mcpToolError(fmt.Errorf("database path or replica URL required"))
 		}
 
-		r, err := loadMCPReplica(path, req.GetString("config", configPath))
+		resources, err := loadMCPReplica(path, req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-		files, err := listMCPLTXFiles(ctx, r, 0)
-		if err != nil {
-			return mcpToolError(err)
+		files, opErr := listMCPLTXFiles(ctx, resources.Replica, 0)
+		var output string
+		if opErr == nil {
+			output, opErr = formatMCPLTXFiles(files)
 		}
-		output, err := formatMCPLTXFiles(files)
-		if err != nil {
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -288,16 +233,16 @@ func StatusTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		_, dbs, err := loadMCPDatabases(req.GetString("config", configPath))
+		resources, err := loadMCPDatabases(req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-		statuses, err := loadMCPStatuses(ctx, dbs, req.GetString("path", ""))
-		if err != nil {
-			return mcpToolError(err)
+		statuses, opErr := loadMCPStatuses(ctx, resources.DBs, req.GetString("path", ""))
+		var output string
+		if opErr == nil {
+			output, opErr = formatMCPStatuses(statuses)
 		}
-		output, err := formatMCPStatuses(statuses)
-		if err != nil {
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -316,12 +261,19 @@ func ResetTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if path == "" {
 			return mcpToolError(fmt.Errorf("database path required"))
 		}
-		db, err := loadMCPResetDB(path, req.GetString("config", configPath))
+		db, resources, err := loadMCPResetDB(path, req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-		if err := db.ResetLocalState(ctx); err != nil {
-			return mcpToolError(fmt.Errorf("reset local state: %w", err))
+		opErr := db.ResetLocalState(ctx)
+		if opErr != nil {
+			opErr = fmt.Errorf("reset local state: %w", opErr)
+		}
+		if resources != nil {
+			opErr = closeMCPResources(opErr, resources)
+		}
+		if opErr != nil {
+			return mcpToolError(opErr)
 		}
 		return mcp.NewToolResultText("Reset complete for " + db.Path() + ".\n"), nil
 	}
@@ -335,32 +287,84 @@ type mcpDBStatus struct {
 	WALSize    string
 }
 
-func loadMCPDatabases(configPath string) (string, []*litestream.DB, error) {
+type mcpDatabases struct {
+	ConfigPath string
+	DBs        []*litestream.DB
+}
+
+func (resources *mcpDatabases) Close() error {
+	var err error
+	for _, db := range resources.DBs {
+		if db.Replica == nil || db.Replica.Client == nil {
+			continue
+		}
+		if closeErr := closeMCPReplica(db.Replica); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close replica for %s: %w", db.Path(), closeErr))
+		}
+	}
+	return err
+}
+
+type mcpReplica struct {
+	Replica   *litestream.Replica
+	Databases *mcpDatabases
+}
+
+type mcpCloser interface {
+	Close() error
+}
+
+func closeMCPResources(opErr error, resources mcpCloser) error {
+	return errors.Join(opErr, resources.Close())
+}
+
+func (resources *mcpReplica) Close() error {
+	if resources.Databases != nil {
+		return resources.Databases.Close()
+	}
+	return closeMCPReplica(resources.Replica)
+}
+
+func closeMCPReplica(r *litestream.Replica) error {
+	if r == nil || r.Client == nil {
+		return nil
+	}
+	closer, ok := r.Client.(litestream.ReplicaClientCloser)
+	if !ok {
+		return nil
+	}
+	if err := closer.Close(); err != nil {
+		return fmt.Errorf("close %s replica: %w", r.Client.Type(), err)
+	}
+	return nil
+}
+
+func loadMCPDatabases(configPath string) (*mcpDatabases, error) {
 	if configPath == "" {
 		configPath = DefaultConfigPath()
 	}
-	config, err := ReadConfigFile(configPath, true)
+	config, err := readConfigFile(configPath, true)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	var dbs []*litestream.DB
+	resources := &mcpDatabases{ConfigPath: configPath}
 	for _, dbConfig := range config.DBs {
 		if dbConfig.Dir != "" {
 			dirDBs, err := NewDBsFromDirectoryConfig(dbConfig)
 			if err != nil {
-				return "", nil, err
+				return nil, errors.Join(err, resources.Close())
 			}
-			dbs = append(dbs, dirDBs...)
+			resources.DBs = append(resources.DBs, dirDBs...)
 			continue
 		}
 		db, err := NewDBFromConfig(dbConfig)
 		if err != nil {
-			return "", nil, err
+			return nil, errors.Join(err, resources.Close())
 		}
-		dbs = append(dbs, db)
+		resources.DBs = append(resources.DBs, db)
 	}
-	return configPath, dbs, nil
+	return resources, nil
 }
 
 func formatMCPDatabases(dbs []*litestream.DB) (string, error) {
@@ -380,7 +384,42 @@ func formatMCPDatabases(dbs []*litestream.DB) (string, error) {
 	return output.String(), nil
 }
 
-func loadMCPRestoreReplica(path, configPath string, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
+func formatMCPInfo(ctx context.Context, configPath string, dbs []*litestream.DB) (string, error) {
+	var summary strings.Builder
+	summary.WriteString("=== Litestream Status Report ===\n\n")
+	summary.WriteString("Version Information:\n")
+	summary.WriteString(Version)
+	summary.WriteString("\n\n")
+	summary.WriteString("Current Config Path:\n")
+	summary.WriteString(configPath + "\n\n")
+
+	dbOutput, err := formatMCPDatabases(dbs)
+	if err != nil {
+		return "", err
+	}
+	summary.WriteString("Databases:\n")
+	summary.WriteString(dbOutput)
+	summary.WriteString("\n")
+
+	summary.WriteString("LTX Files:\n")
+	for _, db := range dbs {
+		files, err := listMCPLTXFiles(ctx, db.Replica, 0)
+		if err != nil {
+			return "", fmt.Errorf("list ltx files for %s: %w", db.Path(), err)
+		}
+		ltxOutput, err := formatMCPLTXFiles(files)
+		if err != nil {
+			return "", err
+		}
+		summary.WriteString("Database: " + db.Path() + "\n")
+		summary.WriteString(ltxOutput)
+		summary.WriteString("\n")
+	}
+
+	return summary.String(), nil
+}
+
+func loadMCPRestoreReplica(path, configPath string, opt *litestream.RestoreOptions) (*mcpReplica, error) {
 	if litestream.IsURL(path) {
 		if opt.OutputPath == "" {
 			return nil, fmt.Errorf("output is required when restoring from a replica URL")
@@ -395,36 +434,90 @@ func loadMCPRestoreReplica(path, configPath string, opt *litestream.RestoreOptio
 		if err != nil {
 			return nil, err
 		}
-		return r, nil
+		return &mcpReplica{Replica: r}, nil
 	}
 
-	_, dbs, err := loadMCPDatabases(configPath)
+	resources, err := loadMCPDatabases(configPath)
 	if err != nil {
 		return nil, err
 	}
-	db, err := selectMCPDatabase(dbs, path)
+	db, err := selectMCPDatabase(resources.DBs, path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, resources.Close())
 	}
 	if opt.OutputPath == "" {
 		opt.OutputPath = db.Path()
 	}
-	return db.Replica, nil
+	return &mcpReplica{Replica: db.Replica, Databases: resources}, nil
 }
 
-func loadMCPReplica(path, configPath string) (*litestream.Replica, error) {
+func loadMCPReplica(path, configPath string) (*mcpReplica, error) {
 	if litestream.IsURL(path) {
-		return NewReplicaFromConfig(&ReplicaConfig{URL: path}, nil)
+		r, err := NewReplicaFromConfig(&ReplicaConfig{URL: path}, nil)
+		if err != nil {
+			return nil, err
+		}
+		return &mcpReplica{Replica: r}, nil
 	}
-	_, dbs, err := loadMCPDatabases(configPath)
+	resources, err := loadMCPDatabases(configPath)
 	if err != nil {
 		return nil, err
 	}
-	db, err := selectMCPDatabase(dbs, path)
+	db, err := selectMCPDatabase(resources.DBs, path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, resources.Close())
 	}
-	return db.Replica, nil
+	return &mcpReplica{Replica: db.Replica, Databases: resources}, nil
+}
+
+func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt litestream.RestoreOptions, ifDBNotExists, ifReplicaExists bool) (string, error) {
+	if ifDBNotExists {
+		if _, err := os.Stat(opt.OutputPath); err == nil {
+			return "database already exists, skipping\n", nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("access output path: %w", err)
+		}
+	}
+	if litestream.IsURL(path) && !ifReplicaExists {
+		if _, err := r.CalcRestoreTarget(ctx, opt); err != nil {
+			return "", err
+		}
+	}
+
+	cmd := &RestoreCommand{}
+	if err := cmd.prepareOutputPath(opt.OutputPath, false); err != nil {
+		return "", err
+	}
+
+	txID, err := cmd.restoreTXID(ctx, r, &opt)
+	if errors.Is(err, litestream.ErrTxNotAvailable) && ifReplicaExists {
+		return "no matching backups found, skipping\n", nil
+	} else if errors.Is(err, litestream.ErrTxNotAvailable) {
+		return "", fmt.Errorf("no matching backup files available")
+	} else if err != nil {
+		return "", err
+	}
+
+	start := time.Now()
+	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) && ifReplicaExists {
+		return "no matching backups found, skipping\n", nil
+	} else if errors.Is(err, litestream.ErrTxNotAvailable) {
+		return "", fmt.Errorf("no matching backup files available")
+	} else if err != nil {
+		return "", err
+	}
+
+	output, err := json.MarshalIndent(RestoreResult{
+		DBPath:         opt.OutputPath,
+		Replica:        r.Client.Type(),
+		TXID:           txID,
+		DurationMS:     time.Since(start).Milliseconds(),
+		IntegrityCheck: "none",
+	}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("format response: %w", err)
+	}
+	return string(output) + "\n", nil
 }
 
 func selectMCPDatabase(dbs []*litestream.DB, path string) (*litestream.DB, error) {
@@ -529,7 +622,7 @@ func loadMCPStatus(ctx context.Context, db *litestream.DB) (mcpDBStatus, error) 
 		status.RemoteTXID = syncStatus.RemoteTXID.String()
 	}
 
-	if info, err := os.Stat(db.Path()); os.IsNotExist(err) {
+	if info, err := os.Stat(db.Path()); errors.Is(err, fs.ErrNotExist) {
 		status.Status = "no database"
 	} else if err != nil {
 		return status, fmt.Errorf("stat database: %w", err)
@@ -547,7 +640,7 @@ func loadMCPStatus(ctx context.Context, db *litestream.DB) (mcpDBStatus, error) 
 
 	if info, err := os.Stat(db.WALPath()); err == nil {
 		status.WALSize = humanize.Bytes(uint64(info.Size()))
-	} else if !os.IsNotExist(err) {
+	} else if !errors.Is(err, fs.ErrNotExist) {
 		return status, fmt.Errorf("stat wal: %w", err)
 	}
 	return status, nil
@@ -576,31 +669,34 @@ func formatMCPStatuses(statuses []mcpDBStatus) (string, error) {
 	return output.String(), nil
 }
 
-func loadMCPResetDB(path, configPath string) (*litestream.DB, error) {
+func loadMCPResetDB(path, configPath string) (*litestream.DB, *mcpDatabases, error) {
 	dbPath, err := expand(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if info, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("database does not exist: %s", dbPath)
+	if info, err := os.Stat(dbPath); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil, fmt.Errorf("database does not exist: %s", dbPath)
 	} else if err != nil {
-		return nil, fmt.Errorf("access database: %w", err)
+		return nil, nil, fmt.Errorf("access database: %w", err)
 	} else if info.IsDir() {
-		return nil, fmt.Errorf("database path is a directory: %s", dbPath)
+		return nil, nil, fmt.Errorf("database path is a directory: %s", dbPath)
 	}
 
 	if configPath != "" {
-		_, dbs, err := loadMCPDatabases(configPath)
+		resources, err := loadMCPDatabases(configPath)
 		if err != nil {
-			return nil, fmt.Errorf("read config: %w", err)
+			return nil, nil, fmt.Errorf("read config: %w", err)
 		}
-		for _, db := range dbs {
+		for _, db := range resources.DBs {
 			if db.Path() == dbPath {
-				return db, nil
+				return db, resources, nil
 			}
 		}
+		if err := resources.Close(); err != nil {
+			return nil, nil, err
+		}
 	}
-	return litestream.NewDB(dbPath), nil
+	return litestream.NewDB(dbPath), nil, nil
 }
 
 func mcpToolError(err error) (*mcp.CallToolResult, error) {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -314,6 +314,8 @@ type mcpCloser interface {
 	Close() error
 }
 
+var errMCPReplicaClientNotClosable = errors.New("replica client does not implement cleanup contract")
+
 func closeMCPResources(opErr error, resources mcpCloser) error {
 	return errors.Join(opErr, resources.Close())
 }
@@ -331,7 +333,7 @@ func closeMCPReplica(r *litestream.Replica) error {
 	}
 	closer, ok := r.Client.(litestream.ReplicaClientCloser)
 	if !ok {
-		return nil
+		return fmt.Errorf("close %s replica: %w", r.Client.Type(), errMCPReplicaClientNotClosable)
 	}
 	if err := closer.Close(); err != nil {
 		return fmt.Errorf("close %s replica: %w", r.Client.Type(), err)

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -193,11 +193,12 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			opt.Parallelism = parallelism
 		}
 
-		r, err := loadMCPRestoreReplica(ctx, path, req.GetString("config", configPath), &opt)
+		r, err := loadMCPRestoreReplica(path, req.GetString("config", configPath), &opt)
 		if err != nil {
 			return mcpToolError(err)
 		}
 
+		ifReplicaExists := req.GetBool("if_replica_exists", false)
 		if req.GetBool("if_db_not_exists", false) {
 			if _, err := os.Stat(opt.OutputPath); err == nil {
 				return mcp.NewToolResultText("database already exists, skipping\n"), nil
@@ -205,7 +206,7 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 				return mcpToolError(fmt.Errorf("access output path: %w", err))
 			}
 		}
-		if litestream.IsURL(path) {
+		if litestream.IsURL(path) && !ifReplicaExists {
 			if _, err := r.CalcRestoreTarget(ctx, opt); err != nil {
 				return mcpToolError(err)
 			}
@@ -218,7 +219,7 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 
 		txID := cmd.restoreTXID(ctx, r, opt)
 		start := time.Now()
-		if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) && req.GetBool("if_replica_exists", false) {
+		if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) && ifReplicaExists {
 			return mcp.NewToolResultText("no matching backups found, skipping\n"), nil
 		} else if errors.Is(err, litestream.ErrTxNotAvailable) {
 			return mcpToolError(fmt.Errorf("no matching backup files available"))
@@ -379,7 +380,7 @@ func formatMCPDatabases(dbs []*litestream.DB) (string, error) {
 	return output.String(), nil
 }
 
-func loadMCPRestoreReplica(ctx context.Context, path, configPath string, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
+func loadMCPRestoreReplica(path, configPath string, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
 	if litestream.IsURL(path) {
 		if opt.OutputPath == "" {
 			return nil, fmt.Errorf("output is required when restoring from a replica URL")

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -1,18 +1,25 @@
 package main
 
 import (
-	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
-	"os/exec"
+	"os"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/MadAppGang/httplog"
+	"github.com/dustin/go-humanize"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream"
 )
 
 type MCPServer struct {
@@ -30,7 +37,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 
 	mcpServer := server.NewMCPServer(
 		"Litestream MCP Server",
-		"1.0.0",
+		Version,
 		server.WithToolCapabilities(false),
 		server.WithRecovery(),
 		server.WithLogging(),
@@ -74,12 +81,6 @@ func (s *MCPServer) Close() error {
 	return s.httpServer.Shutdown(ctx)
 }
 
-// isReplicaURL returns true if the path looks like a replica URL (s3://, gs://, etc.)
-// rather than a local database path. The CLI rejects -config when using replica URLs.
-func isReplicaURL(path string) bool {
-	return strings.Contains(path, "://")
-}
-
 func DatabasesTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_databases",
 		mcp.WithDescription("List databases and their replicas as defined in the Litestream config file. The default path is /etc/litestream.yml but is not required."),
@@ -87,18 +88,15 @@ func DatabasesTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := []string{"databases"}
-		config := configPath
-		if configVal, err := req.RequireString("config"); err == nil {
-			config = configVal
-		}
-		args = append(args, "-config", config)
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		_, dbs, err := loadMCPDatabases(req.GetString("config", configPath))
 		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
+			return mcpToolError(err)
 		}
-		return mcp.NewToolResultText(string(output)), nil
+		output, err := formatMCPDatabases(dbs)
+		if err != nil {
+			return mcpToolError(err)
+		}
+		return mcp.NewToolResultText(output), nil
 	}
 }
 
@@ -109,70 +107,39 @@ func InfoTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		config, dbs, err := loadMCPDatabases(req.GetString("config", configPath))
+		if err != nil {
+			return mcpToolError(err)
+		}
+
 		var summary strings.Builder
 		summary.WriteString("=== Litestream Status Report ===\n\n")
-
-		// Get version info
-		versionCmd := exec.CommandContext(ctx, "litestream", "version")
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			slog.Error("Failed to get version info", "error", err)
-			return mcp.NewToolResultError("Failed to get version info: " + err.Error()), nil
-		}
 		summary.WriteString("Version Information:\n")
-		summary.WriteString(string(versionOutput))
-		summary.WriteString("\n")
-
-		// Get databases info
-		args := []string{"databases"}
-		config := configPath
-		if configVal, err := req.RequireString("config"); err == nil {
-			config = configVal
-		}
+		summary.WriteString(Version)
+		summary.WriteString("\n\n")
 		summary.WriteString("Current Config Path:\n")
 		summary.WriteString(config + "\n\n")
 
-		args = append(args, "-config", config)
-		dbCmd := exec.CommandContext(ctx, "litestream", args...)
-		dbOutput, err := dbCmd.CombinedOutput()
+		dbOutput, err := formatMCPDatabases(dbs)
 		if err != nil {
-			slog.Error("Failed to get databases info", "error", err)
-			return mcp.NewToolResultError("Failed to get databases info: " + err.Error()), nil
+			return mcpToolError(err)
 		}
-
 		summary.WriteString("Databases:\n")
-		summary.WriteString(string(dbOutput))
+		summary.WriteString(dbOutput)
 		summary.WriteString("\n")
 
-		// Parse database paths from output
-		scanner := bufio.NewScanner(strings.NewReader(string(dbOutput)))
-		// Skip header line
-		scanner.Scan()
-		var dbPaths []string
-		for scanner.Scan() {
-			fields := strings.Fields(scanner.Text())
-			if len(fields) > 0 {
-				dbPaths = append(dbPaths, fields[0])
-			}
-		}
-
-		// Get LTX files info for each database
 		summary.WriteString("LTX Files:\n")
-		for _, dbPath := range dbPaths {
-			ltxArgs := []string{"ltx"}
-			if config != "" {
-				ltxArgs = append(ltxArgs, "-config", config)
-			}
-			ltxArgs = append(ltxArgs, dbPath)
-			ltxCmd := exec.CommandContext(ctx, "litestream", ltxArgs...)
-			ltxOutput, err := ltxCmd.CombinedOutput()
+		for _, db := range dbs {
+			files, err := listMCPLTXFiles(ctx, db.Replica, 0)
 			if err != nil {
-				summary.WriteString("Failed to get LTX files for " + dbPath + ": " + err.Error() + "\n")
-				summary.WriteString(string(ltxOutput))
-				continue
+				return mcpToolError(fmt.Errorf("list ltx files for %s: %w", db.Path(), err))
 			}
-			summary.WriteString("Database: " + dbPath + "\n")
-			summary.WriteString(string(ltxOutput))
+			ltxOutput, err := formatMCPLTXFiles(files)
+			if err != nil {
+				return mcpToolError(err)
+			}
+			summary.WriteString("Database: " + db.Path() + "\n")
+			summary.WriteString(ltxOutput)
 			summary.WriteString("\n")
 		}
 
@@ -184,75 +151,102 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_restore",
 		mcp.WithDescription("Restore a database from a Litestream replica."),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Database path or replica URL.")),
-		mcp.WithString("o", mcp.Description("Output path for the restored database. Optional.")),
+		mcp.WithString("output", mcp.Description("Output path for the restored database. Optional.")),
 		mcp.WithString("config", mcp.Description("Path to the Litestream config file. Optional.")),
 		mcp.WithString("txid", mcp.Description("Restore up to a specific transaction ID. Optional.")),
 		mcp.WithString("timestamp", mcp.Description("Restore to a specific point-in-time (RFC3339). Optional.")),
 		mcp.WithString("parallelism", mcp.Description("Number of WAL files to download in parallel. Optional.")),
-		mcp.WithBoolean("if_db_not_exists", mcp.Description("Return 0 if the database already exists. Optional.")),
-		mcp.WithBoolean("if_replica_exists", mcp.Description("Return 0 if no backups found. Optional.")),
+		mcp.WithBoolean("if_db_not_exists", mcp.Description("Skip restore if the database already exists. Optional.")),
+		mcp.WithBoolean("if_replica_exists", mcp.Description("Skip restore if no backups are found. Optional.")),
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := []string{"restore"}
-		if o, err := req.RequireString("o"); err == nil {
-			args = append(args, "-o", o)
+		path := req.GetString("path", "")
+		if path == "" {
+			return mcpToolError(fmt.Errorf("database path or replica URL required"))
 		}
 
-		// Get path first to determine if it's a replica URL
-		path, _ := req.RequireString("path")
-
-		// Only add -config for database paths, not replica URLs
-		// The CLI rejects -config when restoring from a replica URL
-		if !isReplicaURL(path) {
-			config := configPath
-			if configVal, err := req.RequireString("config"); err == nil {
-				config = configVal
+		opt := litestream.NewRestoreOptions()
+		opt.OutputPath = req.GetString("output", "")
+		if opt.OutputPath == "" {
+			opt.OutputPath = req.GetString("o", "")
+		}
+		if value := req.GetString("txid", ""); value != "" {
+			txID, err := ltx.ParseTXID(value)
+			if err != nil {
+				return mcpToolError(fmt.Errorf("invalid txid: %w", err))
 			}
-			if config != "" {
-				args = append(args, "-config", config)
+			opt.TXID = txID
+		}
+		if value := req.GetString("timestamp", ""); value != "" {
+			timestamp, err := time.Parse(time.RFC3339, value)
+			if err != nil {
+				return mcpToolError(fmt.Errorf("invalid timestamp: %w", err))
 			}
+			opt.Timestamp = timestamp
+		}
+		if value := req.GetString("parallelism", ""); value != "" {
+			parallelism, err := strconv.Atoi(value)
+			if err != nil {
+				return mcpToolError(fmt.Errorf("invalid parallelism: %w", err))
+			}
+			opt.Parallelism = parallelism
 		}
 
-		if txid, err := req.RequireString("txid"); err == nil {
-			args = append(args, "-txid", txid)
-		}
-		if timestamp, err := req.RequireString("timestamp"); err == nil {
-			args = append(args, "-timestamp", timestamp)
-		}
-		if parallelism, err := req.RequireString("parallelism"); err == nil {
-			args = append(args, "-parallelism", parallelism)
-		}
-		if ifDBNotExists, err := req.RequireBool("if_db_not_exists"); err == nil {
-			args = append(args, "-if-db-not-exists", strconv.FormatBool(ifDBNotExists))
-		}
-		if ifReplicaExists, err := req.RequireBool("if_replica_exists"); err == nil {
-			args = append(args, "-if-replica-exists", strconv.FormatBool(ifReplicaExists))
-		}
-		if path != "" {
-			args = append(args, path)
-		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		r, err := loadMCPRestoreReplica(ctx, path, req.GetString("config", configPath), &opt)
 		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
+			return mcpToolError(err)
 		}
-		return mcp.NewToolResultText(string(output)), nil
+
+		if req.GetBool("if_db_not_exists", false) {
+			if _, err := os.Stat(opt.OutputPath); err == nil {
+				return mcp.NewToolResultText("database already exists, skipping\n"), nil
+			} else if !os.IsNotExist(err) {
+				return mcpToolError(fmt.Errorf("access output path: %w", err))
+			}
+		}
+		if litestream.IsURL(path) {
+			if _, err := r.CalcRestoreTarget(ctx, opt); err != nil {
+				return mcpToolError(err)
+			}
+		}
+
+		cmd := &RestoreCommand{}
+		if err := cmd.prepareOutputPath(opt.OutputPath, false); err != nil {
+			return mcpToolError(err)
+		}
+
+		txID := cmd.restoreTXID(ctx, r, opt)
+		start := time.Now()
+		if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) && req.GetBool("if_replica_exists", false) {
+			return mcp.NewToolResultText("no matching backups found, skipping\n"), nil
+		} else if errors.Is(err, litestream.ErrTxNotAvailable) {
+			return mcpToolError(fmt.Errorf("no matching backup files available"))
+		} else if err != nil {
+			return mcpToolError(err)
+		}
+
+		output, err := json.MarshalIndent(RestoreResult{
+			DBPath:         opt.OutputPath,
+			Replica:        r.Client.Type(),
+			TXID:           txID,
+			DurationMS:     time.Since(start).Milliseconds(),
+			IntegrityCheck: "none",
+		}, "", "  ")
+		if err != nil {
+			return mcpToolError(fmt.Errorf("format response: %w", err))
+		}
+		return mcp.NewToolResultText(string(output) + "\n"), nil
 	}
 }
 
 func VersionTool() (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_version",
-		mcp.WithDescription("Print the Litestream binary version."),
+		mcp.WithDescription("Print the running Litestream instance's version."),
 	)
 
-	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		cmd := exec.CommandContext(ctx, "litestream", "version")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
-		}
-		return mcp.NewToolResultText(string(output)), nil
+	return tool, func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText(Version + "\n"), nil
 	}
 }
 
@@ -264,58 +258,48 @@ func LTXTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := []string{"ltx"}
-
-		// Get path first to determine if it's a replica URL
-		path, _ := req.RequireString("path")
-
-		// Only add -config for database paths, not replica URLs
-		// The CLI rejects -config when using a replica URL
-		if !isReplicaURL(path) {
-			config := configPath
-			if configVal, err := req.RequireString("config"); err == nil {
-				config = configVal
-			}
-			if config != "" {
-				args = append(args, "-config", config)
-			}
+		path := req.GetString("path", "")
+		if path == "" {
+			return mcpToolError(fmt.Errorf("database path or replica URL required"))
 		}
 
-		if path != "" {
-			args = append(args, path)
-		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		r, err := loadMCPReplica(path, req.GetString("config", configPath))
 		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
+			return mcpToolError(err)
 		}
-		return mcp.NewToolResultText(string(output)), nil
+		files, err := listMCPLTXFiles(ctx, r, 0)
+		if err != nil {
+			return mcpToolError(err)
+		}
+		output, err := formatMCPLTXFiles(files)
+		if err != nil {
+			return mcpToolError(err)
+		}
+		return mcp.NewToolResultText(output), nil
 	}
 }
 
 func StatusTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_status",
-		mcp.WithDescription("Display replication status including database path, status, local transaction ID, and WAL size."),
+		mcp.WithDescription("Display replication status including database path, status, local and remote transaction IDs, and WAL size."),
 		mcp.WithString("config", mcp.Description("Path to the Litestream config file. Optional.")),
 		mcp.WithString("path", mcp.Description("Filter to a specific database path. Optional.")),
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := []string{"status"}
-		config := configPath
-		if configVal, err := req.RequireString("config"); err == nil {
-			config = configVal
-		}
-		args = append(args, "-config", config)
-		if path, err := req.RequireString("path"); err == nil {
-			args = append(args, path)
-		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		_, dbs, err := loadMCPDatabases(req.GetString("config", configPath))
 		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
+			return mcpToolError(err)
 		}
-		return mcp.NewToolResultText(string(output)), nil
+		statuses, err := loadMCPStatuses(ctx, dbs, req.GetString("path", ""))
+		if err != nil {
+			return mcpToolError(err)
+		}
+		output, err := formatMCPStatuses(statuses)
+		if err != nil {
+			return mcpToolError(err)
+		}
+		return mcp.NewToolResultText(output), nil
 	}
 }
 
@@ -327,20 +311,297 @@ func ResetTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	)
 
 	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := []string{"reset"}
-		config := configPath
-		if configVal, err := req.RequireString("config"); err == nil {
-			config = configVal
+		path := req.GetString("path", "")
+		if path == "" {
+			return mcpToolError(fmt.Errorf("database path required"))
 		}
-		args = append(args, "-config", config)
-		if path, err := req.RequireString("path"); err == nil {
-			args = append(args, path)
-		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		db, err := loadMCPResetDB(path, req.GetString("config", configPath))
 		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
+			return mcpToolError(err)
 		}
-		return mcp.NewToolResultText(string(output)), nil
+		if err := db.ResetLocalState(ctx); err != nil {
+			return mcpToolError(fmt.Errorf("reset local state: %w", err))
+		}
+		return mcp.NewToolResultText("Reset complete for " + db.Path() + ".\n"), nil
 	}
+}
+
+type mcpDBStatus struct {
+	Database   string
+	Status     string
+	LocalTXID  string
+	RemoteTXID string
+	WALSize    string
+}
+
+func loadMCPDatabases(configPath string) (string, []*litestream.DB, error) {
+	if configPath == "" {
+		configPath = DefaultConfigPath()
+	}
+	config, err := ReadConfigFile(configPath, true)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var dbs []*litestream.DB
+	for _, dbConfig := range config.DBs {
+		if dbConfig.Dir != "" {
+			dirDBs, err := NewDBsFromDirectoryConfig(dbConfig)
+			if err != nil {
+				return "", nil, err
+			}
+			dbs = append(dbs, dirDBs...)
+			continue
+		}
+		db, err := NewDBFromConfig(dbConfig)
+		if err != nil {
+			return "", nil, err
+		}
+		dbs = append(dbs, db)
+	}
+	return configPath, dbs, nil
+}
+
+func formatMCPDatabases(dbs []*litestream.DB) (string, error) {
+	var output strings.Builder
+	w := tabwriter.NewWriter(&output, 0, 8, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "path\treplica"); err != nil {
+		return "", err
+	}
+	for _, db := range dbs {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", db.Path(), db.Replica.Client.Type()); err != nil {
+			return "", err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+func loadMCPRestoreReplica(ctx context.Context, path, configPath string, opt *litestream.RestoreOptions) (*litestream.Replica, error) {
+	if litestream.IsURL(path) {
+		if opt.OutputPath == "" {
+			return nil, fmt.Errorf("output is required when restoring from a replica URL")
+		}
+		syncInterval := litestream.DefaultSyncInterval
+		r, err := NewReplicaFromConfig(&ReplicaConfig{
+			URL: path,
+			ReplicaSettings: ReplicaSettings{
+				SyncInterval: &syncInterval,
+			},
+		}, nil)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	_, dbs, err := loadMCPDatabases(configPath)
+	if err != nil {
+		return nil, err
+	}
+	db, err := selectMCPDatabase(dbs, path)
+	if err != nil {
+		return nil, err
+	}
+	if opt.OutputPath == "" {
+		opt.OutputPath = db.Path()
+	}
+	return db.Replica, nil
+}
+
+func loadMCPReplica(path, configPath string) (*litestream.Replica, error) {
+	if litestream.IsURL(path) {
+		return NewReplicaFromConfig(&ReplicaConfig{URL: path}, nil)
+	}
+	_, dbs, err := loadMCPDatabases(configPath)
+	if err != nil {
+		return nil, err
+	}
+	db, err := selectMCPDatabase(dbs, path)
+	if err != nil {
+		return nil, err
+	}
+	return db.Replica, nil
+}
+
+func selectMCPDatabase(dbs []*litestream.DB, path string) (*litestream.DB, error) {
+	expandedPath, err := expand(path)
+	if err != nil {
+		return nil, err
+	}
+	for _, db := range dbs {
+		if db.Path() == expandedPath {
+			return db, nil
+		}
+	}
+	return nil, fmt.Errorf("database not found in config: %s", expandedPath)
+}
+
+func listMCPLTXFiles(ctx context.Context, r *litestream.Replica, level int) ([]LTXFileInfo, error) {
+	itr, err := r.Client.LTXFiles(ctx, level, 0, false)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []LTXFileInfo
+	for itr.Next() {
+		info := itr.Item()
+		files = append(files, LTXFileInfo{
+			Level:     info.Level,
+			MinTXID:   info.MinTXID.String(),
+			MaxTXID:   info.MaxTXID.String(),
+			Size:      info.Size,
+			Timestamp: info.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	if err := errors.Join(itr.Err(), itr.Close()); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func formatMCPLTXFiles(files []LTXFileInfo) (string, error) {
+	var output strings.Builder
+	w := tabwriter.NewWriter(&output, 0, 8, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "level\tmin_txid\tmax_txid\tsize\tcreated"); err != nil {
+		return "", err
+	}
+	for _, file := range files {
+		if _, err := fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\n",
+			file.Level,
+			file.MinTXID,
+			file.MaxTXID,
+			file.Size,
+			file.Timestamp,
+		); err != nil {
+			return "", err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+func loadMCPStatuses(ctx context.Context, dbs []*litestream.DB, filterPath string) ([]mcpDBStatus, error) {
+	if filterPath != "" {
+		expandedPath, err := expand(filterPath)
+		if err != nil {
+			return nil, err
+		}
+		filterPath = expandedPath
+	}
+
+	statuses := make([]mcpDBStatus, 0, len(dbs))
+	for _, db := range dbs {
+		if filterPath != "" && db.Path() != filterPath {
+			continue
+		}
+		status, err := loadMCPStatus(ctx, db)
+		if err != nil {
+			return nil, fmt.Errorf("status for %s: %w", db.Path(), err)
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
+func loadMCPStatus(ctx context.Context, db *litestream.DB) (mcpDBStatus, error) {
+	status := mcpDBStatus{
+		Database:   db.Path(),
+		Status:     "unknown",
+		LocalTXID:  "-",
+		RemoteTXID: "-",
+		WALSize:    "0 B",
+	}
+
+	syncStatus, err := db.SyncStatus(ctx)
+	if err != nil {
+		return status, err
+	}
+	if syncStatus.LocalTXID > 0 {
+		status.LocalTXID = syncStatus.LocalTXID.String()
+	}
+	if syncStatus.RemoteTXID > 0 {
+		status.RemoteTXID = syncStatus.RemoteTXID.String()
+	}
+
+	if info, err := os.Stat(db.Path()); os.IsNotExist(err) {
+		status.Status = "no database"
+	} else if err != nil {
+		return status, fmt.Errorf("stat database: %w", err)
+	} else if info.IsDir() {
+		return status, fmt.Errorf("database path is a directory")
+	} else if syncStatus.InSync {
+		status.Status = "ok"
+	} else if syncStatus.LocalTXID == 0 {
+		status.Status = "not initialized"
+	} else if syncStatus.LocalTXID < syncStatus.RemoteTXID {
+		status.Status = "behind"
+	} else {
+		status.Status = "ahead"
+	}
+
+	if info, err := os.Stat(db.WALPath()); err == nil {
+		status.WALSize = humanize.Bytes(uint64(info.Size()))
+	} else if !os.IsNotExist(err) {
+		return status, fmt.Errorf("stat wal: %w", err)
+	}
+	return status, nil
+}
+
+func formatMCPStatuses(statuses []mcpDBStatus) (string, error) {
+	var output strings.Builder
+	w := tabwriter.NewWriter(&output, 0, 8, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "database\tstatus\tlocal txid\tremote txid\twal size"); err != nil {
+		return "", err
+	}
+	for _, status := range statuses {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			status.Database,
+			status.Status,
+			status.LocalTXID,
+			status.RemoteTXID,
+			status.WALSize,
+		); err != nil {
+			return "", err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+func loadMCPResetDB(path, configPath string) (*litestream.DB, error) {
+	dbPath, err := expand(path)
+	if err != nil {
+		return nil, err
+	}
+	if info, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("database does not exist: %s", dbPath)
+	} else if err != nil {
+		return nil, fmt.Errorf("access database: %w", err)
+	} else if info.IsDir() {
+		return nil, fmt.Errorf("database path is a directory: %s", dbPath)
+	}
+
+	if configPath != "" {
+		_, dbs, err := loadMCPDatabases(configPath)
+		if err != nil {
+			return nil, fmt.Errorf("read config: %w", err)
+		}
+		for _, db := range dbs {
+			if db.Path() == dbPath {
+				return db, nil
+			}
+		}
+	}
+	return litestream.NewDB(dbPath), nil
+}
+
+func mcpToolError(err error) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultError(err.Error()), nil
 }

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -22,12 +23,17 @@ import (
 	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/sftp"
 )
 
 type MCPServer struct {
 	ctx        context.Context
 	mux        *http.ServeMux
 	httpServer *http.Server
+	httpCancel context.CancelFunc
+	errCh      chan error
+	httpDone   chan struct{}
+	httpErr    error
 	configPath string
 }
 
@@ -39,7 +45,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 
 	mcpServer := server.NewMCPServer(
 		"Litestream MCP Server",
-		"1.0.0",
+		Version,
 		server.WithToolCapabilities(false),
 		server.WithRecovery(),
 		server.WithLogging(),
@@ -58,18 +64,65 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	return s, nil
 }
 
-func (s *MCPServer) Start(addr string) {
-	s.httpServer = &http.Server{
-		Addr:              addr,
-		Handler:           s.mux,
+func (s *MCPServer) Start(addr string) error {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen for MCP HTTP server: %w", err)
+	}
+	s.httpServer = s.newHTTPServer(s.ctx, listener.Addr().String())
+	s.errCh = make(chan error, 1)
+	s.httpDone = make(chan struct{})
+	go func() {
+		s.httpErr = s.runHTTP(s.ctx, listener)
+		s.errCh <- s.httpErr
+		close(s.httpDone)
+	}()
+	return nil
+}
+
+func (s *MCPServer) runHTTP(ctx context.Context, listener net.Listener) error {
+	defer s.httpCancel()
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("Starting MCP Streamable HTTP server", "addr", listener.Addr().String())
+		errCh <- s.httpServer.Serve(listener)
+	}()
+
+	select {
+	case <-ctx.Done():
+		if err := s.shutdownHTTP(); err != nil {
+			shutdownErr := fmt.Errorf("close MCP HTTP server: %w", err)
+			if err := s.httpServer.Close(); err != nil {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("force close MCP HTTP server: %w", err))
+			}
+			if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("serve MCP HTTP server: %w", err))
+			}
+			return shutdownErr
+		}
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve MCP HTTP server: %w", err)
+		}
+		return nil
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve MCP HTTP server: %w", err)
+		}
+		return nil
+	}
+}
+
+func (s *MCPServer) newHTTPServer(ctx context.Context, addr string) *http.Server {
+	httpCtx, cancel := context.WithCancel(ctx)
+	s.httpCancel = cancel
+	return &http.Server{
+		Addr:    addr,
+		Handler: s.mux,
+		BaseContext: func(net.Listener) context.Context {
+			return httpCtx
+		},
 		ReadHeaderTimeout: 30 * time.Second,
 	}
-	go func() {
-		slog.Info("Starting MCP Streamable HTTP server", "addr", addr)
-		if err := s.httpServer.ListenAndServe(); err != nil {
-			slog.Error("MCP server error", "error", err)
-		}
-	}()
 }
 
 func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +131,25 @@ func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Close attempts to gracefully shutdown the server.
 func (s *MCPServer) Close() error {
-	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+	err := s.shutdownHTTP()
+	if s.httpDone != nil {
+		if err != nil {
+			err = errors.Join(err, s.httpServer.Close())
+		}
+		<-s.httpDone
+		err = errors.Join(err, s.httpErr)
+	}
+	return err
+}
+
+func (s *MCPServer) shutdownHTTP() error {
+	if s.httpServer == nil {
+		return nil
+	}
+	if s.httpCancel != nil {
+		s.httpCancel()
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), 10*time.Second)
 	defer cancel()
 	return s.httpServer.Shutdown(ctx)
 }
@@ -94,8 +165,9 @@ func DatabasesTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		cleanup := startMCPResourceCleanup(ctx, resources)
 		output, opErr := formatMCPDatabases(resources.DBs)
-		if err := closeMCPResources(opErr, resources); err != nil {
+		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -113,8 +185,9 @@ func InfoTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		cleanup := startMCPResourceCleanup(ctx, resources)
 		output, opErr := formatMCPInfo(ctx, resources.ConfigPath, resources.DBs)
-		if err := closeMCPResources(opErr, resources); err != nil {
+		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -171,10 +244,11 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		cleanup := startMCPResourceCleanup(ctx, resources)
 
 		output, opErr := restoreMCP(ctx, path, resources.Replica, opt,
 			req.GetBool("if_db_not_exists", false), req.GetBool("if_replica_exists", false))
-		if err := closeMCPResources(opErr, resources); err != nil {
+		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -183,16 +257,10 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 
 func VersionTool() (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_version",
-		mcp.WithDescription("Print the Litestream binary version."),
+		mcp.WithDescription("Print the running Litestream binary version."),
 	)
-
-	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		cmd := exec.CommandContext(ctx, "litestream", "version")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return mcp.NewToolResultError(strings.TrimSpace(string(output)) + ": " + err.Error()), nil
-		}
-		return mcp.NewToolResultText(string(output)), nil
+	return tool, func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText(Version + "\n"), nil
 	}
 }
 
@@ -213,12 +281,13 @@ func LTXTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		cleanup := startMCPResourceCleanup(ctx, resources)
 		files, opErr := listMCPLTXFiles(ctx, resources.Replica, 0)
 		var output string
 		if opErr == nil {
 			output, opErr = formatMCPLTXFiles(files)
 		}
-		if err := closeMCPResources(opErr, resources); err != nil {
+		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -237,12 +306,13 @@ func StatusTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		cleanup := startMCPResourceCleanup(ctx, resources)
 		statuses, opErr := loadMCPStatuses(ctx, resources.DBs, req.GetString("path", ""))
 		var output string
 		if opErr == nil {
 			output, opErr = formatMCPStatuses(statuses)
 		}
-		if err := closeMCPResources(opErr, resources); err != nil {
+		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
@@ -265,12 +335,16 @@ func ResetTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		var cleanup mcpCloser
+		if resources != nil {
+			cleanup = startMCPResourceCleanup(ctx, resources)
+		}
 		opErr := db.ResetLocalState(ctx)
 		if opErr != nil {
 			opErr = fmt.Errorf("reset local state: %w", opErr)
 		}
 		if resources != nil {
-			opErr = closeMCPResources(opErr, resources)
+			opErr = closeMCPResources(opErr, cleanup)
 		}
 		if opErr != nil {
 			return mcpToolError(opErr)
@@ -315,6 +389,64 @@ type mcpCloser interface {
 }
 
 var errMCPReplicaClientNotClosable = errors.New("replica client does not implement cleanup contract")
+
+type mcpCleanup func() error
+
+func (cleanup mcpCleanup) Close() error {
+	return cleanup()
+}
+
+func startMCPResourceCleanup(ctx context.Context, resources mcpCloser) mcpCloser {
+	var cleanups []func() error
+	addReplica := func(r *litestream.Replica, path string) {
+		closeReplica := func() error {
+			err := closeMCPReplica(r)
+			if err != nil && path != "" {
+				return fmt.Errorf("close replica for %s: %w", path, err)
+			}
+			return err
+		}
+		if r != nil {
+			if _, ok := r.Client.(*sftp.ReplicaClient); ok {
+				cleanups = append(cleanups, closeMCPOnCancellation(ctx, closeReplica))
+				return
+			}
+		}
+		cleanups = append(cleanups, closeReplica)
+	}
+	switch resources := resources.(type) {
+	case *mcpDatabases:
+		for _, db := range resources.DBs {
+			addReplica(db.Replica, db.Path())
+		}
+	case *mcpReplica:
+		if resources.Databases != nil {
+			return startMCPResourceCleanup(ctx, resources.Databases)
+		}
+		addReplica(resources.Replica, "")
+	default:
+		cleanups = append(cleanups, resources.Close)
+	}
+	return mcpCleanup(func() error {
+		err := context.Cause(ctx)
+		for _, cleanup := range cleanups {
+			err = errors.Join(err, cleanup())
+		}
+		return err
+	})
+}
+
+func closeMCPOnCancellation(ctx context.Context, closeResource func() error) func() error {
+	var once sync.Once
+	var closeErr error
+	closeOnce := func() { once.Do(func() { closeErr = closeResource() }) }
+	stop := context.AfterFunc(ctx, closeOnce)
+	return func() error {
+		stop()
+		closeOnce()
+		return closeErr
+	}
+}
 
 func closeMCPResources(opErr error, resources mcpCloser) error {
 	return errors.Join(opErr, resources.Close())

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/benbjohnson/litestream"
+)
+
+func TestMCPReadToolsRunWithoutLitestreamOnPATH(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	fixture := newMCPTestFixture(t)
+
+	tests := []struct {
+		name      string
+		handler   server.ToolHandlerFunc
+		arguments map[string]any
+		contains  []string
+	}{
+		{
+			name:    "databases",
+			handler: handlerFromMCPTool(DatabasesTool(fixture.configPath)),
+			contains: []string{
+				"path",
+				"replica",
+				fixture.dbPath,
+				"file",
+			},
+		},
+		{
+			name:    "info",
+			handler: handlerFromMCPTool(InfoTool(fixture.configPath)),
+			contains: []string{
+				"Litestream Status Report",
+				fixture.configPath,
+				fixture.dbPath,
+				"0000000000000001",
+			},
+		},
+		{
+			name:    "ltx database path",
+			handler: handlerFromMCPTool(LTXTool(fixture.configPath)),
+			arguments: map[string]any{
+				"path": fixture.dbPath,
+			},
+			contains: []string{
+				"min_txid",
+				"max_txid",
+				"0000000000000001",
+			},
+		},
+		{
+			name:    "ltx replica URL",
+			handler: handlerFromMCPTool(LTXTool("")),
+			arguments: map[string]any{
+				"path":   "file://" + fixture.replicaPath,
+				"config": filepath.Join(t.TempDir(), "missing.yml"),
+			},
+			contains: []string{
+				"min_txid",
+				"max_txid",
+				"0000000000000001",
+			},
+		},
+		{
+			name:    "status",
+			handler: handlerFromMCPTool(StatusTool(fixture.configPath)),
+			contains: []string{
+				"local txid",
+				"remote txid",
+				fixture.dbPath,
+				"ok",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text := callMCPToolText(t, tt.handler, tt.arguments)
+			for _, value := range tt.contains {
+				if !strings.Contains(text, value) {
+					t.Fatalf("result does not contain %q:\n%s", value, text)
+				}
+			}
+		})
+	}
+}
+
+func TestRestoreToolRunWithoutLitestreamOnPATH(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	tests := []struct {
+		name      string
+		arguments func(mcpTestFixture, string) map[string]any
+	}{
+		{
+			name: "database path",
+			arguments: func(fixture mcpTestFixture, outputPath string) map[string]any {
+				return map[string]any{
+					"path":   fixture.dbPath,
+					"output": outputPath,
+					"config": fixture.configPath,
+				}
+			},
+		},
+		{
+			name: "replica URL",
+			arguments: func(fixture mcpTestFixture, outputPath string) map[string]any {
+				return map[string]any{
+					"path":   "file://" + fixture.replicaPath,
+					"output": outputPath,
+					"config": filepath.Join(t.TempDir(), "missing.yml"),
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newMCPTestFixture(t)
+			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+			text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), tt.arguments(fixture, outputPath))
+
+			var result RestoreResult
+			if err := json.Unmarshal([]byte(text), &result); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, text)
+			}
+			if result.DBPath != outputPath {
+				t.Fatalf("db path=%q, want %q", result.DBPath, outputPath)
+			}
+			if result.Replica != "file" {
+				t.Fatalf("replica=%q, want file", result.Replica)
+			}
+			if result.TXID == "" {
+				t.Fatal("expected restored txid")
+			}
+			assertRestoreCommandDB(t, outputPath)
+		})
+	}
+}
+
+func TestRestoreToolConditionalBehavior(t *testing.T) {
+	t.Run("database exists", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "existing.sqlite")
+		if err := os.WriteFile(outputPath, []byte("existing"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+			"path":             "file://" + filepath.Join(t.TempDir(), "replica"),
+			"output":           outputPath,
+			"timestamp":        "2026-07-16T12:00:00Z",
+			"if_db_not_exists": true,
+		})
+		if text != "database already exists, skipping\n" {
+			t.Fatalf("unexpected result: %q", text)
+		}
+	})
+
+	t.Run("replica does not exist", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+		text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+			"path":              "file://" + filepath.Join(t.TempDir(), "replica"),
+			"output":            outputPath,
+			"if_replica_exists": true,
+		})
+		if text != "no matching backups found, skipping\n" {
+			t.Fatalf("unexpected result: %q", text)
+		}
+		if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+			t.Fatalf("output exists after skipped restore: %v", err)
+		}
+	})
+}
+
+func TestRestoreToolRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		contains  string
+	}{
+		{
+			name: "txid",
+			arguments: map[string]any{
+				"path": "file:///tmp/replica",
+				"txid": "bad",
+			},
+			contains: "invalid txid",
+		},
+		{
+			name: "timestamp",
+			arguments: map[string]any{
+				"path":      "file:///tmp/replica",
+				"timestamp": "bad",
+			},
+			contains: "invalid timestamp",
+		},
+		{
+			name: "parallelism",
+			arguments: map[string]any{
+				"path":        "file:///tmp/replica",
+				"parallelism": "bad",
+			},
+			contains: "invalid parallelism",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callMCPToolResult(t, handlerFromMCPTool(RestoreTool("")), tt.arguments)
+			if !result.IsError {
+				t.Fatal("expected tool error")
+			}
+			text := mcpToolResultText(t, result)
+			if !strings.Contains(text, tt.contains) {
+				t.Fatalf("error does not contain %q: %s", tt.contains, text)
+			}
+		})
+	}
+}
+
+func TestResetToolRunWithoutLitestreamOnPATH(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	fixture := newMCPTestFixture(t)
+	ltxPath := filepath.Join(filepath.Dir(fixture.dbPath), "."+filepath.Base(fixture.dbPath)+litestream.MetaDirSuffix, "ltx")
+	if _, err := os.Stat(ltxPath); err != nil {
+		t.Fatalf("expected local ltx state: %v", err)
+	}
+
+	text := callMCPToolText(t, handlerFromMCPTool(ResetTool(fixture.configPath)), map[string]any{
+		"path": fixture.dbPath,
+	})
+	if !strings.Contains(text, "Reset complete") {
+		t.Fatalf("unexpected result: %q", text)
+	}
+	if _, err := os.Stat(ltxPath); !os.IsNotExist(err) {
+		t.Fatalf("local ltx state still exists: %v", err)
+	}
+}
+
+func TestVersionToolRunWithoutLitestreamOnPATH(t *testing.T) {
+	const version = "v1.2.3-mcp-test"
+	previous := Version
+	Version = version
+	t.Cleanup(func() { Version = previous })
+	t.Setenv("PATH", t.TempDir())
+
+	text := callMCPToolText(t, handlerFromMCPTool(VersionTool()), nil)
+	if text != version+"\n" {
+		t.Fatalf("version=%q, want %q", text, version+"\n")
+	}
+}
+
+func TestRestoreToolSchema(t *testing.T) {
+	tool, _ := RestoreTool("")
+	if _, ok := tool.InputSchema.Properties["output"]; !ok {
+		t.Fatal("expected output property")
+	}
+	if _, ok := tool.InputSchema.Properties["o"]; ok {
+		t.Fatal("did not expect o property")
+	}
+}
+
+type mcpTestFixture struct {
+	dbPath      string
+	replicaPath string
+	configPath  string
+}
+
+func newMCPTestFixture(t *testing.T) mcpTestFixture {
+	t.Helper()
+
+	replicaPath, _ := createRestoreCommandTestData(t, t.Context())
+	dbPath := filepath.Join(filepath.Dir(replicaPath), "db.sqlite")
+	configPath := filepath.Join(t.TempDir(), "litestream.yml")
+	config := fmt.Sprintf("dbs:\n  - path: %q\n    replica:\n      url: %q\n", dbPath, "file://"+replicaPath)
+	if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return mcpTestFixture{
+		dbPath:      dbPath,
+		replicaPath: replicaPath,
+		configPath:  configPath,
+	}
+}
+
+func handlerFromMCPTool(_ mcp.Tool, handler server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return handler
+}
+
+func callMCPToolText(t *testing.T, handler server.ToolHandlerFunc, arguments map[string]any) string {
+	t.Helper()
+
+	result := callMCPToolResult(t, handler, arguments)
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %s", mcpToolResultText(t, result))
+	}
+	return mcpToolResultText(t, result)
+}
+
+func callMCPToolResult(t *testing.T, handler server.ToolHandlerFunc, arguments map[string]any) *mcp.CallToolResult {
+	t.Helper()
+
+	result, err := handler(t.Context(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: arguments},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func mcpToolResultText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+
+	if len(result.Content) != 1 {
+		t.Fatalf("content length=%d, want 1", len(result.Content))
+	}
+	content, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content type=%T, want mcp.TextContent", result.Content[0])
+	}
+	return content.Text
+}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,8 +15,10 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/mock"
 )
 
 func TestMCPReadToolsRunWithoutLitestreamOnPATH(t *testing.T) {
@@ -90,6 +97,28 @@ func TestMCPReadToolsRunWithoutLitestreamOnPATH(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMCPConfigDoesNotChangeDefaultLogger(t *testing.T) {
+	fixture := newMCPTestFixture(t)
+	data, err := os.ReadFile(fixture.configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, []byte("logging:\n  level: DEBUG\n  type: json\n  stderr: true\n  source: true\n")...)
+	if err := os.WriteFile(fixture.configPath, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := slog.Default()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	callMCPToolText(t, handlerFromMCPTool(DatabasesTool(fixture.configPath)), nil)
+	if slog.Default() != logger {
+		t.Fatal("MCP config load changed the default logger")
 	}
 }
 
@@ -182,7 +211,7 @@ func TestRestoreToolConditionalBehavior(t *testing.T) {
 			if text != "no matching backups found, skipping\n" {
 				t.Fatalf("unexpected result: %q", text)
 			}
-			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+			if _, err := os.Stat(outputPath); !errors.Is(err, fs.ErrNotExist) {
 				t.Fatalf("output exists after skipped restore: %v", err)
 			}
 		})
@@ -200,25 +229,93 @@ func TestMCPReplicaURLSchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r, err := loadMCPReplica(tt.url, filepath.Join(t.TempDir(), "missing.yml"))
+			resources, err := loadMCPReplica(tt.url, filepath.Join(t.TempDir(), "missing.yml"))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := r.Client.Type(); got != tt.name {
+			if got := resources.Replica.Client.Type(); got != tt.name {
 				t.Fatalf("replica type=%q, want %q", got, tt.name)
+			}
+			if err := resources.Close(); err != nil {
+				t.Fatal(err)
 			}
 
 			opt := litestream.NewRestoreOptions()
 			opt.OutputPath = filepath.Join(t.TempDir(), "restored.sqlite")
-			r, err = loadMCPRestoreReplica(tt.url, filepath.Join(t.TempDir(), "missing.yml"), &opt)
+			resources, err = loadMCPRestoreReplica(tt.url, filepath.Join(t.TempDir(), "missing.yml"), &opt)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := r.Client.Type(); got != tt.name {
+			if got := resources.Replica.Client.Type(); got != tt.name {
 				t.Fatalf("restore replica type=%q, want %q", got, tt.name)
+			}
+			if err := resources.Close(); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
+}
+
+func TestMCPRemoteReplicaLifecycle(t *testing.T) {
+	operationErr := errors.New("operation failed")
+	closeErr := errors.New("close failed")
+	client := &mcpClosingReplicaClient{closeErr: closeErr}
+	r := litestream.NewReplica(nil)
+	r.Client = client
+
+	err := closeMCPResources(operationErr, &mcpReplica{Replica: r})
+	if !errors.Is(err, operationErr) {
+		t.Fatalf("error does not include operation failure: %v", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("error does not include close failure: %v", err)
+	}
+	if client.closeN != 1 {
+		t.Fatalf("close count=%d, want 1", client.closeN)
+	}
+}
+
+func TestRestoreTXID(t *testing.T) {
+	t.Run("returns plan error", func(t *testing.T) {
+		planErr := errors.New("list failed")
+		client := &mock.ReplicaClient{
+			LTXFilesFunc: func(context.Context, int, ltx.TXID, bool) (ltx.FileIterator, error) {
+				return nil, planErr
+			},
+		}
+		r := litestream.NewReplica(nil)
+		r.Client = client
+		opt := litestream.NewRestoreOptions()
+
+		if _, err := (&RestoreCommand{}).restoreTXID(t.Context(), r, &opt); !errors.Is(err, planErr) {
+			t.Fatalf("error=%v, want %v", err, planErr)
+		}
+	})
+
+	t.Run("pins planned transaction", func(t *testing.T) {
+		fixture := newMCPTestFixture(t)
+		resources, err := loadMCPReplica("file://"+fixture.replicaPath, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := resources.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+		opt := litestream.NewRestoreOptions()
+
+		txID, err := (&RestoreCommand{}).restoreTXID(t.Context(), resources.Replica, &opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if txID != "0000000000000001" {
+			t.Fatalf("txid=%q, want 0000000000000001", txID)
+		}
+		if opt.TXID != 1 {
+			t.Fatalf("option txid=%s, want 0000000000000001", opt.TXID)
+		}
+	})
 }
 
 func TestRestoreToolRejectsInvalidOptions(t *testing.T) {
@@ -281,21 +378,8 @@ func TestResetToolRunWithoutLitestreamOnPATH(t *testing.T) {
 	if !strings.Contains(text, "Reset complete") {
 		t.Fatalf("unexpected result: %q", text)
 	}
-	if _, err := os.Stat(ltxPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(ltxPath); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("local ltx state still exists: %v", err)
-	}
-}
-
-func TestVersionToolRunWithoutLitestreamOnPATH(t *testing.T) {
-	const version = "v1.2.3-mcp-test"
-	previous := Version
-	Version = version
-	t.Cleanup(func() { Version = previous })
-	t.Setenv("PATH", t.TempDir())
-
-	text := callMCPToolText(t, handlerFromMCPTool(VersionTool()), nil)
-	if text != version+"\n" {
-		t.Fatalf("version=%q, want %q", text, version+"\n")
 	}
 }
 
@@ -313,6 +397,17 @@ type mcpTestFixture struct {
 	dbPath      string
 	replicaPath string
 	configPath  string
+}
+
+type mcpClosingReplicaClient struct {
+	mock.ReplicaClient
+	closeErr error
+	closeN   int
+}
+
+func (c *mcpClosingReplicaClient) Close() error {
+	c.closeN++
+	return c.closeErr
 }
 
 func newMCPTestFixture(t *testing.T) mcpTestFixture {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -275,6 +275,49 @@ func TestMCPRemoteReplicaLifecycle(t *testing.T) {
 	}
 }
 
+func TestMCPReplicaClientCloseContract(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "abs", url: "abs://account@container/path"},
+		{name: "file", url: "file:///tmp/replica"},
+		{name: "gs", url: "gs://bucket/path"},
+		{name: "nats", url: "nats://localhost/bucket"},
+		{name: "oss", url: "oss://bucket/path"},
+		{name: "s3", url: "s3://bucket/path"},
+		{name: "sftp", url: "sftp://user@localhost/path"},
+		{name: "webdav", url: "webdav://localhost/path"},
+		{name: "webdavs", url: "webdavs://localhost/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := litestream.NewReplicaClientFromURL(tt.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			closer, ok := client.(litestream.ReplicaClientCloser)
+			if !ok {
+				t.Fatalf("%s replica client does not implement cleanup contract", client.Type())
+			}
+			if err := closer.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestMCPReplicaClientCloseContractViolation(t *testing.T) {
+	r := litestream.NewReplica(nil)
+	r.Client = &mock.ReplicaClient{}
+
+	err := closeMCPReplica(r)
+	if !errors.Is(err, errMCPReplicaClientNotClosable) {
+		t.Fatalf("error=%v, want %v", err, errMCPReplicaClientNotClosable)
+	}
+}
+
 func TestRestoreTXID(t *testing.T) {
 	t.Run("returns plan error", func(t *testing.T) {
 		planErr := errors.New("list failed")

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -164,20 +164,61 @@ func TestRestoreToolConditionalBehavior(t *testing.T) {
 		}
 	})
 
-	t.Run("replica does not exist", func(t *testing.T) {
-		outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
-		text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
-			"path":              "file://" + filepath.Join(t.TempDir(), "replica"),
-			"output":            outputPath,
-			"if_replica_exists": true,
+	for _, tt := range []struct {
+		name      string
+		timestamp string
+	}{
+		{name: "replica does not exist"},
+		{name: "replica does not exist at timestamp", timestamp: "2026-07-16T12:00:00Z"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+			text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+				"path":              "file://" + filepath.Join(t.TempDir(), "replica"),
+				"output":            outputPath,
+				"timestamp":         tt.timestamp,
+				"if_replica_exists": true,
+			})
+			if text != "no matching backups found, skipping\n" {
+				t.Fatalf("unexpected result: %q", text)
+			}
+			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+				t.Fatalf("output exists after skipped restore: %v", err)
+			}
 		})
-		if text != "no matching backups found, skipping\n" {
-			t.Fatalf("unexpected result: %q", text)
-		}
-		if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
-			t.Fatalf("output exists after skipped restore: %v", err)
-		}
-	})
+	}
+}
+
+func TestMCPReplicaURLSchemes(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "s3", url: "s3://bucket/path"},
+		{name: "gs", url: "gs://bucket/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := loadMCPReplica(tt.url, filepath.Join(t.TempDir(), "missing.yml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := r.Client.Type(); got != tt.name {
+				t.Fatalf("replica type=%q, want %q", got, tt.name)
+			}
+
+			opt := litestream.NewRestoreOptions()
+			opt.OutputPath = filepath.Join(t.TempDir(), "restored.sqlite")
+			r, err = loadMCPRestoreReplica(tt.url, filepath.Join(t.TempDir(), "missing.yml"), &opt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := r.Client.Type(); got != tt.name {
+				t.Fatalf("restore replica type=%q, want %q", got, tt.name)
+			}
+		})
+	}
 }
 
 func TestRestoreToolRejectsInvalidOptions(t *testing.T) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -8,10 +8,13 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -167,8 +170,8 @@ func TestRestoreToolRunWithoutLitestreamOnPATH(t *testing.T) {
 			if result.Replica != "file" {
 				t.Fatalf("replica=%q, want file", result.Replica)
 			}
-			if result.TXID == "" {
-				t.Fatal("expected restored txid")
+			if result.TXID != "" {
+				t.Fatalf("automatic file restore TXID=%q, want unknown", result.TXID)
 			}
 			assertRestoreCommandDB(t, outputPath)
 		})
@@ -346,9 +349,11 @@ func TestRestoreTXID(t *testing.T) {
 				t.Error(err)
 			}
 		})
+		replica := litestream.NewReplica(nil)
+		replica.Client = struct{ litestream.ReplicaClient }{resources.Replica.Client}
 		opt := litestream.NewRestoreOptions()
 
-		txID, err := (&RestoreCommand{}).restoreTXID(t.Context(), resources.Replica, &opt)
+		txID, err := (&RestoreCommand{}).restoreTXID(t.Context(), replica, &opt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -507,4 +512,108 @@ func mcpToolResultText(t *testing.T, result *mcp.CallToolResult) string {
 		t.Fatalf("content type=%T, want mcp.TextContent", result.Content[0])
 	}
 	return content.Text
+}
+
+func TestMCPServerLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	server, err := NewMCP(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Start("127.0.0.1:0"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	other, err := NewMCP(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := other.Start(server.httpServer.Addr); err == nil {
+		t.Fatal("expected bind error")
+	}
+	cancel()
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-server.errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("MCP server did not stop")
+	}
+	listener, err := net.Listen("tcp", server.httpServer.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPVersionWithoutPATH(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	previous := Version
+	Version = "v1.2.3-in-process"
+	t.Cleanup(func() { Version = previous })
+	if got := callMCPToolText(t, handlerFromMCPTool(VersionTool()), nil); got != Version+"\n" {
+		t.Fatalf("version=%q, want %q", got, Version+"\n")
+	}
+}
+
+func TestMCPCancellationCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cause := errors.New("caller canceled")
+	closeErr := errors.New("cleanup failed")
+	closed := make(chan struct{})
+	var calls atomic.Int32
+	cleanup := closeMCPOnCancellation(ctx, func() error {
+		calls.Add(1)
+		close(closed)
+		return closeErr
+	})
+	cancel(cause)
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancellation did not close the resource")
+	}
+	if err := cleanup(); !errors.Is(err, closeErr) {
+		t.Fatalf("cleanup error=%v, want %v", err, closeErr)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("close calls=%d, want 1", got)
+	}
+}
+
+func TestMCPResourceCleanupPreservesErrors(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cause := errors.New("caller canceled")
+	closeErr := errors.New("cleanup failed")
+	opErr := errors.New("operation failed")
+	client := &mcpClosingReplicaClient{closeErr: closeErr}
+	r := litestream.NewReplica(nil)
+	r.Client = client
+	cleanup := startMCPResourceCleanup(ctx, &mcpReplica{Replica: r})
+	cancel(cause)
+	if client.closeN != 0 {
+		t.Fatal("non-SFTP client closed before operation returned")
+	}
+	err := closeMCPResources(opErr, cleanup)
+	for _, want := range []error{opErr, closeErr, cause} {
+		if !errors.Is(err, want) {
+			t.Errorf("error=%v, want %v", err, want)
+		}
+	}
+	if client.closeN != 1 {
+		t.Fatalf("close calls=%d, want 1", client.closeN)
+	}
 }

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -40,7 +40,8 @@ type ReplicateCommand struct {
 	Config Config
 
 	// MCP server
-	MCP *MCPServer
+	MCP      *MCPServer
+	mcpErrCh <-chan error
 
 	// Server for IPC control commands.
 	Server *litestream.Server
@@ -185,7 +186,10 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		go c.MCP.Start(c.Config.MCPAddr)
+		if err := c.MCP.Start(c.Config.MCPAddr); err != nil {
+			return fmt.Errorf("start MCP server: %w", err)
+		}
+		c.mcpErrCh = c.MCP.errCh
 	}
 
 	// Setup databases.
@@ -434,6 +438,7 @@ func (c *ReplicateCommand) runOnce(ctx context.Context) {
 
 // Close closes all open databases.
 func (c *ReplicateCommand) Close(ctx context.Context) error {
+	var closeErr error
 	for _, monitor := range c.directoryMonitors {
 		monitor.Close()
 	}
@@ -441,7 +446,7 @@ func (c *ReplicateCommand) Close(ctx context.Context) error {
 
 	if c.Server != nil {
 		if err := c.Server.Close(); err != nil {
-			slog.Error("error closing control server", "error", err)
+			closeErr = errors.Join(closeErr, fmt.Errorf("close control server: %w", err))
 		}
 	}
 	if c.Store != nil {
@@ -449,16 +454,16 @@ func (c *ReplicateCommand) Close(ctx context.Context) error {
 			if errors.Is(err, litestream.ErrShutdownInterrupted) {
 				slog.Warn("shutdown sync skipped by user interrupt", "error", err)
 			} else {
-				slog.Error("failed to close database", "error", err)
+				closeErr = errors.Join(closeErr, fmt.Errorf("close database: %w", err))
 			}
 		}
 	}
 	if c.Config.MCPAddr != "" && c.MCP != nil {
 		if err := c.MCP.Close(); err != nil {
-			slog.Error("error closing MCP server", "error", err)
+			closeErr = errors.Join(closeErr, fmt.Errorf("close MCP server: %w", err))
 		}
 	}
-	return nil
+	return closeErr
 }
 
 // SetDone sets the done channel used for interrupt handling during shutdown.

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -140,7 +140,16 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 	}
 
-	txid := c.restoreTXID(ctx, r, opt)
+	txid, err := c.restoreTXID(ctx, r, &opt)
+	if errors.Is(err, litestream.ErrTxNotAvailable) {
+		if *ifReplicaExists {
+			slog.Info("no matching backups found")
+			return nil
+		}
+		return fmt.Errorf("no matching backup files available")
+	} else if err != nil {
+		return err
+	}
 	start := time.Now()
 	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) {
 		if *ifReplicaExists {
@@ -251,18 +260,23 @@ func (c *RestoreCommand) printDryRunPlan(plan RestorePlan) {
 	}
 }
 
-func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica, opt litestream.RestoreOptions) string {
+func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica, opt *litestream.RestoreOptions) (string, error) {
 	if opt.TXID != 0 {
-		return opt.TXID.String()
+		return opt.TXID.String(), nil
 	}
 	if opt.Follow {
-		return ""
+		return "", nil
 	}
 	infos, err := litestream.CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
-	if err != nil || len(infos) == 0 {
-		return ""
+	if err != nil {
+		return "", err
 	}
-	return infos[len(infos)-1].MaxTXID.String()
+	if len(infos) == 0 {
+		return "", litestream.ErrTxNotAvailable
+	}
+	opt.TXID = infos[len(infos)-1].MaxTXID
+	opt.Timestamp = time.Time{}
+	return opt.TXID.String(), nil
 }
 
 func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -267,6 +267,9 @@ func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica,
 	if opt.Follow {
 		return "", nil
 	}
+	if _, ok := r.Client.(litestream.ReplicaClientV3); ok {
+		return "", nil
+	}
 	infos, err := litestream.CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
 	if err != nil {
 		return "", err
@@ -320,8 +323,10 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 	}
 
 	// Exit successfully if the output file already exists.
-	if _, err := os.Stat(opt.OutputPath); !os.IsNotExist(err) && ifDBNotExists {
+	if _, err := os.Stat(opt.OutputPath); err == nil && ifDBNotExists {
 		return nil, errSkipDBExists
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot access output path: %w", err)
 	}
 
 	syncInterval := litestream.DefaultSyncInterval
@@ -365,8 +370,10 @@ func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath st
 	}
 
 	// Exit successfully if the output file already exists.
-	if _, err := os.Stat(opt.OutputPath); !os.IsNotExist(err) && ifDBNotExists {
+	if _, err := os.Stat(opt.OutputPath); err == nil && ifDBNotExists {
 		return nil, errSkipDBExists
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot access output path: %w", err)
 	}
 
 	return db.Replica, nil

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/pierrec/lz4/v4"
 
 	litestream "github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
@@ -125,8 +129,8 @@ func TestRestoreCommand_RunJSONOutput(t *testing.T) {
 	if got.Replica != "file" {
 		t.Fatalf("unexpected replica: %s", got.Replica)
 	}
-	if got.TXID == "" {
-		t.Fatal("expected txid")
+	if got.TXID != "" {
+		t.Fatalf("automatic legacy-capable restore reported unverified TXID %q", got.TXID)
 	}
 	if got.DurationMS < 0 {
 		t.Fatalf("unexpected duration_ms: %d", got.DurationMS)
@@ -317,5 +321,115 @@ func assertRestoreCommandDB(t *testing.T, path string) {
 	}
 	if count != 1 {
 		t.Fatalf("count=%d, want 1", count)
+	}
+}
+
+func TestRestoreCommandOutputAccessError(t *testing.T) {
+	for _, fromConfig := range []bool{false, true} {
+		t.Run(map[bool]string{false: "url", true: "config"}[fromConfig], func(t *testing.T) {
+			dir := t.TempDir()
+			output := filepath.Join(dir, strings.Repeat("x", 300))
+			args := []string{"-json", "-if-db-not-exists", "-o", output}
+			if fromConfig {
+				config := filepath.Join(dir, "litestream.yml")
+				dbPath := filepath.Join(dir, "db")
+				content := "dbs:\n  - path: " + dbPath + "\n    replica:\n      url: file://" + dir + "/replica\n"
+				if err := os.WriteFile(config, []byte(content), 0600); err != nil {
+					t.Fatal(err)
+				}
+				args = append(args, "-config", config, dbPath)
+			} else {
+				args = append(args, "file://"+dir+"/replica")
+			}
+			err := (&RestoreCommand{}).Run(t.Context(), args)
+			if err == nil || !strings.Contains(err.Error(), "cannot access output path") {
+				t.Fatalf("error=%v, want output access error", err)
+			}
+		})
+	}
+}
+
+func TestRestoreCommandLegacySelection(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy only", true: "newer legacy"}[mixed], func(t *testing.T) {
+			dir := t.TempDir()
+			replicaPath, restorePath := filepath.Join(dir, "replica"), filepath.Join(dir, "restored.db")
+			if mixed {
+				replicaPath, restorePath = createRestoreCommandTestData(t, t.Context())
+			}
+			source := filepath.Join(dir, "legacy.db")
+			db := testingutil.MustOpenSQLDB(t, source)
+			if _, err := db.ExecContext(t.Context(), "CREATE TABLE t (id INT); INSERT INTO t VALUES (2)"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var compressed bytes.Buffer
+			writer := lz4.NewWriter(&compressed)
+			if _, err := writer.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			snapshotDir := filepath.Join(replicaPath, "generations", "0123456789abcdef", "snapshots")
+			if err := os.MkdirAll(snapshotDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			snapshot := filepath.Join(snapshotDir, "00000000.snapshot.lz4")
+			if err := os.WriteFile(snapshot, compressed.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			newer := time.Now().Add(time.Hour)
+			if err := os.Chtimes(snapshot, newer, newer); err != nil {
+				t.Fatal(err)
+			}
+			output := captureLTXCommandStdout(t, func() {
+				if err := (&RestoreCommand{}).Run(t.Context(), []string{"-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
+					t.Fatal(err)
+				}
+			})
+			var result RestoreResult
+			if err := json.Unmarshal([]byte(output), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.TXID != "" {
+				t.Fatalf("result=%+v, want unknown legacy TXID", result)
+			}
+			restored := testingutil.MustOpenSQLDB(t, restorePath)
+			defer func() {
+				if err := restored.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			var id int
+			if err := restored.QueryRowContext(t.Context(), "SELECT id FROM t").Scan(&id); err != nil {
+				t.Fatal(err)
+			}
+			if id != 2 {
+				t.Fatalf("restored id=%d, want legacy value 2", id)
+			}
+		})
+	}
+}
+
+func TestRestoreCommandExplicitTXIDOutput(t *testing.T) {
+	replicaPath, restorePath := createRestoreCommandTestData(t, t.Context())
+	output := captureLTXCommandStdout(t, func() {
+		if err := (&RestoreCommand{}).Run(t.Context(), []string{"-json", "-txid", "0000000000000001", "-o", restorePath, "file://" + replicaPath}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	var result RestoreResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.TXID != "0000000000000001" {
+		t.Fatalf("result=%+v", result)
 	}
 }

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -26,6 +26,7 @@ func init() {
 const ReplicaClientType = "file"
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 var _ litestream.ReplicaClientV3 = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to disk.
@@ -73,6 +74,10 @@ func (c *ReplicaClient) Type() string {
 
 // Init is a no-op for file replica client as no initialization is required.
 func (c *ReplicaClient) Init(ctx context.Context) error {
+	return nil
+}
+
+func (c *ReplicaClient) Close() error {
 	return nil
 }
 

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -27,6 +27,7 @@ func init() {
 const ReplicaClientType = "file"
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 var _ litestream.ReplicaClientV3 = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to disk.
@@ -74,6 +75,10 @@ func (c *ReplicaClient) Type() string {
 
 // Init is a no-op for file replica client as no initialization is required.
 func (c *ReplicaClient) Init(ctx context.Context) error {
+	return nil
+}
+
+func (c *ReplicaClient) Close() error {
 	return nil
 }
 

--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -32,6 +32,7 @@ const ReplicaClientType = "gs"
 const MetadataKeyTimestamp = "litestream-timestamp"
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to Google Cloud Storage.
 type ReplicaClient struct {
@@ -89,6 +90,20 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	c.bkt = c.client.Bucket(c.Bucket)
 
 	return nil
+}
+
+// Close closes the Google Cloud Storage client.
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client == nil {
+		return nil
+	}
+	err := c.client.Close()
+	c.client = nil
+	c.bkt = nil
+	return err
 }
 
 // DeleteAll deletes all LTX files.

--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -175,17 +175,14 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	fullReader := io.MultiReader(&buf, rd)
 
 	w := c.bkt.Object(key).NewWriter(ctx)
-	defer w.Close()
 
 	// Store timestamp in GCS metadata for accurate timestamp retrieval
 	w.Metadata = map[string]string{
 		MetadataKeyTimestamp: timestamp.Format(time.RFC3339Nano),
 	}
 
-	n, err := io.Copy(w, fullReader)
-	if err != nil {
-		return info, err
-	} else if err := w.Close(); err != nil {
+	n, copyErr := io.Copy(w, fullReader)
+	if err := errors.Join(copyErr, w.Close()); err != nil {
 		return info, err
 	}
 

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"sort"
@@ -34,6 +35,93 @@ const ReplicaClientType = "nats"
 const HeaderKeyTimestamp = "Litestream-Timestamp"
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
+
+type contextDialer struct {
+	mu          sync.Mutex
+	ctx         context.Context
+	dialer      net.Dialer
+	connections map[net.Conn]struct{}
+	active      bool
+	stop        func() bool
+	done        chan struct{}
+	err         error
+}
+
+func newContextDialer(ctx context.Context, timeout time.Duration) *contextDialer {
+	d := &contextDialer{
+		ctx:         ctx,
+		dialer:      net.Dialer{Timeout: timeout},
+		connections: make(map[net.Conn]struct{}),
+		active:      true,
+		done:        make(chan struct{}),
+	}
+	d.stop = context.AfterFunc(ctx, d.cancel)
+	return d
+}
+
+func (d *contextDialer) Dial(network, address string) (net.Conn, error) {
+	d.mu.Lock()
+	ctx := d.ctx
+	d.mu.Unlock()
+
+	conn, err := d.dialer.DialContext(ctx, network, address)
+	if err != nil {
+		if context.Cause(ctx) != nil {
+			return nil, context.Cause(ctx)
+		}
+		return nil, err
+	}
+
+	d.mu.Lock()
+	if !d.active {
+		cause := context.Cause(d.ctx)
+		d.mu.Unlock()
+		if cause != nil {
+			return nil, errors.Join(cause, conn.Close())
+		}
+		return conn, nil
+	}
+	if cause := context.Cause(d.ctx); cause != nil {
+		d.mu.Unlock()
+		return nil, errors.Join(cause, conn.Close())
+	}
+	d.connections[conn] = struct{}{}
+	d.mu.Unlock()
+	return conn, nil
+}
+
+func (d *contextDialer) cancel() {
+	d.mu.Lock()
+	connections := d.connections
+	d.connections = nil
+	d.active = false
+	d.mu.Unlock()
+
+	var err error
+	for conn := range connections {
+		err = errors.Join(err, conn.Close())
+	}
+	d.mu.Lock()
+	d.err = err
+	d.mu.Unlock()
+	close(d.done)
+}
+
+func (d *contextDialer) release() error {
+	if d.stop() {
+		d.mu.Lock()
+		d.ctx = context.Background()
+		d.connections = nil
+		d.active = false
+		d.mu.Unlock()
+		return nil
+	}
+	<-d.done
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.err
+}
 
 // ReplicaClient is a client for writing LTX files to NATS JetStream Object Store.
 type ReplicaClient struct {
@@ -139,14 +227,15 @@ func (c *ReplicaClient) Init(ctx context.Context) error {
 	}
 
 	if err := c.initObjectStore(ctx); err != nil {
-		return fmt.Errorf("nats: failed to initialize object store: %w", err)
+		return errors.Join(fmt.Errorf("nats: failed to initialize object store: %w", err), c.close())
 	}
 
 	return nil
 }
 
 // connect establishes a connection to NATS server with proper configuration.
-func (c *ReplicaClient) connect(_ context.Context) error {
+func (c *ReplicaClient) connect(ctx context.Context) error {
+	dialer := newContextDialer(ctx, c.Timeout)
 	opts := []nats.Option{
 		nats.MaxReconnects(c.MaxReconnects),
 		nats.ReconnectWait(c.ReconnectWait),
@@ -155,6 +244,7 @@ func (c *ReplicaClient) connect(_ context.Context) error {
 		nats.PingInterval(c.PingInterval),
 		nats.MaxPingsOutstanding(c.MaxPingsOut),
 		nats.ReconnectBufSize(c.ReconnectBufSize),
+		nats.SetCustomDialer(dialer),
 	}
 
 	// Authentication options
@@ -184,17 +274,25 @@ func (c *ReplicaClient) connect(_ context.Context) error {
 		opts = append(opts, nats.RootCAs(c.RootCAs...))
 	}
 
-	// Note: NATS Connect doesn't directly support context cancellation during connection
-	// The context parameter is preserved for potential future use
-
 	url := c.URL
 	if url == "" {
 		url = nats.DefaultURL
 	}
 
 	nc, err := nats.Connect(url, opts...)
+	dialErr := dialer.release()
+	if cause := context.Cause(ctx); cause != nil {
+		if nc != nil {
+			nc.Close()
+		}
+		return errors.Join(cause, dialErr)
+	}
 	if err != nil {
-		return fmt.Errorf("failed to connect to NATS server: %w", err)
+		return errors.Join(fmt.Errorf("failed to connect to NATS server: %w", err), dialErr)
+	}
+	if dialErr != nil {
+		nc.Close()
+		return dialErr
 	}
 
 	js, err := jetstream.New(nc)
@@ -229,7 +327,10 @@ func (c *ReplicaClient) initObjectStore(ctx context.Context) error {
 func (c *ReplicaClient) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.close()
+}
 
+func (c *ReplicaClient) close() error {
 	if c.nc != nil {
 		c.nc.Close()
 		c.nc = nil

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"sort"
@@ -34,6 +35,93 @@ const ReplicaClientType = "nats"
 const HeaderKeyTimestamp = "Litestream-Timestamp"
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
+
+type contextDialer struct {
+	mu          sync.Mutex
+	ctx         context.Context
+	dialer      net.Dialer
+	connections map[net.Conn]struct{}
+	active      bool
+	stop        func() bool
+	done        chan struct{}
+	err         error
+}
+
+func newContextDialer(ctx context.Context, timeout time.Duration) *contextDialer {
+	d := &contextDialer{
+		ctx:         ctx,
+		dialer:      net.Dialer{Timeout: timeout},
+		connections: make(map[net.Conn]struct{}),
+		active:      true,
+		done:        make(chan struct{}),
+	}
+	d.stop = context.AfterFunc(ctx, d.cancel)
+	return d
+}
+
+func (d *contextDialer) Dial(network, address string) (net.Conn, error) {
+	d.mu.Lock()
+	ctx := d.ctx
+	d.mu.Unlock()
+
+	conn, err := d.dialer.DialContext(ctx, network, address)
+	if err != nil {
+		if context.Cause(ctx) != nil {
+			return nil, context.Cause(ctx)
+		}
+		return nil, err
+	}
+
+	d.mu.Lock()
+	if !d.active {
+		cause := context.Cause(d.ctx)
+		d.mu.Unlock()
+		if cause != nil {
+			return nil, errors.Join(cause, conn.Close())
+		}
+		return conn, nil
+	}
+	if cause := context.Cause(d.ctx); cause != nil {
+		d.mu.Unlock()
+		return nil, errors.Join(cause, conn.Close())
+	}
+	d.connections[conn] = struct{}{}
+	d.mu.Unlock()
+	return conn, nil
+}
+
+func (d *contextDialer) cancel() {
+	d.mu.Lock()
+	connections := d.connections
+	d.connections = nil
+	d.active = false
+	d.mu.Unlock()
+
+	var err error
+	for conn := range connections {
+		err = errors.Join(err, conn.Close())
+	}
+	d.mu.Lock()
+	d.err = err
+	d.mu.Unlock()
+	close(d.done)
+}
+
+func (d *contextDialer) release() error {
+	if d.stop() {
+		d.mu.Lock()
+		d.ctx = context.Background()
+		d.connections = nil
+		d.active = false
+		d.mu.Unlock()
+		return nil
+	}
+	<-d.done
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.err
+}
 
 // ReplicaClient is a client for writing LTX files to NATS JetStream Object Store.
 type ReplicaClient struct {
@@ -141,22 +229,36 @@ func (c *ReplicaClient) Init(ctx context.Context) error {
 	}
 
 	if err := c.initObjectStore(ctx); err != nil {
-		return fmt.Errorf("nats: failed to initialize object store: %w", err)
+		return errors.Join(fmt.Errorf("nats: failed to initialize object store: %w", err), c.close())
 	}
 
 	return nil
 }
 
 // connect establishes a connection to NATS server with proper configuration.
-func (c *ReplicaClient) connect(_ context.Context) error {
+func (c *ReplicaClient) connect(ctx context.Context) error {
+	dialer := newContextDialer(ctx, c.Timeout)
+	opts := append(c.options(), nats.SetCustomDialer(dialer))
+
 	url := c.URL
 	if url == "" {
 		url = nats.DefaultURL
 	}
 
-	nc, err := nats.Connect(url, c.options()...)
+	nc, err := nats.Connect(url, opts...)
+	dialErr := dialer.release()
+	if cause := context.Cause(ctx); cause != nil {
+		if nc != nil {
+			nc.Close()
+		}
+		return errors.Join(cause, dialErr)
+	}
 	if err != nil {
-		return fmt.Errorf("failed to connect to NATS server: %w", err)
+		return errors.Join(fmt.Errorf("failed to connect to NATS server: %w", err), dialErr)
+	}
+	if dialErr != nil {
+		nc.Close()
+		return dialErr
 	}
 
 	js, err := jetstream.New(nc)
@@ -211,7 +313,6 @@ func (c *ReplicaClient) options() []nats.Option {
 	if len(c.RootCAs) > 0 {
 		opts = append(opts, nats.RootCAs(c.RootCAs...))
 	}
-
 	return opts
 }
 
@@ -236,7 +337,10 @@ func (c *ReplicaClient) initObjectStore(ctx context.Context) error {
 func (c *ReplicaClient) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	return c.close()
+}
 
+func (c *ReplicaClient) close() error {
 	if c.nc != nil {
 		c.nc.Close()
 		c.nc = nil

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -477,8 +477,7 @@ func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, max
 	// If offset is non-zero then discard the beginning bytes.
 	if offset > 0 {
 		if _, err := io.CopyN(io.Discard, objectResult, offset); err != nil {
-			objectResult.Close()
-			return nil, fmt.Errorf("failed to discard offset bytes: %w", err)
+			return nil, fmt.Errorf("failed to discard offset bytes: %w", errors.Join(err, objectResult.Close()))
 		}
 	}
 

--- a/nats/replica_client_test.go
+++ b/nats/replica_client_test.go
@@ -1,6 +1,9 @@
 package nats
 
 import (
+	"context"
+	"errors"
+	"net"
 	"testing"
 	"time"
 
@@ -11,6 +14,53 @@ func TestReplicaClient_Type(t *testing.T) {
 	client := NewReplicaClient()
 	if got, want := client.Type(), "nats"; got != want {
 		t.Fatalf("Type()=%s, want %s", got, want)
+	}
+}
+
+func TestReplicaClient_InitCancellation(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	client := NewReplicaClient()
+	client.URL = "nats://" + listener.Addr().String()
+	client.BucketName = "test"
+	client.Timeout = time.Minute
+	ctx, cancel := context.WithCancelCause(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- client.Init(ctx) }()
+
+	select {
+	case conn := <-accepted:
+		t.Cleanup(func() { _ = conn.Close() })
+	case err := <-acceptErr:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("NATS client did not connect")
+	}
+
+	cancelErr := errors.New("request canceled")
+	cancel(cancelErr)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, cancelErr) {
+			t.Fatalf("error=%v, want %v", err, cancelErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("NATS initialization did not stop after cancellation")
 	}
 }
 

--- a/nats/replica_client_test.go
+++ b/nats/replica_client_test.go
@@ -1,10 +1,13 @@
 package nats
 
 import (
+	"bufio"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,12 +30,56 @@ func TestReplicaClient_Type(t *testing.T) {
 func TestReplicaClient_LTXFiles_InitError(t *testing.T) {
 	client := NewReplicaClient()
 	client.BucketName = "missing-bucket"
-	client.nc = &natsgo.Conn{}
+	client.nc = openTestNATSConn(t)
 	client.js = &objectStoreErrorJetStream{err: jetstream.ErrBucketNotFound}
 
 	if _, err := client.LTXFiles(t.Context(), 0, 0, false); !errors.Is(err, jetstream.ErrBucketNotFound) {
 		t.Fatalf("LTXFiles() error = %v, want %v", err, jetstream.ErrBucketNotFound)
 	}
+}
+
+func openTestNATSConn(t *testing.T) *natsgo.Conn {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		if _, err := io.WriteString(conn, "INFO {}\r\n"); err != nil {
+			return
+		}
+		reader := bufio.NewReader(conn)
+		if _, err := reader.ReadString('\n'); err != nil {
+			return
+		}
+		if _, err := reader.ReadString('\n'); err != nil {
+			return
+		}
+		if _, err := io.WriteString(conn, "PONG\r\n"); err != nil {
+			return
+		}
+		for {
+			if _, err := reader.ReadByte(); err != nil {
+				return
+			}
+		}
+	}()
+
+	nc, err := natsgo.Connect("nats://"+listener.Addr().String(), natsgo.NoReconnect(), natsgo.Timeout(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(nc.Close)
+	return nc
 }
 
 func TestReplicaClient_options_TLS(t *testing.T) {
@@ -143,6 +190,53 @@ func writeTLSFiles(t *testing.T) (rootCAPath, certPath, keyPath string) {
 	}
 
 	return rootCAPath, certPath, keyPath
+}
+
+func TestReplicaClient_InitCancellation(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	client := NewReplicaClient()
+	client.URL = "nats://" + listener.Addr().String()
+	client.BucketName = "test"
+	client.Timeout = time.Minute
+	ctx, cancel := context.WithCancelCause(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- client.Init(ctx) }()
+
+	select {
+	case conn := <-accepted:
+		t.Cleanup(func() { _ = conn.Close() })
+	case err := <-acceptErr:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("NATS client did not connect")
+	}
+
+	cancelErr := errors.New("request canceled")
+	cancel(cancelErr)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, cancelErr) {
+			t.Fatalf("error=%v, want %v", err, cancelErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("NATS initialization did not stop after cancellation")
+	}
 }
 
 func TestReplicaClient_ltxPath(t *testing.T) {

--- a/oss/replica_client.go
+++ b/oss/replica_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
 	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/credentials"
+	osstransport "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/transport"
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -47,13 +49,15 @@ const DefaultRegion = "cn-hangzhou"
 const DefaultMetadataConcurrency = 50
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to Alibaba Cloud OSS.
 type ReplicaClient struct {
-	mu       sync.Mutex
-	client   *oss.Client
-	uploader *oss.Uploader
-	logger   *slog.Logger
+	mu        sync.Mutex
+	client    *oss.Client
+	uploader  *oss.Uploader
+	transport *http.Transport
+	logger    *slog.Logger
 
 	// Alibaba Cloud authentication keys.
 	AccessKeyID     string
@@ -131,6 +135,12 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 
 	// Build configuration
 	cfg := oss.LoadDefaultConfig()
+	httpClient := osstransport.NewHttpClient(&osstransport.Config{})
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		return fmt.Errorf("oss: unexpected http transport type %T", httpClient.Transport)
+	}
+	cfg = cfg.WithHttpClient(httpClient)
 
 	// Configure credentials
 	if c.AccessKeyID != "" && c.AccessKeySecret != "" {
@@ -173,7 +183,21 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		})
 	}
 	c.uploader = c.client.NewUploader(uploaderOpts...)
+	c.transport = transport
 
+	return nil
+}
+
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.transport != nil {
+		c.transport.CloseIdleConnections()
+		c.transport = nil
+	}
+	c.client = nil
+	c.uploader = nil
 	return nil
 }
 

--- a/oss/replica_client_test.go
+++ b/oss/replica_client_test.go
@@ -77,6 +77,39 @@ func TestReplicaClient_Init_Idempotent(t *testing.T) {
 	}
 }
 
+func TestReplicaClient_Close(t *testing.T) {
+	c := NewReplicaClient()
+	c.Bucket = "test-bucket"
+	c.AccessKeyID = "test-key"
+	c.AccessKeySecret = "test-secret"
+
+	if err := c.Init(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	transport := c.transport
+	if transport == nil {
+		t.Fatal("expected initialized transport")
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if c.client != nil || c.uploader != nil || c.transport != nil {
+		t.Fatal("expected client resources to be released")
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Init(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if c.transport == transport {
+		t.Fatal("expected a new transport after reinitialization")
+	}
+}
+
 func TestParseURL(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/replica_client.go
+++ b/replica_client.go
@@ -50,6 +50,11 @@ type ReplicaClient interface {
 	SetLogger(logger *slog.Logger)
 }
 
+// ReplicaClientCloser releases resources owned by a replica client.
+type ReplicaClientCloser interface {
+	Close() error
+}
+
 // FindLTXFiles returns a list of files that match filter.
 // The useMetadata parameter is passed through to LTXFiles to control whether accurate timestamps
 // are fetched from metadata. When true (timestamp-based restore), accurate timestamps are required.

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -546,6 +546,29 @@ func TestReplicaClient_SFTP_HostKeyValidation(t *testing.T) {
 	})
 }
 
+func TestReplicaClient_SFTP_Close(t *testing.T) {
+	privateKey := mustParseTestSFTPHostKey(t)
+	addr := testingutil.MockSFTPServer(t, privateKey)
+
+	c := testingutil.NewSFTPReplicaClient(t)
+	c.User = "foo"
+	c.Host = addr
+	c.HostKey = string(ssh.MarshalAuthorizedKey(privateKey.PublicKey()))
+
+	closer, ok := any(c).(litestream.ReplicaClientCloser)
+	if !ok {
+		t.Fatal("SFTP client does not implement cleanup contract")
+	}
+	for i := 0; i < 2; i++ {
+		if err := c.Init(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if err := closer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestReplicaClient_SFTP_WriteLTXFileAtomic(t *testing.T) {
 	privateKey := mustParseTestSFTPHostKey(t)
 	addr := testingutil.MockSFTPServer(t, privateKey)

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -74,14 +74,16 @@ const DefaultR2Concurrency = 2
 type contentMD5StackKey struct{}
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 var _ litestream.ReplicaClientV3 = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to S3.
 type ReplicaClient struct {
-	mu       sync.Mutex
-	s3       *s3.Client // s3 service
-	uploader *manager.Uploader
-	logger   *slog.Logger
+	mu        sync.Mutex
+	s3        *s3.Client // s3 service
+	uploader  *manager.Uploader
+	transport *http.Transport
+	logger    *slog.Logger
 
 	// AWS authentication keys.
 	AccessKeyID     string
@@ -369,7 +371,7 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// Always configure custom HTTP Transport with controlled keepalive settings
 	// to reduce idle CPU usage from default transport's aggressive keepalives.
 	// See: https://github.com/benbjohnson/litestream/issues/992
-	httpClient.Transport = &http.Transport{
+	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -381,10 +383,16 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+	defer func() {
+		if err != nil {
+			transport.CloseIdleConnections()
+		}
+	}()
+	httpClient.Transport = transport
 
 	// Configure TLS to skip verification if requested
 	if c.SkipVerify {
-		httpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
+		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
 	}
@@ -479,7 +487,22 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		})
 	}
 	c.uploader = manager.NewUploader(c.s3, uploaderOpts...)
+	c.transport = transport
 
+	return nil
+}
+
+// Close closes idle connections owned by the S3 client.
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.transport != nil {
+		c.transport.CloseIdleConnections()
+		c.transport = nil
+	}
+	c.s3 = nil
+	c.uploader = nil
 	return nil
 }
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -363,39 +363,12 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		}
 	}
 
-	// Create HTTP client with 24 hour timeout for long-running operations
-	httpClient := &http.Client{
-		Timeout: 24 * time.Hour,
-	}
-
-	// Always configure custom HTTP Transport with controlled keepalive settings
-	// to reduce idle CPU usage from default transport's aggressive keepalives.
-	// See: https://github.com/benbjohnson/litestream/issues/992
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	httpClient, transport := c.newHTTPClient()
 	defer func() {
 		if err != nil {
 			transport.CloseIdleConnections()
 		}
 	}()
-	httpClient.Transport = transport
-
-	// Configure TLS to skip verification if requested
-	if c.SkipVerify {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	}
 
 	// Build configuration options
 	configOpts := []func(*config.LoadOptions) error{
@@ -490,6 +463,27 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	c.transport = transport
 
 	return nil
+}
+
+func (c *ReplicaClient) newHTTPClient() (*http.Client, *http.Transport) {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if c.SkipVerify {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+	return &http.Client{Timeout: 24 * time.Hour, Transport: transport}, transport
 }
 
 // Close closes idle connections owned by the S3 client.
@@ -603,9 +597,13 @@ func newTransportRetryer() aws.Retryer {
 
 // findBucketRegion looks up the AWS region for a bucket. Returns blank if non-S3.
 func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (string, error) {
+	httpClient, transport := c.newHTTPClient()
+	defer transport.CloseIdleConnections()
+
 	// Build a config with credentials but no region
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithRetryer(newTransportRetryer),
+		config.WithHTTPClient(httpClient),
 	}
 
 	// Add static credentials if provided

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -81,14 +81,16 @@ const DefaultTigrisPartSize = 16 * 1024 * 1024
 type contentMD5StackKey struct{}
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 var _ litestream.ReplicaClientV3 = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files to S3.
 type ReplicaClient struct {
-	mu       sync.Mutex
-	s3       *s3.Client // s3 service
-	uploader *manager.Uploader
-	logger   *slog.Logger
+	mu        sync.Mutex
+	s3        *s3.Client // s3 service
+	uploader  *manager.Uploader
+	transport *http.Transport
+	logger    *slog.Logger
 
 	// AWS authentication keys.
 	AccessKeyID     string
@@ -389,7 +391,7 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// Always configure custom HTTP Transport with controlled keepalive settings
 	// to reduce idle CPU usage from default transport's aggressive keepalives.
 	// See: https://github.com/benbjohnson/litestream/issues/992
-	httpClient.Transport = &http.Transport{
+	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -401,10 +403,16 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+	defer func() {
+		if err != nil {
+			transport.CloseIdleConnections()
+		}
+	}()
+	httpClient.Transport = transport
 
 	// Configure TLS to skip verification if requested
 	if c.SkipVerify {
-		httpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
+		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
 	}
@@ -499,7 +507,22 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		})
 	}
 	c.uploader = manager.NewUploader(c.s3, uploaderOpts...)
+	c.transport = transport
 
+	return nil
+}
+
+// Close closes idle connections owned by the S3 client.
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.transport != nil {
+		c.transport.CloseIdleConnections()
+		c.transport = nil
+	}
+	c.s3 = nil
+	c.uploader = nil
 	return nil
 }
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -383,39 +383,12 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 		}
 	}
 
-	// Create HTTP client with 24 hour timeout for long-running operations
-	httpClient := &http.Client{
-		Timeout: 24 * time.Hour,
-	}
-
-	// Always configure custom HTTP Transport with controlled keepalive settings
-	// to reduce idle CPU usage from default transport's aggressive keepalives.
-	// See: https://github.com/benbjohnson/litestream/issues/992
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	httpClient, transport := c.newHTTPClient()
 	defer func() {
 		if err != nil {
 			transport.CloseIdleConnections()
 		}
 	}()
-	httpClient.Transport = transport
-
-	// Configure TLS to skip verification if requested
-	if c.SkipVerify {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	}
 
 	// Build configuration options
 	configOpts := []func(*config.LoadOptions) error{
@@ -510,6 +483,27 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	c.transport = transport
 
 	return nil
+}
+
+func (c *ReplicaClient) newHTTPClient() (*http.Client, *http.Transport) {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if c.SkipVerify {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+	return &http.Client{Timeout: 24 * time.Hour, Transport: transport}, transport
 }
 
 // Close closes idle connections owned by the S3 client.
@@ -636,9 +630,13 @@ func newTransportRetryer() aws.Retryer {
 
 // findBucketRegion looks up the AWS region for a bucket. Returns blank if non-S3.
 func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (string, error) {
+	httpClient, transport := c.newHTTPClient()
+	defer transport.CloseIdleConnections()
+
 	// Build a config with credentials but no region
 	configOpts := []func(*config.LoadOptions) error{
 		config.WithRetryer(newTransportRetryer),
+		config.WithHTTPClient(httpClient),
 	}
 
 	// Add static credentials if provided

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -87,6 +88,57 @@ func TestIsNotExists(t *testing.T) {
 	}
 	if !isNotExists(wrappedErr) {
 		t.Error("isNotExists should return true for wrapped NoSuchKey error")
+	}
+}
+
+func TestReplicaClient_findBucketRegionClosesTransport(t *testing.T) {
+	idle := make(chan struct{}, 1)
+	closed := make(chan struct{}, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-west-2</LocationConstraint>`)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateIdle:
+			select {
+			case idle <- struct{}{}:
+			default:
+			}
+		case http.StateClosed:
+			select {
+			case closed <- struct{}{}:
+			default:
+			}
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	c := NewReplicaClient()
+	c.Bucket = "test-bucket"
+	c.Endpoint = server.URL
+	c.ForcePathStyle = true
+	c.AccessKeyID = "test-key"
+	c.SecretAccessKey = "test-secret"
+
+	region, err := c.findBucketRegion(t.Context(), c.Bucket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := region, "us-west-2"; got != want {
+		t.Fatalf("region=%q, want %q", got, want)
+	}
+
+	select {
+	case <-idle:
+	default:
+		t.Fatal("expected region lookup connection to become idle")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("region lookup transport did not close its idle connection")
 	}
 }
 

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -132,7 +132,7 @@ func TestReplicaClient_findBucketRegionClosesTransport(t *testing.T) {
 
 	select {
 	case <-idle:
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("expected region lookup connection to become idle")
 	}
 	select {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -94,6 +95,57 @@ func TestIsNotExists(t *testing.T) {
 	}
 	if !isNotExists(wrappedErr) {
 		t.Error("isNotExists should return true for wrapped NoSuchKey error")
+	}
+}
+
+func TestReplicaClient_findBucketRegionClosesTransport(t *testing.T) {
+	idle := make(chan struct{}, 1)
+	closed := make(chan struct{}, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-west-2</LocationConstraint>`)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateIdle:
+			select {
+			case idle <- struct{}{}:
+			default:
+			}
+		case http.StateClosed:
+			select {
+			case closed <- struct{}{}:
+			default:
+			}
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	c := NewReplicaClient()
+	c.Bucket = "test-bucket"
+	c.Endpoint = server.URL
+	c.ForcePathStyle = true
+	c.AccessKeyID = "test-key"
+	c.SecretAccessKey = "test-secret"
+
+	region, err := c.findBucketRegion(t.Context(), c.Bucket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := region, "us-west-2"; got != want {
+		t.Fatalf("region=%q, want %q", got, want)
+	}
+
+	select {
+	case <-idle:
+	default:
+		t.Fatal("expected region lookup connection to become idle")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("region lookup transport did not close its idle connection")
 	}
 }
 

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -139,7 +139,7 @@ func TestReplicaClient_findBucketRegionClosesTransport(t *testing.T) {
 
 	select {
 	case <-idle:
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("expected region lookup connection to become idle")
 	}
 	select {

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -35,6 +35,7 @@ const (
 )
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 
 // ReplicaClient is a client for writing LTX files over SFTP.
 type ReplicaClient struct {
@@ -135,6 +136,7 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *sftp.Client, err error) {
 		User:            c.User,
 		HostKeyCallback: hostkey,
 		BannerCallback:  ssh.BannerDisplayStderr(),
+		Timeout:         c.DialTimeout,
 	}
 	if c.Password != "" {
 		config.Auth = append(config.Auth, ssh.Password(c.Password))
@@ -159,10 +161,39 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *sftp.Client, err error) {
 		host = net.JoinHostPort(c.Host, "22")
 	}
 
-	// Connect via SSH.
-	if c.sshClient, err = ssh.Dial("tcp", host, config); err != nil {
+	conn, err := (&net.Dialer{Timeout: c.DialTimeout}).DialContext(ctx, "tcp", host)
+	if err != nil {
+		if context.Cause(ctx) != nil {
+			return nil, context.Cause(ctx)
+		}
 		return nil, err
 	}
+	var cancelCloseErr error
+	cancelCloseDone := make(chan struct{})
+	stopCancelClose := context.AfterFunc(ctx, func() {
+		cancelCloseErr = conn.Close()
+		close(cancelCloseDone)
+	})
+	waitForCancellation := func() error {
+		if !stopCancelClose() {
+			<-cancelCloseDone
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return errors.Join(cause, cancelCloseErr)
+		}
+		return nil
+	}
+	if c.DialTimeout > 0 {
+		if err := conn.SetDeadline(time.Now().Add(c.DialTimeout)); err != nil {
+			return nil, errors.Join(err, waitForCancellation(), conn.Close())
+		}
+	}
+
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, host, config)
+	if err != nil {
+		return nil, errors.Join(err, waitForCancellation(), conn.Close())
+	}
+	sshClient := ssh.NewClient(sshConn, chans, reqs)
 
 	// Wrap connection with an SFTP client.
 	// Configure options based on client settings
@@ -171,13 +202,37 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *sftp.Client, err error) {
 		opts = append(opts, sftp.UseConcurrentWrites(true))
 	}
 
-	if c.sftpClient, err = sftp.NewClient(c.sshClient, opts...); err != nil {
-		c.sshClient.Close()
-		c.sshClient = nil
-		return nil, err
+	sftpClient, err := sftp.NewClient(sshClient, opts...)
+	if err != nil {
+		return nil, errors.Join(err, waitForCancellation(), sshClient.Close())
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		return nil, errors.Join(err, waitForCancellation(), sftpClient.Close(), sshClient.Close())
+	}
+	if err := waitForCancellation(); err != nil {
+		return nil, errors.Join(err, sftpClient.Close(), sshClient.Close())
 	}
 
-	return c.sftpClient, nil
+	c.sshClient = sshClient
+	c.sftpClient = sftpClient
+	return sftpClient, nil
+}
+
+// Close closes the SFTP and SSH connections.
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var err error
+	if c.sftpClient != nil {
+		err = errors.Join(err, c.sftpClient.Close())
+		c.sftpClient = nil
+	}
+	if c.sshClient != nil {
+		err = errors.Join(err, c.sshClient.Close())
+		c.sshClient = nil
+	}
+	return err
 }
 
 // DeleteAll deletes all LTX files.

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -112,6 +112,10 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *sftp.Client, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
+	}
+
 	if c.sftpClient != nil {
 		return c.sftpClient, nil
 	}
@@ -207,10 +211,10 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *sftp.Client, err error) {
 		return nil, errors.Join(err, waitForCancellation(), sshClient.Close())
 	}
 	if err := conn.SetDeadline(time.Time{}); err != nil {
-		return nil, errors.Join(err, waitForCancellation(), sftpClient.Close(), sshClient.Close())
+		return nil, errors.Join(err, waitForCancellation(), sshClient.Close(), sftpClient.Close())
 	}
 	if err := waitForCancellation(); err != nil {
-		return nil, errors.Join(err, sftpClient.Close(), sshClient.Close())
+		return nil, errors.Join(err, sshClient.Close(), sftpClient.Close())
 	}
 
 	c.sshClient = sshClient
@@ -223,21 +227,25 @@ func (c *ReplicaClient) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var err error
-	if c.sftpClient != nil {
-		err = errors.Join(err, c.sftpClient.Close())
-		c.sftpClient = nil
+	sftpClient, sshClient := c.sftpClient, c.sshClient
+	c.sftpClient, c.sshClient = nil, nil
+
+	var sshErr, sftpErr error
+	if sshClient != nil {
+		sshErr = sshClient.Close()
 	}
-	if c.sshClient != nil {
-		err = errors.Join(err, c.sshClient.Close())
-		c.sshClient = nil
+	if sftpClient != nil {
+		sftpErr = sftpClient.Close()
+		if errors.Is(sftpErr, io.EOF) || errors.Is(sftpErr, net.ErrClosed) {
+			sftpErr = nil
+		}
 	}
-	return err
+	return errors.Join(sshErr, sftpErr)
 }
 
 // DeleteAll deletes all LTX files.
 func (c *ReplicaClient) DeleteAll(ctx context.Context) (err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -281,7 +289,7 @@ func (c *ReplicaClient) DeleteAll(ctx context.Context) (err error) {
 // SFTP uses file ModTime for timestamps, which is set via Chtimes() to preserve original timestamp.
 // The useMetadata parameter is ignored since ModTime always contains the accurate timestamp.
 func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, _ bool) (_ ltx.FileIterator, err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -320,7 +328,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 
 // WriteLTXFile writes a LTX file from rd into a remote file.
 func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, rd io.Reader) (info *ltx.FileInfo, err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -392,7 +400,7 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 // OpenLTXFile returns a reader for an LTX file.
 // Returns os.ErrNotExist if no matching position is found.
 func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (_ io.ReadCloser, err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -421,7 +429,7 @@ func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, max
 
 // DeleteLTXFiles deletes LTX files with at the given positions.
 func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) (err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -444,7 +452,7 @@ func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) (
 
 // Cleanup deletes path & directories after empty.
 func (c *ReplicaClient) Cleanup(ctx context.Context) (err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -458,17 +466,9 @@ func (c *ReplicaClient) Cleanup(ctx context.Context) (err error) {
 }
 
 // resetOnConnError closes & clears the client if a connection error occurs.
-func (c *ReplicaClient) resetOnConnError(err error) {
-	if !errors.Is(err, sftp.ErrSSHFxConnectionLost) {
+func (c *ReplicaClient) resetOnConnError(err *error) {
+	if !errors.Is(*err, sftp.ErrSSHFxConnectionLost) {
 		return
 	}
-
-	if c.sftpClient != nil {
-		c.sftpClient.Close()
-		c.sftpClient = nil
-	}
-	if c.sshClient != nil {
-		c.sshClient.Close()
-		c.sshClient = nil
-	}
+	*err = errors.Join(*err, c.Close())
 }

--- a/sftp/replica_client_test.go
+++ b/sftp/replica_client_test.go
@@ -1,0 +1,56 @@
+package sftp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestReplicaClient_InitCancellation(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	client := NewReplicaClient()
+	client.Host = listener.Addr().String()
+	client.User = "test"
+	client.DialTimeout = time.Minute
+	ctx, cancel := context.WithCancelCause(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- client.Init(ctx) }()
+
+	select {
+	case conn := <-accepted:
+		t.Cleanup(func() { _ = conn.Close() })
+	case err := <-acceptErr:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("SFTP client did not connect")
+	}
+
+	cancelErr := errors.New("request canceled")
+	cancel(cancelErr)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, cancelErr) {
+			t.Fatalf("error=%v, want %v", err, cancelErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SFTP initialization did not stop after cancellation")
+	}
+}

--- a/sftp/replica_client_test.go
+++ b/sftp/replica_client_test.go
@@ -2,10 +2,15 @@ package sftp
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestReplicaClient_InitCancellation(t *testing.T) {
@@ -53,4 +58,125 @@ func TestReplicaClient_InitCancellation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("SFTP initialization did not stop after cancellation")
 	}
+}
+
+func TestReplicaClient_CloseInterruptsRequest(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := &ssh.ServerConfig{NoClientAuth: true}
+	config.AddHostKey(signer)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+		if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			serverErr <- err
+			return
+		}
+		_, channels, requests, err := ssh.NewServerConn(conn, config)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		go ssh.DiscardRequests(requests)
+		for ch := range channels {
+			channel, requests, err := ch.Accept()
+			if err != nil {
+				serverErr <- err
+				return
+			}
+			for request := range requests {
+				if request.Type != "subsystem" {
+					if err := request.Reply(false, nil); err != nil {
+						serverErr <- err
+						return
+					}
+					continue
+				}
+				if err := request.Reply(true, nil); err != nil {
+					serverErr <- err
+					return
+				}
+				server := sftp.NewRequestServer(channel, sftp.Handlers{FileList: &blockedFileLister{started: started, release: release}})
+				serverErr <- errors.Join(server.Serve(), server.Close())
+				return
+			}
+		}
+	}()
+
+	client := NewReplicaClient()
+	client.Host = listener.Addr().String()
+	client.User = "test"
+	client.HostKey = string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+	t.Cleanup(func() { _ = client.Close() })
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	if err := client.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	canceledCtx, cancelCause := context.WithCancelCause(ctx)
+	cause := errors.New("request canceled")
+	cancelCause(cause)
+	if err := client.Init(canceledCtx); !errors.Is(err, cause) {
+		t.Fatalf("cached Init error = %v, want %v", err, cause)
+	}
+	requestErr := make(chan error, 1)
+	go func() {
+		_, err := client.LTXFiles(ctx, 0, 0, false)
+		requestErr <- err
+	}()
+	select {
+	case <-started:
+	case err := <-serverErr:
+		t.Fatalf("server: %v", err)
+	case <-ctx.Done():
+		t.Fatal("directory request did not reach server")
+	}
+	closeErr := make(chan error, 1)
+	go func() { closeErr <- client.Close() }()
+	select {
+	case err := <-closeErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Close blocked on stalled directory request")
+	}
+	select {
+	case err := <-requestErr:
+		if err == nil {
+			t.Fatal("stalled directory request succeeded")
+		}
+	case <-ctx.Done():
+		t.Fatal("directory request did not stop after Close")
+	}
+}
+
+type blockedFileLister struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (l *blockedFileLister) Filelist(*sftp.Request) (sftp.ListerAt, error) {
+	close(l.started)
+	<-l.release
+	return nil, errors.New("request released")
 }

--- a/webdav/replica_client.go
+++ b/webdav/replica_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -106,16 +107,18 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *gowebdav.Client, err error
 		return nil, fmt.Errorf("webdav url required")
 	}
 
-	c.client = gowebdav.NewClient(c.URL, c.Username, c.Password)
-
-	c.client.SetTimeout(c.Timeout)
-
-	if err := c.client.Connect(); err != nil {
-		c.client = nil
+	client := gowebdav.NewClient(c.URL, c.Username, c.Password)
+	client.SetTimeout(c.Timeout)
+	client.SetInterceptor(func(_ string, req *http.Request) {
+		*req = *req.WithContext(ctx)
+	})
+	if err := client.Connect(); err != nil {
 		return nil, fmt.Errorf("webdav: cannot connect to server: %w", err)
 	}
+	client.SetInterceptor(nil)
 
-	return c.client, nil
+	c.client = client
+	return client, nil
 }
 
 func (c *ReplicaClient) DeleteAll(ctx context.Context) error {

--- a/webdav/replica_client.go
+++ b/webdav/replica_client.go
@@ -33,6 +33,7 @@ const (
 )
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
+var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 
 type ReplicaClient struct {
 	mu     sync.Mutex
@@ -92,6 +93,14 @@ func (c *ReplicaClient) Type() string {
 func (c *ReplicaClient) Init(ctx context.Context) error {
 	_, err := c.init(ctx)
 	return err
+}
+
+func (c *ReplicaClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.client = nil
+	return nil
 }
 
 // init initializes the connection and returns the WebDAV client.

--- a/webdav/replica_client.go
+++ b/webdav/replica_client.go
@@ -3,6 +3,7 @@ package webdav
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,9 +37,10 @@ var _ litestream.ReplicaClient = (*ReplicaClient)(nil)
 var _ litestream.ReplicaClientCloser = (*ReplicaClient)(nil)
 
 type ReplicaClient struct {
-	mu     sync.Mutex
-	client *gowebdav.Client
-	logger *slog.Logger
+	mu        sync.Mutex
+	transport *http.Transport
+	connected bool
+	logger    *slog.Logger
 
 	URL      string
 	Username string
@@ -99,7 +101,11 @@ func (c *ReplicaClient) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.client = nil
+	if c.transport != nil {
+		c.transport.CloseIdleConnections()
+		c.transport = nil
+	}
+	c.connected = false
 	return nil
 }
 
@@ -108,25 +114,37 @@ func (c *ReplicaClient) init(ctx context.Context) (_ *gowebdav.Client, err error
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.client != nil {
-		return c.client, nil
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
 	}
 
 	if c.URL == "" {
 		return nil, fmt.Errorf("webdav url required")
 	}
 
+	if c.transport == nil {
+		c.transport = &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: time.Second,
+		}
+	}
 	client := gowebdav.NewClient(c.URL, c.Username, c.Password)
+	client.SetTransport(c.transport)
 	client.SetTimeout(c.Timeout)
 	client.SetInterceptor(func(_ string, req *http.Request) {
 		*req = *req.WithContext(ctx)
 	})
-	if err := client.Connect(); err != nil {
-		return nil, fmt.Errorf("webdav: cannot connect to server: %w", err)
+	if !c.connected {
+		if err := client.Connect(); err != nil {
+			c.transport.CloseIdleConnections()
+			return nil, fmt.Errorf("webdav: cannot connect to server: %w", err)
+		}
+		c.connected = true
 	}
-	client.SetInterceptor(nil)
-
-	c.client = client
 	return client, nil
 }
 
@@ -271,8 +289,7 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 		return nil, fmt.Errorf("webdav: cannot create temp file: %w", err)
 	}
 	defer func() {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
+		err = errors.Join(err, tmpFile.Close(), os.Remove(tmpFile.Name()))
 	}()
 
 	fullReader := io.MultiReader(&buf, rd)
@@ -294,7 +311,7 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	// WriteStreamWithLength requires both a seekable reader and known size,
 	// which we now have from the temp file. This avoids chunked encoding
 	// and ensures reliable uploads across all WebDAV server configurations.
-	if err := client.WriteStreamWithLength(filename, tmpFile, size, 0644); err != nil {
+	if err := client.WriteStreamWithLength(filename, struct{ io.ReadSeeker }{tmpFile}, size, 0644); err != nil {
 		return nil, fmt.Errorf("webdav: cannot write file %q: %w", filename, err)
 	}
 
@@ -342,11 +359,12 @@ func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, max
 
 		if _, err := io.CopyN(io.Discard, rc, offset); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				_ = rc.Close()
+				if closeErr := rc.Close(); closeErr != nil {
+					return nil, fmt.Errorf("webdav: cannot close file %q: %w", filename, closeErr)
+				}
 				return io.NopCloser(bytes.NewReader(nil)), nil
 			}
-			_ = rc.Close()
-			return nil, fmt.Errorf("webdav: cannot skip offset in file %q: %w", filename, err)
+			return nil, fmt.Errorf("webdav: cannot skip offset in file %q: %w", filename, errors.Join(err, rc.Close()))
 		}
 
 		return rc, nil

--- a/webdav/replica_client_test.go
+++ b/webdav/replica_client_test.go
@@ -3,6 +3,7 @@ package webdav_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,6 +34,45 @@ func TestReplicaClient_Init_RequiresURL(t *testing.T) {
 		t.Fatal("expected error when URL is empty")
 	} else if got, want := err.Error(), "webdav url required"; got != want {
 		t.Fatalf("error=%v, want %v", got, want)
+	}
+}
+
+func TestReplicaClient_InitCancellation(t *testing.T) {
+	requestStarted := make(chan struct{}, 1)
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestStarted <- struct{}{}
+		select {
+		case <-r.Context().Done():
+		case <-handlerDone:
+		}
+	}))
+	t.Cleanup(func() {
+		close(handlerDone)
+		server.Close()
+	})
+
+	c := newTestReplicaClient(server.URL)
+	c.Timeout = time.Minute
+	ctx, cancel := context.WithCancelCause(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- c.Init(ctx) }()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("WebDAV client did not connect")
+	}
+
+	cancelErr := errors.New("request canceled")
+	cancel(cancelErr)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, cancelErr) {
+			t.Fatalf("error=%v, want %v", err, cancelErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WebDAV initialization did not stop after cancellation")
 	}
 }
 

--- a/webdav/replica_client_test.go
+++ b/webdav/replica_client_test.go
@@ -337,3 +337,99 @@ func parseRange(header string, size int) (start, end int, err error) {
 	}
 	return start, end, nil
 }
+
+func TestReplicaClient_PostInitCancellation(t *testing.T) {
+	for _, method := range []string{"PROPFIND", http.MethodGet} {
+		t.Run(method, func(t *testing.T) {
+			started := make(chan struct{})
+			var startOnce sync.Once
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodOptions {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if r.Method != method {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				if method == http.MethodGet {
+					w.Header().Set("Content-Length", "100")
+					w.WriteHeader(http.StatusOK)
+					w.(http.Flusher).Flush()
+				}
+				startOnce.Do(func() { close(started) })
+				select {
+				case <-r.Context().Done():
+				case <-release:
+				}
+			}))
+			t.Cleanup(func() {
+				close(release)
+				server.Close()
+			})
+			c := newTestReplicaClient(server.URL)
+			c.Timeout = time.Minute
+			t.Cleanup(func() {
+				if err := c.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			initCtx, initCancel := context.WithCancel(t.Context())
+			if err := c.Init(initCtx); err != nil {
+				t.Fatal(err)
+			}
+			initCancel()
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+			done := make(chan error, 1)
+			opened := make(chan struct{})
+			go func() {
+				if method == "PROPFIND" {
+					itr, err := c.LTXFiles(ctx, 0, 0, false)
+					if itr != nil {
+						err = errors.Join(err, itr.Close())
+					}
+					done <- err
+					return
+				}
+				rc, err := c.OpenLTXFile(ctx, 0, 1, 1, 0, 0)
+				if err == nil {
+					close(opened)
+					_, err = io.ReadAll(rc)
+					err = errors.Join(err, rc.Close())
+				}
+				done <- err
+			}()
+			select {
+			case <-started:
+			case <-time.After(2 * time.Second):
+				t.Fatal("post-init operation did not start")
+			}
+			if method == http.MethodGet {
+				select {
+				case <-opened:
+				case <-time.After(2 * time.Second):
+					t.Fatal("GET did not return response body")
+				}
+			}
+			independentCtx, independentCancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer independentCancel()
+			if err := c.DeleteAll(independentCtx); err != nil {
+				t.Fatalf("independent operation while request pending: %v", err)
+			}
+			cancel()
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("error=%v, want context canceled", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("post-init operation did not stop after cancellation")
+			}
+			if err := c.DeleteAll(independentCtx); err != nil {
+				t.Fatalf("independent operation after cancellation: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Replace the remaining MCP tool subprocess calls with Litestream's in-process configuration, database, replica, restore, and storage APIs.

**In scope:**
- Load configured databases through `ReadConfigFile` and `NewDBFromConfig`
- Restore configured database paths and direct replica URLs through `Replica.Restore` and `Replica.CalcRestoreTarget`
- List LTX files through `ReplicaClient.LTXFiles`
- Report local and remote replication status through `DB.SyncStatus`
- Reset local state through `DB.ResetLocalState`
- Preserve MCP text output and conditional restore behavior
- Add regression coverage for local database paths and replica URLs with no `litestream` binary on `PATH`

**Not in scope:**
- Daemon-control MCP tools tracked by #1372
- Connected remote-daemon behavior

## Motivation and Context

The MCP handlers previously contained seven `exec.CommandContext(ctx, "litestream", ...)` call sites. This made each tool depend on whichever binary `PATH` resolved, added process-spawn overhead, discarded typed errors, and allowed the running MCP server to disagree with the executable it invoked.

The regression tests clear `PATH` before exercising databases, info, LTX, status, restore, reset, and version behavior. They cover both configured local database paths and direct file-backed replica URLs.

Current `main` still contains the version shell-out addressed by #1365/#1375, so this branch includes the equivalent in-process version behavior needed to ensure no MCP handler retains a `PATH` dependency.

Closes #1367

## How Has This Been Tested?

```bash
go test ./cmd/litestream -run 'Test(MCPReadToolsRunWithoutLitestreamOnPATH|RestoreTool|ResetToolRunWithoutLitestreamOnPATH|VersionToolRunWithoutLitestreamOnPATH)' -count=1
go test ./... -count=1
go test -race ./... -count=1
go build ./...
go vet ./...
pre-commit run --all-files
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
