### PR TITLE
feat(mcp): return structured JSON tool output alongside text

### DIFF
--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -94,7 +94,7 @@ type databasesInput struct {
 }
 
 type databasesOutput struct {
-	Text string `json:"text" jsonschema:"Databases and replicas from the Litestream config file."`
+	Databases []DatabaseInfo `json:"databases" jsonschema:"Databases and replicas from the Litestream config file."`
 }
 
 func DatabasesTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[databasesInput, databasesOutput]) {
@@ -106,19 +106,18 @@ func DatabasesTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[databasesIn
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input databasesInput) (*mcp.CallToolResult, databasesOutput, error) {
-		args := []string{"databases"}
+		args := []string{"databases", "-json"}
 		config := configPath
 		if input.Config != nil {
 			config = *input.Config
 		}
 		args = append(args, "-config", config)
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		databases, err := runJSONCommand[[]DatabaseInfo](ctx, args...)
 		if err != nil {
-			return nil, databasesOutput{}, commandError(output, err)
+			return nil, databasesOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), databasesOutput{Text: text}, nil
+		text := fmt.Sprintf("Found %s.", countNoun(len(databases), "configured database", "configured databases"))
+		return textResult(text), databasesOutput{Databases: databases}, nil
 	}
 }
 
@@ -126,8 +125,15 @@ type infoInput struct {
 	Config *string `json:"config,omitempty" jsonschema:"Path to the Litestream config file. Optional."`
 }
 
+type infoDatabaseOutput struct {
+	DatabaseInfo
+	LTXFiles []LTXFileInfo `json:"ltx_files" jsonschema:"LTX files for the database."`
+}
+
 type infoOutput struct {
-	Text string `json:"text" jsonschema:"Comprehensive Litestream status report."`
+	Version   string               `json:"version" jsonschema:"Running Litestream instance version."`
+	Config    string               `json:"config" jsonschema:"Path to the Litestream config file."`
+	Databases []infoDatabaseOutput `json:"databases" jsonschema:"Configured databases and their LTX files."`
 }
 
 func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoOutput]) {
@@ -139,69 +145,43 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input infoInput) (*mcp.CallToolResult, infoOutput, error) {
-		var summary strings.Builder
-		summary.WriteString("=== Litestream Status Report ===\n\n")
-
-		versionCmd := exec.CommandContext(ctx, "litestream", "version")
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			return nil, infoOutput{}, fmt.Errorf("get version info: %w", commandError(versionOutput, err))
-		}
-		summary.WriteString("Version Information:\n")
-		summary.WriteString(string(versionOutput))
-		summary.WriteString("\n")
-
-		args := []string{"databases"}
 		config := configPath
 		if input.Config != nil {
 			config = *input.Config
 		}
-		summary.WriteString("Current Config Path:\n")
-		summary.WriteString(config + "\n\n")
 
-		args = append(args, "-config", config)
-		dbCmd := exec.CommandContext(ctx, "litestream", args...)
-		dbOutput, err := dbCmd.CombinedOutput()
+		databases, err := runJSONCommand[[]DatabaseInfo](ctx, "databases", "-json", "-config", config)
 		if err != nil {
-			return nil, infoOutput{}, fmt.Errorf("get databases info: %w", commandError(dbOutput, err))
+			return nil, infoOutput{}, fmt.Errorf("get databases info: %w", err)
 		}
 
-		summary.WriteString("Databases:\n")
-		summary.WriteString(string(dbOutput))
-		summary.WriteString("\n")
-
-		scanner := bufio.NewScanner(strings.NewReader(string(dbOutput)))
-		scanner.Scan()
-		var dbPaths []string
-		for scanner.Scan() {
-			fields := strings.Fields(scanner.Text())
-			if len(fields) > 0 {
-				dbPaths = append(dbPaths, fields[0])
-			}
+		output := infoOutput{
+			Version:   Version,
+			Config:    config,
+			Databases: make([]infoDatabaseOutput, 0, len(databases)),
 		}
-		if err := scanner.Err(); err != nil {
-			return nil, infoOutput{}, fmt.Errorf("scan databases info: %w", err)
-		}
-
-		summary.WriteString("LTX Files:\n")
-		for _, dbPath := range dbPaths {
-			ltxArgs := []string{"ltx"}
+		ltxFileCount := 0
+		for _, database := range databases {
+			ltxArgs := []string{"ltx", "-json"}
 			if config != "" {
 				ltxArgs = append(ltxArgs, "-config", config)
 			}
-			ltxArgs = append(ltxArgs, dbPath)
-			ltxCmd := exec.CommandContext(ctx, "litestream", ltxArgs...)
-			ltxOutput, err := ltxCmd.CombinedOutput()
+			ltxArgs = append(ltxArgs, database.Path)
+			files, err := runJSONCommand[[]LTXFileInfo](ctx, ltxArgs...)
 			if err != nil {
-				return nil, infoOutput{}, fmt.Errorf("get LTX files for %s: %w", dbPath, commandError(ltxOutput, err))
+				return nil, infoOutput{}, fmt.Errorf("get LTX files for %s: %w", database.Path, err)
 			}
-			summary.WriteString("Database: " + dbPath + "\n")
-			summary.WriteString(string(ltxOutput))
-			summary.WriteString("\n")
+			ltxFileCount += len(files)
+			output.Databases = append(output.Databases, infoDatabaseOutput{
+				DatabaseInfo: database,
+				LTXFiles:     files,
+			})
 		}
 
-		text := summary.String()
-		return textResult(text), infoOutput{Text: text}, nil
+		text := fmt.Sprintf("Litestream %s has %s and %s.", Version,
+			countNoun(len(databases), "configured database", "configured databases"),
+			countNoun(ltxFileCount, "LTX file", "LTX files"))
+		return textResult(text), output, nil
 	}
 }
 
@@ -217,7 +197,8 @@ type restoreInput struct {
 }
 
 type restoreOutput struct {
-	Text string `json:"text" jsonschema:"Restore command output."`
+	Status string         `json:"status" jsonschema:"Restore command outcome."`
+	Result *RestoreResult `json:"result,omitempty" jsonschema:"Restore details when a database was restored."`
 }
 
 func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput, restoreOutput]) {
@@ -229,7 +210,7 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input restoreInput) (*mcp.CallToolResult, restoreOutput, error) {
-		args := []string{"restore"}
+		args := []string{"restore", "-json"}
 		if input.Output != nil {
 			args = append(args, "-o", *input.Output)
 		}
@@ -262,20 +243,32 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		stdout, _, err := runCommand(ctx, args...)
 		if err != nil {
-			return nil, restoreOutput{}, commandError(output, err)
+			return nil, restoreOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), restoreOutput{Text: text}, nil
+		if len(bytes.TrimSpace(stdout)) == 0 {
+			output := restoreOutput{Status: "skipped"}
+			return textResult(fmt.Sprintf("Restore skipped for %s.", input.Path)), output, nil
+		}
+
+		var result RestoreResult
+		if err := json.Unmarshal(stdout, &result); err != nil {
+			return nil, restoreOutput{}, fmt.Errorf("decode restore JSON output: %w", err)
+		}
+		text := fmt.Sprintf("Restored %s using the %s replica", result.DBPath, result.Replica)
+		if result.TXID != "" {
+			text += " at TXID " + result.TXID
+		}
+		text += "."
+		return textResult(text), restoreOutput{Status: "restored", Result: &result}, nil
 	}
 }
 
 type versionInput struct{}
 
 type versionOutput struct {
-	Text string `json:"text" jsonschema:"Running Litestream instance version."`
+	Version string `json:"version" jsonschema:"Running Litestream instance version."`
 }
 
 func VersionTool() (*mcp.Tool, mcp.ToolHandlerFor[versionInput, versionOutput]) {
@@ -286,8 +279,7 @@ func VersionTool() (*mcp.Tool, mcp.ToolHandlerFor[versionInput, versionOutput]) 
 	}
 
 	return tool, func(context.Context, *mcp.CallToolRequest, versionInput) (*mcp.CallToolResult, versionOutput, error) {
-		text := Version + "\n"
-		return textResult(text), versionOutput{Text: text}, nil
+		return textResult(fmt.Sprintf("Litestream %s.", Version)), versionOutput{Version: Version}, nil
 	}
 }
 
@@ -297,7 +289,7 @@ type ltxInput struct {
 }
 
 type ltxOutput struct {
-	Text string `json:"text" jsonschema:"LTX files for the database or replica URL."`
+	Files []LTXFileInfo `json:"files" jsonschema:"LTX files for the database or replica URL."`
 }
 
 func LTXTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[ltxInput, ltxOutput]) {
@@ -309,7 +301,7 @@ func LTXTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[ltxInput, ltxOutp
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input ltxInput) (*mcp.CallToolResult, ltxOutput, error) {
-		args := []string{"ltx"}
+		args := []string{"ltx", "-json"}
 
 		if !isReplicaURL(input.Path) {
 			config := configPath
@@ -324,13 +316,12 @@ func LTXTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[ltxInput, ltxOutp
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		files, err := runJSONCommand[[]LTXFileInfo](ctx, args...)
 		if err != nil {
-			return nil, ltxOutput{}, commandError(output, err)
+			return nil, ltxOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), ltxOutput{Text: text}, nil
+		text := fmt.Sprintf("Found %s for %s.", countNoun(len(files), "LTX file", "LTX files"), input.Path)
+		return textResult(text), ltxOutput{Files: files}, nil
 	}
 }
 
@@ -340,7 +331,7 @@ type statusInput struct {
 }
 
 type statusOutput struct {
-	Text string `json:"text" jsonschema:"Litestream replication status."`
+	Databases []DBStatus `json:"databases" jsonschema:"Replication status for configured databases."`
 }
 
 func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, statusOutput]) {
@@ -352,7 +343,7 @@ func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, s
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input statusInput) (*mcp.CallToolResult, statusOutput, error) {
-		args := []string{"status"}
+		args := []string{"status", "-json"}
 		config := configPath
 		if input.Config != nil {
 			config = *input.Config
@@ -361,13 +352,12 @@ func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, s
 		if input.Path != nil {
 			args = append(args, *input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		statuses, err := runJSONCommand[[]DBStatus](ctx, args...)
 		if err != nil {
-			return nil, statusOutput{}, commandError(output, err)
+			return nil, statusOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), statusOutput{Text: text}, nil
+		text := fmt.Sprintf("Reported replication status for %s.", countNoun(len(statuses), "database", "databases"))
+		return textResult(text), statusOutput{Databases: statuses}, nil
 	}
 }
 
@@ -377,7 +367,8 @@ type resetInput struct {
 }
 
 type resetOutput struct {
-	Text string `json:"text" jsonschema:"Reset command output."`
+	Path   string `json:"path" jsonschema:"Database path passed to the reset command."`
+	Status string `json:"status" jsonschema:"Reset command outcome."`
 }
 
 func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, resetOutput]) {
@@ -398,13 +389,12 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		_, _, err := runCommand(ctx, args...)
 		if err != nil {
-			return nil, resetOutput{}, commandError(output, err)
+			return nil, resetOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), resetOutput{Text: text}, nil
+		text := fmt.Sprintf("Reset command completed for %s.", input.Path)
+		return textResult(text), resetOutput{Path: input.Path, Status: "completed"}, nil
 	}
 }
 
@@ -412,11 +402,42 @@ func textResult(text string) *mcp.CallToolResult {
 	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}
 }
 
-func commandError(output []byte, err error) error {
-	if message := strings.TrimSpace(string(output)); message != "" {
+func runJSONCommand[Output any](ctx context.Context, args ...string) (Output, error) {
+	var output Output
+	stdout, _, err := runCommand(ctx, args...)
+	if err != nil {
+		return output, err
+	}
+	if err := json.Unmarshal(stdout, &output); err != nil {
+		return output, fmt.Errorf("decode %s JSON output: %w", args[0], err)
+	}
+	return output, nil
+}
+
+func runCommand(ctx context.Context, args ...string) ([]byte, []byte, error) {
+	cmd := exec.CommandContext(ctx, "litestream", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, nil, commandError(stdout.Bytes(), stderr.Bytes(), err)
+	}
+	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
+func commandError(stdout, stderr []byte, err error) error {
+	message := strings.TrimSpace(strings.Join([]string{string(stderr), string(stdout)}, "\n"))
+	if message != "" {
 		return fmt.Errorf("%s: %w", message, err)
 	}
 	return err
+}
+
+func countNoun(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", count, plural)
 }
 
 func boolPointer(value bool) *bool {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,12 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os/exec"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -149,6 +150,9 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 		if input.Config != nil {
 			config = *input.Config
 		}
+		if config == "" {
+			config = DefaultConfigPath()
+		}
 
 		databases, err := runJSONCommand[[]DatabaseInfo](ctx, "databases", "-json", "-config", config)
 		if err != nil {
@@ -197,7 +201,8 @@ type restoreInput struct {
 }
 
 type restoreOutput struct {
-	Status string         `json:"status" jsonschema:"Restore command outcome."`
+	Status RestoreStatus  `json:"status" jsonschema:"Restore command outcome."`
+	Reason RestoreReason  `json:"reason,omitempty" jsonschema:"Stable reason when the restore was skipped."`
 	Result *RestoreResult `json:"result,omitempty" jsonschema:"Restore details when a database was restored."`
 }
 
@@ -235,33 +240,44 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 			args = append(args, "-parallelism", *input.Parallelism)
 		}
 		if input.IfDBNotExists != nil {
-			args = append(args, "-if-db-not-exists", strconv.FormatBool(*input.IfDBNotExists))
+			args = append(args, fmt.Sprintf("-if-db-not-exists=%t", *input.IfDBNotExists))
 		}
 		if input.IfReplicaExists != nil {
-			args = append(args, "-if-replica-exists", strconv.FormatBool(*input.IfReplicaExists))
+			args = append(args, fmt.Sprintf("-if-replica-exists=%t", *input.IfReplicaExists))
 		}
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		stdout, _, err := runCommand(ctx, args...)
+		output, err := runJSONCommand[RestoreOutput](ctx, args...)
 		if err != nil {
 			return nil, restoreOutput{}, err
 		}
-		if len(bytes.TrimSpace(stdout)) == 0 {
-			output := restoreOutput{Status: "skipped"}
-			return textResult(fmt.Sprintf("Restore skipped for %s.", input.Path)), output, nil
+		switch output.Status {
+		case RestoreStatusRestored:
+			if output.RestoreResult == nil {
+				return nil, restoreOutput{}, fmt.Errorf("restore JSON output missing result")
+			}
+			text := fmt.Sprintf("Restored %s using the %s replica", output.DBPath, output.Replica)
+			if output.TXID != "" {
+				text += " at TXID " + output.TXID
+			}
+			return textResult(text + "."), restoreOutput{Status: output.Status, Result: output.RestoreResult}, nil
+		case RestoreStatusSkipped:
+			switch output.Reason {
+			case RestoreReasonDatabaseExists:
+				path := input.Path
+				if input.Output != nil && *input.Output != "" {
+					path = *input.Output
+				}
+				return textResult(fmt.Sprintf("Restore skipped because the database already exists at %s.", path)), restoreOutput{Status: output.Status, Reason: output.Reason}, nil
+			case RestoreReasonNoMatchingBackups:
+				return textResult(fmt.Sprintf("Restore skipped for %s because no matching backups were found.", input.Path)), restoreOutput{Status: output.Status, Reason: output.Reason}, nil
+			default:
+				return nil, restoreOutput{}, fmt.Errorf("unknown restore skip reason %q", output.Reason)
+			}
+		default:
+			return nil, restoreOutput{}, fmt.Errorf("unknown restore status %q", output.Status)
 		}
-
-		var result RestoreResult
-		if err := json.Unmarshal(stdout, &result); err != nil {
-			return nil, restoreOutput{}, fmt.Errorf("decode restore JSON output: %w", err)
-		}
-		text := fmt.Sprintf("Restored %s using the %s replica", result.DBPath, result.Replica)
-		if result.TXID != "" {
-			text += " at TXID " + result.TXID
-		}
-		text += "."
-		return textResult(text), restoreOutput{Status: "restored", Result: &result}, nil
 	}
 }
 
@@ -420,6 +436,9 @@ func runCommand(ctx context.Context, args ...string) ([]byte, []byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			err = errors.Join(cause, err)
+		}
 		return nil, nil, commandError(stdout.Bytes(), stderr.Bytes(), err)
 	}
 	return stdout.Bytes(), stderr.Bytes(), nil

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -189,7 +189,7 @@ type databasesInput struct {
 }
 
 type databasesOutput struct {
-	Text string `json:"text" jsonschema:"Databases and replicas from the Litestream config file."`
+	Databases []DatabaseInfo `json:"databases" jsonschema:"Databases and replicas from the Litestream config file."`
 }
 
 func DatabasesTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[databasesInput, databasesOutput]) {
@@ -201,19 +201,18 @@ func DatabasesTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[databasesIn
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input databasesInput) (*mcp.CallToolResult, databasesOutput, error) {
-		args := []string{"databases"}
+		args := []string{"databases", "-json"}
 		config := configPath
 		if input.Config != nil {
 			config = *input.Config
 		}
 		args = append(args, "-config", config)
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		databases, err := runJSONCommand[[]DatabaseInfo](ctx, args...)
 		if err != nil {
-			return nil, databasesOutput{}, commandError(output, err)
+			return nil, databasesOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), databasesOutput{Text: text}, nil
+		text := fmt.Sprintf("Found %s.", countNoun(len(databases), "configured database", "configured databases"))
+		return textResult(text), databasesOutput{Databases: databases}, nil
 	}
 }
 
@@ -221,8 +220,15 @@ type infoInput struct {
 	Config *string `json:"config,omitempty" jsonschema:"Path to the Litestream config file. Optional."`
 }
 
+type infoDatabaseOutput struct {
+	DatabaseInfo
+	LTXFiles []LTXFileInfo `json:"ltx_files" jsonschema:"LTX files for the database."`
+}
+
 type infoOutput struct {
-	Text string `json:"text" jsonschema:"Comprehensive Litestream status report."`
+	Version   string               `json:"version" jsonschema:"Running Litestream instance version."`
+	Config    string               `json:"config" jsonschema:"Path to the Litestream config file."`
+	Databases []infoDatabaseOutput `json:"databases" jsonschema:"Configured databases and their LTX files."`
 }
 
 func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoOutput]) {
@@ -234,69 +240,43 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input infoInput) (*mcp.CallToolResult, infoOutput, error) {
-		var summary strings.Builder
-		summary.WriteString("=== Litestream Status Report ===\n\n")
-
-		versionCmd := exec.CommandContext(ctx, "litestream", "version")
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			return nil, infoOutput{}, fmt.Errorf("get version info: %w", commandError(versionOutput, err))
-		}
-		summary.WriteString("Version Information:\n")
-		summary.WriteString(string(versionOutput))
-		summary.WriteString("\n")
-
-		args := []string{"databases"}
 		config := configPath
 		if input.Config != nil {
 			config = *input.Config
 		}
-		summary.WriteString("Current Config Path:\n")
-		summary.WriteString(config + "\n\n")
 
-		args = append(args, "-config", config)
-		dbCmd := exec.CommandContext(ctx, "litestream", args...)
-		dbOutput, err := dbCmd.CombinedOutput()
+		databases, err := runJSONCommand[[]DatabaseInfo](ctx, "databases", "-json", "-config", config)
 		if err != nil {
-			return nil, infoOutput{}, fmt.Errorf("get databases info: %w", commandError(dbOutput, err))
+			return nil, infoOutput{}, fmt.Errorf("get databases info: %w", err)
 		}
 
-		summary.WriteString("Databases:\n")
-		summary.WriteString(string(dbOutput))
-		summary.WriteString("\n")
-
-		scanner := bufio.NewScanner(strings.NewReader(string(dbOutput)))
-		scanner.Scan()
-		var dbPaths []string
-		for scanner.Scan() {
-			fields := strings.Fields(scanner.Text())
-			if len(fields) > 0 {
-				dbPaths = append(dbPaths, fields[0])
-			}
+		output := infoOutput{
+			Version:   Version,
+			Config:    config,
+			Databases: make([]infoDatabaseOutput, 0, len(databases)),
 		}
-		if err := scanner.Err(); err != nil {
-			return nil, infoOutput{}, fmt.Errorf("scan databases info: %w", err)
-		}
-
-		summary.WriteString("LTX Files:\n")
-		for _, dbPath := range dbPaths {
-			ltxArgs := []string{"ltx"}
+		ltxFileCount := 0
+		for _, database := range databases {
+			ltxArgs := []string{"ltx", "-json"}
 			if config != "" {
 				ltxArgs = append(ltxArgs, "-config", config)
 			}
-			ltxArgs = append(ltxArgs, dbPath)
-			ltxCmd := exec.CommandContext(ctx, "litestream", ltxArgs...)
-			ltxOutput, err := ltxCmd.CombinedOutput()
+			ltxArgs = append(ltxArgs, database.Path)
+			files, err := runJSONCommand[[]LTXFileInfo](ctx, ltxArgs...)
 			if err != nil {
-				return nil, infoOutput{}, fmt.Errorf("get LTX files for %s: %w", dbPath, commandError(ltxOutput, err))
+				return nil, infoOutput{}, fmt.Errorf("get LTX files for %s: %w", database.Path, err)
 			}
-			summary.WriteString("Database: " + dbPath + "\n")
-			summary.WriteString(string(ltxOutput))
-			summary.WriteString("\n")
+			ltxFileCount += len(files)
+			output.Databases = append(output.Databases, infoDatabaseOutput{
+				DatabaseInfo: database,
+				LTXFiles:     files,
+			})
 		}
 
-		text := summary.String()
-		return textResult(text), infoOutput{Text: text}, nil
+		text := fmt.Sprintf("Litestream %s has %s and %s.", Version,
+			countNoun(len(databases), "configured database", "configured databases"),
+			countNoun(ltxFileCount, "LTX file", "LTX files"))
+		return textResult(text), output, nil
 	}
 }
 
@@ -312,7 +292,8 @@ type restoreInput struct {
 }
 
 type restoreOutput struct {
-	Text string `json:"text" jsonschema:"Restore command output."`
+	Status string         `json:"status" jsonschema:"Restore command outcome."`
+	Result *RestoreResult `json:"result,omitempty" jsonschema:"Restore details when a database was restored."`
 }
 
 func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput, restoreOutput]) {
@@ -324,7 +305,7 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input restoreInput) (*mcp.CallToolResult, restoreOutput, error) {
-		args := []string{"restore"}
+		args := []string{"restore", "-json"}
 		if input.Output != nil {
 			args = append(args, "-o", *input.Output)
 		}
@@ -357,20 +338,32 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		stdout, _, err := runCommand(ctx, args...)
 		if err != nil {
-			return nil, restoreOutput{}, commandError(output, err)
+			return nil, restoreOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), restoreOutput{Text: text}, nil
+		if len(bytes.TrimSpace(stdout)) == 0 {
+			output := restoreOutput{Status: "skipped"}
+			return textResult(fmt.Sprintf("Restore skipped for %s.", input.Path)), output, nil
+		}
+
+		var result RestoreResult
+		if err := json.Unmarshal(stdout, &result); err != nil {
+			return nil, restoreOutput{}, fmt.Errorf("decode restore JSON output: %w", err)
+		}
+		text := fmt.Sprintf("Restored %s using the %s replica", result.DBPath, result.Replica)
+		if result.TXID != "" {
+			text += " at TXID " + result.TXID
+		}
+		text += "."
+		return textResult(text), restoreOutput{Status: "restored", Result: &result}, nil
 	}
 }
 
 type versionInput struct{}
 
 type versionOutput struct {
-	Text string `json:"text" jsonschema:"Running Litestream instance version."`
+	Version string `json:"version" jsonschema:"Running Litestream instance version."`
 }
 
 func VersionTool() (*mcp.Tool, mcp.ToolHandlerFor[versionInput, versionOutput]) {
@@ -381,8 +374,7 @@ func VersionTool() (*mcp.Tool, mcp.ToolHandlerFor[versionInput, versionOutput]) 
 	}
 
 	return tool, func(context.Context, *mcp.CallToolRequest, versionInput) (*mcp.CallToolResult, versionOutput, error) {
-		text := Version + "\n"
-		return textResult(text), versionOutput{Text: text}, nil
+		return textResult(fmt.Sprintf("Litestream %s.", Version)), versionOutput{Version: Version}, nil
 	}
 }
 
@@ -392,7 +384,7 @@ type ltxInput struct {
 }
 
 type ltxOutput struct {
-	Text string `json:"text" jsonschema:"LTX files for the database or replica URL."`
+	Files []LTXFileInfo `json:"files" jsonschema:"LTX files for the database or replica URL."`
 }
 
 func LTXTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[ltxInput, ltxOutput]) {
@@ -404,7 +396,7 @@ func LTXTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[ltxInput, ltxOutp
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input ltxInput) (*mcp.CallToolResult, ltxOutput, error) {
-		args := []string{"ltx"}
+		args := []string{"ltx", "-json"}
 
 		if !isReplicaURL(input.Path) {
 			config := configPath
@@ -419,13 +411,12 @@ func LTXTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[ltxInput, ltxOutp
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		files, err := runJSONCommand[[]LTXFileInfo](ctx, args...)
 		if err != nil {
-			return nil, ltxOutput{}, commandError(output, err)
+			return nil, ltxOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), ltxOutput{Text: text}, nil
+		text := fmt.Sprintf("Found %s for %s.", countNoun(len(files), "LTX file", "LTX files"), input.Path)
+		return textResult(text), ltxOutput{Files: files}, nil
 	}
 }
 
@@ -435,7 +426,7 @@ type statusInput struct {
 }
 
 type statusOutput struct {
-	Text string `json:"text" jsonschema:"Litestream replication status."`
+	Databases []DBStatus `json:"databases" jsonschema:"Replication status for configured databases."`
 }
 
 func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, statusOutput]) {
@@ -447,7 +438,7 @@ func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, s
 	}
 
 	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input statusInput) (*mcp.CallToolResult, statusOutput, error) {
-		args := []string{"status"}
+		args := []string{"status", "-json"}
 		config := configPath
 		if input.Config != nil {
 			config = *input.Config
@@ -456,13 +447,12 @@ func StatusTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[statusInput, s
 		if input.Path != nil {
 			args = append(args, *input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		statuses, err := runJSONCommand[[]DBStatus](ctx, args...)
 		if err != nil {
-			return nil, statusOutput{}, commandError(output, err)
+			return nil, statusOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), statusOutput{Text: text}, nil
+		text := fmt.Sprintf("Reported replication status for %s.", countNoun(len(statuses), "database", "databases"))
+		return textResult(text), statusOutput{Databases: statuses}, nil
 	}
 }
 
@@ -472,7 +462,8 @@ type resetInput struct {
 }
 
 type resetOutput struct {
-	Text string `json:"text" jsonschema:"Reset command output."`
+	Path   string `json:"path" jsonschema:"Database path passed to the reset command."`
+	Status string `json:"status" jsonschema:"Reset command outcome."`
 }
 
 func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, resetOutput]) {
@@ -493,13 +484,12 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		cmd := exec.CommandContext(ctx, "litestream", args...)
-		output, err := cmd.CombinedOutput()
+		_, _, err := runCommand(ctx, args...)
 		if err != nil {
-			return nil, resetOutput{}, commandError(output, err)
+			return nil, resetOutput{}, err
 		}
-		text := string(output)
-		return textResult(text), resetOutput{Text: text}, nil
+		text := fmt.Sprintf("Reset command completed for %s.", input.Path)
+		return textResult(text), resetOutput{Path: input.Path, Status: "completed"}, nil
 	}
 }
 
@@ -507,11 +497,42 @@ func textResult(text string) *mcp.CallToolResult {
 	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}
 }
 
-func commandError(output []byte, err error) error {
-	if message := strings.TrimSpace(string(output)); message != "" {
+func runJSONCommand[Output any](ctx context.Context, args ...string) (Output, error) {
+	var output Output
+	stdout, _, err := runCommand(ctx, args...)
+	if err != nil {
+		return output, err
+	}
+	if err := json.Unmarshal(stdout, &output); err != nil {
+		return output, fmt.Errorf("decode %s JSON output: %w", args[0], err)
+	}
+	return output, nil
+}
+
+func runCommand(ctx context.Context, args ...string) ([]byte, []byte, error) {
+	cmd := exec.CommandContext(ctx, "litestream", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, nil, commandError(stdout.Bytes(), stderr.Bytes(), err)
+	}
+	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
+func commandError(stdout, stderr []byte, err error) error {
+	message := strings.TrimSpace(strings.Join([]string{string(stderr), string(stdout)}, "\n"))
+	if message != "" {
 		return fmt.Errorf("%s: %w", message, err)
 	}
 	return err
+}
+
+func countNoun(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", count, plural)
 }
 
 func boolPointer(value bool) *bool {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,7 +11,6 @@ import (
 	"net/http"
 	"os/exec"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -244,6 +244,9 @@ func InfoTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[infoInput, infoO
 		if input.Config != nil {
 			config = *input.Config
 		}
+		if config == "" {
+			config = DefaultConfigPath()
+		}
 
 		databases, err := runJSONCommand[[]DatabaseInfo](ctx, "databases", "-json", "-config", config)
 		if err != nil {
@@ -292,7 +295,8 @@ type restoreInput struct {
 }
 
 type restoreOutput struct {
-	Status string         `json:"status" jsonschema:"Restore command outcome."`
+	Status RestoreStatus  `json:"status" jsonschema:"Restore command outcome."`
+	Reason RestoreReason  `json:"reason,omitempty" jsonschema:"Stable reason when the restore was skipped."`
 	Result *RestoreResult `json:"result,omitempty" jsonschema:"Restore details when a database was restored."`
 }
 
@@ -330,33 +334,44 @@ func RestoreTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[restoreInput,
 			args = append(args, "-parallelism", *input.Parallelism)
 		}
 		if input.IfDBNotExists != nil {
-			args = append(args, "-if-db-not-exists", strconv.FormatBool(*input.IfDBNotExists))
+			args = append(args, fmt.Sprintf("-if-db-not-exists=%t", *input.IfDBNotExists))
 		}
 		if input.IfReplicaExists != nil {
-			args = append(args, "-if-replica-exists", strconv.FormatBool(*input.IfReplicaExists))
+			args = append(args, fmt.Sprintf("-if-replica-exists=%t", *input.IfReplicaExists))
 		}
 		if input.Path != "" {
 			args = append(args, input.Path)
 		}
-		stdout, _, err := runCommand(ctx, args...)
+		output, err := runJSONCommand[RestoreOutput](ctx, args...)
 		if err != nil {
 			return nil, restoreOutput{}, err
 		}
-		if len(bytes.TrimSpace(stdout)) == 0 {
-			output := restoreOutput{Status: "skipped"}
-			return textResult(fmt.Sprintf("Restore skipped for %s.", input.Path)), output, nil
+		switch output.Status {
+		case RestoreStatusRestored:
+			if output.RestoreResult == nil {
+				return nil, restoreOutput{}, fmt.Errorf("restore JSON output missing result")
+			}
+			text := fmt.Sprintf("Restored %s using the %s replica", output.DBPath, output.Replica)
+			if output.TXID != "" {
+				text += " at TXID " + output.TXID
+			}
+			return textResult(text + "."), restoreOutput{Status: output.Status, Result: output.RestoreResult}, nil
+		case RestoreStatusSkipped:
+			switch output.Reason {
+			case RestoreReasonDatabaseExists:
+				path := input.Path
+				if input.Output != nil && *input.Output != "" {
+					path = *input.Output
+				}
+				return textResult(fmt.Sprintf("Restore skipped because the database already exists at %s.", path)), restoreOutput{Status: output.Status, Reason: output.Reason}, nil
+			case RestoreReasonNoMatchingBackups:
+				return textResult(fmt.Sprintf("Restore skipped for %s because no matching backups were found.", input.Path)), restoreOutput{Status: output.Status, Reason: output.Reason}, nil
+			default:
+				return nil, restoreOutput{}, fmt.Errorf("unknown restore skip reason %q", output.Reason)
+			}
+		default:
+			return nil, restoreOutput{}, fmt.Errorf("unknown restore status %q", output.Status)
 		}
-
-		var result RestoreResult
-		if err := json.Unmarshal(stdout, &result); err != nil {
-			return nil, restoreOutput{}, fmt.Errorf("decode restore JSON output: %w", err)
-		}
-		text := fmt.Sprintf("Restored %s using the %s replica", result.DBPath, result.Replica)
-		if result.TXID != "" {
-			text += " at TXID " + result.TXID
-		}
-		text += "."
-		return textResult(text), restoreOutput{Status: "restored", Result: &result}, nil
 	}
 }
 
@@ -515,6 +530,9 @@ func runCommand(ctx context.Context, args ...string) ([]byte, []byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			err = errors.Join(cause, err)
+		}
 		return nil, nil, commandError(stdout.Bytes(), stderr.Bytes(), err)
 	}
 	return stdout.Bytes(), stderr.Bytes(), nil

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -75,13 +75,25 @@ func TestMCPServerTools(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		readOnly    bool
-		destructive bool
-		properties  map[string]string
-		required    []string
+		readOnly         bool
+		destructive      bool
+		properties       map[string]string
+		required         []string
+		outputProperties []string
+		outputRequired   []string
 	}{
-		"litestream_databases": {readOnly: true, properties: map[string]string{"config": "string"}},
-		"litestream_info":      {readOnly: true, properties: map[string]string{"config": "string"}},
+		"litestream_databases": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string"},
+			outputProperties: []string{"databases"},
+			outputRequired:   []string{"databases"},
+		},
+		"litestream_info": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string"},
+			outputProperties: []string{"config", "databases", "version"},
+			outputRequired:   []string{"config", "databases", "version"},
+		},
 		"litestream_restore": {
 			destructive: true,
 			properties: map[string]string{
@@ -94,12 +106,35 @@ func TestMCPServerTools(t *testing.T) {
 				"timestamp":         "string",
 				"txid":              "string",
 			},
-			required: []string{"path"},
+			required:         []string{"path"},
+			outputProperties: []string{"result", "status"},
+			outputRequired:   []string{"status"},
 		},
-		"litestream_ltx":     {readOnly: true, properties: map[string]string{"config": "string", "path": "string"}, required: []string{"path"}},
-		"litestream_version": {readOnly: true},
-		"litestream_status":  {readOnly: true, properties: map[string]string{"config": "string", "path": "string"}},
-		"litestream_reset":   {destructive: true, properties: map[string]string{"config": "string", "path": "string"}, required: []string{"path"}},
+		"litestream_ltx": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string", "path": "string"},
+			required:         []string{"path"},
+			outputProperties: []string{"files"},
+			outputRequired:   []string{"files"},
+		},
+		"litestream_version": {
+			readOnly:         true,
+			outputProperties: []string{"version"},
+			outputRequired:   []string{"version"},
+		},
+		"litestream_status": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string", "path": "string"},
+			outputProperties: []string{"databases"},
+			outputRequired:   []string{"databases"},
+		},
+		"litestream_reset": {
+			destructive:      true,
+			properties:       map[string]string{"config": "string", "path": "string"},
+			required:         []string{"path"},
+			outputProperties: []string{"path", "status"},
+			outputRequired:   []string{"path", "status"},
+		},
 	}
 
 	if got, want := len(result.Tools), len(tests); got != want {
@@ -151,15 +186,15 @@ func TestMCPServerTools(t *testing.T) {
 
 		outputSchema := jsonObject(t, tool.OutputSchema)
 		outputProperties := schemaProperties(t, outputSchema)
-		if got := slices.Sorted(maps.Keys(outputProperties)); !reflect.DeepEqual(got, []string{"text"}) {
-			t.Errorf("%s output properties=%v, want [text]", tool.Name, got)
+		if got := slices.Sorted(maps.Keys(outputProperties)); !reflect.DeepEqual(got, test.outputProperties) {
+			t.Errorf("%s output properties=%v, want %v", tool.Name, got, test.outputProperties)
 		}
-		if property := jsonObject(t, outputProperties["text"]); property["description"] == "" {
-			t.Errorf("%s output property text has no description", tool.Name)
-		} else if got := property["type"]; got != "string" {
-			t.Errorf("%s output property text type=%v, want string", tool.Name, got)
+		for name, property := range outputProperties {
+			if property := jsonObject(t, property); property["description"] == "" {
+				t.Errorf("%s output property %s has no description", tool.Name, name)
+			}
 		}
-		if got, want := schemaRequired(outputSchema), []string{"text"}; !reflect.DeepEqual(got, want) {
+		if got, want := schemaRequired(outputSchema), test.outputRequired; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s required output properties=%v, want %v", tool.Name, got, want)
 		}
 	}
@@ -210,10 +245,10 @@ func TestMCPServerTools(t *testing.T) {
 	if callResult.IsError {
 		t.Fatalf("version tool error: %#v", callResult.Content)
 	}
-	if got, want := callResult.StructuredContent, map[string]any{"text": version + "\n"}; !reflect.DeepEqual(got, want) {
+	if got, want := callResult.StructuredContent, map[string]any{"version": version}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("version structured content=%v, want %v", got, want)
 	}
-	if got, want := textContent(t, callResult), version+"\n"; got != want {
+	if got, want := textContent(t, callResult), "Litestream "+version+"."; got != want {
 		t.Fatalf("version text content=%q, want %q", got, want)
 	}
 }
@@ -244,8 +279,9 @@ func TestMCPToolBehavior(t *testing.T) {
 		t.Skip("requires a POSIX shell")
 	}
 
-	setVersion(t, "v1.2.3-mcp-test")
-	installFakeLitestream(t)
+	const version = "v1.2.3-mcp-test"
+	setVersion(t, version)
+	argsPath := installFakeLitestream(t)
 
 	server, err := NewMCP(t.Context(), "/default/litestream.yml")
 	if err != nil {
@@ -266,14 +302,20 @@ func TestMCPToolBehavior(t *testing.T) {
 	})
 
 	tests := []struct {
-		name      string
-		arguments map[string]any
-		want      string
+		name           string
+		arguments      map[string]any
+		wantText       string
+		wantStructured any
+		wantArgs       string
 	}{
 		{
 			name:      "litestream_databases",
 			arguments: map[string]any{"config": ""},
-			want:      "<databases><-config><>\n",
+			wantText:  "Found 1 configured database.",
+			wantStructured: map[string]any{
+				"databases": []any{map[string]any{"path": "/data/db", "replica": "s3"}},
+			},
+			wantArgs: "<databases><-json><-config><>\n",
 		},
 		{
 			name: "litestream_restore",
@@ -287,27 +329,65 @@ func TestMCPToolBehavior(t *testing.T) {
 				"if_db_not_exists":  false,
 				"if_replica_exists": true,
 			},
-			want: "<restore><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
+			wantText: "Restored /restore/db using the file replica at TXID 0000000000000004.",
+			wantStructured: map[string]any{
+				"status": "restored",
+				"result": map[string]any{
+					"db_path":         "/restore/db",
+					"replica":         "file",
+					"txid":            "0000000000000004",
+					"duration_ms":     float64(125),
+					"integrity_check": "none",
+				},
+			},
+			wantArgs: "<restore><-json><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
 		},
 		{
 			name:      "litestream_ltx",
 			arguments: map[string]any{"path": "/data/db", "config": ""},
-			want:      "<ltx></data/db>\n",
+			wantText:  "Found 1 LTX file for /data/db.",
+			wantStructured: map[string]any{
+				"files": []any{map[string]any{
+					"level":     float64(0),
+					"min_txid":  "0000000000000001",
+					"max_txid":  "0000000000000004",
+					"size":      float64(8192),
+					"timestamp": "2026-04-24T12:00:00Z",
+				}},
+			},
+			wantArgs: "<ltx><-json></data/db>\n",
 		},
 		{
 			name:      "litestream_status",
 			arguments: map[string]any{"config": "", "path": ""},
-			want:      "<status><-config><><>\n",
+			wantText:  "Reported replication status for 1 database.",
+			wantStructured: map[string]any{
+				"databases": []any{map[string]any{
+					"database":   "/data/db",
+					"status":     "ok",
+					"local_txid": "0000000000000004",
+					"wal_size":   "32 kB",
+				}},
+			},
+			wantArgs: "<status><-json><-config><><>\n",
 		},
 		{
 			name:      "litestream_reset",
 			arguments: map[string]any{"path": "/data/db", "config": ""},
-			want:      "<reset><-config><></data/db>\n",
+			wantText:  "Reset command completed for /data/db.",
+			wantStructured: map[string]any{
+				"path":   "/data/db",
+				"status": "completed",
+			},
+			wantArgs: "<reset><-config><></data/db>\n",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(argsPath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
 			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: test.name, Arguments: test.arguments})
 			if err != nil {
 				t.Fatal(err)
@@ -315,16 +395,25 @@ func TestMCPToolBehavior(t *testing.T) {
 			if result.IsError {
 				t.Fatalf("tool error: %#v", result.Content)
 			}
-			if got := textContent(t, result); got != test.want {
-				t.Fatalf("text content=%q, want %q", got, test.want)
+			if got := textContent(t, result); got != test.wantText {
+				t.Fatalf("text content=%q, want %q", got, test.wantText)
 			}
-			if got, want := result.StructuredContent, map[string]any{"text": test.want}; !reflect.DeepEqual(got, want) {
-				t.Fatalf("structured content=%v, want %v", got, want)
+			if got := result.StructuredContent; !reflect.DeepEqual(got, test.wantStructured) {
+				t.Fatalf("structured content=%v, want %v", got, test.wantStructured)
+			}
+			args, err := os.ReadFile(argsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := string(args); got != test.wantArgs {
+				t.Fatalf("command arguments=%q, want %q", got, test.wantArgs)
 			}
 		})
 	}
 
-	t.Setenv("LITESTREAM_TEST_DATABASES_TABLE", "1")
+	if err := os.WriteFile(argsPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "litestream_info",
 		Arguments: map[string]any{"config": "/custom/litestream.yml"},
@@ -335,15 +424,34 @@ func TestMCPToolBehavior(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("info tool error: %#v", result.Content)
 	}
-	for _, want := range []string{
-		"Litestream test-version",
-		"Current Config Path:\n/custom/litestream.yml",
-		"Database: /data/db",
-		"<ltx><-config></custom/litestream.yml></data/db>",
-	} {
-		if got := textContent(t, result); !strings.Contains(got, want) {
-			t.Errorf("info text content does not contain %q: %q", want, got)
-		}
+	if got, want := textContent(t, result), "Litestream "+version+" has 1 configured database and 1 LTX file."; got != want {
+		t.Fatalf("info text content=%q, want %q", got, want)
+	}
+	wantInfo := map[string]any{
+		"version": version,
+		"config":  "/custom/litestream.yml",
+		"databases": []any{map[string]any{
+			"path":    "/data/db",
+			"replica": "s3",
+			"ltx_files": []any{map[string]any{
+				"level":     float64(0),
+				"min_txid":  "0000000000000001",
+				"max_txid":  "0000000000000004",
+				"size":      float64(8192),
+				"timestamp": "2026-04-24T12:00:00Z",
+			}},
+		}},
+	}
+	if got := result.StructuredContent; !reflect.DeepEqual(got, wantInfo) {
+		t.Fatalf("info structured content=%v, want %v", got, wantInfo)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := "<databases><-json><-config></custom/litestream.yml>\n<ltx><-json><-config></custom/litestream.yml></data/db>\n"
+	if got := string(args); got != wantArgs {
+		t.Fatalf("info command arguments=%q, want %q", got, wantArgs)
 	}
 
 	t.Setenv("LITESTREAM_TEST_FAIL", "ltx")
@@ -361,6 +469,25 @@ func TestMCPToolBehavior(t *testing.T) {
 		if got := textContent(t, result); !strings.Contains(got, want) {
 			t.Errorf("info error does not contain %q: %q", want, got)
 		}
+	}
+
+	t.Setenv("LITESTREAM_TEST_FAIL", "")
+	t.Setenv("LITESTREAM_TEST_SKIP", "restore")
+	result, err = session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "litestream_restore",
+		Arguments: map[string]any{"path": "/data/db"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("skipped restore tool error: %#v", result.Content)
+	}
+	if got, want := textContent(t, result), "Restore skipped for /data/db."; got != want {
+		t.Fatalf("skipped restore text content=%q, want %q", got, want)
+	}
+	if got, want := result.StructuredContent, map[string]any{"status": "skipped"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("skipped restore structured content=%v, want %v", got, want)
 	}
 }
 
@@ -437,34 +564,50 @@ func schemaRequired(schema map[string]any) []string {
 	return required
 }
 
-func installFakeLitestream(t *testing.T) {
+func installFakeLitestream(t *testing.T) string {
 	t.Helper()
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "litestream")
+	argsPath := filepath.Join(dir, "args")
 	script := `#!/bin/sh
+if [ -n "$LITESTREAM_TEST_ARGS_FILE" ]; then
+  for argument in "$@"; do
+    printf '<%s>' "$argument" >> "$LITESTREAM_TEST_ARGS_FILE"
+  done
+  printf '\n' >> "$LITESTREAM_TEST_ARGS_FILE"
+fi
 if [ "$LITESTREAM_TEST_FAIL" = "$1" ]; then
 	printf 'failure from %s\n' "$1" >&2
 	exit 1
 fi
-if [ "$1" = "version" ]; then
-	printf 'Litestream test-version\n'
+if [ "$LITESTREAM_TEST_SKIP" = "$1" ]; then
 	exit 0
 fi
-if [ "$1" = "databases" ] && [ "$LITESTREAM_TEST_DATABASES_TABLE" = "1" ]; then
-	printf 'path replica\n'
-	printf '/data/db s3://bucket/db\n'
-	exit 0
-fi
-for argument in "$@"; do
-	printf '<%s>' "$argument"
-done
-printf '\n'
+case "$1" in
+  databases)
+    printf '[{"path":"/data/db","replica":"s3"}]\n'
+    ;;
+  restore)
+    printf '{"db_path":"/restore/db","replica":"file","txid":"0000000000000004","duration_ms":125,"integrity_check":"none"}\n'
+    ;;
+  ltx)
+    printf '[{"level":0,"min_txid":"0000000000000001","max_txid":"0000000000000004","size":8192,"timestamp":"2026-04-24T12:00:00Z"}]\n'
+    ;;
+  status)
+    printf '[{"database":"/data/db","status":"ok","local_txid":"0000000000000004","wal_size":"32 kB"}]\n'
+    ;;
+  reset)
+    printf 'Reset complete.\n'
+    ;;
+esac
 `
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("LITESTREAM_TEST_ARGS_FILE", argsPath)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
 }
 
 func postMCPRequest(t *testing.T, endpoint, method, protocolVersion string, params map[string]any) (map[string]any, http.Header) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,17 +5,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -107,7 +111,7 @@ func TestMCPServerTools(t *testing.T) {
 				"txid":              "string",
 			},
 			required:         []string{"path"},
-			outputProperties: []string{"result", "status"},
+			outputProperties: []string{"reason", "result", "status"},
 			outputRequired:   []string{"status"},
 		},
 		"litestream_ltx": {
@@ -340,7 +344,7 @@ func TestMCPToolBehavior(t *testing.T) {
 					"integrity_check": "none",
 				},
 			},
-			wantArgs: "<restore><-json><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
+			wantArgs: "<restore><-json><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists=false><-if-replica-exists=true></data/db>\n",
 		},
 		{
 			name:      "litestream_ltx",
@@ -472,22 +476,102 @@ func TestMCPToolBehavior(t *testing.T) {
 	}
 
 	t.Setenv("LITESTREAM_TEST_FAIL", "")
-	t.Setenv("LITESTREAM_TEST_SKIP", "restore")
+	t.Setenv("LITESTREAM_CONFIG", "/effective/litestream.yml")
+	if err := os.WriteFile(argsPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	result, err = session.CallTool(t.Context(), &mcp.CallToolParams{
-		Name:      "litestream_restore",
-		Arguments: map[string]any{"path": "/data/db"},
+		Name:      "litestream_info",
+		Arguments: map[string]any{"config": ""},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.IsError {
-		t.Fatalf("skipped restore tool error: %#v", result.Content)
+		t.Fatalf("info tool error: %#v", result.Content)
 	}
-	if got, want := textContent(t, result), "Restore skipped for /data/db."; got != want {
-		t.Fatalf("skipped restore text content=%q, want %q", got, want)
+	if got, want := result.StructuredContent.(map[string]any)["config"], "/effective/litestream.yml"; got != want {
+		t.Fatalf("info config=%v, want %q", got, want)
 	}
-	if got, want := result.StructuredContent, map[string]any{"status": "skipped"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("skipped restore structured content=%v, want %v", got, want)
+	args, err = os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs = "<databases><-json><-config></effective/litestream.yml>\n<ltx><-json><-config></effective/litestream.yml></data/db>\n"
+	if got := string(args); got != wantArgs {
+		t.Fatalf("info command arguments=%q, want %q", got, wantArgs)
+	}
+}
+
+func TestMCPRestoreSkipReasons(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	installRestoreLitestream(t)
+	_, handler := RestoreTool("")
+	trueValue := true
+	tests := []struct {
+		name       string
+		input      func(*testing.T) restoreInput
+		wantReason RestoreReason
+		wantText   func(restoreInput) string
+	}{
+		{
+			name: "DatabaseExists",
+			input: func(t *testing.T) restoreInput {
+				outputPath := filepath.Join(t.TempDir(), "db")
+				if err := os.WriteFile(outputPath, []byte("existing"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return restoreInput{
+					Path:          "file://" + t.TempDir(),
+					Output:        &outputPath,
+					IfDBNotExists: &trueValue,
+				}
+			},
+			wantReason: RestoreReasonDatabaseExists,
+			wantText: func(input restoreInput) string {
+				return fmt.Sprintf("Restore skipped because the database already exists at %s.", *input.Output)
+			},
+		},
+		{
+			name: "NoMatchingBackups",
+			input: func(t *testing.T) restoreInput {
+				outputPath := filepath.Join(t.TempDir(), "db")
+				return restoreInput{
+					Path:            "file://" + t.TempDir(),
+					Output:          &outputPath,
+					IfReplicaExists: &trueValue,
+				}
+			},
+			wantReason: RestoreReasonNoMatchingBackups,
+			wantText: func(input restoreInput) string {
+				return fmt.Sprintf("Restore skipped for %s because no matching backups were found.", input.Path)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := tt.input(t)
+			result, output, err := handler(t.Context(), nil, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := textContent(t, result), tt.wantText(input); got != want {
+				t.Fatalf("text content=%q, want %q", got, want)
+			}
+			if output.Status != RestoreStatusSkipped {
+				t.Fatalf("status=%q, want %q", output.Status, RestoreStatusSkipped)
+			}
+			if output.Reason != tt.wantReason {
+				t.Fatalf("reason=%q, want %q", output.Reason, tt.wantReason)
+			}
+			if output.Result != nil {
+				t.Fatalf("result=%v, want nil", output.Result)
+			}
+		})
 	}
 }
 
@@ -506,6 +590,51 @@ func TestMCPToolContextCancellation(t *testing.T) {
 	}
 	if result != nil {
 		t.Fatalf("result=%v, want nil", result)
+	}
+}
+
+func TestMCPToolContextCancellationAfterStart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	installFakeLitestream(t)
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("LITESTREAM_TEST_BLOCK", "ltx")
+	t.Setenv("LITESTREAM_TEST_READY_FILE", readyPath)
+	_, handler := LTXTool("/default/litestream.yml")
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	type response struct {
+		result *mcp.CallToolResult
+		err    error
+	}
+	responseCh := make(chan response, 1)
+	go func() {
+		result, _, err := handler(ctx, nil, ltxInput{Path: "/data/db"})
+		responseCh <- response{result: result, err: err}
+	}()
+
+	waitForPath(t, readyPath)
+	cancel()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case response := <-responseCh:
+		if !errors.Is(response.err, context.Canceled) {
+			t.Fatalf("error=%v, want context canceled", response.err)
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(response.err, &exitErr) {
+			t.Fatalf("error=%v, want process exit error", response.err)
+		}
+		if response.result != nil {
+			t.Fatalf("result=%v, want nil", response.result)
+		}
+	case <-timer.C:
+		t.Fatal("timed out waiting for canceled tool call")
 	}
 }
 
@@ -581,15 +710,16 @@ if [ "$LITESTREAM_TEST_FAIL" = "$1" ]; then
 	printf 'failure from %s\n' "$1" >&2
 	exit 1
 fi
-if [ "$LITESTREAM_TEST_SKIP" = "$1" ]; then
-	exit 0
+if [ "$LITESTREAM_TEST_BLOCK" = "$1" ]; then
+	: > "$LITESTREAM_TEST_READY_FILE"
+	exec sleep 60
 fi
 case "$1" in
   databases)
     printf '[{"path":"/data/db","replica":"s3"}]\n'
     ;;
   restore)
-    printf '{"db_path":"/restore/db","replica":"file","txid":"0000000000000004","duration_ms":125,"integrity_check":"none"}\n'
+	printf '{"status":"restored","db_path":"/restore/db","replica":"file","txid":"0000000000000004","duration_ms":125,"integrity_check":"none"}\n'
     ;;
   ltx)
     printf '[{"level":0,"min_txid":"0000000000000001","max_txid":"0000000000000004","size":8192,"timestamp":"2026-04-24T12:00:00Z"}]\n'
@@ -660,6 +790,65 @@ func postMCPRequest(t *testing.T, endpoint, method, protocolVersion string, para
 		t.Fatalf("MCP response error=%v", rpcError)
 	}
 	return object, response.Header
+}
+
+func installRestoreLitestream(t *testing.T) {
+	t.Helper()
+
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "litestream")
+	script := `#!/bin/sh
+LITESTREAM_TEST_MCP_RESTORE=1 exec "$LITESTREAM_TEST_BINARY" -test.run=^TestMCPRestoreCommandHarness$ -- "$@"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LITESTREAM_TEST_BINARY", testBinary)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestMCPRestoreCommandHarness(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MCP_RESTORE") != "1" {
+		t.Skip("helper process only")
+	}
+
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		os.Exit(2)
+	}
+	if err := NewMain().Run(context.Background(), os.Args[separator+1:]); err != nil {
+		if _, writeErr := fmt.Fprintln(os.Stderr, err); writeErr != nil {
+			os.Exit(2)
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func waitForPath(t *testing.T, path string) {
+	t.Helper()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s", path)
+		}
+	}
 }
 
 func textContent(t *testing.T, result *mcp.CallToolResult) string {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -109,7 +112,7 @@ func TestMCPServerTools(t *testing.T) {
 				"txid":              "string",
 			},
 			required:         []string{"path"},
-			outputProperties: []string{"result", "status"},
+			outputProperties: []string{"reason", "result", "status"},
 			outputRequired:   []string{"status"},
 		},
 		"litestream_ltx": {
@@ -515,7 +518,7 @@ func TestMCPToolBehavior(t *testing.T) {
 					"integrity_check": "none",
 				},
 			},
-			wantArgs: "<restore><-json><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
+			wantArgs: "<restore><-json><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists=false><-if-replica-exists=true></data/db>\n",
 		},
 		{
 			name:      "litestream_ltx",
@@ -647,22 +650,102 @@ func TestMCPToolBehavior(t *testing.T) {
 	}
 
 	t.Setenv("LITESTREAM_TEST_FAIL", "")
-	t.Setenv("LITESTREAM_TEST_SKIP", "restore")
+	t.Setenv("LITESTREAM_CONFIG", "/effective/litestream.yml")
+	if err := os.WriteFile(argsPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	result, err = session.CallTool(t.Context(), &mcp.CallToolParams{
-		Name:      "litestream_restore",
-		Arguments: map[string]any{"path": "/data/db"},
+		Name:      "litestream_info",
+		Arguments: map[string]any{"config": ""},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.IsError {
-		t.Fatalf("skipped restore tool error: %#v", result.Content)
+		t.Fatalf("info tool error: %#v", result.Content)
 	}
-	if got, want := textContent(t, result), "Restore skipped for /data/db."; got != want {
-		t.Fatalf("skipped restore text content=%q, want %q", got, want)
+	if got, want := result.StructuredContent.(map[string]any)["config"], "/effective/litestream.yml"; got != want {
+		t.Fatalf("info config=%v, want %q", got, want)
 	}
-	if got, want := result.StructuredContent, map[string]any{"status": "skipped"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("skipped restore structured content=%v, want %v", got, want)
+	args, err = os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs = "<databases><-json><-config></effective/litestream.yml>\n<ltx><-json><-config></effective/litestream.yml></data/db>\n"
+	if got := string(args); got != wantArgs {
+		t.Fatalf("info command arguments=%q, want %q", got, wantArgs)
+	}
+}
+
+func TestMCPRestoreSkipReasons(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	installRestoreLitestream(t)
+	_, handler := RestoreTool("")
+	trueValue := true
+	tests := []struct {
+		name       string
+		input      func(*testing.T) restoreInput
+		wantReason RestoreReason
+		wantText   func(restoreInput) string
+	}{
+		{
+			name: "DatabaseExists",
+			input: func(t *testing.T) restoreInput {
+				outputPath := filepath.Join(t.TempDir(), "db")
+				if err := os.WriteFile(outputPath, []byte("existing"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return restoreInput{
+					Path:          "file://" + t.TempDir(),
+					Output:        &outputPath,
+					IfDBNotExists: &trueValue,
+				}
+			},
+			wantReason: RestoreReasonDatabaseExists,
+			wantText: func(input restoreInput) string {
+				return fmt.Sprintf("Restore skipped because the database already exists at %s.", *input.Output)
+			},
+		},
+		{
+			name: "NoMatchingBackups",
+			input: func(t *testing.T) restoreInput {
+				outputPath := filepath.Join(t.TempDir(), "db")
+				return restoreInput{
+					Path:            "file://" + t.TempDir(),
+					Output:          &outputPath,
+					IfReplicaExists: &trueValue,
+				}
+			},
+			wantReason: RestoreReasonNoMatchingBackups,
+			wantText: func(input restoreInput) string {
+				return fmt.Sprintf("Restore skipped for %s because no matching backups were found.", input.Path)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := tt.input(t)
+			result, output, err := handler(t.Context(), nil, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := textContent(t, result), tt.wantText(input); got != want {
+				t.Fatalf("text content=%q, want %q", got, want)
+			}
+			if output.Status != RestoreStatusSkipped {
+				t.Fatalf("status=%q, want %q", output.Status, RestoreStatusSkipped)
+			}
+			if output.Reason != tt.wantReason {
+				t.Fatalf("reason=%q, want %q", output.Reason, tt.wantReason)
+			}
+			if output.Result != nil {
+				t.Fatalf("result=%v, want nil", output.Result)
+			}
+		})
 	}
 }
 
@@ -681,6 +764,51 @@ func TestMCPToolContextCancellation(t *testing.T) {
 	}
 	if result != nil {
 		t.Fatalf("result=%v, want nil", result)
+	}
+}
+
+func TestMCPToolContextCancellationAfterStart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	installFakeLitestream(t)
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("LITESTREAM_TEST_BLOCK", "ltx")
+	t.Setenv("LITESTREAM_TEST_READY_FILE", readyPath)
+	_, handler := LTXTool("/default/litestream.yml")
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	type response struct {
+		result *mcp.CallToolResult
+		err    error
+	}
+	responseCh := make(chan response, 1)
+	go func() {
+		result, _, err := handler(ctx, nil, ltxInput{Path: "/data/db"})
+		responseCh <- response{result: result, err: err}
+	}()
+
+	waitForPath(t, readyPath)
+	cancel()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case response := <-responseCh:
+		if !errors.Is(response.err, context.Canceled) {
+			t.Fatalf("error=%v, want context canceled", response.err)
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(response.err, &exitErr) {
+			t.Fatalf("error=%v, want process exit error", response.err)
+		}
+		if response.result != nil {
+			t.Fatalf("result=%v, want nil", response.result)
+		}
+	case <-timer.C:
+		t.Fatal("timed out waiting for canceled tool call")
 	}
 }
 
@@ -756,15 +884,16 @@ if [ "$LITESTREAM_TEST_FAIL" = "$1" ]; then
 	printf 'failure from %s\n' "$1" >&2
 	exit 1
 fi
-if [ "$LITESTREAM_TEST_SKIP" = "$1" ]; then
-	exit 0
+if [ "$LITESTREAM_TEST_BLOCK" = "$1" ]; then
+	: > "$LITESTREAM_TEST_READY_FILE"
+	exec sleep 60
 fi
 case "$1" in
   databases)
     printf '[{"path":"/data/db","replica":"s3"}]\n'
     ;;
   restore)
-    printf '{"db_path":"/restore/db","replica":"file","txid":"0000000000000004","duration_ms":125,"integrity_check":"none"}\n'
+	printf '{"status":"restored","db_path":"/restore/db","replica":"file","txid":"0000000000000004","duration_ms":125,"integrity_check":"none"}\n'
     ;;
   ltx)
     printf '[{"level":0,"min_txid":"0000000000000001","max_txid":"0000000000000004","size":8192,"timestamp":"2026-04-24T12:00:00Z"}]\n'
@@ -835,6 +964,65 @@ func postMCPRequest(t *testing.T, endpoint, method, protocolVersion string, para
 		t.Fatalf("MCP response error=%v", rpcError)
 	}
 	return object, response.Header
+}
+
+func installRestoreLitestream(t *testing.T) {
+	t.Helper()
+
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "litestream")
+	script := `#!/bin/sh
+LITESTREAM_TEST_MCP_RESTORE=1 exec "$LITESTREAM_TEST_BINARY" -test.run=^TestMCPRestoreCommandHarness$ -- "$@"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LITESTREAM_TEST_BINARY", testBinary)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestMCPRestoreCommandHarness(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MCP_RESTORE") != "1" {
+		t.Skip("helper process only")
+	}
+
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		os.Exit(2)
+	}
+	if err := NewMain().Run(context.Background(), os.Args[separator+1:]); err != nil {
+		if _, writeErr := fmt.Fprintln(os.Stderr, err); writeErr != nil {
+			os.Exit(2)
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func waitForPath(t *testing.T, path string) {
+	t.Helper()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s", path)
+		}
+	}
 }
 
 func textContent(t *testing.T, result *mcp.CallToolResult) string {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -888,6 +888,13 @@ if [ "$LITESTREAM_TEST_BLOCK" = "$1" ]; then
 	: > "$LITESTREAM_TEST_READY_FILE"
 	exec sleep 60
 fi
+if [ -n "$LITESTREAM_TEST_STDERR" ]; then
+ printf '%s\n' "$LITESTREAM_TEST_STDERR" >&2
+fi
+if [ -n "$LITESTREAM_TEST_JSON" ]; then
+ printf '%s\n' "$LITESTREAM_TEST_JSON"
+ exit 0
+fi
 case "$1" in
   databases)
     printf '[{"path":"/data/db","replica":"s3"}]\n'
@@ -1088,5 +1095,56 @@ func TestMCPServerLifecycle(t *testing.T) {
 	}
 	if err := listener.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMCPRestoreOutputAccessError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	installRestoreLitestream(t)
+	_, handler := RestoreTool("")
+	output := filepath.Join(t.TempDir(), strings.Repeat("x", 300))
+	result, _, err := handler(t.Context(), nil, restoreInput{Path: "file://" + t.TempDir(), Output: &output, IfDBNotExists: boolPointer(true)})
+	if err == nil || !strings.Contains(err.Error(), "cannot access output path") || result != nil {
+		t.Fatalf("result=%v error=%v, want output access error", result, err)
+	}
+}
+
+func TestMCPRestoreRejectsMalformedOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	installFakeLitestream(t)
+	_, handler := RestoreTool("")
+	for _, tt := range []struct{ output, want string }{
+		{"{", "decode restore JSON"},
+		{`{"status":"unknown"}`, "unknown restore status"},
+		{`{"status":"skipped","reason":"unknown"}`, "unknown restore skip reason"},
+		{`{"status":"restored"}`, "missing result"},
+	} {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Setenv("LITESTREAM_TEST_JSON", tt.output)
+			result, _, err := handler(t.Context(), nil, restoreInput{Path: "/tmp/db"})
+			if err == nil || !strings.Contains(err.Error(), tt.want) || result != nil {
+				t.Fatalf("result=%v error=%v, want %s", result, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestMCPJSONIgnoresDiagnosticStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	installFakeLitestream(t)
+	t.Setenv("LITESTREAM_TEST_STDERR", "diagnostic on stderr")
+	_, handler := DatabasesTool("")
+	_, output, err := handler(t.Context(), nil, databasesInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(output.Databases) != 1 {
+		t.Fatalf("databases=%v", output.Databases)
 	}
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -77,13 +77,25 @@ func TestMCPServerTools(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		readOnly    bool
-		destructive bool
-		properties  map[string]string
-		required    []string
+		readOnly         bool
+		destructive      bool
+		properties       map[string]string
+		required         []string
+		outputProperties []string
+		outputRequired   []string
 	}{
-		"litestream_databases": {readOnly: true, properties: map[string]string{"config": "string"}},
-		"litestream_info":      {readOnly: true, properties: map[string]string{"config": "string"}},
+		"litestream_databases": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string"},
+			outputProperties: []string{"databases"},
+			outputRequired:   []string{"databases"},
+		},
+		"litestream_info": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string"},
+			outputProperties: []string{"config", "databases", "version"},
+			outputRequired:   []string{"config", "databases", "version"},
+		},
 		"litestream_restore": {
 			destructive: true,
 			properties: map[string]string{
@@ -96,12 +108,35 @@ func TestMCPServerTools(t *testing.T) {
 				"timestamp":         "string",
 				"txid":              "string",
 			},
-			required: []string{"path"},
+			required:         []string{"path"},
+			outputProperties: []string{"result", "status"},
+			outputRequired:   []string{"status"},
 		},
-		"litestream_ltx":     {readOnly: true, properties: map[string]string{"config": "string", "path": "string"}, required: []string{"path"}},
-		"litestream_version": {readOnly: true},
-		"litestream_status":  {readOnly: true, properties: map[string]string{"config": "string", "path": "string"}},
-		"litestream_reset":   {destructive: true, properties: map[string]string{"config": "string", "path": "string"}, required: []string{"path"}},
+		"litestream_ltx": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string", "path": "string"},
+			required:         []string{"path"},
+			outputProperties: []string{"files"},
+			outputRequired:   []string{"files"},
+		},
+		"litestream_version": {
+			readOnly:         true,
+			outputProperties: []string{"version"},
+			outputRequired:   []string{"version"},
+		},
+		"litestream_status": {
+			readOnly:         true,
+			properties:       map[string]string{"config": "string", "path": "string"},
+			outputProperties: []string{"databases"},
+			outputRequired:   []string{"databases"},
+		},
+		"litestream_reset": {
+			destructive:      true,
+			properties:       map[string]string{"config": "string", "path": "string"},
+			required:         []string{"path"},
+			outputProperties: []string{"path", "status"},
+			outputRequired:   []string{"path", "status"},
+		},
 	}
 
 	if got, want := len(result.Tools), len(tests); got != want {
@@ -153,15 +188,15 @@ func TestMCPServerTools(t *testing.T) {
 
 		outputSchema := jsonObject(t, tool.OutputSchema)
 		outputProperties := schemaProperties(t, outputSchema)
-		if got := slices.Sorted(maps.Keys(outputProperties)); !reflect.DeepEqual(got, []string{"text"}) {
-			t.Errorf("%s output properties=%v, want [text]", tool.Name, got)
+		if got := slices.Sorted(maps.Keys(outputProperties)); !reflect.DeepEqual(got, test.outputProperties) {
+			t.Errorf("%s output properties=%v, want %v", tool.Name, got, test.outputProperties)
 		}
-		if property := jsonObject(t, outputProperties["text"]); property["description"] == "" {
-			t.Errorf("%s output property text has no description", tool.Name)
-		} else if got := property["type"]; got != "string" {
-			t.Errorf("%s output property text type=%v, want string", tool.Name, got)
+		for name, property := range outputProperties {
+			if property := jsonObject(t, property); property["description"] == "" {
+				t.Errorf("%s output property %s has no description", tool.Name, name)
+			}
 		}
-		if got, want := schemaRequired(outputSchema), []string{"text"}; !reflect.DeepEqual(got, want) {
+		if got, want := schemaRequired(outputSchema), test.outputRequired; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s required output properties=%v, want %v", tool.Name, got, want)
 		}
 	}
@@ -219,10 +254,10 @@ func TestMCPServerTools(t *testing.T) {
 	if callResult.IsError {
 		t.Fatalf("version tool error: %#v", callResult.Content)
 	}
-	if got, want := callResult.StructuredContent, map[string]any{"text": version + "\n"}; !reflect.DeepEqual(got, want) {
+	if got, want := callResult.StructuredContent, map[string]any{"version": version}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("version structured content=%v, want %v", got, want)
 	}
-	if got, want := textContent(t, callResult), version+"\n"; got != want {
+	if got, want := textContent(t, callResult), "Litestream "+version+"."; got != want {
 		t.Fatalf("version text content=%q, want %q", got, want)
 	}
 }
@@ -419,8 +454,9 @@ func TestMCPToolBehavior(t *testing.T) {
 		t.Skip("requires a POSIX shell")
 	}
 
-	setVersion(t, "v1.2.3-mcp-test")
-	installFakeLitestream(t)
+	const version = "v1.2.3-mcp-test"
+	setVersion(t, version)
+	argsPath := installFakeLitestream(t)
 
 	server, err := NewMCP(t.Context(), "/default/litestream.yml")
 	if err != nil {
@@ -441,14 +477,20 @@ func TestMCPToolBehavior(t *testing.T) {
 	})
 
 	tests := []struct {
-		name      string
-		arguments map[string]any
-		want      string
+		name           string
+		arguments      map[string]any
+		wantText       string
+		wantStructured any
+		wantArgs       string
 	}{
 		{
 			name:      "litestream_databases",
 			arguments: map[string]any{"config": ""},
-			want:      "<databases><-config><>\n",
+			wantText:  "Found 1 configured database.",
+			wantStructured: map[string]any{
+				"databases": []any{map[string]any{"path": "/data/db", "replica": "s3"}},
+			},
+			wantArgs: "<databases><-json><-config><>\n",
 		},
 		{
 			name: "litestream_restore",
@@ -462,27 +504,65 @@ func TestMCPToolBehavior(t *testing.T) {
 				"if_db_not_exists":  false,
 				"if_replica_exists": true,
 			},
-			want: "<restore><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
+			wantText: "Restored /restore/db using the file replica at TXID 0000000000000004.",
+			wantStructured: map[string]any{
+				"status": "restored",
+				"result": map[string]any{
+					"db_path":         "/restore/db",
+					"replica":         "file",
+					"txid":            "0000000000000004",
+					"duration_ms":     float64(125),
+					"integrity_check": "none",
+				},
+			},
+			wantArgs: "<restore><-json><-o><><-txid><><-timestamp><><-parallelism><><-if-db-not-exists><false><-if-replica-exists><true></data/db>\n",
 		},
 		{
 			name:      "litestream_ltx",
 			arguments: map[string]any{"path": "/data/db", "config": ""},
-			want:      "<ltx></data/db>\n",
+			wantText:  "Found 1 LTX file for /data/db.",
+			wantStructured: map[string]any{
+				"files": []any{map[string]any{
+					"level":     float64(0),
+					"min_txid":  "0000000000000001",
+					"max_txid":  "0000000000000004",
+					"size":      float64(8192),
+					"timestamp": "2026-04-24T12:00:00Z",
+				}},
+			},
+			wantArgs: "<ltx><-json></data/db>\n",
 		},
 		{
 			name:      "litestream_status",
 			arguments: map[string]any{"config": "", "path": ""},
-			want:      "<status><-config><><>\n",
+			wantText:  "Reported replication status for 1 database.",
+			wantStructured: map[string]any{
+				"databases": []any{map[string]any{
+					"database":   "/data/db",
+					"status":     "ok",
+					"local_txid": "0000000000000004",
+					"wal_size":   "32 kB",
+				}},
+			},
+			wantArgs: "<status><-json><-config><><>\n",
 		},
 		{
 			name:      "litestream_reset",
 			arguments: map[string]any{"path": "/data/db", "config": ""},
-			want:      "<reset><-config><></data/db>\n",
+			wantText:  "Reset command completed for /data/db.",
+			wantStructured: map[string]any{
+				"path":   "/data/db",
+				"status": "completed",
+			},
+			wantArgs: "<reset><-config><></data/db>\n",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(argsPath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
 			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: test.name, Arguments: test.arguments})
 			if err != nil {
 				t.Fatal(err)
@@ -490,16 +570,25 @@ func TestMCPToolBehavior(t *testing.T) {
 			if result.IsError {
 				t.Fatalf("tool error: %#v", result.Content)
 			}
-			if got := textContent(t, result); got != test.want {
-				t.Fatalf("text content=%q, want %q", got, test.want)
+			if got := textContent(t, result); got != test.wantText {
+				t.Fatalf("text content=%q, want %q", got, test.wantText)
 			}
-			if got, want := result.StructuredContent, map[string]any{"text": test.want}; !reflect.DeepEqual(got, want) {
-				t.Fatalf("structured content=%v, want %v", got, want)
+			if got := result.StructuredContent; !reflect.DeepEqual(got, test.wantStructured) {
+				t.Fatalf("structured content=%v, want %v", got, test.wantStructured)
+			}
+			args, err := os.ReadFile(argsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := string(args); got != test.wantArgs {
+				t.Fatalf("command arguments=%q, want %q", got, test.wantArgs)
 			}
 		})
 	}
 
-	t.Setenv("LITESTREAM_TEST_DATABASES_TABLE", "1")
+	if err := os.WriteFile(argsPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "litestream_info",
 		Arguments: map[string]any{"config": "/custom/litestream.yml"},
@@ -510,15 +599,34 @@ func TestMCPToolBehavior(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("info tool error: %#v", result.Content)
 	}
-	for _, want := range []string{
-		"Litestream test-version",
-		"Current Config Path:\n/custom/litestream.yml",
-		"Database: /data/db",
-		"<ltx><-config></custom/litestream.yml></data/db>",
-	} {
-		if got := textContent(t, result); !strings.Contains(got, want) {
-			t.Errorf("info text content does not contain %q: %q", want, got)
-		}
+	if got, want := textContent(t, result), "Litestream "+version+" has 1 configured database and 1 LTX file."; got != want {
+		t.Fatalf("info text content=%q, want %q", got, want)
+	}
+	wantInfo := map[string]any{
+		"version": version,
+		"config":  "/custom/litestream.yml",
+		"databases": []any{map[string]any{
+			"path":    "/data/db",
+			"replica": "s3",
+			"ltx_files": []any{map[string]any{
+				"level":     float64(0),
+				"min_txid":  "0000000000000001",
+				"max_txid":  "0000000000000004",
+				"size":      float64(8192),
+				"timestamp": "2026-04-24T12:00:00Z",
+			}},
+		}},
+	}
+	if got := result.StructuredContent; !reflect.DeepEqual(got, wantInfo) {
+		t.Fatalf("info structured content=%v, want %v", got, wantInfo)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := "<databases><-json><-config></custom/litestream.yml>\n<ltx><-json><-config></custom/litestream.yml></data/db>\n"
+	if got := string(args); got != wantArgs {
+		t.Fatalf("info command arguments=%q, want %q", got, wantArgs)
 	}
 
 	t.Setenv("LITESTREAM_TEST_FAIL", "ltx")
@@ -536,6 +644,25 @@ func TestMCPToolBehavior(t *testing.T) {
 		if got := textContent(t, result); !strings.Contains(got, want) {
 			t.Errorf("info error does not contain %q: %q", want, got)
 		}
+	}
+
+	t.Setenv("LITESTREAM_TEST_FAIL", "")
+	t.Setenv("LITESTREAM_TEST_SKIP", "restore")
+	result, err = session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "litestream_restore",
+		Arguments: map[string]any{"path": "/data/db"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("skipped restore tool error: %#v", result.Content)
+	}
+	if got, want := textContent(t, result), "Restore skipped for /data/db."; got != want {
+		t.Fatalf("skipped restore text content=%q, want %q", got, want)
+	}
+	if got, want := result.StructuredContent, map[string]any{"status": "skipped"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("skipped restore structured content=%v, want %v", got, want)
 	}
 }
 
@@ -612,34 +739,50 @@ func schemaRequired(schema map[string]any) []string {
 	return required
 }
 
-func installFakeLitestream(t *testing.T) {
+func installFakeLitestream(t *testing.T) string {
 	t.Helper()
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "litestream")
+	argsPath := filepath.Join(dir, "args")
 	script := `#!/bin/sh
+if [ -n "$LITESTREAM_TEST_ARGS_FILE" ]; then
+  for argument in "$@"; do
+    printf '<%s>' "$argument" >> "$LITESTREAM_TEST_ARGS_FILE"
+  done
+  printf '\n' >> "$LITESTREAM_TEST_ARGS_FILE"
+fi
 if [ "$LITESTREAM_TEST_FAIL" = "$1" ]; then
 	printf 'failure from %s\n' "$1" >&2
 	exit 1
 fi
-if [ "$1" = "version" ]; then
-	printf 'Litestream test-version\n'
+if [ "$LITESTREAM_TEST_SKIP" = "$1" ]; then
 	exit 0
 fi
-if [ "$1" = "databases" ] && [ "$LITESTREAM_TEST_DATABASES_TABLE" = "1" ]; then
-	printf 'path replica\n'
-	printf '/data/db s3://bucket/db\n'
-	exit 0
-fi
-for argument in "$@"; do
-	printf '<%s>' "$argument"
-done
-printf '\n'
+case "$1" in
+  databases)
+    printf '[{"path":"/data/db","replica":"s3"}]\n'
+    ;;
+  restore)
+    printf '{"db_path":"/restore/db","replica":"file","txid":"0000000000000004","duration_ms":125,"integrity_check":"none"}\n'
+    ;;
+  ltx)
+    printf '[{"level":0,"min_txid":"0000000000000001","max_txid":"0000000000000004","size":8192,"timestamp":"2026-04-24T12:00:00Z"}]\n'
+    ;;
+  status)
+    printf '[{"database":"/data/db","status":"ok","local_txid":"0000000000000004","wal_size":"32 kB"}]\n'
+    ;;
+  reset)
+    printf 'Reset complete.\n'
+    ;;
+esac
 `
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("LITESTREAM_TEST_ARGS_FILE", argsPath)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
 }
 
 func postMCPRequest(t *testing.T, endpoint, method, protocolVersion string, params map[string]any) (map[string]any, http.Header) {

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -99,6 +99,12 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 		if r, err = c.loadFromURL(ctx, fs.Arg(0), *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
 			slog.Info("database already exists, skipping")
+			if *jsonOutput {
+				return printRestoreOutput(RestoreOutput{
+					Status: RestoreStatusSkipped,
+					Reason: RestoreReasonDatabaseExists,
+				})
+			}
 			return nil
 		} else if err != nil {
 			return err
@@ -109,6 +115,12 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 		if r, err = c.loadFromConfig(ctx, fs.Arg(0), *configPath, !*noExpandEnv, *ifDBNotExists, &opt); errors.Is(err, errSkipDBExists) {
 			slog.Info("database already exists, skipping")
+			if *jsonOutput {
+				return printRestoreOutput(RestoreOutput{
+					Status: RestoreStatusSkipped,
+					Reason: RestoreReasonDatabaseExists,
+				})
+			}
 			return nil
 		} else if err != nil {
 			return err
@@ -145,6 +157,12 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) {
 		if *ifReplicaExists {
 			slog.Info("no matching backups found")
+			if *jsonOutput {
+				return printRestoreOutput(RestoreOutput{
+					Status: RestoreStatusSkipped,
+					Reason: RestoreReasonNoMatchingBackups,
+				})
+			}
 			return nil
 		}
 		return fmt.Errorf("no matching backup files available")
@@ -152,17 +170,16 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	if *jsonOutput {
-		output, err := json.MarshalIndent(RestoreResult{
-			DBPath:         opt.OutputPath,
-			Replica:        r.Client.Type(),
-			TXID:           txid,
-			DurationMS:     time.Since(start).Milliseconds(),
-			IntegrityCheck: *integrityCheck,
-		}, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to format response: %w", err)
-		}
-		fmt.Println(string(output))
+		return printRestoreOutput(RestoreOutput{
+			Status: RestoreStatusRestored,
+			RestoreResult: &RestoreResult{
+				DBPath:         opt.OutputPath,
+				Replica:        r.Client.Type(),
+				TXID:           txid,
+				DurationMS:     time.Since(start).Milliseconds(),
+				IntegrityCheck: *integrityCheck,
+			},
+		})
 	}
 	return nil
 }
@@ -185,12 +202,43 @@ type RestorePlanFile struct {
 	Timestamp string `json:"timestamp"`
 }
 
+type RestoreStatus string
+
+const (
+	RestoreStatusRestored RestoreStatus = "restored"
+	RestoreStatusSkipped  RestoreStatus = "skipped"
+)
+
+type RestoreReason string
+
+const (
+	RestoreReasonDatabaseExists    RestoreReason = "database_exists"
+	RestoreReasonNoMatchingBackups RestoreReason = "no_matching_backups"
+)
+
+type RestoreOutput struct {
+	Status RestoreStatus `json:"status"`
+	Reason RestoreReason `json:"reason,omitempty"`
+	*RestoreResult
+}
+
 type RestoreResult struct {
 	DBPath         string `json:"db_path"`
 	Replica        string `json:"replica"`
 	TXID           string `json:"txid"`
 	DurationMS     int64  `json:"duration_ms"`
 	IntegrityCheck string `json:"integrity_check"`
+}
+
+func printRestoreOutput(result RestoreOutput) error {
+	output, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format response: %w", err)
+	}
+	if _, err := fmt.Println(string(output)); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
+	return nil
 }
 
 func (c *RestoreCommand) dryRunPlan(ctx context.Context, source string, r *litestream.Replica, opt litestream.RestoreOptions) (RestorePlan, error) {
@@ -403,7 +451,7 @@ Arguments:
 	    Overwrite an existing output database and SQLite sidecar files.
 
 	-json
-	    Output raw JSON summary on successful restore.
+	    Output raw JSON outcome.
 
 	-f
 	    Follow mode. After restoring, continuously poll for and apply

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -152,9 +152,12 @@ func (c *RestoreCommand) Run(ctx context.Context, args []string) (err error) {
 		}
 	}
 
-	txid := c.restoreTXID(ctx, r, opt)
+	txid, err := c.restoreTXID(ctx, r, &opt)
 	start := time.Now()
-	if err := r.Restore(ctx, opt); errors.Is(err, litestream.ErrTxNotAvailable) {
+	if err == nil {
+		err = r.Restore(ctx, opt)
+	}
+	if errors.Is(err, litestream.ErrTxNotAvailable) {
 		if *ifReplicaExists {
 			slog.Info("no matching backups found")
 			if *jsonOutput {
@@ -299,18 +302,26 @@ func (c *RestoreCommand) printDryRunPlan(plan RestorePlan) {
 	}
 }
 
-func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica, opt litestream.RestoreOptions) string {
+func (c *RestoreCommand) restoreTXID(ctx context.Context, r *litestream.Replica, opt *litestream.RestoreOptions) (string, error) {
 	if opt.TXID != 0 {
-		return opt.TXID.String()
+		return opt.TXID.String(), nil
 	}
 	if opt.Follow {
-		return ""
+		return "", nil
+	}
+	if _, ok := r.Client.(litestream.ReplicaClientV3); ok {
+		return "", nil
 	}
 	infos, err := litestream.CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
-	if err != nil || len(infos) == 0 {
-		return ""
+	if err != nil {
+		return "", err
 	}
-	return infos[len(infos)-1].MaxTXID.String()
+	if len(infos) == 0 {
+		return "", litestream.ErrTxNotAvailable
+	}
+	opt.TXID = infos[len(infos)-1].MaxTXID
+	opt.Timestamp = time.Time{}
+	return opt.TXID.String(), nil
 }
 
 func (c *RestoreCommand) prepareOutputPath(path string, force bool) error {
@@ -354,8 +365,10 @@ func (c *RestoreCommand) loadFromURL(ctx context.Context, replicaURL string, ifD
 	}
 
 	// Exit successfully if the output file already exists.
-	if _, err := os.Stat(opt.OutputPath); !os.IsNotExist(err) && ifDBNotExists {
+	if _, err := os.Stat(opt.OutputPath); err == nil && ifDBNotExists {
 		return nil, errSkipDBExists
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot access output path: %w", err)
 	}
 
 	syncInterval := litestream.DefaultSyncInterval
@@ -399,8 +412,10 @@ func (c *RestoreCommand) loadFromConfig(_ context.Context, dbPath, configPath st
 	}
 
 	// Exit successfully if the output file already exists.
-	if _, err := os.Stat(opt.OutputPath); !os.IsNotExist(err) && ifDBNotExists {
+	if _, err := os.Stat(opt.OutputPath); err == nil && ifDBNotExists {
 		return nil, errSkipDBExists
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot access output path: %w", err)
 	}
 
 	return db.Replica, nil

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -115,9 +115,18 @@ func TestRestoreCommand_RunJSONOutput(t *testing.T) {
 		}
 	})
 
-	var got RestoreResult
+	var got RestoreOutput
 	if err := json.Unmarshal([]byte(output), &got); err != nil {
 		t.Fatalf("failed to parse output: %v\n%s", err, output)
+	}
+	if got.Status != RestoreStatusRestored {
+		t.Fatalf("unexpected status: %s", got.Status)
+	}
+	if got.Reason != "" {
+		t.Fatalf("unexpected reason: %s", got.Reason)
+	}
+	if got.RestoreResult == nil {
+		t.Fatal("expected restore result")
 	}
 	if got.DBPath != restorePath {
 		t.Fatalf("unexpected db path: %s", got.DBPath)
@@ -136,6 +145,57 @@ func TestRestoreCommand_RunJSONOutput(t *testing.T) {
 	}
 	if _, err := os.Stat(restorePath); err != nil {
 		t.Fatalf("expected restored database: %v", err)
+	}
+}
+
+func TestRestoreCommand_RunJSONSkipOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       func(*testing.T) []string
+		wantReason RestoreReason
+	}{
+		{
+			name: "DatabaseExists",
+			args: func(t *testing.T) []string {
+				restorePath := filepath.Join(t.TempDir(), "db")
+				if err := os.WriteFile(restorePath, []byte("existing"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return []string{"-json", "-if-db-not-exists", "-o", restorePath, "file://" + t.TempDir()}
+			},
+			wantReason: RestoreReasonDatabaseExists,
+		},
+		{
+			name: "NoMatchingBackups",
+			args: func(t *testing.T) []string {
+				return []string{"-json", "-if-replica-exists", "-o", filepath.Join(t.TempDir(), "db"), "file://" + t.TempDir()}
+			},
+			wantReason: RestoreReasonNoMatchingBackups,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := captureLTXCommandStdout(t, func() {
+				if err := (&RestoreCommand{}).Run(t.Context(), tt.args(t)); err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			var got RestoreOutput
+			if err := json.Unmarshal([]byte(output), &got); err != nil {
+				t.Fatalf("failed to parse output: %v\n%s", err, output)
+			}
+			if got.Status != RestoreStatusSkipped {
+				t.Fatalf("status=%q, want %q", got.Status, RestoreStatusSkipped)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("reason=%q, want %q", got.Reason, tt.wantReason)
+			}
+			if got.RestoreResult != nil {
+				t.Fatalf("result=%v, want nil", got.RestoreResult)
+			}
+		})
 	}
 }
 

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/pierrec/lz4/v4"
 
 	litestream "github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
@@ -134,8 +138,8 @@ func TestRestoreCommand_RunJSONOutput(t *testing.T) {
 	if got.Replica != "file" {
 		t.Fatalf("unexpected replica: %s", got.Replica)
 	}
-	if got.TXID == "" {
-		t.Fatal("expected txid")
+	if got.TXID != "" {
+		t.Fatalf("automatic legacy-capable restore reported unverified TXID %q", got.TXID)
 	}
 	if got.DurationMS < 0 {
 		t.Fatalf("unexpected duration_ms: %d", got.DurationMS)
@@ -377,5 +381,115 @@ func assertRestoreCommandDB(t *testing.T, path string) {
 	}
 	if count != 1 {
 		t.Fatalf("count=%d, want 1", count)
+	}
+}
+
+func TestRestoreCommandOutputAccessError(t *testing.T) {
+	for _, fromConfig := range []bool{false, true} {
+		t.Run(map[bool]string{false: "url", true: "config"}[fromConfig], func(t *testing.T) {
+			dir := t.TempDir()
+			output := filepath.Join(dir, strings.Repeat("x", 300))
+			args := []string{"-json", "-if-db-not-exists", "-o", output}
+			if fromConfig {
+				config := filepath.Join(dir, "litestream.yml")
+				dbPath := filepath.Join(dir, "db")
+				content := "dbs:\n  - path: " + dbPath + "\n    replica:\n      url: file://" + dir + "/replica\n"
+				if err := os.WriteFile(config, []byte(content), 0600); err != nil {
+					t.Fatal(err)
+				}
+				args = append(args, "-config", config, dbPath)
+			} else {
+				args = append(args, "file://"+dir+"/replica")
+			}
+			err := (&RestoreCommand{}).Run(t.Context(), args)
+			if err == nil || !strings.Contains(err.Error(), "cannot access output path") {
+				t.Fatalf("error=%v, want output access error", err)
+			}
+		})
+	}
+}
+
+func TestRestoreCommandLegacySelection(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy only", true: "newer legacy"}[mixed], func(t *testing.T) {
+			dir := t.TempDir()
+			replicaPath, restorePath := filepath.Join(dir, "replica"), filepath.Join(dir, "restored.db")
+			if mixed {
+				replicaPath, restorePath = createRestoreCommandTestData(t, t.Context())
+			}
+			source := filepath.Join(dir, "legacy.db")
+			db := testingutil.MustOpenSQLDB(t, source)
+			if _, err := db.ExecContext(t.Context(), "CREATE TABLE t (id INT); INSERT INTO t VALUES (2)"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var compressed bytes.Buffer
+			writer := lz4.NewWriter(&compressed)
+			if _, err := writer.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			snapshotDir := filepath.Join(replicaPath, "generations", "0123456789abcdef", "snapshots")
+			if err := os.MkdirAll(snapshotDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			snapshot := filepath.Join(snapshotDir, "00000000.snapshot.lz4")
+			if err := os.WriteFile(snapshot, compressed.Bytes(), 0600); err != nil {
+				t.Fatal(err)
+			}
+			newer := time.Now().Add(time.Hour)
+			if err := os.Chtimes(snapshot, newer, newer); err != nil {
+				t.Fatal(err)
+			}
+			output := captureLTXCommandStdout(t, func() {
+				if err := (&RestoreCommand{}).Run(t.Context(), []string{"-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
+					t.Fatal(err)
+				}
+			})
+			var result RestoreOutput
+			if err := json.Unmarshal([]byte(output), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.RestoreResult == nil || result.TXID != "" {
+				t.Fatalf("result=%+v, want unknown legacy TXID", result)
+			}
+			restored := testingutil.MustOpenSQLDB(t, restorePath)
+			defer func() {
+				if err := restored.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			var id int
+			if err := restored.QueryRowContext(t.Context(), "SELECT id FROM t").Scan(&id); err != nil {
+				t.Fatal(err)
+			}
+			if id != 2 {
+				t.Fatalf("restored id=%d, want legacy value 2", id)
+			}
+		})
+	}
+}
+
+func TestRestoreCommandExplicitTXIDOutput(t *testing.T) {
+	replicaPath, restorePath := createRestoreCommandTestData(t, t.Context())
+	output := captureLTXCommandStdout(t, func() {
+		if err := (&RestoreCommand{}).Run(t.Context(), []string{"-json", "-txid", "0000000000000001", "-o", restorePath, "file://" + replicaPath}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	var result RestoreOutput
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.RestoreResult == nil || result.TXID != "0000000000000001" {
+		t.Fatalf("result=%+v", result)
 	}
 }


### PR DESCRIPTION
## Description

Returns typed machine-readable MCP `structuredContent` alongside concise text summaries for all seven Litestream tools.

- Reuses the existing CLI JSON result types for databases, LTX files, replication status, and restore results.
- Runs JSON-capable commands with `-json` and decodes stdout separately from stderr.
- Preserves structured outcomes for version, reset, successful restores, and idempotently skipped restores.
- Expands MCP tests to verify output schemas, structured payloads, text summaries, subprocess arguments, errors, and cancellation.

### Scope

**In scope:**
- Structured output schemas and values for the existing MCP tools.
- Concise human/model-readable summaries.
- Compatibility coverage for successful and skipped tool outcomes.

**Not in scope:**
- The official SDK migration, which is provided by the stacked base PR.
- Replacing subprocess-backed tools with in-process calls (#1367).
- Adding restore preview or integrity-check tools (#1371).

## Motivation and Context

The MCP handlers previously returned combined command output as plain text and exposed only a `text` field as structured content. Machine consumers could not reliably inspect database, LTX, status, or restore fields even though the underlying CLI commands already provide stable JSON output.

Closes #1369

This PR is stacked on #1378 and intentionally targets `issue-1368-refactor-mcp-migrate-to-the-official-modelcontextprotocol-go`.

## How Has This Been Tested?

- `go test -race -v ./...`
- `go vet ./...`
- `pre-commit run --all-files`
- `go build -o /tmp/litestream-issue-1369 ./cmd/litestream`
- `go mod verify`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality not to work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (no documentation changes needed; configuration and CLI contracts are unchanged)
