### PR TITLE
feat(mcp): add restore plan and integrity checks

### DIFF
--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -48,6 +48,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcpServer.AddTool(InfoTool(configPath))
 	mcpServer.AddTool(DatabasesTool(configPath))
 	mcpServer.AddTool(RestoreTool(configPath))
+	mcpServer.AddTool(RestorePlanTool(configPath))
 	mcpServer.AddTool(LTXTool(configPath))
 	mcpServer.AddTool(VersionTool())
 	mcpServer.AddTool(StatusTool(configPath))
@@ -130,6 +131,7 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		mcp.WithString("txid", mcp.Description("Restore up to a specific transaction ID. Optional.")),
 		mcp.WithString("timestamp", mcp.Description("Restore to a specific point-in-time (RFC3339). Optional.")),
 		mcp.WithString("parallelism", mcp.Description("Number of WAL files to download in parallel. Optional.")),
+		mcp.WithString("integrity_check", mcp.Description("Post-restore integrity check mode. Optional."), mcp.Enum("none", "quick", "full"), mcp.DefaultString("none")),
 		mcp.WithBoolean("if_db_not_exists", mcp.Description("Skip restore if the database already exists. Optional.")),
 		mcp.WithBoolean("if_replica_exists", mcp.Description("Skip restore if no backups are found. Optional.")),
 	)
@@ -145,19 +147,9 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if opt.OutputPath == "" {
 			opt.OutputPath = req.GetString("o", "")
 		}
-		if value := req.GetString("txid", ""); value != "" {
-			txID, err := ltx.ParseTXID(value)
-			if err != nil {
-				return mcpToolError(fmt.Errorf("invalid txid: %w", err))
-			}
-			opt.TXID = txID
-		}
-		if value := req.GetString("timestamp", ""); value != "" {
-			timestamp, err := time.Parse(time.RFC3339, value)
-			if err != nil {
-				return mcpToolError(fmt.Errorf("invalid timestamp: %w", err))
-			}
-			opt.Timestamp = timestamp
+		var err error
+		if opt.TXID, opt.Timestamp, err = parseMCPRestoreTarget(req); err != nil {
+			return mcpToolError(err)
 		}
 		if value := req.GetString("parallelism", ""); value != "" {
 			parallelism, err := strconv.Atoi(value)
@@ -166,18 +158,66 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			}
 			opt.Parallelism = parallelism
 		}
+		integrityCheck := req.GetString("integrity_check", "none")
+		if opt.IntegrityCheck, err = parseMCPIntegrityCheck(integrityCheck); err != nil {
+			return mcpToolError(err)
+		}
 
 		resources, err := loadMCPRestoreReplica(path, req.GetString("config", configPath), &opt)
 		if err != nil {
 			return mcpToolError(err)
 		}
 
-		output, opErr := restoreMCP(ctx, path, resources.Replica, opt,
+		output, opErr := restoreMCP(ctx, path, resources.Replica, opt, integrityCheck,
 			req.GetBool("if_db_not_exists", false), req.GetBool("if_replica_exists", false))
 		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
+	}
+}
+
+func RestorePlanTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
+	tool := mcp.NewTool("litestream_restore_plan",
+		mcp.WithDescription("Preview the ordered snapshot and LTX files for a restore without writing a database."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("path", mcp.Required(), mcp.Description("Database path or replica URL.")),
+		mcp.WithString("output", mcp.Description("Target database path to include in the plan. Optional.")),
+		mcp.WithString("config", mcp.Description("Path to the Litestream config file. Optional, ignored for replica URLs.")),
+		mcp.WithString("txid", mcp.Description("Restore up to a specific transaction ID. Optional.")),
+		mcp.WithString("timestamp", mcp.Description("Restore to a specific point-in-time (RFC3339). Optional.")),
+	)
+
+	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path := req.GetString("path", "")
+		if path == "" {
+			return mcpToolError(fmt.Errorf("database path or replica URL required"))
+		}
+
+		opt := litestream.NewRestoreOptions()
+		opt.OutputPath = req.GetString("output", "")
+		var err error
+		if opt.TXID, opt.Timestamp, err = parseMCPRestoreTarget(req); err != nil {
+			return mcpToolError(err)
+		}
+
+		r, err := loadMCPReplica(path, req.GetString("config", configPath))
+		if err != nil {
+			return mcpToolError(err)
+		}
+		plan, err := (&RestoreCommand{}).dryRunPlan(ctx, path, r, opt)
+		if errors.Is(err, litestream.ErrTxNotAvailable) {
+			return mcpToolError(fmt.Errorf("no matching backup files available"))
+		} else if err != nil {
+			return mcpToolError(err)
+		}
+
+		output, err := json.MarshalIndent(plan, "", "  ")
+		if err != nil {
+			return mcpToolError(fmt.Errorf("format response: %w", err))
+		}
+		return mcp.NewToolResultText(string(output) + "\n"), nil
 	}
 }
 
@@ -453,6 +493,41 @@ func loadMCPRestoreReplica(path, configPath string, opt *litestream.RestoreOptio
 	return &mcpReplica{Replica: db.Replica, Databases: resources}, nil
 }
 
+func parseMCPRestoreTarget(req mcp.CallToolRequest) (ltx.TXID, time.Time, error) {
+	var txID ltx.TXID
+	if value := req.GetString("txid", ""); value != "" {
+		var err error
+		if txID, err = ltx.ParseTXID(value); err != nil {
+			return 0, time.Time{}, fmt.Errorf("invalid txid: %w", err)
+		}
+	}
+
+	var timestamp time.Time
+	if value := req.GetString("timestamp", ""); value != "" {
+		var err error
+		if timestamp, err = time.Parse(time.RFC3339, value); err != nil {
+			return 0, time.Time{}, fmt.Errorf("invalid timestamp: %w", err)
+		}
+	}
+	if txID != 0 && !timestamp.IsZero() {
+		return 0, time.Time{}, fmt.Errorf("cannot specify both txid and timestamp")
+	}
+	return txID, timestamp, nil
+}
+
+func parseMCPIntegrityCheck(value string) (litestream.IntegrityCheckMode, error) {
+	switch value {
+	case "none":
+		return litestream.IntegrityCheckNone, nil
+	case "quick":
+		return litestream.IntegrityCheckQuick, nil
+	case "full":
+		return litestream.IntegrityCheckFull, nil
+	default:
+		return litestream.IntegrityCheckNone, fmt.Errorf("invalid integrity_check: %s", value)
+	}
+}
+
 func loadMCPReplica(path, configPath string) (*mcpReplica, error) {
 	if litestream.IsURL(path) {
 		r, err := NewReplicaFromConfig(&ReplicaConfig{URL: path}, nil)
@@ -472,7 +547,7 @@ func loadMCPReplica(path, configPath string) (*mcpReplica, error) {
 	return &mcpReplica{Replica: db.Replica, Databases: resources}, nil
 }
 
-func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt litestream.RestoreOptions, ifDBNotExists, ifReplicaExists bool) (string, error) {
+func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt litestream.RestoreOptions, integrityCheck string, ifDBNotExists, ifReplicaExists bool) (string, error) {
 	if ifDBNotExists {
 		if _, err := os.Stat(opt.OutputPath); err == nil {
 			return "database already exists, skipping\n", nil
@@ -514,7 +589,7 @@ func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt lit
 		Replica:        r.Client.Type(),
 		TXID:           txID,
 		DurationMS:     time.Since(start).Milliseconds(),
-		IntegrityCheck: "none",
+		IntegrityCheck: integrityCheck,
 	}, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("format response: %w", err)

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -202,14 +202,15 @@ func RestorePlanTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			return mcpToolError(err)
 		}
 
-		r, err := loadMCPReplica(path, req.GetString("config", configPath))
+		resources, err := loadMCPReplica(path, req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-		plan, err := (&RestoreCommand{}).dryRunPlan(ctx, path, r, opt)
-		if errors.Is(err, litestream.ErrTxNotAvailable) {
-			return mcpToolError(fmt.Errorf("no matching backup files available"))
-		} else if err != nil {
+		plan, opErr := (&RestoreCommand{}).dryRunPlan(ctx, path, resources.Replica, opt)
+		if errors.Is(opErr, litestream.ErrTxNotAvailable) {
+			opErr = fmt.Errorf("no matching backup files available")
+		}
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
 

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -253,7 +253,7 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 
 func RestorePlanTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool("litestream_restore_plan",
-		mcp.WithDescription("Preview the ordered snapshot and LTX files for a restore without writing a database."),
+		mcp.WithDescription("Preview the ordered LTX files for a restore without writing a database. When legacy backups exist, specify an explicit TXID to preview LTX."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Database path or replica URL.")),
@@ -280,11 +280,12 @@ func RestorePlanTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if err != nil {
 			return mcpToolError(err)
 		}
+		cleanup := startMCPResourceCleanup(ctx, resources)
 		plan, opErr := (&RestoreCommand{}).dryRunPlan(ctx, path, resources.Replica, opt)
 		if errors.Is(opErr, litestream.ErrTxNotAvailable) {
 			opErr = fmt.Errorf("no matching backup files available")
 		}
-		if err := closeMCPResources(opErr, resources); err != nil {
+		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -54,6 +54,7 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcpServer.AddTool(InfoTool(configPath))
 	mcpServer.AddTool(DatabasesTool(configPath))
 	mcpServer.AddTool(RestoreTool(configPath))
+	mcpServer.AddTool(RestorePlanTool(configPath))
 	mcpServer.AddTool(LTXTool(configPath))
 	mcpServer.AddTool(VersionTool())
 	mcpServer.AddTool(StatusTool(configPath))
@@ -203,6 +204,7 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		mcp.WithString("txid", mcp.Description("Restore up to a specific transaction ID. Optional.")),
 		mcp.WithString("timestamp", mcp.Description("Restore to a specific point-in-time (RFC3339). Optional.")),
 		mcp.WithString("parallelism", mcp.Description("Number of WAL files to download in parallel. Optional.")),
+		mcp.WithString("integrity_check", mcp.Description("Post-restore integrity check mode. Optional."), mcp.Enum("none", "quick", "full"), mcp.DefaultString("none")),
 		mcp.WithBoolean("if_db_not_exists", mcp.Description("Skip restore if the database already exists. Optional.")),
 		mcp.WithBoolean("if_replica_exists", mcp.Description("Skip restore if no backups are found. Optional.")),
 	)
@@ -218,19 +220,9 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		if opt.OutputPath == "" {
 			opt.OutputPath = req.GetString("o", "")
 		}
-		if value := req.GetString("txid", ""); value != "" {
-			txID, err := ltx.ParseTXID(value)
-			if err != nil {
-				return mcpToolError(fmt.Errorf("invalid txid: %w", err))
-			}
-			opt.TXID = txID
-		}
-		if value := req.GetString("timestamp", ""); value != "" {
-			timestamp, err := time.Parse(time.RFC3339, value)
-			if err != nil {
-				return mcpToolError(fmt.Errorf("invalid timestamp: %w", err))
-			}
-			opt.Timestamp = timestamp
+		var err error
+		if opt.TXID, opt.Timestamp, err = parseMCPRestoreTarget(req); err != nil {
+			return mcpToolError(err)
 		}
 		if value := req.GetString("parallelism", ""); value != "" {
 			parallelism, err := strconv.Atoi(value)
@@ -239,6 +231,10 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			}
 			opt.Parallelism = parallelism
 		}
+		integrityCheck := req.GetString("integrity_check", "none")
+		if opt.IntegrityCheck, err = parseMCPIntegrityCheck(integrityCheck); err != nil {
+			return mcpToolError(err)
+		}
 
 		resources, err := loadMCPRestoreReplica(path, req.GetString("config", configPath), &opt)
 		if err != nil {
@@ -246,12 +242,56 @@ func RestoreTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 		}
 		cleanup := startMCPResourceCleanup(ctx, resources)
 
-		output, opErr := restoreMCP(ctx, path, resources.Replica, opt,
+		output, opErr := restoreMCP(ctx, path, resources.Replica, opt, integrityCheck,
 			req.GetBool("if_db_not_exists", false), req.GetBool("if_replica_exists", false))
 		if err := closeMCPResources(opErr, cleanup); err != nil {
 			return mcpToolError(err)
 		}
 		return mcp.NewToolResultText(output), nil
+	}
+}
+
+func RestorePlanTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
+	tool := mcp.NewTool("litestream_restore_plan",
+		mcp.WithDescription("Preview the ordered snapshot and LTX files for a restore without writing a database."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("path", mcp.Required(), mcp.Description("Database path or replica URL.")),
+		mcp.WithString("output", mcp.Description("Target database path to include in the plan. Optional.")),
+		mcp.WithString("config", mcp.Description("Path to the Litestream config file. Optional, ignored for replica URLs.")),
+		mcp.WithString("txid", mcp.Description("Restore up to a specific transaction ID. Optional.")),
+		mcp.WithString("timestamp", mcp.Description("Restore to a specific point-in-time (RFC3339). Optional.")),
+	)
+
+	return tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path := req.GetString("path", "")
+		if path == "" {
+			return mcpToolError(fmt.Errorf("database path or replica URL required"))
+		}
+
+		opt := litestream.NewRestoreOptions()
+		opt.OutputPath = req.GetString("output", "")
+		var err error
+		if opt.TXID, opt.Timestamp, err = parseMCPRestoreTarget(req); err != nil {
+			return mcpToolError(err)
+		}
+
+		r, err := loadMCPReplica(path, req.GetString("config", configPath))
+		if err != nil {
+			return mcpToolError(err)
+		}
+		plan, err := (&RestoreCommand{}).dryRunPlan(ctx, path, r, opt)
+		if errors.Is(err, litestream.ErrTxNotAvailable) {
+			return mcpToolError(fmt.Errorf("no matching backup files available"))
+		} else if err != nil {
+			return mcpToolError(err)
+		}
+
+		output, err := json.MarshalIndent(plan, "", "  ")
+		if err != nil {
+			return mcpToolError(fmt.Errorf("format response: %w", err))
+		}
+		return mcp.NewToolResultText(string(output) + "\n"), nil
 	}
 }
 
@@ -585,6 +625,41 @@ func loadMCPRestoreReplica(path, configPath string, opt *litestream.RestoreOptio
 	return &mcpReplica{Replica: db.Replica, Databases: resources}, nil
 }
 
+func parseMCPRestoreTarget(req mcp.CallToolRequest) (ltx.TXID, time.Time, error) {
+	var txID ltx.TXID
+	if value := req.GetString("txid", ""); value != "" {
+		var err error
+		if txID, err = ltx.ParseTXID(value); err != nil {
+			return 0, time.Time{}, fmt.Errorf("invalid txid: %w", err)
+		}
+	}
+
+	var timestamp time.Time
+	if value := req.GetString("timestamp", ""); value != "" {
+		var err error
+		if timestamp, err = time.Parse(time.RFC3339, value); err != nil {
+			return 0, time.Time{}, fmt.Errorf("invalid timestamp: %w", err)
+		}
+	}
+	if txID != 0 && !timestamp.IsZero() {
+		return 0, time.Time{}, fmt.Errorf("cannot specify both txid and timestamp")
+	}
+	return txID, timestamp, nil
+}
+
+func parseMCPIntegrityCheck(value string) (litestream.IntegrityCheckMode, error) {
+	switch value {
+	case "none":
+		return litestream.IntegrityCheckNone, nil
+	case "quick":
+		return litestream.IntegrityCheckQuick, nil
+	case "full":
+		return litestream.IntegrityCheckFull, nil
+	default:
+		return litestream.IntegrityCheckNone, fmt.Errorf("invalid integrity_check: %s", value)
+	}
+}
+
 func loadMCPReplica(path, configPath string) (*mcpReplica, error) {
 	if litestream.IsURL(path) {
 		r, err := NewReplicaFromConfig(&ReplicaConfig{URL: path}, nil)
@@ -604,7 +679,7 @@ func loadMCPReplica(path, configPath string) (*mcpReplica, error) {
 	return &mcpReplica{Replica: db.Replica, Databases: resources}, nil
 }
 
-func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt litestream.RestoreOptions, ifDBNotExists, ifReplicaExists bool) (string, error) {
+func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt litestream.RestoreOptions, integrityCheck string, ifDBNotExists, ifReplicaExists bool) (string, error) {
 	if ifDBNotExists {
 		if _, err := os.Stat(opt.OutputPath); err == nil {
 			return "database already exists, skipping\n", nil
@@ -646,7 +721,7 @@ func restoreMCP(ctx context.Context, path string, r *litestream.Replica, opt lit
 		Replica:        r.Client.Type(),
 		TXID:           txID,
 		DurationMS:     time.Since(start).Milliseconds(),
-		IntegrityCheck: "none",
+		IntegrityCheck: integrityCheck,
 	}, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("format response: %w", err)

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -276,14 +276,15 @@ func RestorePlanTool(configPath string) (mcp.Tool, server.ToolHandlerFunc) {
 			return mcpToolError(err)
 		}
 
-		r, err := loadMCPReplica(path, req.GetString("config", configPath))
+		resources, err := loadMCPReplica(path, req.GetString("config", configPath))
 		if err != nil {
 			return mcpToolError(err)
 		}
-		plan, err := (&RestoreCommand{}).dryRunPlan(ctx, path, r, opt)
-		if errors.Is(err, litestream.ErrTxNotAvailable) {
-			return mcpToolError(fmt.Errorf("no matching backup files available"))
-		} else if err != nil {
+		plan, opErr := (&RestoreCommand{}).dryRunPlan(ctx, path, resources.Replica, opt)
+		if errors.Is(opErr, litestream.ErrTxNotAvailable) {
+			opErr = fmt.Errorf("no matching backup files available")
+		}
+		if err := closeMCPResources(opErr, resources); err != nil {
 			return mcpToolError(err)
 		}
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -180,24 +182,48 @@ func TestRestoreToolRunWithoutLitestreamOnPATH(t *testing.T) {
 }
 
 func TestRestoreToolIntegrityCheck(t *testing.T) {
+	fixture := newMCPTestFixture(t)
+	corruptMCPTestFixture(t, fixture)
+
+	t.Run("none", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+		text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+			"path":            "file://" + fixture.replicaPath,
+			"output":          outputPath,
+			"integrity_check": "none",
+		})
+
+		var result RestoreResult
+		if err := json.Unmarshal([]byte(text), &result); err != nil {
+			t.Fatalf("decode result: %v\n%s", err, text)
+		}
+		if result.IntegrityCheck != "none" {
+			t.Fatalf("integrity check=%q, want none", result.IntegrityCheck)
+		}
+		if _, err := os.Stat(outputPath); err != nil {
+			t.Fatalf("stat restored database: %v", err)
+		}
+	})
+
 	for _, mode := range []string{"quick", "full"} {
 		t.Run(mode, func(t *testing.T) {
-			fixture := newMCPTestFixture(t)
 			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
-			text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+			result := callMCPToolResult(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
 				"path":            "file://" + fixture.replicaPath,
 				"output":          outputPath,
 				"integrity_check": mode,
 			})
-
-			var result RestoreResult
-			if err := json.Unmarshal([]byte(text), &result); err != nil {
-				t.Fatalf("decode result: %v\n%s", err, text)
+			if !result.IsError {
+				t.Fatal("expected tool error")
 			}
-			if result.IntegrityCheck != mode {
-				t.Fatalf("integrity check=%q, want %q", result.IntegrityCheck, mode)
+			if text := mcpToolResultText(t, result); !strings.Contains(text, "post-restore integrity check") {
+				t.Fatalf("unexpected error: %s", text)
 			}
-			assertRestoreCommandDB(t, outputPath)
+			for _, path := range []string{outputPath, outputPath + "-shm", outputPath + "-wal"} {
+				if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+					t.Fatalf("failed restore output exists at %q: %v", path, err)
+				}
+			}
 		})
 	}
 }
@@ -285,7 +311,7 @@ func TestRestorePlanTool(t *testing.T) {
 					t.Fatalf("restore plan is out of order at indexes %d and %d", i-1, i)
 				}
 			}
-			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+			if _, err := os.Stat(outputPath); !errors.Is(err, fs.ErrNotExist) {
 				t.Fatalf("restore plan created output: %v", err)
 			}
 		})
@@ -657,6 +683,60 @@ func newMCPTestFixture(t *testing.T) mcpTestFixture {
 		dbPath:      dbPath,
 		replicaPath: replicaPath,
 		configPath:  configPath,
+	}
+}
+
+func corruptMCPTestFixture(t *testing.T, fixture mcpTestFixture) {
+	t.Helper()
+
+	dbPath := filepath.Join(filepath.Dir(fixture.replicaPath), "db.sqlite")
+	data, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) < 100 {
+		t.Fatalf("database is too small: %d bytes", len(data))
+	}
+
+	pageSize := int(binary.BigEndian.Uint16(data[16:18]))
+	if pageSize == 1 {
+		pageSize = 65536
+	}
+	if pageSize == 0 || len(data)%pageSize != 0 || len(data) <= pageSize {
+		t.Fatalf("invalid test database size=%d page_size=%d", len(data), pageSize)
+	}
+	for i := pageSize; i < len(data); i++ {
+		data[i] = 0xde
+	}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  uint32(pageSize),
+		Commit:    uint32(len(data) / pageSize),
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for offset := 0; offset < len(data); offset += pageSize {
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: uint32(offset/pageSize + 1)}, data[offset:offset+pageSize]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := litestream.LTXFilePath(fixture.replicaPath, 0, 1, 1)
+	if err := os.WriteFile(path, buf.Bytes(), 0600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -205,24 +205,40 @@ func TestRestoreToolIntegrityCheck(t *testing.T) {
 func TestRestorePlanTool(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	fixture := newMCPTestFixture(t)
-	timestamp := time.Now().Add(time.Hour).Format(time.RFC3339)
+	baseTime := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	for txID := ltx.TXID(1); txID <= 3; txID++ {
+		path := litestream.LTXFilePath(fixture.replicaPath, 0, txID, txID)
+		if txID > 1 {
+			if err := os.WriteFile(path, []byte("ltx"), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		createdAt := baseTime.Add(time.Duration(txID-1) * time.Hour)
+		if err := os.Chtimes(path, createdAt, createdAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	timestamp := baseTime.Add(90 * time.Minute).Format(time.RFC3339)
 
 	tests := []struct {
 		name          string
 		arguments     map[string]any
 		includeOutput bool
+		fileN         int
 	}{
 		{
 			name:          "database path with txid",
 			includeOutput: true,
+			fileN:         2,
 			arguments: map[string]any{
 				"path":   fixture.dbPath,
 				"config": fixture.configPath,
-				"txid":   "0000000000000001",
+				"txid":   "0000000000000002",
 			},
 		},
 		{
-			name: "replica URL with timestamp",
+			name:  "replica URL with timestamp",
+			fileN: 2,
 			arguments: map[string]any{
 				"path":      "file://" + fixture.replicaPath,
 				"config":    filepath.Join(t.TempDir(), "missing.yml"),
@@ -255,11 +271,11 @@ func TestRestorePlanTool(t *testing.T) {
 			if plan.Replica != "file" {
 				t.Fatalf("replica=%q, want file", plan.Replica)
 			}
-			if plan.MinTXID == "" || plan.MaxTXID == "" {
-				t.Fatalf("expected txid range: %#v", plan)
+			if plan.MinTXID != "0000000000000001" || plan.MaxTXID != "0000000000000002" {
+				t.Fatalf("txid range=%s-%s, want 0000000000000001-0000000000000002", plan.MinTXID, plan.MaxTXID)
 			}
-			if len(plan.Files) == 0 {
-				t.Fatal("expected restore plan files")
+			if len(plan.Files) != tt.fileN {
+				t.Fatalf("files=%d, want %d", len(plan.Files), tt.fileN)
 			}
 			for i, file := range plan.Files {
 				if file.Name == "" || file.MinTXID == "" || file.MaxTXID == "" {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -170,7 +171,154 @@ func TestRestoreToolRunWithoutLitestreamOnPATH(t *testing.T) {
 			if result.TXID == "" {
 				t.Fatal("expected restored txid")
 			}
+			if result.IntegrityCheck != "none" {
+				t.Fatalf("integrity check=%q, want none", result.IntegrityCheck)
+			}
 			assertRestoreCommandDB(t, outputPath)
+		})
+	}
+}
+
+func TestRestoreToolIntegrityCheck(t *testing.T) {
+	for _, mode := range []string{"quick", "full"} {
+		t.Run(mode, func(t *testing.T) {
+			fixture := newMCPTestFixture(t)
+			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+			text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+				"path":            "file://" + fixture.replicaPath,
+				"output":          outputPath,
+				"integrity_check": mode,
+			})
+
+			var result RestoreResult
+			if err := json.Unmarshal([]byte(text), &result); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, text)
+			}
+			if result.IntegrityCheck != mode {
+				t.Fatalf("integrity check=%q, want %q", result.IntegrityCheck, mode)
+			}
+			assertRestoreCommandDB(t, outputPath)
+		})
+	}
+}
+
+func TestRestorePlanTool(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	fixture := newMCPTestFixture(t)
+	timestamp := time.Now().Add(time.Hour).Format(time.RFC3339)
+
+	tests := []struct {
+		name          string
+		arguments     map[string]any
+		includeOutput bool
+	}{
+		{
+			name:          "database path with txid",
+			includeOutput: true,
+			arguments: map[string]any{
+				"path":   fixture.dbPath,
+				"config": fixture.configPath,
+				"txid":   "0000000000000001",
+			},
+		},
+		{
+			name: "replica URL with timestamp",
+			arguments: map[string]any{
+				"path":      "file://" + fixture.replicaPath,
+				"config":    filepath.Join(t.TempDir(), "missing.yml"),
+				"timestamp": timestamp,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+			if tt.includeOutput {
+				tt.arguments["output"] = outputPath
+			}
+			text := callMCPToolText(t, handlerFromMCPTool(RestorePlanTool("")), tt.arguments)
+			wantSource := tt.arguments["path"].(string)
+
+			var plan RestorePlan
+			if err := json.Unmarshal([]byte(text), &plan); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, text)
+			}
+			if plan.Source != wantSource {
+				t.Fatalf("source=%q, want %q", plan.Source, wantSource)
+			}
+			if tt.includeOutput && plan.TargetPath != outputPath {
+				t.Fatalf("target path=%q, want %q", plan.TargetPath, outputPath)
+			} else if !tt.includeOutput && plan.TargetPath != "" {
+				t.Fatalf("target path=%q, want empty", plan.TargetPath)
+			}
+			if plan.Replica != "file" {
+				t.Fatalf("replica=%q, want file", plan.Replica)
+			}
+			if plan.MinTXID == "" || plan.MaxTXID == "" {
+				t.Fatalf("expected txid range: %#v", plan)
+			}
+			if len(plan.Files) == 0 {
+				t.Fatal("expected restore plan files")
+			}
+			for i, file := range plan.Files {
+				if file.Name == "" || file.MinTXID == "" || file.MaxTXID == "" {
+					t.Fatalf("incomplete plan file at index %d: %#v", i, file)
+				}
+				if i > 0 && file.MaxTXID <= plan.Files[i-1].MaxTXID {
+					t.Fatalf("restore plan is out of order at indexes %d and %d", i-1, i)
+				}
+			}
+			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+				t.Fatalf("restore plan created output: %v", err)
+			}
+		})
+	}
+}
+
+func TestRestorePlanToolRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		contains  string
+	}{
+		{
+			name: "txid",
+			arguments: map[string]any{
+				"path": "file:///tmp/replica",
+				"txid": "bad",
+			},
+			contains: "invalid txid",
+		},
+		{
+			name: "timestamp",
+			arguments: map[string]any{
+				"path":      "file:///tmp/replica",
+				"timestamp": "bad",
+			},
+			contains: "invalid timestamp",
+		},
+		{
+			name: "txid and timestamp",
+			arguments: map[string]any{
+				"path":      "file:///tmp/replica",
+				"txid":      "0000000000000001",
+				"timestamp": "2026-07-17T12:00:00Z",
+			},
+			contains: "cannot specify both txid and timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callMCPToolResult(t, handlerFromMCPTool(RestorePlanTool("")), tt.arguments)
+			if !result.IsError {
+				t.Fatal("expected tool error")
+			}
+			text := mcpToolResultText(t, result)
+			if !strings.Contains(text, tt.contains) {
+				t.Fatalf("error does not contain %q: %s", tt.contains, text)
+			}
 		})
 	}
 }
@@ -391,6 +539,14 @@ func TestRestoreToolRejectsInvalidOptions(t *testing.T) {
 			},
 			contains: "invalid parallelism",
 		},
+		{
+			name: "integrity check",
+			arguments: map[string]any{
+				"path":            "file:///tmp/replica",
+				"integrity_check": "invalid",
+			},
+			contains: "invalid integrity_check",
+		},
 	}
 
 	for _, tt := range tests {
@@ -433,6 +589,24 @@ func TestRestoreToolSchema(t *testing.T) {
 	}
 	if _, ok := tool.InputSchema.Properties["o"]; ok {
 		t.Fatal("did not expect o property")
+	}
+	if _, ok := tool.InputSchema.Properties["integrity_check"]; !ok {
+		t.Fatal("expected integrity_check property")
+	}
+}
+
+func TestRestorePlanToolSchema(t *testing.T) {
+	tool, _ := RestorePlanTool("")
+	if tool.Annotations.ReadOnlyHint == nil || !*tool.Annotations.ReadOnlyHint {
+		t.Fatal("expected read-only hint")
+	}
+	if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint {
+		t.Fatal("expected non-destructive hint")
+	}
+	for _, name := range []string{"path", "output", "config", "txid", "timestamp"} {
+		if _, ok := tool.InputSchema.Properties[name]; !ok {
+			t.Fatalf("expected %s property", name)
+		}
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -182,24 +184,48 @@ func TestRestoreToolRunWithoutLitestreamOnPATH(t *testing.T) {
 }
 
 func TestRestoreToolIntegrityCheck(t *testing.T) {
+	fixture := newMCPTestFixture(t)
+	corruptMCPTestFixture(t, fixture)
+
+	t.Run("none", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+		text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+			"path":            "file://" + fixture.replicaPath,
+			"output":          outputPath,
+			"integrity_check": "none",
+		})
+
+		var result RestoreResult
+		if err := json.Unmarshal([]byte(text), &result); err != nil {
+			t.Fatalf("decode result: %v\n%s", err, text)
+		}
+		if result.IntegrityCheck != "none" {
+			t.Fatalf("integrity check=%q, want none", result.IntegrityCheck)
+		}
+		if _, err := os.Stat(outputPath); err != nil {
+			t.Fatalf("stat restored database: %v", err)
+		}
+	})
+
 	for _, mode := range []string{"quick", "full"} {
 		t.Run(mode, func(t *testing.T) {
-			fixture := newMCPTestFixture(t)
 			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
-			text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+			result := callMCPToolResult(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
 				"path":            "file://" + fixture.replicaPath,
 				"output":          outputPath,
 				"integrity_check": mode,
 			})
-
-			var result RestoreResult
-			if err := json.Unmarshal([]byte(text), &result); err != nil {
-				t.Fatalf("decode result: %v\n%s", err, text)
+			if !result.IsError {
+				t.Fatal("expected tool error")
 			}
-			if result.IntegrityCheck != mode {
-				t.Fatalf("integrity check=%q, want %q", result.IntegrityCheck, mode)
+			if text := mcpToolResultText(t, result); !strings.Contains(text, "post-restore integrity check") {
+				t.Fatalf("unexpected error: %s", text)
 			}
-			assertRestoreCommandDB(t, outputPath)
+			for _, path := range []string{outputPath, outputPath + "-shm", outputPath + "-wal"} {
+				if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+					t.Fatalf("failed restore output exists at %q: %v", path, err)
+				}
+			}
 		})
 	}
 }
@@ -287,7 +313,7 @@ func TestRestorePlanTool(t *testing.T) {
 					t.Fatalf("restore plan is out of order at indexes %d and %d", i-1, i)
 				}
 			}
-			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+			if _, err := os.Stat(outputPath); !errors.Is(err, fs.ErrNotExist) {
 				t.Fatalf("restore plan created output: %v", err)
 			}
 		})
@@ -661,6 +687,60 @@ func newMCPTestFixture(t *testing.T) mcpTestFixture {
 		dbPath:      dbPath,
 		replicaPath: replicaPath,
 		configPath:  configPath,
+	}
+}
+
+func corruptMCPTestFixture(t *testing.T, fixture mcpTestFixture) {
+	t.Helper()
+
+	dbPath := filepath.Join(filepath.Dir(fixture.replicaPath), "db.sqlite")
+	data, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) < 100 {
+		t.Fatalf("database is too small: %d bytes", len(data))
+	}
+
+	pageSize := int(binary.BigEndian.Uint16(data[16:18]))
+	if pageSize == 1 {
+		pageSize = 65536
+	}
+	if pageSize == 0 || len(data)%pageSize != 0 || len(data) <= pageSize {
+		t.Fatalf("invalid test database size=%d page_size=%d", len(data), pageSize)
+	}
+	for i := pageSize; i < len(data); i++ {
+		data[i] = 0xde
+	}
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:   ltx.Version,
+		Flags:     ltx.HeaderFlagNoChecksum,
+		PageSize:  uint32(pageSize),
+		Commit:    uint32(len(data) / pageSize),
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for offset := 0; offset < len(data); offset += pageSize {
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: uint32(offset/pageSize + 1)}, data[offset:offset+pageSize]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := litestream.LTXFilePath(fixture.replicaPath, 0, 1, 1)
+	if err := os.WriteFile(path, buf.Bytes(), 0600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -173,7 +173,154 @@ func TestRestoreToolRunWithoutLitestreamOnPATH(t *testing.T) {
 			if result.TXID != "" {
 				t.Fatalf("automatic file restore TXID=%q, want unknown", result.TXID)
 			}
+			if result.IntegrityCheck != "none" {
+				t.Fatalf("integrity check=%q, want none", result.IntegrityCheck)
+			}
 			assertRestoreCommandDB(t, outputPath)
+		})
+	}
+}
+
+func TestRestoreToolIntegrityCheck(t *testing.T) {
+	for _, mode := range []string{"quick", "full"} {
+		t.Run(mode, func(t *testing.T) {
+			fixture := newMCPTestFixture(t)
+			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+			text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+				"path":            "file://" + fixture.replicaPath,
+				"output":          outputPath,
+				"integrity_check": mode,
+			})
+
+			var result RestoreResult
+			if err := json.Unmarshal([]byte(text), &result); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, text)
+			}
+			if result.IntegrityCheck != mode {
+				t.Fatalf("integrity check=%q, want %q", result.IntegrityCheck, mode)
+			}
+			assertRestoreCommandDB(t, outputPath)
+		})
+	}
+}
+
+func TestRestorePlanTool(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	fixture := newMCPTestFixture(t)
+	timestamp := time.Now().Add(time.Hour).Format(time.RFC3339)
+
+	tests := []struct {
+		name          string
+		arguments     map[string]any
+		includeOutput bool
+	}{
+		{
+			name:          "database path with txid",
+			includeOutput: true,
+			arguments: map[string]any{
+				"path":   fixture.dbPath,
+				"config": fixture.configPath,
+				"txid":   "0000000000000001",
+			},
+		},
+		{
+			name: "replica URL with timestamp",
+			arguments: map[string]any{
+				"path":      "file://" + fixture.replicaPath,
+				"config":    filepath.Join(t.TempDir(), "missing.yml"),
+				"timestamp": timestamp,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "restored.sqlite")
+			if tt.includeOutput {
+				tt.arguments["output"] = outputPath
+			}
+			text := callMCPToolText(t, handlerFromMCPTool(RestorePlanTool("")), tt.arguments)
+			wantSource := tt.arguments["path"].(string)
+
+			var plan RestorePlan
+			if err := json.Unmarshal([]byte(text), &plan); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, text)
+			}
+			if plan.Source != wantSource {
+				t.Fatalf("source=%q, want %q", plan.Source, wantSource)
+			}
+			if tt.includeOutput && plan.TargetPath != outputPath {
+				t.Fatalf("target path=%q, want %q", plan.TargetPath, outputPath)
+			} else if !tt.includeOutput && plan.TargetPath != "" {
+				t.Fatalf("target path=%q, want empty", plan.TargetPath)
+			}
+			if plan.Replica != "file" {
+				t.Fatalf("replica=%q, want file", plan.Replica)
+			}
+			if plan.MinTXID == "" || plan.MaxTXID == "" {
+				t.Fatalf("expected txid range: %#v", plan)
+			}
+			if len(plan.Files) == 0 {
+				t.Fatal("expected restore plan files")
+			}
+			for i, file := range plan.Files {
+				if file.Name == "" || file.MinTXID == "" || file.MaxTXID == "" {
+					t.Fatalf("incomplete plan file at index %d: %#v", i, file)
+				}
+				if i > 0 && file.MaxTXID <= plan.Files[i-1].MaxTXID {
+					t.Fatalf("restore plan is out of order at indexes %d and %d", i-1, i)
+				}
+			}
+			if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+				t.Fatalf("restore plan created output: %v", err)
+			}
+		})
+	}
+}
+
+func TestRestorePlanToolRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		contains  string
+	}{
+		{
+			name: "txid",
+			arguments: map[string]any{
+				"path": "file:///tmp/replica",
+				"txid": "bad",
+			},
+			contains: "invalid txid",
+		},
+		{
+			name: "timestamp",
+			arguments: map[string]any{
+				"path":      "file:///tmp/replica",
+				"timestamp": "bad",
+			},
+			contains: "invalid timestamp",
+		},
+		{
+			name: "txid and timestamp",
+			arguments: map[string]any{
+				"path":      "file:///tmp/replica",
+				"txid":      "0000000000000001",
+				"timestamp": "2026-07-17T12:00:00Z",
+			},
+			contains: "cannot specify both txid and timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callMCPToolResult(t, handlerFromMCPTool(RestorePlanTool("")), tt.arguments)
+			if !result.IsError {
+				t.Fatal("expected tool error")
+			}
+			text := mcpToolResultText(t, result)
+			if !strings.Contains(text, tt.contains) {
+				t.Fatalf("error does not contain %q: %s", tt.contains, text)
+			}
 		})
 	}
 }
@@ -396,6 +543,14 @@ func TestRestoreToolRejectsInvalidOptions(t *testing.T) {
 			},
 			contains: "invalid parallelism",
 		},
+		{
+			name: "integrity check",
+			arguments: map[string]any{
+				"path":            "file:///tmp/replica",
+				"integrity_check": "invalid",
+			},
+			contains: "invalid integrity_check",
+		},
 	}
 
 	for _, tt := range tests {
@@ -438,6 +593,24 @@ func TestRestoreToolSchema(t *testing.T) {
 	}
 	if _, ok := tool.InputSchema.Properties["o"]; ok {
 		t.Fatal("did not expect o property")
+	}
+	if _, ok := tool.InputSchema.Properties["integrity_check"]; !ok {
+		t.Fatal("expected integrity_check property")
+	}
+}
+
+func TestRestorePlanToolSchema(t *testing.T) {
+	tool, _ := RestorePlanTool("")
+	if tool.Annotations.ReadOnlyHint == nil || !*tool.Annotations.ReadOnlyHint {
+		t.Fatal("expected read-only hint")
+	}
+	if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint {
+		t.Fatal("expected non-destructive hint")
+	}
+	for _, name := range []string{"path", "output", "config", "txid", "timestamp"} {
+		if _, ok := tool.InputSchema.Properties[name]; !ok {
+			t.Fatalf("expected %s property", name)
+		}
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal/testingutil"
 	"github.com/benbjohnson/litestream/mock"
 )
 
@@ -884,5 +885,87 @@ func TestMCPResourceCleanupPreservesErrors(t *testing.T) {
 	}
 	if client.closeN != 1 {
 		t.Fatalf("close calls=%d, want 1", client.closeN)
+	}
+}
+
+func TestRestorePlanPreservesExistingOutput(t *testing.T) {
+	fixture := newMCPTestFixture(t)
+	outputPath := filepath.Join(t.TempDir(), "existing.sqlite")
+	const original = "existing database contents"
+	if err := os.WriteFile(outputPath, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+	callMCPToolText(t, handlerFromMCPTool(RestorePlanTool("")), map[string]any{
+		"path":   "file://" + fixture.replicaPath,
+		"output": outputPath,
+	})
+	if got, err := os.ReadFile(outputPath); err != nil || string(got) != original {
+		t.Fatalf("output=%q, error=%v; want original contents", got, err)
+	}
+}
+
+func TestRestorePlanPreservesCancellationCause(t *testing.T) {
+	fixture := newMCPTestFixture(t)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cause := errors.New("preview canceled by caller")
+	cancel(cause)
+	_, handler := RestorePlanTool("")
+	result, err := handler(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: map[string]any{"path": "file://" + fixture.replicaPath}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError || !strings.Contains(mcpToolResultText(t, result), cause.Error()) {
+		t.Fatalf("preview did not preserve cancellation: %#v", result)
+	}
+}
+
+func TestMCPRestoreLegacyPreviewAndIntegrity(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mixed=%t", mixed), func(t *testing.T) {
+			replicaPath, outputPath := createLegacyRestoreCommandTestData(t, mixed)
+			const original = "existing output"
+			if err := os.WriteFile(outputPath, []byte(original), 0600); err != nil {
+				t.Fatal(err)
+			}
+			arguments := map[string]any{"path": "file://" + replicaPath, "output": outputPath}
+			result := callMCPToolResult(t, handlerFromMCPTool(RestorePlanTool("")), arguments)
+			if !result.IsError || !strings.Contains(mcpToolResultText(t, result), "legacy backups") {
+				t.Fatalf("expected unsupported legacy preview: %#v", result)
+			}
+			if mixed {
+				arguments["txid"] = "0000000000000001"
+				callMCPToolText(t, handlerFromMCPTool(RestorePlanTool("")), arguments)
+			}
+			if got, err := os.ReadFile(outputPath); err != nil || string(got) != original {
+				t.Fatalf("output=%q, error=%v; want original contents", got, err)
+			}
+
+			for _, mode := range []string{"none", "quick", "full"} {
+				t.Run(mode, func(t *testing.T) {
+					path := filepath.Join(t.TempDir(), "restored.sqlite")
+					text := callMCPToolText(t, handlerFromMCPTool(RestoreTool("")), map[string]any{
+						"path": "file://" + replicaPath, "output": path, "integrity_check": mode,
+					})
+					var result RestoreResult
+					if err := json.Unmarshal([]byte(text), &result); err != nil {
+						t.Fatal(err)
+					}
+					if result.IntegrityCheck != mode || result.TXID != "" {
+						t.Fatalf("restore result=%#v", result)
+					}
+					db := testingutil.MustOpenSQLDB(t, path)
+					t.Cleanup(func() { testingutil.MustCloseSQLDB(t, db) })
+					var id int
+					if err := db.QueryRowContext(t.Context(), "SELECT id FROM t").Scan(&id); err != nil {
+						t.Fatal(err)
+					}
+					if id != 2 {
+						t.Fatalf("restored row=%d, want legacy row 2", id)
+					}
+				})
+			}
+		})
 	}
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -207,24 +207,40 @@ func TestRestoreToolIntegrityCheck(t *testing.T) {
 func TestRestorePlanTool(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	fixture := newMCPTestFixture(t)
-	timestamp := time.Now().Add(time.Hour).Format(time.RFC3339)
+	baseTime := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	for txID := ltx.TXID(1); txID <= 3; txID++ {
+		path := litestream.LTXFilePath(fixture.replicaPath, 0, txID, txID)
+		if txID > 1 {
+			if err := os.WriteFile(path, []byte("ltx"), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		createdAt := baseTime.Add(time.Duration(txID-1) * time.Hour)
+		if err := os.Chtimes(path, createdAt, createdAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	timestamp := baseTime.Add(90 * time.Minute).Format(time.RFC3339)
 
 	tests := []struct {
 		name          string
 		arguments     map[string]any
 		includeOutput bool
+		fileN         int
 	}{
 		{
 			name:          "database path with txid",
 			includeOutput: true,
+			fileN:         2,
 			arguments: map[string]any{
 				"path":   fixture.dbPath,
 				"config": fixture.configPath,
-				"txid":   "0000000000000001",
+				"txid":   "0000000000000002",
 			},
 		},
 		{
-			name: "replica URL with timestamp",
+			name:  "replica URL with timestamp",
+			fileN: 2,
 			arguments: map[string]any{
 				"path":      "file://" + fixture.replicaPath,
 				"config":    filepath.Join(t.TempDir(), "missing.yml"),
@@ -257,11 +273,11 @@ func TestRestorePlanTool(t *testing.T) {
 			if plan.Replica != "file" {
 				t.Fatalf("replica=%q, want file", plan.Replica)
 			}
-			if plan.MinTXID == "" || plan.MaxTXID == "" {
-				t.Fatalf("expected txid range: %#v", plan)
+			if plan.MinTXID != "0000000000000001" || plan.MaxTXID != "0000000000000002" {
+				t.Fatalf("txid range=%s-%s, want 0000000000000001-0000000000000002", plan.MinTXID, plan.MaxTXID)
 			}
-			if len(plan.Files) == 0 {
-				t.Fatal("expected restore plan files")
+			if len(plan.Files) != tt.fileN {
+				t.Fatalf("files=%d, want %d", len(plan.Files), tt.fileN)
 			}
 			for i, file := range plan.Files {
 				if file.Name == "" || file.MinTXID == "" || file.MaxTXID == "" {

--- a/cmd/litestream/restore.go
+++ b/cmd/litestream/restore.go
@@ -207,6 +207,16 @@ func (c *RestoreCommand) dryRunPlan(ctx context.Context, source string, r *lites
 		return RestorePlan{}, fmt.Errorf("cannot use -dry-run with -f")
 	}
 
+	if client, ok := r.Client.(litestream.ReplicaClientV3); ok && opt.TXID == 0 {
+		createdAt, updatedAt, err := r.TimeBoundsV3(ctx, client)
+		if err != nil {
+			return RestorePlan{}, fmt.Errorf("inspect legacy backups for restore preview: %w", err)
+		}
+		if !createdAt.IsZero() || !updatedAt.IsZero() {
+			return RestorePlan{}, fmt.Errorf("automatic restore preview is unsupported when legacy backups exist; specify a TXID to preview LTX backups")
+		}
+	}
+
 	infos, err := litestream.CalcRestorePlan(ctx, r.Client, opt.TXID, opt.Timestamp, r.Logger())
 	if err != nil {
 		return RestorePlan{}, err

--- a/cmd/litestream/restore_test.go
+++ b/cmd/litestream/restore_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -352,43 +353,7 @@ func TestRestoreCommandOutputAccessError(t *testing.T) {
 func TestRestoreCommandLegacySelection(t *testing.T) {
 	for _, mixed := range []bool{false, true} {
 		t.Run(map[bool]string{false: "legacy only", true: "newer legacy"}[mixed], func(t *testing.T) {
-			dir := t.TempDir()
-			replicaPath, restorePath := filepath.Join(dir, "replica"), filepath.Join(dir, "restored.db")
-			if mixed {
-				replicaPath, restorePath = createRestoreCommandTestData(t, t.Context())
-			}
-			source := filepath.Join(dir, "legacy.db")
-			db := testingutil.MustOpenSQLDB(t, source)
-			if _, err := db.ExecContext(t.Context(), "CREATE TABLE t (id INT); INSERT INTO t VALUES (2)"); err != nil {
-				t.Fatal(err)
-			}
-			if err := db.Close(); err != nil {
-				t.Fatal(err)
-			}
-			data, err := os.ReadFile(source)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var compressed bytes.Buffer
-			writer := lz4.NewWriter(&compressed)
-			if _, err := writer.Write(data); err != nil {
-				t.Fatal(err)
-			}
-			if err := writer.Close(); err != nil {
-				t.Fatal(err)
-			}
-			snapshotDir := filepath.Join(replicaPath, "generations", "0123456789abcdef", "snapshots")
-			if err := os.MkdirAll(snapshotDir, 0755); err != nil {
-				t.Fatal(err)
-			}
-			snapshot := filepath.Join(snapshotDir, "00000000.snapshot.lz4")
-			if err := os.WriteFile(snapshot, compressed.Bytes(), 0600); err != nil {
-				t.Fatal(err)
-			}
-			newer := time.Now().Add(time.Hour)
-			if err := os.Chtimes(snapshot, newer, newer); err != nil {
-				t.Fatal(err)
-			}
+			replicaPath, restorePath := createLegacyRestoreCommandTestData(t, mixed)
 			output := captureLTXCommandStdout(t, func() {
 				if err := (&RestoreCommand{}).Run(t.Context(), []string{"-json", "-o", restorePath, "file://" + replicaPath}); err != nil {
 					t.Fatal(err)
@@ -431,5 +396,104 @@ func TestRestoreCommandExplicitTXIDOutput(t *testing.T) {
 	}
 	if result.TXID != "0000000000000001" {
 		t.Fatalf("result=%+v", result)
+	}
+}
+
+func createLegacyRestoreCommandTestData(t *testing.T, mixed bool) (replicaPath, restorePath string) {
+	t.Helper()
+	dir := t.TempDir()
+	replicaPath, restorePath = filepath.Join(dir, "replica"), filepath.Join(dir, "restored.db")
+	if mixed {
+		replicaPath, restorePath = createRestoreCommandTestData(t, t.Context())
+	}
+	source := filepath.Join(dir, "legacy.db")
+	db := testingutil.MustOpenSQLDB(t, source)
+	if _, err := db.ExecContext(t.Context(), "CREATE TABLE t (id INT); INSERT INTO t VALUES (2)"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var compressed bytes.Buffer
+	writer := lz4.NewWriter(&compressed)
+	if _, err := writer.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshotDir := filepath.Join(replicaPath, "generations", "0123456789abcdef", "snapshots")
+	if err := os.MkdirAll(snapshotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := filepath.Join(snapshotDir, "00000000.snapshot.lz4")
+	if err := os.WriteFile(snapshot, compressed.Bytes(), 0600); err != nil {
+		t.Fatal(err)
+	}
+	newer := time.Now().Add(time.Hour)
+	if err := os.Chtimes(snapshot, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	return replicaPath, restorePath
+}
+
+func TestRestoreCommandDryRunLegacy(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy only", true: "mixed"}[mixed], func(t *testing.T) {
+			replicaPath, outputPath := createLegacyRestoreCommandTestData(t, mixed)
+			sentinel := []byte("existing database contents")
+			if err := os.WriteFile(outputPath, sentinel, 0600); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{"-dry-run", "-json", "-o", outputPath}
+			err := (&RestoreCommand{}).Run(t.Context(), append(args, "file://"+replicaPath))
+			if err == nil || !strings.Contains(err.Error(), "automatic restore preview is unsupported") {
+				t.Fatalf("error=%v, want unsupported legacy preview", err)
+			}
+			if mixed {
+				output := captureLTXCommandStdout(t, func() {
+					if err := (&RestoreCommand{}).Run(t.Context(), append(args, "-txid", "0000000000000001", "file://"+replicaPath)); err != nil {
+						t.Fatal(err)
+					}
+				})
+				var plan RestorePlan
+				if err := json.Unmarshal([]byte(output), &plan); err != nil {
+					t.Fatal(err)
+				}
+				if plan.MaxTXID != "0000000000000001" || len(plan.Files) == 0 {
+					t.Fatalf("unexpected LTX plan: %+v", plan)
+				}
+			}
+			got, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, sentinel) {
+				t.Fatalf("preview modified output: %q", got)
+			}
+		})
+	}
+}
+
+type restorePreviewErrorClient struct {
+	*file.ReplicaClient
+	err error
+}
+
+func (c *restorePreviewErrorClient) GenerationsV3(context.Context) ([]string, error) {
+	return nil, c.err
+}
+
+func TestRestoreCommandDryRunLegacyLookupError(t *testing.T) {
+	lookupErr := errors.New("legacy listing failed")
+	client := &restorePreviewErrorClient{ReplicaClient: file.NewReplicaClient(t.TempDir()), err: lookupErr}
+	replica := litestream.NewReplicaWithClient(nil, client)
+	_, err := (&RestoreCommand{}).dryRunPlan(t.Context(), "replica", replica, litestream.NewRestoreOptions())
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("error=%v, want %v", err, lookupErr)
 	}
 }

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -14,3 +14,9 @@ Add a row when a new Litestream feature lands that still needs user-facing docs 
 ## AI Documentation Status
 
 Internal AI documentation (this repo) was tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106), now closed.
+
+## MCP Restore Preview and Integrity Checks
+
+The `litestream_restore_plan` tool in #1381 returns an ordered LTX restore plan without modifying its optional output path. Automatic and timestamp-based previews are unsupported when legacy v0.3.x backups are present, including mixed legacy/LTX replicas. An explicit `txid` selects an LTX preview. This restriction avoids presenting a plan that differs from automatic restore's legacy selection; full legacy preview support remains future work.
+
+The `litestream_restore` tool accepts `integrity_check` values `none`, `quick`, and `full`. Failed integrity checks return a tool error and remove the failed restore output. User-facing website documentation is still pending for these MCP options.

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -199,6 +199,39 @@ func TestReplicaClient_OpenLTXFile(t *testing.T) {
 	})
 }
 
+func TestReplicaClient_Close(t *testing.T) {
+	RunWithReplicaClient(t, "Reconnect", func(t *testing.T, c litestream.ReplicaClient) {
+		if c.Type() != "nats" && c.Type() != "sftp" {
+			t.Skip("replica client does not retain a connection")
+		}
+
+		closer, ok := c.(litestream.ReplicaClientCloser)
+		if !ok {
+			t.Fatalf("client type %q does not implement cleanup contract", c.Type())
+		}
+		t.Cleanup(func() {
+			if err := closer.Close(); err != nil {
+				t.Errorf("close replica client: %v", err)
+			}
+		})
+
+		for i := 0; i < 2; i++ {
+			itr, err := c.LTXFiles(t.Context(), 0, 0, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for itr.Next() {
+			}
+			if err := errors.Join(itr.Err(), itr.Close()); err != nil {
+				t.Fatal(err)
+			}
+			if err := closer.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
 func TestReplicaClient_DeleteWALSegments(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Helper()
@@ -534,6 +567,29 @@ func TestReplicaClient_SFTP_HostKeyValidation(t *testing.T) {
 			t.Errorf("Expected warning not found")
 		}
 	})
+}
+
+func TestReplicaClient_SFTP_Close(t *testing.T) {
+	privateKey := mustParseTestSFTPHostKey(t)
+	addr := testingutil.MockSFTPServer(t, privateKey)
+
+	c := testingutil.NewSFTPReplicaClient(t)
+	c.User = "foo"
+	c.Host = addr
+	c.HostKey = string(ssh.MarshalAuthorizedKey(privateKey.PublicKey()))
+
+	closer, ok := any(c).(litestream.ReplicaClientCloser)
+	if !ok {
+		t.Fatal("SFTP client does not implement cleanup contract")
+	}
+	for i := 0; i < 2; i++ {
+		if err := c.Init(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if err := closer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func TestReplicaClient_SFTP_WriteLTXFileAtomic(t *testing.T) {

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -200,6 +200,39 @@ func TestReplicaClient_OpenLTXFile(t *testing.T) {
 	})
 }
 
+func TestReplicaClient_Close(t *testing.T) {
+	RunWithReplicaClient(t, "Reconnect", func(t *testing.T, c litestream.ReplicaClient) {
+		if c.Type() != "nats" && c.Type() != "sftp" {
+			t.Skip("replica client does not retain a connection")
+		}
+
+		closer, ok := c.(litestream.ReplicaClientCloser)
+		if !ok {
+			t.Fatalf("client type %q does not implement cleanup contract", c.Type())
+		}
+		t.Cleanup(func() {
+			if err := closer.Close(); err != nil {
+				t.Errorf("close replica client: %v", err)
+			}
+		})
+
+		for i := 0; i < 2; i++ {
+			itr, err := c.LTXFiles(t.Context(), 0, 0, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for itr.Next() {
+			}
+			if err := errors.Join(itr.Err(), itr.Close()); err != nil {
+				t.Fatal(err)
+			}
+			if err := closer.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
 func TestReplicaClient_DeleteWALSegments(t *testing.T) {
 	RunWithReplicaClient(t, "OK", func(t *testing.T, c litestream.ReplicaClient) {
 		t.Helper()

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -223,21 +223,25 @@ func (c *ReplicaClient) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var err error
-	if c.sftpClient != nil {
-		err = errors.Join(err, c.sftpClient.Close())
-		c.sftpClient = nil
+	sftpClient, sshClient := c.sftpClient, c.sshClient
+	c.sftpClient, c.sshClient = nil, nil
+
+	var sshErr, sftpErr error
+	if sshClient != nil {
+		sshErr = sshClient.Close()
 	}
-	if c.sshClient != nil {
-		err = errors.Join(err, c.sshClient.Close())
-		c.sshClient = nil
+	if sftpClient != nil {
+		sftpErr = sftpClient.Close()
+		if errors.Is(sftpErr, io.EOF) || errors.Is(sftpErr, net.ErrClosed) {
+			sftpErr = nil
+		}
 	}
-	return err
+	return errors.Join(sshErr, sftpErr)
 }
 
 // DeleteAll deletes all LTX files.
 func (c *ReplicaClient) DeleteAll(ctx context.Context) (err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -281,7 +285,7 @@ func (c *ReplicaClient) DeleteAll(ctx context.Context) (err error) {
 // SFTP uses file ModTime for timestamps, which is set via Chtimes() to preserve original timestamp.
 // The useMetadata parameter is ignored since ModTime always contains the accurate timestamp.
 func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, _ bool) (_ ltx.FileIterator, err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -320,7 +324,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 
 // WriteLTXFile writes a LTX file from rd into a remote file.
 func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, rd io.Reader) (info *ltx.FileInfo, err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -392,7 +396,7 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 // OpenLTXFile returns a reader for an LTX file.
 // Returns os.ErrNotExist if no matching position is found.
 func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (_ io.ReadCloser, err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -421,7 +425,7 @@ func (c *ReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, max
 
 // DeleteLTXFiles deletes LTX files with at the given positions.
 func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) (err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -444,7 +448,7 @@ func (c *ReplicaClient) DeleteLTXFiles(ctx context.Context, a []*ltx.FileInfo) (
 
 // Cleanup deletes path & directories after empty.
 func (c *ReplicaClient) Cleanup(ctx context.Context) (err error) {
-	defer func() { c.resetOnConnError(err) }()
+	defer c.resetOnConnError(&err)
 
 	sftpClient, err := c.init(ctx)
 	if err != nil {
@@ -458,17 +462,9 @@ func (c *ReplicaClient) Cleanup(ctx context.Context) (err error) {
 }
 
 // resetOnConnError closes & clears the client if a connection error occurs.
-func (c *ReplicaClient) resetOnConnError(err error) {
-	if !errors.Is(err, sftp.ErrSSHFxConnectionLost) {
+func (c *ReplicaClient) resetOnConnError(err *error) {
+	if !errors.Is(*err, sftp.ErrSSHFxConnectionLost) {
 		return
 	}
-
-	if c.sftpClient != nil {
-		c.sftpClient.Close()
-		c.sftpClient = nil
-	}
-	if c.sshClient != nil {
-		c.sshClient.Close()
-		c.sshClient = nil
-	}
+	*err = errors.Join(*err, c.Close())
 }


### PR DESCRIPTION
## Description

Adds a read-only `litestream_restore_plan` MCP tool that resolves configured database paths and replica URLs in-process, accepts optional TXID or timestamp targets, and returns the ordered restore plan produced by `litestream.CalcRestorePlan`. The tool advertises `readOnlyHint: true` and does not create its optional output path.

Adds an `integrity_check` option to `litestream_restore` with `none`, `quick`, and `full` modes, passes the selected mode to the restore library, and reports it in the restore result.

This is a stacked PR containing only the issue #1371 delta above #1367. It does not pull in other MCP branches.

## Motivation and Context

The MCP restore surface could perform a restore but could not safely preview the snapshot and LTX files that would be applied. It also always reported the integrity mode as `none` and provided no way to request the library-supported post-restore checks.

Investigation evidence:
- The MCP restore schema had no dry-run or integrity-check input.
- The MCP restore result hard-coded `integrity_check` to `none`.
- The #1367 base provides in-process replica resolution, while the existing restore plan path delegates to `litestream.CalcRestorePlan`.

Closes #1371

## How Has This Been Tested?

- `go test ./cmd/litestream -run 'Test(RestorePlanTool|RestoreTool|MCP)' -count=1`
- `go test -v ./cmd/litestream`
- `go build ./...`
- `go test ./...`
- `go test -race -v ./...`
- `pre-commit run --all-files`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
