### PR TITLE
feat(mcp): add standalone command

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -166,6 +166,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 			} else {
 				slog.Info("replication complete, litestream shutting down")
 			}
+		case err = <-c.mcpErrCh:
+			slog.Info("MCP server exited, litestream shutting down")
 		case sig := <-signalCh:
 			slog.Info("signal received, litestream shutting down", "signal", sig)
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -191,9 +191,7 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		}
 
 		// Gracefully close.
-		if e := c.Close(ctx); e != nil && err == nil {
-			err = e
-		}
+		err = errors.Join(err, c.Close(ctx))
 		slog.Info("litestream shut down")
 		return err
 

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -137,6 +137,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 	switch cmd {
 	case "databases":
 		return (&DatabasesCommand{}).Run(ctx, args)
+	case "mcp":
+		return (&MCPCommand{}).Run(ctx, args)
 	case "replicate":
 		c := NewReplicateCommand()
 		if err := c.ParseFlags(ctx, args); err != nil {
@@ -248,6 +250,7 @@ The commands are:
 	info         show daemon information
 	list         list all managed databases
 	ltx          list available LTX files for a database
+	mcp          runs the MCP server
 	register     register a database for replication
 	replicate    runs a server to replicate databases
 	reset        reset local state for a database

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -142,6 +142,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 	switch cmd {
 	case "databases":
 		return (&DatabasesCommand{}).Run(ctx, args)
+	case "mcp":
+		return (&MCPCommand{}).Run(ctx, args)
 	case "replicate":
 		c := NewReplicateCommand()
 		if err := c.ParseFlags(ctx, args); err != nil {
@@ -260,6 +262,7 @@ The commands are:
 	info         show daemon information
 	list         list all managed databases
 	ltx          list available LTX files for a database
+	mcp          runs the MCP server
 	register     register a database for replication
 	replicate    runs a server to replicate databases
 	reset        reset local state for a database

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -79,6 +79,15 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 
 	for {
 		select {
+		case err := <-c.mcpErrCh:
+			if err != nil {
+				slog.Error("MCP server exited", "error", err)
+			}
+			if closeErr := c.Close(s.ctx); closeErr != nil {
+				slog.Error("cannot close replication", "error", closeErr)
+			}
+			statusCh <- svc.Status{State: svc.StopPending}
+			return true, 3
 		case req := <-r:
 			switch req.Cmd {
 			case svc.Stop:

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -19,6 +19,8 @@ const defaultConfigPath = `C:\Litestream\litestream.yml`
 // serviceName is the Windows Service name.
 const serviceName = "Litestream"
 
+const windowsServiceCloseExitCode = 4
+
 // isWindowsService returns true if currently executing within a Windows service.
 func isWindowsService() (bool, error) {
 	return svc.IsWindowsService()
@@ -51,7 +53,9 @@ func runWindowsService(ctx context.Context) error {
 
 // windowsService is an interface adapter for svc.Handler.
 type windowsService struct {
-	ctx context.Context
+	ctx          context.Context
+	command      *ReplicateCommand
+	closeCommand func(context.Context, *ReplicateCommand) error
 }
 
 func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, statusCh chan<- svc.Status) (svcSpecificEC bool, exitCode uint32) {
@@ -61,10 +65,13 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 	statusCh <- svc.Status{State: svc.StartPending}
 
 	// Instantiate replication command and load configuration.
-	c := NewReplicateCommand()
-	if c.Config, err = ReadConfigFile(DefaultConfigPath(), true); err != nil {
-		slog.Error("cannot load configuration", "error", err)
-		return true, 1
+	c := s.command
+	if c == nil {
+		c = NewReplicateCommand()
+		if c.Config, err = ReadConfigFile(DefaultConfigPath(), true); err != nil {
+			slog.Error("cannot load configuration", "error", err)
+			return true, 1
+		}
 	}
 
 	// Execute replication command.
@@ -83,7 +90,7 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 			if err != nil {
 				slog.Error("MCP server exited", "error", err)
 			}
-			if closeErr := c.Close(s.ctx); closeErr != nil {
+			if closeErr := s.close(c); closeErr != nil {
 				slog.Error("cannot close replication", "error", closeErr)
 			}
 			statusCh <- svc.Status{State: svc.StopPending}
@@ -91,7 +98,11 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 		case req := <-r:
 			switch req.Cmd {
 			case svc.Stop:
-				c.Close(s.ctx)
+				if err := s.close(c); err != nil {
+					slog.Error("cannot close replication", "error", err)
+					statusCh <- svc.Status{State: svc.StopPending}
+					return true, windowsServiceCloseExitCode
+				}
 				statusCh <- svc.Status{State: svc.StopPending}
 				return false, windows.NO_ERROR
 			case svc.Interrogate:
@@ -101,6 +112,13 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 			}
 		}
 	}
+}
+
+func (s *windowsService) close(c *ReplicateCommand) error {
+	if s.closeCommand != nil {
+		return s.closeCommand(s.ctx, c)
+	}
+	return c.Close(s.ctx)
 }
 
 // Ensure implementation implements io.Writer interface.

--- a/cmd/litestream/main_windows.go
+++ b/cmd/litestream/main_windows.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -115,10 +117,18 @@ func (s *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, stat
 }
 
 func (s *windowsService) close(c *ReplicateCommand) error {
-	if s.closeCommand != nil {
-		return s.closeCommand(s.ctx, c)
+	var stopErr error
+	if c.cmd != nil && c.cmd.Process != nil {
+		if err := c.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			stopErr = fmt.Errorf("stop exec process: %w", err)
+		} else {
+			<-c.execCh
+		}
 	}
-	return c.Close(s.ctx)
+	if s.closeCommand != nil {
+		return errors.Join(stopErr, s.closeCommand(s.ctx, c))
+	}
+	return errors.Join(stopErr, c.Close(s.ctx))
 }
 
 // Ensure implementation implements io.Writer interface.

--- a/cmd/litestream/main_windows_test.go
+++ b/cmd/litestream/main_windows_test.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+func TestWindowsServiceExecuteStopCloseError(t *testing.T) {
+	closeErr := errors.New("test close error")
+	command := NewReplicateCommand()
+	command.Config = DefaultConfig()
+	service := &windowsService{
+		ctx:     t.Context(),
+		command: command,
+		closeCommand: func(ctx context.Context, command *ReplicateCommand) error {
+			return errors.Join(closeErr, command.Close(ctx))
+		},
+	}
+	requestCh := make(chan svc.ChangeRequest, 1)
+	requestCh <- svc.ChangeRequest{Cmd: svc.Stop}
+	statusCh := make(chan svc.Status, 3)
+
+	serviceSpecific, exitCode := service.Execute(nil, requestCh, statusCh)
+	if !serviceSpecific {
+		t.Fatal("serviceSpecific=false, want true")
+	}
+	if exitCode != windowsServiceCloseExitCode {
+		t.Fatalf("exitCode=%d, want %d", exitCode, windowsServiceCloseExitCode)
+	}
+
+	states := make([]svc.State, 0, len(statusCh))
+	close(statusCh)
+	for status := range statusCh {
+		states = append(states, status.State)
+	}
+	want := []svc.State{svc.StartPending, svc.Running, svc.StopPending}
+	if !slices.Equal(states, want) {
+		t.Fatalf("states=%v, want %v", states, want)
+	}
+}

--- a/cmd/litestream/main_windows_test.go
+++ b/cmd/litestream/main_windows_test.go
@@ -5,8 +5,11 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
 	"slices"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows/svc"
 )
@@ -43,4 +46,29 @@ func TestWindowsServiceExecuteStopCloseError(t *testing.T) {
 	if !slices.Equal(states, want) {
 		t.Fatalf("states=%v, want %v", states, want)
 	}
+}
+
+func TestWindowsServiceCloseStopsExec(t *testing.T) {
+	command := NewReplicateCommand()
+	command.cmd = exec.Command(os.Args[0], "-test.run=^TestWindowsServiceExecHelper$")
+	command.cmd.Env = append(os.Environ(), "LITESTREAM_TEST_SERVICE_EXEC=1")
+	command.execCh = make(chan error, 1)
+	if err := command.cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	go func() { command.execCh <- command.cmd.Wait() }()
+	service := &windowsService{ctx: t.Context()}
+	if err := service.close(command); err != nil {
+		t.Fatal(err)
+	}
+	if command.cmd.ProcessState == nil || command.cmd.ProcessState.Success() {
+		t.Fatal("exec child was not terminated and reaped")
+	}
+}
+
+func TestWindowsServiceExecHelper(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_SERVICE_EXEC") != "1" {
+		t.Skip("helper process only")
+	}
+	time.Sleep(time.Minute)
 }

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -102,6 +102,7 @@ type MCPServer struct {
 	server     *mcp.Server
 	mux        *http.ServeMux
 	httpServer *http.Server
+	errCh      chan error
 	configPath string
 }
 
@@ -140,19 +141,17 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	return s, nil
 }
 
-func (s *MCPServer) Start(addr string) {
+func (s *MCPServer) Start(addr string) error {
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
-		slog.Error("MCP server error", "error", err)
-		return
+		return fmt.Errorf("listen for MCP HTTP server: %w", err)
 	}
 	s.httpServer = s.newHTTPServer(listener.Addr().String())
+	s.errCh = make(chan error, 1)
 	go func() {
-		slog.Info("Starting MCP Streamable HTTP server", "addr", listener.Addr().String())
-		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("MCP server error", "error", err)
-		}
+		s.errCh <- s.runHTTP(s.ctx, listener)
 	}()
+	return nil
 }
 
 func (s *MCPServer) RunStdio(ctx context.Context) error {
@@ -161,6 +160,10 @@ func (s *MCPServer) RunStdio(ctx context.Context) error {
 
 func (s *MCPServer) RunHTTP(ctx context.Context, listener net.Listener) error {
 	s.httpServer = s.newHTTPServer(listener.Addr().String())
+	return s.runHTTP(ctx, listener)
+}
+
+func (s *MCPServer) runHTTP(ctx context.Context, listener net.Listener) error {
 	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("Starting MCP Streamable HTTP server", "addr", listener.Addr().String())

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -25,10 +25,12 @@ import (
 	"github.com/benbjohnson/litestream/internal"
 )
 
+// MCPCommand represents a command that runs the MCP server.
 type MCPCommand struct {
 	listener net.Listener
 }
 
+// Run executes the command.
 func (c *MCPCommand) Run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("litestream-mcp", flag.ContinueOnError)
 	addr := fs.String("addr", "", "HTTP bind address")
@@ -50,27 +52,24 @@ func (c *MCPCommand) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	if *addr == "" {
-		err = server.RunStdio(runCtx)
-	} else {
-		listener := c.listener
-		if listener == nil {
-			listener, err = net.Listen("tcp", *addr)
-			if err != nil {
-				return fmt.Errorf("listen for MCP HTTP server: %w", err)
+	return runMCPTransport(ctx, func(runCtx context.Context) error {
+		if *addr == "" {
+			err = server.RunStdio(runCtx)
+		} else {
+			listener := c.listener
+			if listener == nil {
+				listener, err = net.Listen("tcp", *addr)
+				if err != nil {
+					return fmt.Errorf("listen for MCP HTTP server: %w", err)
+				}
 			}
+			err = server.RunHTTP(runCtx, listener)
 		}
-		err = server.RunHTTP(runCtx, listener)
-	}
-	if errors.Is(err, context.Canceled) {
-		return nil
-	}
-	return err
+		return err
+	})
 }
 
+// Usage prints the help screen to STDOUT.
 func (c *MCPCommand) Usage() {
 	fmt.Printf(`
 The mcp command runs the Litestream MCP server without the replication daemon.
@@ -97,11 +96,42 @@ Examples:
 `[1:], DefaultConfigPath())
 }
 
+func runMCPTransport(ctx context.Context, run func(context.Context) error) error {
+	runCtx, stop := mcpSignalContext(ctx)
+	defer stop()
+	err := run(runCtx)
+	cause := context.Cause(runCtx)
+	if cause != nil && errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func mcpSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancelCause(parent)
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case sig := <-signalCh:
+			signal.Stop(signalCh)
+			cancel(fmt.Errorf("%s signal received", sig))
+		case <-ctx.Done():
+			signal.Stop(signalCh)
+		}
+	}()
+	return ctx, func() {
+		signal.Stop(signalCh)
+		cancel(context.Canceled)
+	}
+}
+
 type MCPServer struct {
 	ctx        context.Context
 	server     *mcp.Server
 	mux        *http.ServeMux
 	httpServer *http.Server
+	httpCancel context.CancelFunc
 	errCh      chan error
 	configPath string
 }
@@ -146,7 +176,7 @@ func (s *MCPServer) Start(addr string) error {
 	if err != nil {
 		return fmt.Errorf("listen for MCP HTTP server: %w", err)
 	}
-	s.httpServer = s.newHTTPServer(listener.Addr().String())
+	s.httpServer = s.newHTTPServer(s.ctx, listener.Addr().String())
 	s.errCh = make(chan error, 1)
 	go func() {
 		s.errCh <- s.runHTTP(s.ctx, listener)
@@ -159,11 +189,12 @@ func (s *MCPServer) RunStdio(ctx context.Context) error {
 }
 
 func (s *MCPServer) RunHTTP(ctx context.Context, listener net.Listener) error {
-	s.httpServer = s.newHTTPServer(listener.Addr().String())
+	s.httpServer = s.newHTTPServer(ctx, listener.Addr().String())
 	return s.runHTTP(ctx, listener)
 }
 
 func (s *MCPServer) runHTTP(ctx context.Context, listener net.Listener) error {
+	defer s.httpCancel()
 	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("Starting MCP Streamable HTTP server", "addr", listener.Addr().String())
@@ -194,10 +225,15 @@ func (s *MCPServer) runHTTP(ctx context.Context, listener net.Listener) error {
 	}
 }
 
-func (s *MCPServer) newHTTPServer(addr string) *http.Server {
+func (s *MCPServer) newHTTPServer(ctx context.Context, addr string) *http.Server {
+	httpCtx, cancel := context.WithCancel(ctx)
+	s.httpCancel = cancel
 	return &http.Server{
-		Addr:              addr,
-		Handler:           s.mux,
+		Addr:    addr,
+		Handler: s.mux,
+		BaseContext: func(net.Listener) context.Context {
+			return httpCtx
+		},
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 }
@@ -210,6 +246,9 @@ func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *MCPServer) Close() error {
 	if s.httpServer == nil {
 		return nil
+	}
+	if s.httpCancel != nil {
+		s.httpCancel()
 	}
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), 10*time.Second)
 	defer cancel()

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,22 +3,103 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"os"
 	"os/exec"
+	"os/signal"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/MadAppGang/httplog"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/benbjohnson/litestream/internal"
 )
+
+type MCPCommand struct {
+	listener net.Listener
+}
+
+func (c *MCPCommand) Run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("litestream-mcp", flag.ContinueOnError)
+	addr := fs.String("addr", "", "HTTP bind address")
+	configPath := fs.String("config", "", "config path")
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() > 0 {
+		return fmt.Errorf("too many arguments")
+	}
+	if *configPath == "" {
+		*configPath = DefaultConfigPath()
+	}
+
+	internal.InitLog(os.Stderr, "INFO", "text", false)
+
+	server, err := NewMCP(ctx, *configPath)
+	if err != nil {
+		return err
+	}
+
+	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if *addr == "" {
+		err = server.RunStdio(runCtx)
+	} else {
+		listener := c.listener
+		if listener == nil {
+			listener, err = net.Listen("tcp", *addr)
+			if err != nil {
+				return fmt.Errorf("listen for MCP HTTP server: %w", err)
+			}
+		}
+		err = server.RunHTTP(runCtx, listener)
+	}
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func (c *MCPCommand) Usage() {
+	fmt.Printf(`
+The mcp command runs the Litestream MCP server without the replication daemon.
+
+Usage:
+
+	litestream mcp [arguments]
+
+Arguments:
+
+	-addr ADDR
+	    Serves MCP over Streamable HTTP at ADDR instead of stdio.
+
+	-config PATH
+	    Specifies the default configuration file used by MCP tools.
+	    Defaults to %s
+
+Examples:
+
+	$ litestream mcp
+	$ litestream mcp --config /path/to/litestream.yml
+	$ litestream mcp --addr 127.0.0.1:3001
+
+`[1:], DefaultConfigPath())
+}
 
 type MCPServer struct {
 	ctx        context.Context
+	server     *mcp.Server
 	mux        *http.ServeMux
 	httpServer *http.Server
 	configPath string
@@ -50,6 +131,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcp.AddTool(mcpServer, statusTool, statusHandler)
 	resetTool, resetHandler := ResetTool(configPath)
 	mcp.AddTool(mcpServer, resetTool, resetHandler)
+	s.server = mcpServer
 
 	s.mux = http.NewServeMux()
 	s.mux.Handle("/", httplog.Logger(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
@@ -59,17 +141,62 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 }
 
 func (s *MCPServer) Start(addr string) {
-	s.httpServer = &http.Server{
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("MCP server error", "error", err)
+		return
+	}
+	s.httpServer = s.newHTTPServer(listener.Addr().String())
+	go func() {
+		slog.Info("Starting MCP Streamable HTTP server", "addr", listener.Addr().String())
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("MCP server error", "error", err)
+		}
+	}()
+}
+
+func (s *MCPServer) RunStdio(ctx context.Context) error {
+	return s.server.Run(ctx, &mcp.StdioTransport{})
+}
+
+func (s *MCPServer) RunHTTP(ctx context.Context, listener net.Listener) error {
+	s.httpServer = s.newHTTPServer(listener.Addr().String())
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("Starting MCP Streamable HTTP server", "addr", listener.Addr().String())
+		errCh <- s.httpServer.Serve(listener)
+	}()
+
+	select {
+	case <-ctx.Done():
+		if err := s.Close(); err != nil {
+			shutdownErr := fmt.Errorf("close MCP HTTP server: %w", err)
+			if err := s.httpServer.Close(); err != nil {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("force close MCP HTTP server: %w", err))
+			}
+			if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("serve MCP HTTP server: %w", err))
+			}
+			return shutdownErr
+		}
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve MCP HTTP server: %w", err)
+		}
+		return nil
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve MCP HTTP server: %w", err)
+		}
+		return nil
+	}
+}
+
+func (s *MCPServer) newHTTPServer(addr string) *http.Server {
+	return &http.Server{
 		Addr:              addr,
 		Handler:           s.mux,
 		ReadHeaderTimeout: 30 * time.Second,
 	}
-	go func() {
-		slog.Info("Starting MCP Streamable HTTP server", "addr", addr)
-		if err := s.httpServer.ListenAndServe(); err != nil {
-			slog.Error("MCP server error", "error", err)
-		}
-	}()
 }
 
 func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +205,10 @@ func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Close attempts to gracefully shutdown the server.
 func (s *MCPServer) Close() error {
-	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+	if s.httpServer == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), 10*time.Second)
 	defer cancel()
 	return s.httpServer.Shutdown(ctx)
 }

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -4,22 +4,100 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
+	"os/signal"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/MadAppGang/httplog"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/benbjohnson/litestream/internal"
 )
 
 const mcpCatalogCacheTTL = 5 * time.Minute
+
+type MCPCommand struct {
+	listener net.Listener
+}
+
+func (c *MCPCommand) Run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("litestream-mcp", flag.ContinueOnError)
+	addr := fs.String("addr", "", "HTTP bind address")
+	configPath := fs.String("config", "", "config path")
+	fs.Usage = c.Usage
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() > 0 {
+		return fmt.Errorf("too many arguments")
+	}
+	if *configPath == "" {
+		*configPath = DefaultConfigPath()
+	}
+
+	internal.InitLog(os.Stderr, "INFO", "text", false)
+
+	server, err := NewMCP(ctx, *configPath)
+	if err != nil {
+		return err
+	}
+
+	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if *addr == "" {
+		err = server.RunStdio(runCtx)
+	} else {
+		listener := c.listener
+		if listener == nil {
+			listener, err = net.Listen("tcp", *addr)
+			if err != nil {
+				return fmt.Errorf("listen for MCP HTTP server: %w", err)
+			}
+		}
+		err = server.RunHTTP(runCtx, listener)
+	}
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func (c *MCPCommand) Usage() {
+	fmt.Printf(`
+The mcp command runs the Litestream MCP server without the replication daemon.
+
+Usage:
+
+	litestream mcp [arguments]
+
+Arguments:
+
+	-addr ADDR
+	    Serves MCP over Streamable HTTP at ADDR instead of stdio.
+
+	-config PATH
+	    Specifies the default configuration file used by MCP tools.
+	    Defaults to %s
+
+Examples:
+
+	$ litestream mcp
+	$ litestream mcp --config /path/to/litestream.yml
+	$ litestream mcp --addr 127.0.0.1:3001
+
+`[1:], DefaultConfigPath())
+}
 
 type MCPServer struct {
 	ctx        context.Context
@@ -102,6 +180,15 @@ func (s *MCPServer) Start(addr string) error {
 		close(s.httpDone)
 	}()
 	return nil
+}
+
+func (s *MCPServer) RunStdio(ctx context.Context) error {
+	return s.mcpServer.Run(ctx, &mcp.StdioTransport{})
+}
+
+func (s *MCPServer) RunHTTP(ctx context.Context, listener net.Listener) error {
+	s.httpServer = s.newHTTPServer(ctx, listener.Addr().String())
+	return s.runHTTP(ctx, listener)
 }
 
 func (s *MCPServer) runHTTP(ctx context.Context, listener net.Listener) error {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -103,7 +103,7 @@ func runMCPTransport(ctx context.Context, run func(context.Context) error) error
 	defer stop()
 	err := run(runCtx)
 	cause := context.Cause(runCtx)
-	if cause != nil && errors.Is(err, context.Canceled) {
+	if cause != nil && err == context.Canceled {
 		return nil
 	}
 	return err

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -27,10 +27,12 @@ import (
 
 const mcpCatalogCacheTTL = 5 * time.Minute
 
+// MCPCommand represents a command that runs the MCP server.
 type MCPCommand struct {
 	listener net.Listener
 }
 
+// Run executes the command.
 func (c *MCPCommand) Run(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("litestream-mcp", flag.ContinueOnError)
 	addr := fs.String("addr", "", "HTTP bind address")
@@ -52,27 +54,24 @@ func (c *MCPCommand) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	if *addr == "" {
-		err = server.RunStdio(runCtx)
-	} else {
-		listener := c.listener
-		if listener == nil {
-			listener, err = net.Listen("tcp", *addr)
-			if err != nil {
-				return fmt.Errorf("listen for MCP HTTP server: %w", err)
+	return runMCPTransport(ctx, func(runCtx context.Context) error {
+		if *addr == "" {
+			err = server.RunStdio(runCtx)
+		} else {
+			listener := c.listener
+			if listener == nil {
+				listener, err = net.Listen("tcp", *addr)
+				if err != nil {
+					return fmt.Errorf("listen for MCP HTTP server: %w", err)
+				}
 			}
+			err = server.RunHTTP(runCtx, listener)
 		}
-		err = server.RunHTTP(runCtx, listener)
-	}
-	if errors.Is(err, context.Canceled) {
-		return nil
-	}
-	return err
+		return err
+	})
 }
 
+// Usage prints the help screen to STDOUT.
 func (c *MCPCommand) Usage() {
 	fmt.Printf(`
 The mcp command runs the Litestream MCP server without the replication daemon.
@@ -97,6 +96,36 @@ Examples:
 	$ litestream mcp --addr 127.0.0.1:3001
 
 `[1:], DefaultConfigPath())
+}
+
+func runMCPTransport(ctx context.Context, run func(context.Context) error) error {
+	runCtx, stop := mcpSignalContext(ctx)
+	defer stop()
+	err := run(runCtx)
+	cause := context.Cause(runCtx)
+	if cause != nil && errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func mcpSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancelCause(parent)
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case sig := <-signalCh:
+			signal.Stop(signalCh)
+			cancel(fmt.Errorf("%s signal received", sig))
+		case <-ctx.Done():
+			signal.Stop(signalCh)
+		}
+	}()
+	return ctx, func() {
+		signal.Stop(signalCh)
+		cancel(context.Canceled)
+	}
 }
 
 type MCPServer struct {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"maps"
 	"net"
@@ -18,6 +20,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -112,18 +115,17 @@ func TestMCPCommandHTTP(t *testing.T) {
 	if got, want := len(result.Tools), 7; got != want {
 		t.Fatalf("tool count=%d, want %d", got, want)
 	}
-	if err := session.Close(); err != nil {
-		t.Fatal(err)
-	}
-
 	cancel()
 	select {
 	case err := <-errCh:
 		if err != nil {
 			t.Fatalf("run: %v", err)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("HTTP command did not stop after cancellation")
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -137,9 +139,6 @@ func TestMCPCommandEmbeddedHTTP(t *testing.T) {
 	}
 
 	session := connectMCPHTTP(t, "http://"+server.httpServer.Addr)
-	if err := session.Close(); err != nil {
-		t.Fatal(err)
-	}
 	if err := server.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -148,9 +147,85 @@ func TestMCPCommandEmbeddedHTTP(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("embedded HTTP server did not stop")
 	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPCommandSecondSignal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX process signals")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMCPCommandSecondSignalHelper$")
+	cmd.Env = append(os.Environ(), "LITESTREAM_TEST_MCP_SECOND_SIGNAL=1")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	var waitErr error
+	waitDone := make(chan struct{})
+	go func() {
+		waitErr = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-waitDone:
+		default:
+			if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				t.Error(err)
+			}
+			<-waitDone
+		}
+	})
+
+	scanner := bufio.NewScanner(stderr)
+	if !scanner.Scan() || scanner.Text() != "ready" {
+		t.Fatalf("ready line=%q, error=%v", scanner.Text(), scanner.Err())
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	if !scanner.Scan() || scanner.Text() != "canceled" {
+		t.Fatalf("canceled line=%q, error=%v", scanner.Text(), scanner.Err())
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-waitDone:
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			t.Fatalf("wait error=%v, want exit error", waitErr)
+		}
+		status, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok || !status.Signaled() || status.Signal() != syscall.SIGTERM {
+			t.Fatalf("wait status=%v, want SIGTERM", exitErr.Sys())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second signal did not terminate MCP command")
+	}
+}
+
+func TestMCPCommandSecondSignalHelper(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MCP_SECOND_SIGNAL") != "1" {
+		t.Skip("helper process only")
+	}
+	err := runMCPTransport(context.Background(), func(ctx context.Context) error {
+		fmt.Fprintln(os.Stderr, "ready")
+		<-ctx.Done()
+		fmt.Fprintln(os.Stderr, "canceled")
+		select {}
+	})
+	t.Fatalf("run returned: %v", err)
 }
 
 func TestMCPCommandFlagsAndUsage(t *testing.T) {
@@ -732,7 +807,13 @@ func connectMCPHTTP(t *testing.T, endpoint string) *mcp.ClientSession {
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
-		session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: endpoint}, nil)
+		transport := &mcp.StreamableClientTransport{
+			Endpoint: endpoint,
+			HTTPClient: &http.Client{
+				Transport: mcpTestRoundTripper{},
+			},
+		}
+		session, err := client.Connect(t.Context(), transport, nil)
 		if err == nil {
 			return session
 		}
@@ -741,6 +822,20 @@ func connectMCPHTTP(t *testing.T, endpoint string) *mcp.ClientSession {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+type mcpTestRoundTripper struct{}
+
+func (mcpTestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodDelete {
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	}
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func captureMCPStdout(t *testing.T, fn func()) string {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,20 +5,141 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"io"
 	"maps"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func TestMCPCommandStdio(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMCPCommandStdioHelper$")
+	cmd.Env = append(os.Environ(), "LITESTREAM_TEST_MCP_STDIO=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	result, err := session.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(result.Tools), 7; got != want {
+		t.Fatalf("tool count=%d, want %d", got, want)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close session: %v\nstderr:\n%s", err, stderr.String())
+	}
+}
+
+func TestMCPCommandStdioHelper(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MCP_STDIO") != "1" {
+		t.Skip("helper process only")
+	}
+	if err := NewMain().Run(context.Background(), []string{"mcp", "--config", "/test/litestream.yml"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPCommandHTTP(t *testing.T) {
+	listener := availableTCPListener(t)
+	addr := listener.Addr().String()
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- (&MCPCommand{listener: listener}).Run(ctx, []string{"--addr", addr, "--config", "/test/litestream.yml"})
+	}()
+
+	session := connectMCPHTTP(t, "http://"+addr)
+	result, err := session.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(result.Tools), 7; got != want {
+		t.Fatalf("tool count=%d, want %d", got, want)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP command did not stop after cancellation")
+	}
+}
+
+func TestMCPCommandEmbeddedHTTP(t *testing.T) {
+	server, err := NewMCP(t.Context(), "/test/litestream.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Start("127.0.0.1:0")
+
+	session := connectMCPHTTP(t, "http://"+server.httpServer.Addr)
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPCommandFlagsAndUsage(t *testing.T) {
+	if err := (&MCPCommand{}).Run(t.Context(), []string{"unexpected"}); err == nil || err.Error() != "too many arguments" {
+		t.Fatalf("error=%v, want too many arguments", err)
+	}
+
+	output := captureMCPStdout(t, func() {
+		if err := (&MCPCommand{}).Run(t.Context(), []string{"-help"}); !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("error=%v, want flag.ErrHelp", err)
+		}
+		(&MCPCommand{}).Usage()
+		(&Main{}).Usage()
+	})
+	for _, want := range []string{"litestream mcp", "-addr ADDR", "MCP server", "mcp          runs the MCP server"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("usage missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestMCPCommandHTTPBindError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	err = (&MCPCommand{}).Run(t.Context(), []string{"--addr", listener.Addr().String()})
+	if err == nil || !strings.Contains(err.Error(), "listen for MCP HTTP server") {
+		t.Fatalf("error=%v, want listen error", err)
+	}
+}
 
 func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
@@ -538,4 +659,57 @@ func setVersion(t *testing.T, version string) {
 	previous := Version
 	Version = version
 	t.Cleanup(func() { Version = previous })
+}
+
+func availableTCPListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return listener
+}
+
+func connectMCPHTTP(t *testing.T, endpoint string) *mcp.ClientSession {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+		session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: endpoint}, nil)
+		if err == nil {
+			return session
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connect to %s: %v", endpoint, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func captureMCPStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	stdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = stdout })
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -57,6 +57,44 @@ func TestMCPCommandStdioHelper(t *testing.T) {
 	}
 }
 
+func TestMCPCommandStdioContextCancellation(t *testing.T) {
+	stdin, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutReader, stdout, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	previousStdin, previousStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdin, stdout
+	t.Cleanup(func() {
+		os.Stdin, os.Stdout = previousStdin, previousStdout
+		for _, file := range []*os.File{stdin, stdinWriter, stdoutReader, stdout} {
+			if err := file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+				t.Error(err)
+			}
+		}
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- (&MCPCommand{}).Run(ctx, nil)
+	}()
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stdio command did not stop after cancellation")
+	}
+}
+
 func TestMCPCommandHTTP(t *testing.T) {
 	listener := availableTCPListener(t)
 	addr := listener.Addr().String()
@@ -94,7 +132,9 @@ func TestMCPCommandEmbeddedHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	server.Start("127.0.0.1:0")
+	if err := server.Start("127.0.0.1:0"); err != nil {
+		t.Fatal(err)
+	}
 
 	session := connectMCPHTTP(t, "http://"+server.httpServer.Addr)
 	if err := session.Close(); err != nil {
@@ -102,6 +142,14 @@ func TestMCPCommandEmbeddedHTTP(t *testing.T) {
 	}
 	if err := server.Close(); err != nil {
 		t.Fatal(err)
+	}
+	select {
+	case err := <-server.errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("embedded HTTP server did not stop")
 	}
 }
 
@@ -138,6 +186,13 @@ func TestMCPCommandHTTPBindError(t *testing.T) {
 	err = (&MCPCommand{}).Run(t.Context(), []string{"--addr", listener.Addr().String()})
 	if err == nil || !strings.Contains(err.Error(), "listen for MCP HTTP server") {
 		t.Fatalf("error=%v, want listen error", err)
+	}
+
+	cmd := NewReplicateCommand()
+	cmd.Config.MCPAddr = listener.Addr().String()
+	err = cmd.Run(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "start MCP server: listen for MCP HTTP server") {
+		t.Fatalf("embedded error=%v, want listen error", err)
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -39,6 +39,12 @@ func TestMCPCommandStdio(t *testing.T) {
 		t.Fatalf("connect: %v\nstderr:\n%s", err, stderr.String())
 	}
 
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
 	result, err := session.ListTools(t.Context(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +166,9 @@ func TestMCPCommandSecondSignal(t *testing.T) {
 		t.Skip("requires POSIX process signals")
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestMCPCommandSecondSignalHelper$")
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestMCPCommandSecondSignalHelper$")
 	cmd.Env = append(os.Environ(), "LITESTREAM_TEST_MCP_SECOND_SIGNAL=1")
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -1080,4 +1088,27 @@ func captureMCPStdout(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	return string(output)
+}
+
+func TestMCPTransportPreservesCancellationErrors(t *testing.T) {
+	shutdownErr := errors.New("shutdown failed")
+	for _, joined := range []bool{false, true} {
+		t.Run(fmt.Sprint(joined), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			err := runMCPTransport(ctx, func(context.Context) error {
+				if joined {
+					return errors.Join(context.Canceled, shutdownErr)
+				}
+				return context.Canceled
+			})
+			if joined {
+				if !errors.Is(err, shutdownErr) {
+					t.Fatalf("error=%v, want shutdown failure", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"io"
 	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -21,6 +23,123 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func TestMCPCommandStdio(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMCPCommandStdioHelper$")
+	cmd.Env = append(os.Environ(), "LITESTREAM_TEST_MCP_STDIO=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	result, err := session.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(result.Tools), 7; got != want {
+		t.Fatalf("tool count=%d, want %d", got, want)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close session: %v\nstderr:\n%s", err, stderr.String())
+	}
+}
+
+func TestMCPCommandStdioHelper(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MCP_STDIO") != "1" {
+		t.Skip("helper process only")
+	}
+	if err := NewMain().Run(context.Background(), []string{"mcp", "--config", "/test/litestream.yml"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPCommandHTTP(t *testing.T) {
+	listener := availableTCPListener(t)
+	addr := listener.Addr().String()
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- (&MCPCommand{listener: listener}).Run(ctx, []string{"--addr", addr, "--config", "/test/litestream.yml"})
+	}()
+
+	session := connectMCPHTTP(t, "http://"+addr)
+	result, err := session.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(result.Tools), 7; got != want {
+		t.Fatalf("tool count=%d, want %d", got, want)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP command did not stop after cancellation")
+	}
+}
+
+func TestMCPCommandEmbeddedHTTP(t *testing.T) {
+	server, err := NewMCP(t.Context(), "/test/litestream.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Start("127.0.0.1:0")
+
+	session := connectMCPHTTP(t, "http://"+server.httpServer.Addr)
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPCommandFlagsAndUsage(t *testing.T) {
+	if err := (&MCPCommand{}).Run(t.Context(), []string{"unexpected"}); err == nil || err.Error() != "too many arguments" {
+		t.Fatalf("error=%v, want too many arguments", err)
+	}
+
+	output := captureMCPStdout(t, func() {
+		if err := (&MCPCommand{}).Run(t.Context(), []string{"-help"}); !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("error=%v, want flag.ErrHelp", err)
+		}
+		(&MCPCommand{}).Usage()
+		(&Main{}).Usage()
+	})
+	for _, want := range []string{"litestream mcp", "-addr ADDR", "MCP server", "mcp          runs the MCP server"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("usage missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestMCPCommandHTTPBindError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	err = (&MCPCommand{}).Run(t.Context(), []string{"--addr", listener.Addr().String()})
+	if err == nil || !strings.Contains(err.Error(), "listen for MCP HTTP server") {
+		t.Fatalf("error=%v, want listen error", err)
+	}
+}
 
 func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
@@ -758,4 +877,57 @@ func TestMCPServerLifecycle(t *testing.T) {
 	if err := listener.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func availableTCPListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return listener
+}
+
+func connectMCPHTTP(t *testing.T, endpoint string) *mcp.ClientSession {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+		session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: endpoint}, nil)
+		if err == nil {
+			return session
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connect to %s: %v", endpoint, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func captureMCPStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	stdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = stdout })
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"maps"
 	"net"
@@ -18,6 +20,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -112,18 +115,17 @@ func TestMCPCommandHTTP(t *testing.T) {
 	if got, want := len(result.Tools), 7; got != want {
 		t.Fatalf("tool count=%d, want %d", got, want)
 	}
-	if err := session.Close(); err != nil {
-		t.Fatal(err)
-	}
-
 	cancel()
 	select {
 	case err := <-errCh:
 		if err != nil {
 			t.Fatalf("run: %v", err)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("HTTP command did not stop after cancellation")
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -137,9 +139,6 @@ func TestMCPCommandEmbeddedHTTP(t *testing.T) {
 	}
 
 	session := connectMCPHTTP(t, "http://"+server.httpServer.Addr)
-	if err := session.Close(); err != nil {
-		t.Fatal(err)
-	}
 	if err := server.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -148,9 +147,85 @@ func TestMCPCommandEmbeddedHTTP(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("embedded HTTP server did not stop")
 	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMCPCommandSecondSignal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX process signals")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMCPCommandSecondSignalHelper$")
+	cmd.Env = append(os.Environ(), "LITESTREAM_TEST_MCP_SECOND_SIGNAL=1")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	var waitErr error
+	waitDone := make(chan struct{})
+	go func() {
+		waitErr = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-waitDone:
+		default:
+			if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				t.Error(err)
+			}
+			<-waitDone
+		}
+	})
+
+	scanner := bufio.NewScanner(stderr)
+	if !scanner.Scan() || scanner.Text() != "ready" {
+		t.Fatalf("ready line=%q, error=%v", scanner.Text(), scanner.Err())
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	if !scanner.Scan() || scanner.Text() != "canceled" {
+		t.Fatalf("canceled line=%q, error=%v", scanner.Text(), scanner.Err())
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-waitDone:
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			t.Fatalf("wait error=%v, want exit error", waitErr)
+		}
+		status, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok || !status.Signaled() || status.Signal() != syscall.SIGTERM {
+			t.Fatalf("wait status=%v, want SIGTERM", exitErr.Sys())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second signal did not terminate MCP command")
+	}
+}
+
+func TestMCPCommandSecondSignalHelper(t *testing.T) {
+	if os.Getenv("LITESTREAM_TEST_MCP_SECOND_SIGNAL") != "1" {
+		t.Skip("helper process only")
+	}
+	err := runMCPTransport(context.Background(), func(ctx context.Context) error {
+		fmt.Fprintln(os.Stderr, "ready")
+		<-ctx.Done()
+		fmt.Fprintln(os.Stderr, "canceled")
+		select {}
+	})
+	t.Fatalf("run returned: %v", err)
 }
 
 func TestMCPCommandFlagsAndUsage(t *testing.T) {
@@ -950,7 +1025,13 @@ func connectMCPHTTP(t *testing.T, endpoint string) *mcp.ClientSession {
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
-		session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: endpoint}, nil)
+		transport := &mcp.StreamableClientTransport{
+			Endpoint: endpoint,
+			HTTPClient: &http.Client{
+				Transport: mcpTestRoundTripper{},
+			},
+		}
+		session, err := client.Connect(t.Context(), transport, nil)
 		if err == nil {
 			return session
 		}
@@ -959,6 +1040,20 @@ func connectMCPHTTP(t *testing.T, endpoint string) *mcp.ClientSession {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+type mcpTestRoundTripper struct{}
+
+func (mcpTestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodDelete {
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	}
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func captureMCPStdout(t *testing.T, fn func()) string {

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -40,7 +40,8 @@ type ReplicateCommand struct {
 	Config Config
 
 	// MCP server
-	MCP *MCPServer
+	MCP      *MCPServer
+	mcpErrCh <-chan error
 
 	// Server for IPC control commands.
 	Server *litestream.Server
@@ -185,7 +186,10 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		go c.MCP.Start(c.Config.MCPAddr)
+		if err := c.MCP.Start(c.Config.MCPAddr); err != nil {
+			return fmt.Errorf("start MCP server: %w", err)
+		}
+		c.mcpErrCh = c.MCP.errCh
 	}
 
 	// Setup databases.
@@ -455,7 +459,7 @@ func (c *ReplicateCommand) Close(ctx context.Context) error {
 	}
 	if c.Config.MCPAddr != "" && c.MCP != nil {
 		if err := c.MCP.Close(); err != nil {
-			slog.Error("error closing MCP server", "error", err)
+			return fmt.Errorf("close MCP server: %w", err)
 		}
 	}
 	return nil

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -14,3 +14,13 @@ Add a row when a new Litestream feature lands that still needs user-facing docs 
 ## AI Documentation Status
 
 Internal AI documentation (this repo) was tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106), now closed.
+
+## Standalone MCP command (PR #1380)
+
+Pending publication with [#1380](https://github.com/benbjohnson/litestream/pull/1380): update the MCP reference with the standalone command and transport selection.
+
+`litestream mcp` runs without starting the replication daemon. Stdio is the default transport. Configure a local MCP client to launch `litestream` with arguments `mcp --config /path/to/litestream.yml`. Protocol messages use stdout and logs use stderr.
+
+Use `litestream mcp --addr 127.0.0.1:3001 --config /path/to/litestream.yml` for Streamable HTTP. Keep remote access behind an authenticated proxy, SSH tunnel, or VPN. The existing `mcp-addr` YAML setting continues to enable HTTP MCP inside `litestream replicate`.
+
+Both standalone transports stop on interrupt or termination signals. Existing tools still require the Litestream executable on PATH until the in-process execution change in #1377 is combined with this command.


### PR DESCRIPTION
## Description

Adds a standalone `litestream mcp` command that runs independently of the replication daemon.

- Uses stdio by default for local MCP clients.
- Uses Streamable HTTP when `--addr` is provided.
- Accepts `--config` as the default configuration path for MCP tools.
- Directs command logging to stderr so stdio protocol messages remain clean.
- Preserves the existing replicate-embedded `mcp-addr` HTTP path.
- Gracefully disconnects active Streamable HTTP clients during shutdown.
- Restores default signal handling after the first shutdown signal.

This PR is stacked on #1378. It intentionally does not pull in the #1377 in-process handler work; that integration will be reconciled separately.

### Scope

**In scope:**
- Standalone MCP command dispatch and help.
- Stdio and Streamable HTTP transports.
- Graceful signal and HTTP shutdown handling, including connected clients.
- Error propagation for embedded and Windows service shutdown paths.
- Regression coverage for standalone and embedded HTTP shutdown, second-signal termination, and Windows service close failures.

**Out of scope:**
- In-process MCP tool handlers from #1377.
- The required update to `https://litestream.io/reference/mcp/` documenting the standalone command and stdio and HTTP client configurations.

This implements the code portion of #1370. The issue must remain open until the external reference documentation acceptance criterion is complete.

## Motivation and Context

The MCP server previously ran only as an HTTP service embedded in `litestream replicate`. Local clients such as Claude Desktop and Cursor commonly launch MCP servers over stdio and should not need to run the replication daemon alongside the server.

Relates to #1370

## How Has This Been Tested?

- `go build ./...`
- `go test -race ./...`
- `go test -race ./cmd/litestream -run '^TestMCPCommand' -count=10`
- Windows command-package cross-compilation with `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c`
- `go vet ./...`
- `staticcheck ./...`
- `pre-commit run --all-files`
- `golangci-lint run --new-from-rev issue-1368-refactor-mcp-migrate-to-the-official-modelcontextprotocol-go`
- `GOTOOLCHAIN=go1.25.12 govulncheck ./...`

The transport tests establish real MCP client sessions over stdio, standalone Streamable HTTP, and the existing embedded HTTP server path. The HTTP shutdown tests keep the client's persistent SSE stream connected while stopping the server.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the external user documentation; #1370 remains open until this is complete
