### PR TITLE
feat(mcp): add daemon control tools

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -171,6 +171,11 @@ jobs:
       - run: go test -v ./sftp
       - run: go test -v ./cmd/litestream
 
+      - name: Compile command tests for 32-bit Linux ARM
+        run: |
+          GOOS=linux GOARCH=arm GOARM=6 go test -c -o /dev/null ./cmd/litestream
+          GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./cmd/litestream
+
 
   ltx-behavioral-gate:
     name: LTX Behavioral Gate (short)

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -176,7 +176,6 @@ jobs:
           GOOS=linux GOARCH=arm GOARM=6 go test -c -o /dev/null ./cmd/litestream
           GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./cmd/litestream
 
-
   ltx-behavioral-gate:
     name: LTX Behavioral Gate (short)
     runs-on: ubuntu-latest

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -182,7 +182,6 @@ jobs:
           GOOS=linux GOARCH=arm GOARM=6 go test -c -o /dev/null ./cmd/litestream
           GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./cmd/litestream
 
-
   ltx-behavioral-gate:
     name: LTX Behavioral Gate (short)
     runs-on: ubuntu-latest

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -177,6 +177,12 @@ jobs:
       - name: Test v0.3 WAL ordering on 32-bit
         run: CGO_ENABLED=0 GOOS=linux GOARCH=386 go test -v ./file ./s3 -run '^TestReplicaClient_WALSegmentsV3$'
 
+      - name: Compile command tests for 32-bit Linux ARM
+        run: |
+          GOOS=linux GOARCH=arm GOARM=6 go test -c -o /dev/null ./cmd/litestream
+          GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./cmd/litestream
+
+
   ltx-behavioral-gate:
     name: LTX Behavioral Gate (short)
     runs-on: ubuntu-latest

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -30,7 +31,7 @@ const (
 	defaultDaemonSocketPath   = "/var/run/litestream.sock"
 	defaultDaemonReadTimeout  = 10
 	defaultDaemonWriteTimeout = 30
-	maxDaemonTimeoutSeconds   = int64((1<<63 - 1) / time.Second)
+	maxDaemonTimeoutSeconds   = int64(math.MaxInt64 / time.Second)
 )
 
 type MCPServer struct {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -2,19 +2,34 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/MadAppGang/httplog"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/benbjohnson/litestream"
+)
+
+const (
+	defaultDaemonSocketPath   = "/var/run/litestream.sock"
+	defaultDaemonReadTimeout  = 10
+	defaultDaemonWriteTimeout = 30
 )
 
 type MCPServer struct {
@@ -50,6 +65,20 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcp.AddTool(mcpServer, statusTool, statusHandler)
 	resetTool, resetHandler := ResetTool(configPath)
 	mcp.AddTool(mcpServer, resetTool, resetHandler)
+	daemonListTool, daemonListHandler := DaemonListTool()
+	mcp.AddTool(mcpServer, daemonListTool, daemonListHandler)
+	daemonSyncTool, daemonSyncHandler := DaemonSyncTool()
+	mcp.AddTool(mcpServer, daemonSyncTool, daemonSyncHandler)
+	daemonInfoTool, daemonInfoHandler := DaemonInfoTool()
+	mcp.AddTool(mcpServer, daemonInfoTool, daemonInfoHandler)
+	daemonStartTool, daemonStartHandler := DaemonStartTool()
+	mcp.AddTool(mcpServer, daemonStartTool, daemonStartHandler)
+	daemonStopTool, daemonStopHandler := DaemonStopTool()
+	mcp.AddTool(mcpServer, daemonStopTool, daemonStopHandler)
+	daemonRegisterTool, daemonRegisterHandler := DaemonRegisterTool()
+	mcp.AddTool(mcpServer, daemonRegisterTool, daemonRegisterHandler)
+	daemonUnregisterTool, daemonUnregisterHandler := DaemonUnregisterTool()
+	mcp.AddTool(mcpServer, daemonUnregisterTool, daemonUnregisterHandler)
 
 	s.mux = http.NewServeMux()
 	s.mux.Handle("/", httplog.Logger(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
@@ -406,6 +435,314 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 		text := string(output)
 		return textResult(text), resetOutput{Text: text}, nil
 	}
+}
+
+type daemonOutput struct {
+	Text string `json:"text" jsonschema:"Daemon response encoded as JSON."`
+}
+
+type daemonListInput struct {
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonListTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonListInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_list",
+		Description: "List databases managed by a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		InputSchema: nonNullableInputSchema[daemonListInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonListInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonReadTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.ListResponse
+		if err := client.do(ctx, http.MethodGet, "/list", nil, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonSyncInput struct {
+	Path    string  `json:"path" jsonschema:"Database path managed by the Litestream daemon."`
+	Wait    *bool   `json:"wait,omitempty" jsonschema:"Wait for remote replication to complete. Optional."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonSyncTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonSyncInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_sync",
+		Description: "Force an immediate sync for a database managed by a running Litestream daemon, optionally waiting for remote replication.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonSyncInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonSyncInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.SyncResponse
+		request := litestream.SyncRequest{
+			Path:    input.Path,
+			Wait:    input.Wait != nil && *input.Wait,
+			Timeout: client.timeoutSeconds,
+		}
+		if err := client.do(ctx, http.MethodPost, "/sync", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonInfoInput struct {
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonInfoTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonInfoInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_daemon_info",
+		Description: "Get version, process, uptime, and database count information from a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		InputSchema: nonNullableInputSchema[daemonInfoInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonInfoInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonReadTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.InfoResponse
+		if err := client.do(ctx, http.MethodGet, "/info", nil, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonStartInput struct {
+	Path    string  `json:"path" jsonschema:"Database path managed by the Litestream daemon."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonStartTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStartInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_start",
+		Description: "Start replication for a database managed by a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonStartInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStartInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.StartResponse
+		request := litestream.StartRequest{Path: input.Path, Timeout: client.timeoutSeconds}
+		if err := client.do(ctx, http.MethodPost, "/start", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonStopInput struct {
+	Path    string  `json:"path" jsonschema:"Database path managed by the Litestream daemon."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonStopTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStopInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_stop",
+		Description: "Stop replication for a database managed by a running Litestream daemon after a final sync.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonStopInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStopInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.StopResponse
+		request := litestream.StopRequest{Path: input.Path, Timeout: client.timeoutSeconds}
+		if err := client.do(ctx, http.MethodPost, "/stop", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonRegisterInput struct {
+	Path       string  `json:"path" jsonschema:"Database path to register with the Litestream daemon."`
+	ReplicaURL string  `json:"replica_url" jsonschema:"Replica URL for the database."`
+	Socket     *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout    *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonRegisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonRegisterInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_register",
+		Description: "Register a database and replica with a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonRegisterInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonRegisterInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.RegisterDatabaseResponse
+		request := litestream.RegisterDatabaseRequest{Path: input.Path, ReplicaURL: input.ReplicaURL}
+		if err := client.do(ctx, http.MethodPost, "/register", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonUnregisterInput struct {
+	Path    string  `json:"path" jsonschema:"Database path to unregister from the Litestream daemon."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonUnregisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonUnregisterInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_unregister",
+		Description: "Stop replication and unregister a database from a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonUnregisterInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonUnregisterInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.UnregisterDatabaseResponse
+		request := litestream.UnregisterDatabaseRequest{Path: input.Path, Timeout: client.timeoutSeconds}
+		if err := client.do(ctx, http.MethodPost, "/unregister", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonClient struct {
+	socketPath     string
+	timeoutSeconds int
+}
+
+func newDaemonClient(socket *string, timeout *int, defaultTimeout int) (*daemonClient, error) {
+	socketPath := defaultDaemonSocketPath
+	if socket != nil {
+		socketPath = *socket
+	}
+	if socketPath == "" {
+		return nil, fmt.Errorf("daemon socket path required")
+	}
+
+	timeoutSeconds := defaultTimeout
+	if timeout != nil {
+		timeoutSeconds = *timeout
+	}
+	if timeoutSeconds <= 0 {
+		return nil, fmt.Errorf("timeout must be greater than 0")
+	}
+
+	return &daemonClient{socketPath: socketPath, timeoutSeconds: timeoutSeconds}, nil
+}
+
+func (c *daemonClient) do(ctx context.Context, method, endpoint string, input, output any) error {
+	var body io.Reader
+	if input != nil {
+		data, err := json.Marshal(input)
+		if err != nil {
+			return fmt.Errorf("marshal daemon request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, "http://localhost"+endpoint, body)
+	if err != nil {
+		return fmt.Errorf("create daemon request: %w", err)
+	}
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	timeout := time.Duration(c.timeoutSeconds) * time.Second
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: timeout}).DialContext(ctx, "unix", c.socketPath)
+		},
+	}
+	client := &http.Client{Transport: transport, Timeout: timeout}
+	defer client.CloseIdleConnections()
+
+	response, err := client.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return daemonConnectionError(c.socketPath, err)
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("read daemon response: %w", err)
+	}
+
+	operation := strings.TrimPrefix(endpoint, "/")
+	if response.StatusCode != http.StatusOK {
+		var daemonError litestream.ErrorResponse
+		if err := json.Unmarshal(data, &daemonError); err == nil && daemonError.Error != "" {
+			return fmt.Errorf("%s failed: %s", operation, daemonError.Error)
+		}
+		if message := strings.TrimSpace(string(data)); message != "" {
+			return fmt.Errorf("%s failed: %s", operation, message)
+		}
+		return fmt.Errorf("%s failed with status %s", operation, response.Status)
+	}
+	if err := json.Unmarshal(data, output); err != nil {
+		return fmt.Errorf("parse %s response: %w", operation, err)
+	}
+	return nil
+}
+
+func daemonConnectionError(socketPath string, err error) error {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED) {
+		return fmt.Errorf("no Litestream daemon is running at socket %s: %w", socketPath, err)
+	}
+	return fmt.Errorf("connect to Litestream daemon at socket %s: %w", socketPath, err)
+}
+
+func daemonResult(response any) (*mcp.CallToolResult, daemonOutput, error) {
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return nil, daemonOutput{}, fmt.Errorf("format daemon response: %w", err)
+	}
+	text := string(data) + "\n"
+	return textResult(text), daemonOutput{Text: text}, nil
 }
 
 func textResult(text string) *mcp.CallToolResult {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -30,6 +30,7 @@ const (
 	defaultDaemonSocketPath   = "/var/run/litestream.sock"
 	defaultDaemonReadTimeout  = 10
 	defaultDaemonWriteTimeout = 30
+	maxDaemonTimeoutSeconds   = int64((1<<63 - 1) / time.Second)
 )
 
 type MCPServer struct {
@@ -667,6 +668,9 @@ func newDaemonClient(socket *string, timeout *int, defaultTimeout int) (*daemonC
 	if timeoutSeconds <= 0 {
 		return nil, fmt.Errorf("timeout must be greater than 0")
 	}
+	if int64(timeoutSeconds) > maxDaemonTimeoutSeconds {
+		return nil, fmt.Errorf("timeout must be at most %d seconds", maxDaemonTimeoutSeconds)
+	}
 
 	return &daemonClient{socketPath: socketPath, timeoutSeconds: timeoutSeconds}, nil
 }
@@ -702,6 +706,9 @@ func (c *daemonClient) do(ctx context.Context, method, endpoint string, input, o
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("litestream daemon request timed out after %s at socket %s: %w", timeout, c.socketPath, err)
 		}
 		return daemonConnectionError(c.socketPath, err)
 	}

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -30,7 +31,7 @@ const (
 	defaultDaemonSocketPath   = "/var/run/litestream.sock"
 	defaultDaemonReadTimeout  = 10
 	defaultDaemonWriteTimeout = 30
-	maxDaemonTimeoutSeconds   = int64((1<<63 - 1) / time.Second)
+	maxDaemonTimeoutSeconds   = int64(math.MaxInt64 / time.Second)
 )
 
 const mcpCatalogCacheTTL = 5 * time.Minute

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -532,16 +532,12 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 	}
 }
 
-type daemonOutput struct {
-	Text string `json:"text" jsonschema:"Daemon response encoded as JSON."`
-}
-
 type daemonListInput struct {
 	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
 	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonListTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonListInput, daemonOutput]) {
+func DaemonListTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonListInput, litestream.ListResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_list",
 		Description: "List databases managed by a running Litestream daemon.",
@@ -549,15 +545,15 @@ func DaemonListTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonListInput, daemonOutp
 		InputSchema: nonNullableInputSchema[daemonListInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonListInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonListInput) (*mcp.CallToolResult, litestream.ListResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonReadTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.ListResponse{}, err
 		}
 
 		var response litestream.ListResponse
 		if err := client.do(ctx, http.MethodGet, "/list", nil, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.ListResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -570,7 +566,7 @@ type daemonSyncInput struct {
 	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonSyncTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonSyncInput, daemonOutput]) {
+func DaemonSyncTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonSyncInput, litestream.SyncResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_sync",
 		Description: "Force an immediate sync for a database managed by a running Litestream daemon, optionally waiting for remote replication.",
@@ -578,10 +574,10 @@ func DaemonSyncTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonSyncInput, daemonOutp
 		InputSchema: nonNullableInputSchema[daemonSyncInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonSyncInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonSyncInput) (*mcp.CallToolResult, litestream.SyncResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.SyncResponse{}, err
 		}
 
 		var response litestream.SyncResponse
@@ -591,7 +587,7 @@ func DaemonSyncTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonSyncInput, daemonOutp
 			Timeout: client.timeoutSeconds,
 		}
 		if err := client.do(ctx, http.MethodPost, "/sync", request, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.SyncResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -602,7 +598,7 @@ type daemonInfoInput struct {
 	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonInfoTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonInfoInput, daemonOutput]) {
+func DaemonInfoTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonInfoInput, litestream.InfoResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_daemon_info",
 		Description: "Get version, process, uptime, and database count information from a running Litestream daemon.",
@@ -610,15 +606,15 @@ func DaemonInfoTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonInfoInput, daemonOutp
 		InputSchema: nonNullableInputSchema[daemonInfoInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonInfoInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonInfoInput) (*mcp.CallToolResult, litestream.InfoResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonReadTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.InfoResponse{}, err
 		}
 
 		var response litestream.InfoResponse
 		if err := client.do(ctx, http.MethodGet, "/info", nil, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.InfoResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -630,7 +626,7 @@ type daemonStartInput struct {
 	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonStartTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStartInput, daemonOutput]) {
+func DaemonStartTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStartInput, litestream.StartResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_start",
 		Description: "Start replication for a database managed by a running Litestream daemon.",
@@ -638,16 +634,16 @@ func DaemonStartTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStartInput, daemonOu
 		InputSchema: nonNullableInputSchema[daemonStartInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStartInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStartInput) (*mcp.CallToolResult, litestream.StartResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.StartResponse{}, err
 		}
 
 		var response litestream.StartResponse
 		request := litestream.StartRequest{Path: input.Path, Timeout: client.timeoutSeconds}
 		if err := client.do(ctx, http.MethodPost, "/start", request, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.StartResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -659,7 +655,7 @@ type daemonStopInput struct {
 	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonStopTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStopInput, daemonOutput]) {
+func DaemonStopTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStopInput, litestream.StopResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_stop",
 		Description: "Stop replication for a database managed by a running Litestream daemon after a final sync.",
@@ -667,16 +663,16 @@ func DaemonStopTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStopInput, daemonOutp
 		InputSchema: nonNullableInputSchema[daemonStopInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStopInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStopInput) (*mcp.CallToolResult, litestream.StopResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.StopResponse{}, err
 		}
 
 		var response litestream.StopResponse
 		request := litestream.StopRequest{Path: input.Path, Timeout: client.timeoutSeconds}
 		if err := client.do(ctx, http.MethodPost, "/stop", request, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.StopResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -689,7 +685,7 @@ type daemonRegisterInput struct {
 	Timeout    *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonRegisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonRegisterInput, daemonOutput]) {
+func DaemonRegisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonRegisterInput, litestream.RegisterDatabaseResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_register",
 		Description: "Register a database and replica with a running Litestream daemon.",
@@ -697,16 +693,16 @@ func DaemonRegisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonRegisterInput, da
 		InputSchema: nonNullableInputSchema[daemonRegisterInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonRegisterInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonRegisterInput) (*mcp.CallToolResult, litestream.RegisterDatabaseResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.RegisterDatabaseResponse{}, err
 		}
 
 		var response litestream.RegisterDatabaseResponse
 		request := litestream.RegisterDatabaseRequest{Path: input.Path, ReplicaURL: input.ReplicaURL}
 		if err := client.do(ctx, http.MethodPost, "/register", request, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.RegisterDatabaseResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -718,7 +714,7 @@ type daemonUnregisterInput struct {
 	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
 }
 
-func DaemonUnregisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonUnregisterInput, daemonOutput]) {
+func DaemonUnregisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonUnregisterInput, litestream.UnregisterDatabaseResponse]) {
 	tool := &mcp.Tool{
 		Name:        "litestream_unregister",
 		Description: "Stop replication and unregister a database from a running Litestream daemon.",
@@ -726,16 +722,16 @@ func DaemonUnregisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonUnregisterInput
 		InputSchema: nonNullableInputSchema[daemonUnregisterInput](),
 	}
 
-	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonUnregisterInput) (*mcp.CallToolResult, daemonOutput, error) {
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonUnregisterInput) (*mcp.CallToolResult, litestream.UnregisterDatabaseResponse, error) {
 		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
 		if err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.UnregisterDatabaseResponse{}, err
 		}
 
 		var response litestream.UnregisterDatabaseResponse
 		request := litestream.UnregisterDatabaseRequest{Path: input.Path, Timeout: client.timeoutSeconds}
 		if err := client.do(ctx, http.MethodPost, "/unregister", request, &response); err != nil {
-			return nil, daemonOutput{}, err
+			return nil, litestream.UnregisterDatabaseResponse{}, err
 		}
 		return daemonResult(response)
 	}
@@ -798,7 +794,7 @@ func (c *daemonClient) do(ctx context.Context, method, endpoint string, input, o
 
 	response, err := client.Do(request)
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
 			return ctxErr
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -806,11 +802,10 @@ func (c *daemonClient) do(ctx context.Context, method, endpoint string, input, o
 		}
 		return daemonConnectionError(c.socketPath, err)
 	}
-	defer response.Body.Close()
-
-	data, err := io.ReadAll(response.Body)
-	if err != nil {
-		return fmt.Errorf("read daemon response: %w", err)
+	data, readErr := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return fmt.Errorf("read daemon response: %w", errors.Join(err, context.Cause(ctx)))
 	}
 
 	operation := strings.TrimPrefix(endpoint, "/")
@@ -837,13 +832,14 @@ func daemonConnectionError(socketPath string, err error) error {
 	return fmt.Errorf("connect to Litestream daemon at socket %s: %w", socketPath, err)
 }
 
-func daemonResult(response any) (*mcp.CallToolResult, daemonOutput, error) {
+func daemonResult[Response any](response Response) (*mcp.CallToolResult, Response, error) {
 	data, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {
-		return nil, daemonOutput{}, fmt.Errorf("format daemon response: %w", err)
+		var zero Response
+		return nil, zero, fmt.Errorf("format daemon response: %w", err)
 	}
 	text := string(data) + "\n"
-	return textResult(text), daemonOutput{Text: text}, nil
+	return textResult(text), response, nil
 }
 
 func textResult(text string) *mcp.CallToolResult {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -2,21 +2,34 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/MadAppGang/httplog"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/benbjohnson/litestream"
+)
+
+const (
+	defaultDaemonSocketPath   = "/var/run/litestream.sock"
+	defaultDaemonReadTimeout  = 10
+	defaultDaemonWriteTimeout = 30
 )
 
 const mcpCatalogCacheTTL = 5 * time.Minute
@@ -60,6 +73,20 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcp.AddTool(mcpServer, statusTool, statusHandler)
 	resetTool, resetHandler := ResetTool(configPath)
 	mcp.AddTool(mcpServer, resetTool, resetHandler)
+	daemonListTool, daemonListHandler := DaemonListTool()
+	mcp.AddTool(mcpServer, daemonListTool, daemonListHandler)
+	daemonSyncTool, daemonSyncHandler := DaemonSyncTool()
+	mcp.AddTool(mcpServer, daemonSyncTool, daemonSyncHandler)
+	daemonInfoTool, daemonInfoHandler := DaemonInfoTool()
+	mcp.AddTool(mcpServer, daemonInfoTool, daemonInfoHandler)
+	daemonStartTool, daemonStartHandler := DaemonStartTool()
+	mcp.AddTool(mcpServer, daemonStartTool, daemonStartHandler)
+	daemonStopTool, daemonStopHandler := DaemonStopTool()
+	mcp.AddTool(mcpServer, daemonStopTool, daemonStopHandler)
+	daemonRegisterTool, daemonRegisterHandler := DaemonRegisterTool()
+	mcp.AddTool(mcpServer, daemonRegisterTool, daemonRegisterHandler)
+	daemonUnregisterTool, daemonUnregisterHandler := DaemonUnregisterTool()
+	mcp.AddTool(mcpServer, daemonUnregisterTool, daemonUnregisterHandler)
 
 	s.mux = http.NewServeMux()
 	s.mux.Handle("/", newMCPHandler(mcpServer))
@@ -501,6 +528,314 @@ func ResetTool(configPath string) (*mcp.Tool, mcp.ToolHandlerFor[resetInput, res
 		text := string(output)
 		return textResult(text), resetOutput{Text: text}, nil
 	}
+}
+
+type daemonOutput struct {
+	Text string `json:"text" jsonschema:"Daemon response encoded as JSON."`
+}
+
+type daemonListInput struct {
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonListTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonListInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_list",
+		Description: "List databases managed by a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		InputSchema: nonNullableInputSchema[daemonListInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonListInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonReadTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.ListResponse
+		if err := client.do(ctx, http.MethodGet, "/list", nil, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonSyncInput struct {
+	Path    string  `json:"path" jsonschema:"Database path managed by the Litestream daemon."`
+	Wait    *bool   `json:"wait,omitempty" jsonschema:"Wait for remote replication to complete. Optional."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonSyncTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonSyncInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_sync",
+		Description: "Force an immediate sync for a database managed by a running Litestream daemon, optionally waiting for remote replication.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonSyncInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonSyncInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.SyncResponse
+		request := litestream.SyncRequest{
+			Path:    input.Path,
+			Wait:    input.Wait != nil && *input.Wait,
+			Timeout: client.timeoutSeconds,
+		}
+		if err := client.do(ctx, http.MethodPost, "/sync", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonInfoInput struct {
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonInfoTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonInfoInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_daemon_info",
+		Description: "Get version, process, uptime, and database count information from a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		InputSchema: nonNullableInputSchema[daemonInfoInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonInfoInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonReadTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.InfoResponse
+		if err := client.do(ctx, http.MethodGet, "/info", nil, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonStartInput struct {
+	Path    string  `json:"path" jsonschema:"Database path managed by the Litestream daemon."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonStartTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStartInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_start",
+		Description: "Start replication for a database managed by a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonStartInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStartInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.StartResponse
+		request := litestream.StartRequest{Path: input.Path, Timeout: client.timeoutSeconds}
+		if err := client.do(ctx, http.MethodPost, "/start", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonStopInput struct {
+	Path    string  `json:"path" jsonschema:"Database path managed by the Litestream daemon."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonStopTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonStopInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_stop",
+		Description: "Stop replication for a database managed by a running Litestream daemon after a final sync.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonStopInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonStopInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.StopResponse
+		request := litestream.StopRequest{Path: input.Path, Timeout: client.timeoutSeconds}
+		if err := client.do(ctx, http.MethodPost, "/stop", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonRegisterInput struct {
+	Path       string  `json:"path" jsonschema:"Database path to register with the Litestream daemon."`
+	ReplicaURL string  `json:"replica_url" jsonschema:"Replica URL for the database."`
+	Socket     *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout    *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonRegisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonRegisterInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_register",
+		Description: "Register a database and replica with a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonRegisterInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonRegisterInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.RegisterDatabaseResponse
+		request := litestream.RegisterDatabaseRequest{Path: input.Path, ReplicaURL: input.ReplicaURL}
+		if err := client.do(ctx, http.MethodPost, "/register", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonUnregisterInput struct {
+	Path    string  `json:"path" jsonschema:"Database path to unregister from the Litestream daemon."`
+	Socket  *string `json:"socket,omitempty" jsonschema:"Path to the Litestream daemon control socket. Optional."`
+	Timeout *int    `json:"timeout,omitempty" jsonschema:"Maximum time to wait in seconds. Optional."`
+}
+
+func DaemonUnregisterTool() (*mcp.Tool, mcp.ToolHandlerFor[daemonUnregisterInput, daemonOutput]) {
+	tool := &mcp.Tool{
+		Name:        "litestream_unregister",
+		Description: "Stop replication and unregister a database from a running Litestream daemon.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false, DestructiveHint: boolPointer(true)},
+		InputSchema: nonNullableInputSchema[daemonUnregisterInput](),
+	}
+
+	return tool, func(ctx context.Context, _ *mcp.CallToolRequest, input daemonUnregisterInput) (*mcp.CallToolResult, daemonOutput, error) {
+		client, err := newDaemonClient(input.Socket, input.Timeout, defaultDaemonWriteTimeout)
+		if err != nil {
+			return nil, daemonOutput{}, err
+		}
+
+		var response litestream.UnregisterDatabaseResponse
+		request := litestream.UnregisterDatabaseRequest{Path: input.Path, Timeout: client.timeoutSeconds}
+		if err := client.do(ctx, http.MethodPost, "/unregister", request, &response); err != nil {
+			return nil, daemonOutput{}, err
+		}
+		return daemonResult(response)
+	}
+}
+
+type daemonClient struct {
+	socketPath     string
+	timeoutSeconds int
+}
+
+func newDaemonClient(socket *string, timeout *int, defaultTimeout int) (*daemonClient, error) {
+	socketPath := defaultDaemonSocketPath
+	if socket != nil {
+		socketPath = *socket
+	}
+	if socketPath == "" {
+		return nil, fmt.Errorf("daemon socket path required")
+	}
+
+	timeoutSeconds := defaultTimeout
+	if timeout != nil {
+		timeoutSeconds = *timeout
+	}
+	if timeoutSeconds <= 0 {
+		return nil, fmt.Errorf("timeout must be greater than 0")
+	}
+
+	return &daemonClient{socketPath: socketPath, timeoutSeconds: timeoutSeconds}, nil
+}
+
+func (c *daemonClient) do(ctx context.Context, method, endpoint string, input, output any) error {
+	var body io.Reader
+	if input != nil {
+		data, err := json.Marshal(input)
+		if err != nil {
+			return fmt.Errorf("marshal daemon request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, "http://localhost"+endpoint, body)
+	if err != nil {
+		return fmt.Errorf("create daemon request: %w", err)
+	}
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	timeout := time.Duration(c.timeoutSeconds) * time.Second
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: timeout}).DialContext(ctx, "unix", c.socketPath)
+		},
+	}
+	client := &http.Client{Transport: transport, Timeout: timeout}
+	defer client.CloseIdleConnections()
+
+	response, err := client.Do(request)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return daemonConnectionError(c.socketPath, err)
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("read daemon response: %w", err)
+	}
+
+	operation := strings.TrimPrefix(endpoint, "/")
+	if response.StatusCode != http.StatusOK {
+		var daemonError litestream.ErrorResponse
+		if err := json.Unmarshal(data, &daemonError); err == nil && daemonError.Error != "" {
+			return fmt.Errorf("%s failed: %s", operation, daemonError.Error)
+		}
+		if message := strings.TrimSpace(string(data)); message != "" {
+			return fmt.Errorf("%s failed: %s", operation, message)
+		}
+		return fmt.Errorf("%s failed with status %s", operation, response.Status)
+	}
+	if err := json.Unmarshal(data, output); err != nil {
+		return fmt.Errorf("parse %s response: %w", operation, err)
+	}
+	return nil
+}
+
+func daemonConnectionError(socketPath string, err error) error {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED) {
+		return fmt.Errorf("no Litestream daemon is running at socket %s: %w", socketPath, err)
+	}
+	return fmt.Errorf("connect to Litestream daemon at socket %s: %w", socketPath, err)
+}
+
+func daemonResult(response any) (*mcp.CallToolResult, daemonOutput, error) {
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return nil, daemonOutput{}, fmt.Errorf("format daemon response: %w", err)
+	}
+	text := string(data) + "\n"
+	return textResult(text), daemonOutput{Text: text}, nil
 }
 
 func textResult(text string) *mcp.CallToolResult {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -30,6 +30,7 @@ const (
 	defaultDaemonSocketPath   = "/var/run/litestream.sock"
 	defaultDaemonReadTimeout  = 10
 	defaultDaemonWriteTimeout = 30
+	maxDaemonTimeoutSeconds   = int64((1<<63 - 1) / time.Second)
 )
 
 const mcpCatalogCacheTTL = 5 * time.Minute
@@ -760,6 +761,9 @@ func newDaemonClient(socket *string, timeout *int, defaultTimeout int) (*daemonC
 	if timeoutSeconds <= 0 {
 		return nil, fmt.Errorf("timeout must be greater than 0")
 	}
+	if int64(timeoutSeconds) > maxDaemonTimeoutSeconds {
+		return nil, fmt.Errorf("timeout must be at most %d seconds", maxDaemonTimeoutSeconds)
+	}
 
 	return &daemonClient{socketPath: socketPath, timeoutSeconds: timeoutSeconds}, nil
 }
@@ -795,6 +799,9 @@ func (c *daemonClient) do(ctx context.Context, method, endpoint string, input, o
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("litestream daemon request timed out after %s at socket %s: %w", timeout, c.socketPath, err)
 		}
 		return daemonConnectionError(c.socketPath, err)
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -559,7 +559,8 @@ func TestNewDaemonClientTimeoutValidation(t *testing.T) {
 		{name: "negative", timeout: -1, want: "timeout must be greater than 0"},
 	}
 	if strconv.IntSize == 64 {
-		tests = append(tests, testCase{name: "duration overflow", timeout: int(maxDaemonTimeoutSeconds + 1), want: "timeout must be at most"})
+		overflowTimeout := int64(maxDaemonTimeoutSeconds + 1)
+		tests = append(tests, testCase{name: "duration overflow", timeout: int(overflowTimeout), want: "timeout must be at most"})
 	}
 
 	for _, test := range tests {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -577,7 +577,8 @@ func TestNewDaemonClientTimeoutValidation(t *testing.T) {
 		{name: "negative", timeout: -1, want: "timeout must be greater than 0"},
 	}
 	if strconv.IntSize == 64 {
-		tests = append(tests, testCase{name: "duration overflow", timeout: int(maxDaemonTimeoutSeconds + 1), want: "timeout must be at most"})
+		overflowTimeout := int64(maxDaemonTimeoutSeconds + 1)
+		tests = append(tests, testCase{name: "duration overflow", timeout: int(overflowTimeout), want: "timeout must be at most"})
 	}
 
 	for _, test := range tests {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -15,11 +15,18 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+type daemonToolCallResult struct {
+	result *mcp.CallToolResult
+	err    error
+}
 
 func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
@@ -287,15 +294,7 @@ func TestMCPDaemonToolBehavior(t *testing.T) {
 		}
 	})
 
-	socketPath := mcpTestSocketPath(t)
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	daemonServer := httptest.NewUnstartedServer(handler)
-	daemonServer.Listener = listener
-	daemonServer.Start()
-	t.Cleanup(daemonServer.Close)
+	socketPath := startMCPDaemonTestServer(t, handler)
 
 	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
 	if err != nil {
@@ -407,6 +406,170 @@ func TestMCPDaemonToolsNoDaemon(t *testing.T) {
 			}
 			if got := textContent(t, result); !strings.Contains(got, "no Litestream daemon is running at socket "+socketPath) {
 				t.Fatalf("error=%q, want no-daemon message", got)
+			}
+		})
+	}
+
+	t.Run("stale socket", func(t *testing.T) {
+		staleSocketPath := mcpTestSocketPath(t)
+		listener, err := net.Listen("unix", staleSocketPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		listener.(*net.UnixListener).SetUnlinkOnClose(false)
+		if err := listener.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      "litestream_list",
+			Arguments: map[string]any{"socket": staleSocketPath},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result.IsError {
+			t.Fatal("tool succeeded, want error")
+		}
+		if got := textContent(t, result); !strings.Contains(got, "no Litestream daemon is running at socket "+staleSocketPath) {
+			t.Fatalf("error=%q, want no-daemon message", got)
+		}
+	})
+}
+
+func TestMCPDaemonToolContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	requestStarted := make(chan struct{})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	})
+	socketPath := startMCPDaemonTestServer(t, handler)
+
+	_, toolHandler := DaemonInfoTool()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	timeout := 10
+	done := make(chan daemonToolCallResult, 1)
+	go func() {
+		result, _, err := toolHandler(ctx, nil, daemonInfoInput{Socket: &socketPath, Timeout: &timeout})
+		done <- daemonToolCallResult{result: result, err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon request did not start")
+	}
+
+	select {
+	case call := <-done:
+		if !errors.Is(call.err, context.Canceled) {
+			t.Fatalf("error=%v, want context canceled", call.err)
+		}
+		if call.result != nil {
+			t.Fatalf("result=%v, want nil", call.result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon tool did not return after context cancellation")
+	}
+}
+
+func TestMCPDaemonToolTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	requestStarted := make(chan struct{})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	})
+	socketPath := startMCPDaemonTestServer(t, handler)
+
+	_, toolHandler := DaemonInfoTool()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	timeout := 1
+	done := make(chan daemonToolCallResult, 1)
+	go func() {
+		result, _, err := toolHandler(ctx, nil, daemonInfoInput{Socket: &socketPath, Timeout: &timeout})
+		done <- daemonToolCallResult{result: result, err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon request did not start")
+	}
+
+	select {
+	case call := <-done:
+		if !errors.Is(call.err, context.DeadlineExceeded) {
+			t.Fatalf("error=%v, want deadline exceeded", call.err)
+		}
+		if !strings.Contains(call.err.Error(), "daemon request timed out after 1s") {
+			t.Fatalf("error=%v, want timeout message", call.err)
+		}
+		if call.result != nil {
+			t.Fatalf("result=%v, want nil", call.result)
+		}
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("daemon tool exceeded its timeout")
+	}
+}
+
+func TestMCPDaemonToolReturnsDaemonError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		if _, err := io.WriteString(w, `{"error":"database is not running"}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+	socketPath := startMCPDaemonTestServer(t, handler)
+
+	_, toolHandler := DaemonSyncTool()
+	result, _, err := toolHandler(t.Context(), nil, daemonSyncInput{Path: "/data/db", Socket: &socketPath})
+	if err == nil || err.Error() != "sync failed: database is not running" {
+		t.Fatalf("error=%v, want daemon error", err)
+	}
+	if result != nil {
+		t.Fatalf("result=%v, want nil", result)
+	}
+}
+
+func TestNewDaemonClientTimeoutValidation(t *testing.T) {
+	type testCase struct {
+		name    string
+		timeout int
+		want    string
+	}
+	tests := []testCase{
+		{name: "zero", timeout: 0, want: "timeout must be greater than 0"},
+		{name: "negative", timeout: -1, want: "timeout must be greater than 0"},
+	}
+	if strconv.IntSize == 64 {
+		tests = append(tests, testCase{name: "duration overflow", timeout: int(maxDaemonTimeoutSeconds + 1), want: "timeout must be at most"})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := newDaemonClient(nil, &test.timeout, defaultDaemonReadTimeout)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v, want %q", err, test.want)
+			}
+			if client != nil {
+				t.Fatalf("client=%v, want nil", client)
 			}
 		})
 	}
@@ -754,6 +917,21 @@ func mcpTestSocketPath(t *testing.T) string {
 		}
 	})
 	return path
+}
+
+func startMCPDaemonTestServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+
+	socketPath := mcpTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+	return socketPath
 }
 
 func assertJSONEqual(t *testing.T, got, want []byte) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"maps"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -100,6 +101,33 @@ func TestMCPServerTools(t *testing.T) {
 		"litestream_version": {readOnly: true},
 		"litestream_status":  {readOnly: true, properties: map[string]string{"config": "string", "path": "string"}},
 		"litestream_reset":   {destructive: true, properties: map[string]string{"config": "string", "path": "string"}, required: []string{"path"}},
+		"litestream_list":    {readOnly: true, properties: map[string]string{"socket": "string", "timeout": "integer"}},
+		"litestream_sync": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer", "wait": "boolean"},
+			required:    []string{"path"},
+		},
+		"litestream_daemon_info": {readOnly: true, properties: map[string]string{"socket": "string", "timeout": "integer"}},
+		"litestream_start": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path"},
+		},
+		"litestream_stop": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path"},
+		},
+		"litestream_register": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "replica_url": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path", "replica_url"},
+		},
+		"litestream_unregister": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path"},
+		},
 	}
 
 	if got, want := len(result.Tools), len(tests); got != want {
@@ -215,6 +243,172 @@ func TestMCPServerTools(t *testing.T) {
 	}
 	if got, want := textContent(t, callResult), version+"\n"; got != want {
 		t.Fatalf("version text content=%q, want %q", got, want)
+	}
+}
+
+func TestMCPDaemonToolBehavior(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	type capturedRequest struct {
+		method string
+		path   string
+		body   []byte
+	}
+
+	responses := map[string]string{
+		"/list":       `{"databases":[{"path":"/data/db","status":"replicating"}]}`,
+		"/sync":       `{"status":"synced","path":"/data/db","txid":12,"replicated_txid":12}`,
+		"/info":       `{"version":"v1.2.3","pid":123,"uptime_seconds":60,"started_at":"2026-07-17T12:00:00Z","database_count":1}`,
+		"/start":      `{"status":"started","path":"/data/db","txid":12}`,
+		"/stop":       `{"status":"stopped","path":"/data/db","txid":12}`,
+		"/register":   `{"status":"registered","path":"/data/new.db"}`,
+		"/unregister": `{"status":"unregistered","path":"/data/db","txid":12}`,
+	}
+	requests := make(chan capturedRequest, len(responses))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		requests <- capturedRequest{method: r.Method, path: r.URL.Path, body: body}
+
+		response, ok := responses[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, response); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+
+	socketPath := mcpTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	daemonServer := httptest.NewUnstartedServer(handler)
+	daemonServer.Listener = listener
+	daemonServer.Start()
+	t.Cleanup(daemonServer.Close)
+
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	tests := []struct {
+		name      string
+		method    string
+		path      string
+		arguments map[string]any
+		body      string
+	}{
+		{name: "litestream_list", method: http.MethodGet, path: "/list", arguments: map[string]any{"socket": socketPath, "timeout": 5}},
+		{name: "litestream_sync", method: http.MethodPost, path: "/sync", arguments: map[string]any{"path": "/data/db", "wait": true, "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","wait":true,"timeout":5}`},
+		{name: "litestream_daemon_info", method: http.MethodGet, path: "/info", arguments: map[string]any{"socket": socketPath, "timeout": 5}},
+		{name: "litestream_start", method: http.MethodPost, path: "/start", arguments: map[string]any{"path": "/data/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","timeout":5}`},
+		{name: "litestream_stop", method: http.MethodPost, path: "/stop", arguments: map[string]any{"path": "/data/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","timeout":5}`},
+		{name: "litestream_register", method: http.MethodPost, path: "/register", arguments: map[string]any{"path": "/data/new.db", "replica_url": "file:///backup/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/new.db","replica_url":"file:///backup/db"}`},
+		{name: "litestream_unregister", method: http.MethodPost, path: "/unregister", arguments: map[string]any{"path": "/data/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","timeout":5}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: test.name, Arguments: test.arguments})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError {
+				t.Fatalf("tool error: %#v", result.Content)
+			}
+
+			request := <-requests
+			if request.method != test.method {
+				t.Errorf("request method=%q, want %q", request.method, test.method)
+			}
+			if request.path != test.path {
+				t.Errorf("request path=%q, want %q", request.path, test.path)
+			}
+			assertJSONEqual(t, request.body, []byte(test.body))
+
+			text := textContent(t, result)
+			assertJSONEqual(t, []byte(text), []byte(responses[test.path]))
+			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("structured content=%v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestMCPDaemonToolsNoDaemon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	socketPath := mcpTestSocketPath(t)
+	tests := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{name: "litestream_list", arguments: map[string]any{"socket": socketPath}},
+		{name: "litestream_sync", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+		{name: "litestream_daemon_info", arguments: map[string]any{"socket": socketPath}},
+		{name: "litestream_start", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+		{name: "litestream_stop", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+		{name: "litestream_register", arguments: map[string]any{"path": "/data/db", "replica_url": "file:///backup/db", "socket": socketPath}},
+		{name: "litestream_unregister", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: test.name, Arguments: test.arguments})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.IsError {
+				t.Fatal("tool succeeded, want error")
+			}
+			if got := textContent(t, result); !strings.Contains(got, "no Litestream daemon is running at socket "+socketPath) {
+				t.Fatalf("error=%q, want no-daemon message", got)
+			}
+		})
 	}
 }
 
@@ -538,4 +732,48 @@ func setVersion(t *testing.T, version string) {
 	previous := Version
 	Version = version
 	t.Cleanup(func() { Version = previous })
+}
+
+func mcpTestSocketPath(t *testing.T) string {
+	t.Helper()
+
+	file, err := os.CreateTemp("/tmp", "ls-mcp-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			t.Error(err)
+		}
+	})
+	return path
+}
+
+func assertJSONEqual(t *testing.T, got, want []byte) {
+	t.Helper()
+
+	if len(got) == 0 || len(want) == 0 {
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON=%q, want %q", got, want)
+		}
+		return
+	}
+
+	var gotValue, wantValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("unmarshal JSON %q: %v", got, err)
+	}
+	if err := json.Unmarshal(want, &wantValue); err != nil {
+		t.Fatalf("unmarshal expected JSON %q: %v", want, err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("JSON=%v, want %v", gotValue, wantValue)
+	}
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -15,12 +15,18 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+type daemonToolCallResult struct {
+	result *mcp.CallToolResult
+	err    error
+}
 
 func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
@@ -306,15 +312,7 @@ func TestMCPDaemonToolBehavior(t *testing.T) {
 		}
 	})
 
-	socketPath := mcpTestSocketPath(t)
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	daemonServer := httptest.NewUnstartedServer(handler)
-	daemonServer.Listener = listener
-	daemonServer.Start()
-	t.Cleanup(daemonServer.Close)
+	socketPath := startMCPDaemonTestServer(t, handler)
 
 	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
 	if err != nil {
@@ -426,6 +424,170 @@ func TestMCPDaemonToolsNoDaemon(t *testing.T) {
 			}
 			if got := textContent(t, result); !strings.Contains(got, "no Litestream daemon is running at socket "+socketPath) {
 				t.Fatalf("error=%q, want no-daemon message", got)
+			}
+		})
+	}
+
+	t.Run("stale socket", func(t *testing.T) {
+		staleSocketPath := mcpTestSocketPath(t)
+		listener, err := net.Listen("unix", staleSocketPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		listener.(*net.UnixListener).SetUnlinkOnClose(false)
+		if err := listener.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      "litestream_list",
+			Arguments: map[string]any{"socket": staleSocketPath},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result.IsError {
+			t.Fatal("tool succeeded, want error")
+		}
+		if got := textContent(t, result); !strings.Contains(got, "no Litestream daemon is running at socket "+staleSocketPath) {
+			t.Fatalf("error=%q, want no-daemon message", got)
+		}
+	})
+}
+
+func TestMCPDaemonToolContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	requestStarted := make(chan struct{})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	})
+	socketPath := startMCPDaemonTestServer(t, handler)
+
+	_, toolHandler := DaemonInfoTool()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	timeout := 10
+	done := make(chan daemonToolCallResult, 1)
+	go func() {
+		result, _, err := toolHandler(ctx, nil, daemonInfoInput{Socket: &socketPath, Timeout: &timeout})
+		done <- daemonToolCallResult{result: result, err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon request did not start")
+	}
+
+	select {
+	case call := <-done:
+		if !errors.Is(call.err, context.Canceled) {
+			t.Fatalf("error=%v, want context canceled", call.err)
+		}
+		if call.result != nil {
+			t.Fatalf("result=%v, want nil", call.result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon tool did not return after context cancellation")
+	}
+}
+
+func TestMCPDaemonToolTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	requestStarted := make(chan struct{})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	})
+	socketPath := startMCPDaemonTestServer(t, handler)
+
+	_, toolHandler := DaemonInfoTool()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	timeout := 1
+	done := make(chan daemonToolCallResult, 1)
+	go func() {
+		result, _, err := toolHandler(ctx, nil, daemonInfoInput{Socket: &socketPath, Timeout: &timeout})
+		done <- daemonToolCallResult{result: result, err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon request did not start")
+	}
+
+	select {
+	case call := <-done:
+		if !errors.Is(call.err, context.DeadlineExceeded) {
+			t.Fatalf("error=%v, want deadline exceeded", call.err)
+		}
+		if !strings.Contains(call.err.Error(), "daemon request timed out after 1s") {
+			t.Fatalf("error=%v, want timeout message", call.err)
+		}
+		if call.result != nil {
+			t.Fatalf("result=%v, want nil", call.result)
+		}
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("daemon tool exceeded its timeout")
+	}
+}
+
+func TestMCPDaemonToolReturnsDaemonError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		if _, err := io.WriteString(w, `{"error":"database is not running"}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+	socketPath := startMCPDaemonTestServer(t, handler)
+
+	_, toolHandler := DaemonSyncTool()
+	result, _, err := toolHandler(t.Context(), nil, daemonSyncInput{Path: "/data/db", Socket: &socketPath})
+	if err == nil || err.Error() != "sync failed: database is not running" {
+		t.Fatalf("error=%v, want daemon error", err)
+	}
+	if result != nil {
+		t.Fatalf("result=%v, want nil", result)
+	}
+}
+
+func TestNewDaemonClientTimeoutValidation(t *testing.T) {
+	type testCase struct {
+		name    string
+		timeout int
+		want    string
+	}
+	tests := []testCase{
+		{name: "zero", timeout: 0, want: "timeout must be greater than 0"},
+		{name: "negative", timeout: -1, want: "timeout must be greater than 0"},
+	}
+	if strconv.IntSize == 64 {
+		tests = append(tests, testCase{name: "duration overflow", timeout: int(maxDaemonTimeoutSeconds + 1), want: "timeout must be at most"})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := newDaemonClient(nil, &test.timeout, defaultDaemonReadTimeout)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v, want %q", err, test.want)
+			}
+			if client != nil {
+				t.Fatalf("client=%v, want nil", client)
 			}
 		})
 	}
@@ -928,6 +1090,21 @@ func mcpTestSocketPath(t *testing.T) string {
 		}
 	})
 	return path
+}
+
+func startMCPDaemonTestServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+
+	socketPath := mcpTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+	return socketPath
 }
 
 func assertJSONEqual(t *testing.T, got, want []byte) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -102,6 +102,33 @@ func TestMCPServerTools(t *testing.T) {
 		"litestream_version": {readOnly: true},
 		"litestream_status":  {readOnly: true, properties: map[string]string{"config": "string", "path": "string"}},
 		"litestream_reset":   {destructive: true, properties: map[string]string{"config": "string", "path": "string"}, required: []string{"path"}},
+		"litestream_list":    {readOnly: true, properties: map[string]string{"socket": "string", "timeout": "integer"}},
+		"litestream_sync": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer", "wait": "boolean"},
+			required:    []string{"path"},
+		},
+		"litestream_daemon_info": {readOnly: true, properties: map[string]string{"socket": "string", "timeout": "integer"}},
+		"litestream_start": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path"},
+		},
+		"litestream_stop": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path"},
+		},
+		"litestream_register": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "replica_url": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path", "replica_url"},
+		},
+		"litestream_unregister": {
+			destructive: true,
+			properties:  map[string]string{"path": "string", "socket": "string", "timeout": "integer"},
+			required:    []string{"path"},
+		},
 	}
 
 	if got, want := len(result.Tools), len(tests); got != want {
@@ -235,6 +262,172 @@ func assertMCPResultCaching(t *testing.T, result map[string]any) {
 	}
 	if got, want := result["cacheScope"], "public"; got != want {
 		t.Errorf("cacheScope=%v, want %q", got, want)
+	}
+}
+
+func TestMCPDaemonToolBehavior(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	type capturedRequest struct {
+		method string
+		path   string
+		body   []byte
+	}
+
+	responses := map[string]string{
+		"/list":       `{"databases":[{"path":"/data/db","status":"replicating"}]}`,
+		"/sync":       `{"status":"synced","path":"/data/db","txid":12,"replicated_txid":12}`,
+		"/info":       `{"version":"v1.2.3","pid":123,"uptime_seconds":60,"started_at":"2026-07-17T12:00:00Z","database_count":1}`,
+		"/start":      `{"status":"started","path":"/data/db","txid":12}`,
+		"/stop":       `{"status":"stopped","path":"/data/db","txid":12}`,
+		"/register":   `{"status":"registered","path":"/data/new.db"}`,
+		"/unregister": `{"status":"unregistered","path":"/data/db","txid":12}`,
+	}
+	requests := make(chan capturedRequest, len(responses))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		requests <- capturedRequest{method: r.Method, path: r.URL.Path, body: body}
+
+		response, ok := responses[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, response); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	})
+
+	socketPath := mcpTestSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	daemonServer := httptest.NewUnstartedServer(handler)
+	daemonServer.Listener = listener
+	daemonServer.Start()
+	t.Cleanup(daemonServer.Close)
+
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	tests := []struct {
+		name      string
+		method    string
+		path      string
+		arguments map[string]any
+		body      string
+	}{
+		{name: "litestream_list", method: http.MethodGet, path: "/list", arguments: map[string]any{"socket": socketPath, "timeout": 5}},
+		{name: "litestream_sync", method: http.MethodPost, path: "/sync", arguments: map[string]any{"path": "/data/db", "wait": true, "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","wait":true,"timeout":5}`},
+		{name: "litestream_daemon_info", method: http.MethodGet, path: "/info", arguments: map[string]any{"socket": socketPath, "timeout": 5}},
+		{name: "litestream_start", method: http.MethodPost, path: "/start", arguments: map[string]any{"path": "/data/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","timeout":5}`},
+		{name: "litestream_stop", method: http.MethodPost, path: "/stop", arguments: map[string]any{"path": "/data/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","timeout":5}`},
+		{name: "litestream_register", method: http.MethodPost, path: "/register", arguments: map[string]any{"path": "/data/new.db", "replica_url": "file:///backup/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/new.db","replica_url":"file:///backup/db"}`},
+		{name: "litestream_unregister", method: http.MethodPost, path: "/unregister", arguments: map[string]any{"path": "/data/db", "socket": socketPath, "timeout": 5}, body: `{"path":"/data/db","timeout":5}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: test.name, Arguments: test.arguments})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError {
+				t.Fatalf("tool error: %#v", result.Content)
+			}
+
+			request := <-requests
+			if request.method != test.method {
+				t.Errorf("request method=%q, want %q", request.method, test.method)
+			}
+			if request.path != test.path {
+				t.Errorf("request path=%q, want %q", request.path, test.path)
+			}
+			assertJSONEqual(t, request.body, []byte(test.body))
+
+			text := textContent(t, result)
+			assertJSONEqual(t, []byte(text), []byte(responses[test.path]))
+			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("structured content=%v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestMCPDaemonToolsNoDaemon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix sockets")
+	}
+
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	socketPath := mcpTestSocketPath(t)
+	tests := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{name: "litestream_list", arguments: map[string]any{"socket": socketPath}},
+		{name: "litestream_sync", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+		{name: "litestream_daemon_info", arguments: map[string]any{"socket": socketPath}},
+		{name: "litestream_start", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+		{name: "litestream_stop", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+		{name: "litestream_register", arguments: map[string]any{"path": "/data/db", "replica_url": "file:///backup/db", "socket": socketPath}},
+		{name: "litestream_unregister", arguments: map[string]any{"path": "/data/db", "socket": socketPath}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: test.name, Arguments: test.arguments})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.IsError {
+				t.Fatal("tool succeeded, want error")
+			}
+			if got := textContent(t, result); !strings.Contains(got, "no Litestream daemon is running at socket "+socketPath) {
+				t.Fatalf("error=%q, want no-daemon message", got)
+			}
+		})
 	}
 }
 
@@ -713,6 +906,50 @@ func setVersion(t *testing.T, version string) {
 	previous := Version
 	Version = version
 	t.Cleanup(func() { Version = previous })
+}
+
+func mcpTestSocketPath(t *testing.T) string {
+	t.Helper()
+
+	file, err := os.CreateTemp("/tmp", "ls-mcp-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			t.Error(err)
+		}
+	})
+	return path
+}
+
+func assertJSONEqual(t *testing.T, got, want []byte) {
+	t.Helper()
+
+	if len(got) == 0 || len(want) == 0 {
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON=%q, want %q", got, want)
+		}
+		return
+	}
+
+	var gotValue, wantValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("unmarshal JSON %q: %v", got, err)
+	}
+	if err := json.Unmarshal(want, &wantValue); err != nil {
+		t.Fatalf("unmarshal expected JSON %q: %v", want, err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("JSON=%v, want %v", gotValue, wantValue)
+	}
 }
 
 func TestMCPServerLifecycle(t *testing.T) {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -184,6 +184,26 @@ func TestMCPServerTools(t *testing.T) {
 			t.Errorf("%s required properties=%v, want %v", tool.Name, got, test.required)
 		}
 
+		daemonProperties := map[string][]string{
+			"litestream_list":        {"databases"},
+			"litestream_sync":        {"path", "replicated_txid", "status", "txid"},
+			"litestream_daemon_info": {"database_count", "pid", "started_at", "uptime_seconds", "version"},
+			"litestream_start":       {"path", "status", "txid"},
+			"litestream_stop":        {"path", "status", "txid"},
+			"litestream_register":    {"path", "status"},
+			"litestream_unregister":  {"path", "status", "txid"},
+		}
+		if want, ok := daemonProperties[tool.Name]; ok {
+			schema := jsonObject(t, tool.OutputSchema)
+			if got := slices.Sorted(maps.Keys(schemaProperties(t, schema))); !reflect.DeepEqual(got, want) {
+				t.Errorf("%s output properties=%v, want %v", tool.Name, got, want)
+			}
+			if got := schemaRequired(schema); !reflect.DeepEqual(got, want) {
+				t.Errorf("%s required output properties=%v, want %v", tool.Name, got, want)
+			}
+			continue
+		}
+
 		outputSchema := jsonObject(t, tool.OutputSchema)
 		outputProperties := schemaProperties(t, outputSchema)
 		if got := slices.Sorted(maps.Keys(outputProperties)); !reflect.DeepEqual(got, []string{"text"}) {
@@ -369,9 +389,11 @@ func TestMCPDaemonToolBehavior(t *testing.T) {
 
 			text := textContent(t, result)
 			assertJSONEqual(t, []byte(text), []byte(responses[test.path]))
-			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
-				t.Fatalf("structured content=%v, want %v", got, want)
+			structured, err := json.Marshal(result.StructuredContent)
+			if err != nil {
+				t.Fatal(err)
 			}
+			assertJSONEqual(t, structured, []byte(responses[test.path]))
 		})
 	}
 }
@@ -459,41 +481,44 @@ func TestMCPDaemonToolContextCancellation(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires Unix sockets")
 	}
+	for _, cause := range []error{context.Canceled, errors.New("daemon request canceled by caller")} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			requestStarted := make(chan struct{})
+			handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				close(requestStarted)
+				<-r.Context().Done()
+			})
+			socketPath := startMCPDaemonTestServer(t, handler)
 
-	requestStarted := make(chan struct{})
-	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		close(requestStarted)
-		<-r.Context().Done()
-	})
-	socketPath := startMCPDaemonTestServer(t, handler)
+			_, toolHandler := DaemonInfoTool()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			t.Cleanup(func() { cancel(context.Canceled) })
+			timeout := 10
+			done := make(chan daemonToolCallResult, 1)
+			go func() {
+				result, _, err := toolHandler(ctx, nil, daemonInfoInput{Socket: &socketPath, Timeout: &timeout})
+				done <- daemonToolCallResult{result: result, err: err}
+			}()
 
-	_, toolHandler := DaemonInfoTool()
-	ctx, cancel := context.WithCancel(t.Context())
-	t.Cleanup(cancel)
-	timeout := 10
-	done := make(chan daemonToolCallResult, 1)
-	go func() {
-		result, _, err := toolHandler(ctx, nil, daemonInfoInput{Socket: &socketPath, Timeout: &timeout})
-		done <- daemonToolCallResult{result: result, err: err}
-	}()
+			select {
+			case <-requestStarted:
+				cancel(cause)
+			case <-time.After(2 * time.Second):
+				t.Fatal("daemon request did not start")
+			}
 
-	select {
-	case <-requestStarted:
-		cancel()
-	case <-time.After(2 * time.Second):
-		t.Fatal("daemon request did not start")
-	}
-
-	select {
-	case call := <-done:
-		if !errors.Is(call.err, context.Canceled) {
-			t.Fatalf("error=%v, want context canceled", call.err)
-		}
-		if call.result != nil {
-			t.Fatalf("result=%v, want nil", call.result)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("daemon tool did not return after context cancellation")
+			select {
+			case call := <-done:
+				if !errors.Is(call.err, cause) {
+					t.Fatalf("error=%v, want %v", call.err, cause)
+				}
+				if call.result != nil {
+					t.Fatalf("result=%v, want nil", call.result)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("daemon tool did not return after context cancellation")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Adds seven daemon-control tools to the official MCP SDK surface:

- `litestream_list` and `litestream_daemon_info` are annotated read-only.
- `litestream_sync`, `litestream_start`, `litestream_stop`, `litestream_register`, and `litestream_unregister` are annotated mutating and destructive.
- Each tool calls the corresponding HTTP endpoint over the daemon Unix socket and accepts optional socket and timeout inputs.
- Sync exposes the daemon's wait behavior for remote replication.
- Successful daemon responses are returned as JSON text, while missing or refused sockets return a clear no-daemon error.

## Motivation and Context

The daemon already exposes `/list`, `/sync`, `/info`, `/start`, `/stop`, `/register`, and `/unregister`, but the MCP server did not register tools for those endpoints. Assistants therefore could not inspect or control the running daemon through MCP.

The MCP behavior test now exercises all seven methods, paths, request bodies, and responses over a real Unix socket. A separate matrix verifies that every tool reports `no Litestream daemon is running` when the socket is absent.

## Scope

**In scope:**

- Official Go SDK tool registration and annotations.
- Unix-socket IPC requests with context and timeout propagation.
- Daemon response and connection error handling.
- Tool schema, behavior, and no-daemon tests.

**Not in scope:**

- Structured outputs beyond the existing `text` output contract.
- Standalone MCP transport changes.
- Changes from other MCP feature branches.

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| List or inspect a running daemon | No MCP tool | Read-only MCP tools call daemon IPC |
| Sync, start, stop, register, or unregister | No MCP tool | Destructive MCP tools call daemon IPC |
| Sync and wait for remote replication | Unavailable through MCP | `litestream_sync` accepts `wait: true` |
| Daemon is not running | No daemon tool behavior | Clear no-daemon tool error |

## How Has This Been Tested?

- `go test -race ./...`
- `go vet ./...`
- `go mod verify`
- `pre-commit run --all-files`
- `validation_dir=$(mktemp -d); go build -o "${validation_dir}/litestream" ./cmd/litestream`
- `validation_dir=$(mktemp -d); GOOS=windows CGO_ENABLED=0 go test -c -o "${validation_dir}/litestream.test.exe" ./cmd/litestream`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (not needed; no configuration or CLI behavior changed)

## Related

- Stacked on #1378
- Closes #1372
