### PR TITLE
test(mcp): add per-tool integration coverage

### DIFF
--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -20,6 +20,7 @@ import (
 type MCPServer struct {
 	ctx        context.Context
 	mux        *http.ServeMux
+	mcpServer  *mcp.Server
 	httpServer *http.Server
 	configPath string
 }
@@ -29,31 +30,31 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 		ctx:        ctx,
 		configPath: configPath,
 	}
-	mcpServer := mcp.NewServer(
+	s.mcpServer = mcp.NewServer(
 		&mcp.Implementation{Name: "Litestream MCP Server", Version: Version},
 		&mcp.ServerOptions{
 			Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 		},
 	)
-	mcpServer.AddReceivingMiddleware(recoveryMiddleware)
+	s.mcpServer.AddReceivingMiddleware(recoveryMiddleware)
 	infoTool, infoHandler := InfoTool(configPath)
-	mcp.AddTool(mcpServer, infoTool, infoHandler)
+	mcp.AddTool(s.mcpServer, infoTool, infoHandler)
 	databasesTool, databasesHandler := DatabasesTool(configPath)
-	mcp.AddTool(mcpServer, databasesTool, databasesHandler)
+	mcp.AddTool(s.mcpServer, databasesTool, databasesHandler)
 	restoreTool, restoreHandler := RestoreTool(configPath)
-	mcp.AddTool(mcpServer, restoreTool, restoreHandler)
+	mcp.AddTool(s.mcpServer, restoreTool, restoreHandler)
 	ltxTool, ltxHandler := LTXTool(configPath)
-	mcp.AddTool(mcpServer, ltxTool, ltxHandler)
+	mcp.AddTool(s.mcpServer, ltxTool, ltxHandler)
 	versionTool, versionHandler := VersionTool()
-	mcp.AddTool(mcpServer, versionTool, versionHandler)
+	mcp.AddTool(s.mcpServer, versionTool, versionHandler)
 	statusTool, statusHandler := StatusTool(configPath)
-	mcp.AddTool(mcpServer, statusTool, statusHandler)
+	mcp.AddTool(s.mcpServer, statusTool, statusHandler)
 	resetTool, resetHandler := ResetTool(configPath)
-	mcp.AddTool(mcpServer, resetTool, resetHandler)
+	mcp.AddTool(s.mcpServer, resetTool, resetHandler)
 
 	s.mux = http.NewServeMux()
 	s.mux.Handle("/", httplog.Logger(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
-		return mcpServer
+		return s.mcpServer
 	}, &mcp.StreamableHTTPOptions{Stateless: true})))
 	return s, nil
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net/http"
@@ -18,6 +19,10 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/file"
+	"github.com/benbjohnson/litestream/internal/testingutil"
 )
 
 func TestMCPServerTools(t *testing.T) {
@@ -364,6 +369,165 @@ func TestMCPToolBehavior(t *testing.T) {
 	}
 }
 
+func TestMCPToolIntegration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	const version = "v1.2.3-mcp-test"
+	setVersion(t, version)
+	installLitestreamTestCLI(t)
+	fixture := newMCPToolFixture(t)
+
+	server, err := NewMCP(t.Context(), fixture.configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := connectMCPTestSession(t, server)
+
+	tests := []struct {
+		name             string
+		successArguments map[string]any
+		successContains  []string
+		verifySuccess    func(*testing.T)
+		errorArguments   map[string]any
+		errorContains    string
+	}{
+		{
+			name:             "litestream_databases",
+			successArguments: map[string]any{},
+			successContains:  []string{fixture.dbPath, "file"},
+			errorArguments:   map[string]any{"config": fixture.missingConfigPath},
+			errorContains:    fixture.missingConfigPath,
+		},
+		{
+			name:             "litestream_info",
+			successArguments: map[string]any{},
+			successContains:  []string{"=== Litestream Status Report ===", fixture.dbPath, fixture.txid},
+			errorArguments:   map[string]any{"config": fixture.missingConfigPath},
+			errorContains:    fixture.missingConfigPath,
+		},
+		{
+			name: "litestream_restore",
+			successArguments: map[string]any{
+				"path": fixture.replicaURL,
+				"o":    fixture.restorePath,
+			},
+			verifySuccess: func(t *testing.T) {
+				db := testingutil.MustOpenSQLDB(t, fixture.restorePath)
+				t.Cleanup(func() {
+					if err := db.Close(); err != nil {
+						t.Error(err)
+					}
+				})
+				var count int
+				if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM test`).Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != 1 {
+					t.Fatalf("restored row count=%d, want 1", count)
+				}
+			},
+			errorArguments: map[string]any{
+				"path": fixture.missingReplicaURL,
+				"o":    fixture.failedRestorePath,
+			},
+			errorContains: "no matching backup files available",
+		},
+		{
+			name:             "litestream_ltx",
+			successArguments: map[string]any{"path": fixture.replicaURL},
+			successContains:  []string{fixture.txid},
+			errorArguments:   map[string]any{"path": ""},
+			errorContains:    "database path or replica URL required",
+		},
+		{
+			name:             "litestream_version",
+			successArguments: map[string]any{},
+			successContains:  []string{version},
+			errorArguments:   map[string]any{"unexpected": true},
+			errorContains:    "unexpected",
+		},
+		{
+			name:             "litestream_status",
+			successArguments: map[string]any{},
+			successContains:  []string{fixture.dbPath, "ok"},
+			errorArguments:   map[string]any{"config": fixture.missingConfigPath},
+			errorContains:    fixture.missingConfigPath,
+		},
+		{
+			name:             "litestream_reset",
+			successArguments: map[string]any{"path": fixture.dbPath},
+			successContains:  []string{"Reset complete."},
+			verifySuccess: func(t *testing.T) {
+				if _, err := os.Stat(fixture.localLTXPath); !os.IsNotExist(err) {
+					t.Fatalf("local LTX file still exists after reset: %v", err)
+				}
+			},
+			errorArguments: map[string]any{"path": fixture.missingDBPath},
+			errorContains:  "database does not exist",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+				Name:      test.name,
+				Arguments: test.successArguments,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError {
+				t.Fatalf("tool error: %s", textContent(t, result))
+			}
+			text := textContent(t, result)
+			for _, want := range test.successContains {
+				if !strings.Contains(text, want) {
+					t.Errorf("success content does not contain %q: %q", want, text)
+				}
+			}
+			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
+				t.Errorf("structured content=%v, want %v", got, want)
+			}
+			if test.verifySuccess != nil {
+				test.verifySuccess(t)
+			}
+
+			result, err = session.CallTool(t.Context(), &mcp.CallToolParams{
+				Name:      test.name,
+				Arguments: test.errorArguments,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.IsError {
+				t.Fatalf("tool succeeded, want error: %s", textContent(t, result))
+			}
+			if got := textContent(t, result); !strings.Contains(got, test.errorContains) {
+				t.Fatalf("error content does not contain %q: %q", test.errorContains, got)
+			}
+		})
+	}
+}
+
+func TestMCPCLIProcess(t *testing.T) {
+	if os.Getenv("LITESTREAM_MCP_TEST_CLI") != "1" {
+		t.Skip("helper process only")
+	}
+
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		fmt.Fprintln(os.Stderr, "missing command arguments")
+		os.Exit(2)
+	}
+	if err := NewMain().Run(context.Background(), os.Args[separator+1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
 func TestMCPToolContextCancellation(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires a POSIX shell")
@@ -538,4 +702,126 @@ func setVersion(t *testing.T, version string) {
 	previous := Version
 	Version = version
 	t.Cleanup(func() { Version = previous })
+}
+
+type mcpToolFixture struct {
+	configPath        string
+	missingConfigPath string
+	dbPath            string
+	missingDBPath     string
+	replicaURL        string
+	missingReplicaURL string
+	restorePath       string
+	failedRestorePath string
+	localLTXPath      string
+	txid              string
+}
+
+func newMCPToolFixture(t *testing.T) mcpToolFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db.sqlite")
+	replicaPath := filepath.Join(dir, "replica")
+
+	db := testingutil.NewDB(t, dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.Replica = litestream.NewReplicaWithClient(db, file.NewReplicaClient(replicaPath))
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb := testingutil.MustOpenSQLDB(t, dbPath)
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE test (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO test DEFAULT VALUES`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SyncAndWait(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	localLTXPaths, err := filepath.Glob(filepath.Join(db.LTXDir(), "0", "*.ltx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(localLTXPaths) == 0 {
+		t.Fatal("no local LTX files created")
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := filepath.Join(dir, "litestream.yml")
+	config := fmt.Sprintf("dbs:\n  - path: %s\n    replicas:\n      - url: file://%s\n", dbPath, replicaPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return mcpToolFixture{
+		configPath:        configPath,
+		missingConfigPath: filepath.Join(dir, "missing.yml"),
+		dbPath:            dbPath,
+		missingDBPath:     filepath.Join(dir, "missing.db"),
+		replicaURL:        "file://" + replicaPath,
+		missingReplicaURL: "file://" + filepath.Join(dir, "missing-replica"),
+		restorePath:       filepath.Join(dir, "restored.sqlite"),
+		failedRestorePath: filepath.Join(dir, "failed.sqlite"),
+		localLTXPath:      localLTXPaths[0],
+		txid:              pos.TXID.String(),
+	}
+}
+
+func installLitestreamTestCLI(t *testing.T) {
+	t.Helper()
+
+	testBinary, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "litestream")
+	script := "#!/bin/sh\nexec \"$LITESTREAM_MCP_TEST_BINARY\" -test.run=^TestMCPCLIProcess$ -- \"$@\"\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LITESTREAM_MCP_TEST_BINARY", testBinary)
+	t.Setenv("LITESTREAM_MCP_TEST_CLI", "1")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func connectMCPTestSession(t *testing.T, server *MCPServer) *mcp.ClientSession {
+	t.Helper()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.mcpServer.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := serverSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	clientSession, err := client.Connect(t.Context(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := clientSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return clientSession
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -460,7 +461,7 @@ func TestMCPToolIntegration(t *testing.T) {
 			successArguments: map[string]any{"path": fixture.dbPath},
 			successContains:  []string{"Reset complete."},
 			verifySuccess: func(t *testing.T) {
-				if _, err := os.Stat(fixture.localLTXPath); !os.IsNotExist(err) {
+				if _, err := os.Stat(fixture.localLTXPath); !errors.Is(err, fs.ErrNotExist) {
 					t.Fatalf("local LTX file still exists after reset: %v", err)
 				}
 			},

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -487,9 +487,6 @@ func TestMCPToolIntegration(t *testing.T) {
 					t.Errorf("success content does not contain %q: %q", want, text)
 				}
 			}
-			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
-				t.Errorf("structured content=%v, want %v", got, want)
-			}
 			if test.verifySuccess != nil {
 				test.verifySuccess(t)
 			}
@@ -732,8 +729,24 @@ func newMCPToolFixture(t *testing.T) mcpToolFixture {
 	if err := db.Open(); err != nil {
 		t.Fatal(err)
 	}
+	dbClosed := false
+	t.Cleanup(func() {
+		if !dbClosed {
+			if err := db.Close(context.Background()); err != nil {
+				t.Error(err)
+			}
+		}
+	})
 
 	sqldb := testingutil.MustOpenSQLDB(t, dbPath)
+	sqldbClosed := false
+	t.Cleanup(func() {
+		if !sqldbClosed {
+			if err := sqldb.Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	})
 	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE test (id INTEGER PRIMARY KEY)`); err != nil {
 		t.Fatal(err)
 	}
@@ -757,9 +770,11 @@ func newMCPToolFixture(t *testing.T) mcpToolFixture {
 	if err := sqldb.Close(); err != nil {
 		t.Fatal(err)
 	}
+	sqldbClosed = true
 	if err := db.Close(t.Context()); err != nil {
 		t.Fatal(err)
 	}
+	dbClosed = true
 
 	configPath := filepath.Join(dir, "litestream.yml")
 	config := fmt.Sprintf("dbs:\n  - path: %s\n    replicas:\n      - url: file://%s\n", dbPath, replicaPath)

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net"
 	"net/http"
@@ -635,7 +636,7 @@ func TestMCPToolIntegration(t *testing.T) {
 			successArguments: map[string]any{"path": fixture.dbPath},
 			successContains:  []string{"Reset complete."},
 			verifySuccess: func(t *testing.T) {
-				if _, err := os.Stat(fixture.localLTXPath); !os.IsNotExist(err) {
+				if _, err := os.Stat(fixture.localLTXPath); !errors.Is(err, fs.ErrNotExist) {
 					t.Fatalf("local LTX file still exists after reset: %v", err)
 				}
 			},

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -639,6 +639,19 @@ func TestMCPToolIntegration(t *testing.T) {
 				if _, err := os.Stat(fixture.localLTXPath); !errors.Is(err, fs.ErrNotExist) {
 					t.Fatalf("local LTX file still exists after reset: %v", err)
 				}
+				db := testingutil.MustOpenSQLDB(t, fixture.dbPath)
+				t.Cleanup(func() {
+					if err := db.Close(); err != nil {
+						t.Error(err)
+					}
+				})
+				var id int
+				if err := db.QueryRowContext(t.Context(), `SELECT id FROM test`).Scan(&id); err != nil {
+					t.Fatal(err)
+				}
+				if id != 1 {
+					t.Fatalf("database row after reset=%d, want 1", id)
+				}
 			},
 			errorArguments: map[string]any{"path": fixture.missingDBPath},
 			errorContains:  "database does not exist",
@@ -679,6 +692,11 @@ func TestMCPToolIntegration(t *testing.T) {
 			}
 			if got := textContent(t, result); !strings.Contains(got, test.errorContains) {
 				t.Fatalf("error content does not contain %q: %q", test.errorContains, got)
+			}
+			if test.name == "litestream_restore" {
+				if _, err := os.Stat(fixture.failedRestorePath); !errors.Is(err, fs.ErrNotExist) {
+					t.Fatalf("failed restore created output: %v", err)
+				}
 			}
 		})
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net"
@@ -20,6 +21,10 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/file"
+	"github.com/benbjohnson/litestream/internal/testingutil"
 )
 
 func TestMCPServerTools(t *testing.T) {
@@ -539,6 +544,165 @@ func TestMCPToolBehavior(t *testing.T) {
 	}
 }
 
+func TestMCPToolIntegration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	const version = "v1.2.3-mcp-test"
+	setVersion(t, version)
+	installLitestreamTestCLI(t)
+	fixture := newMCPToolFixture(t)
+
+	server, err := NewMCP(t.Context(), fixture.configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := connectMCPTestSession(t, server)
+
+	tests := []struct {
+		name             string
+		successArguments map[string]any
+		successContains  []string
+		verifySuccess    func(*testing.T)
+		errorArguments   map[string]any
+		errorContains    string
+	}{
+		{
+			name:             "litestream_databases",
+			successArguments: map[string]any{},
+			successContains:  []string{fixture.dbPath, "file"},
+			errorArguments:   map[string]any{"config": fixture.missingConfigPath},
+			errorContains:    fixture.missingConfigPath,
+		},
+		{
+			name:             "litestream_info",
+			successArguments: map[string]any{},
+			successContains:  []string{"=== Litestream Status Report ===", fixture.dbPath, fixture.txid},
+			errorArguments:   map[string]any{"config": fixture.missingConfigPath},
+			errorContains:    fixture.missingConfigPath,
+		},
+		{
+			name: "litestream_restore",
+			successArguments: map[string]any{
+				"path": fixture.replicaURL,
+				"o":    fixture.restorePath,
+			},
+			verifySuccess: func(t *testing.T) {
+				db := testingutil.MustOpenSQLDB(t, fixture.restorePath)
+				t.Cleanup(func() {
+					if err := db.Close(); err != nil {
+						t.Error(err)
+					}
+				})
+				var count int
+				if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM test`).Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != 1 {
+					t.Fatalf("restored row count=%d, want 1", count)
+				}
+			},
+			errorArguments: map[string]any{
+				"path": fixture.missingReplicaURL,
+				"o":    fixture.failedRestorePath,
+			},
+			errorContains: "no matching backup files available",
+		},
+		{
+			name:             "litestream_ltx",
+			successArguments: map[string]any{"path": fixture.replicaURL},
+			successContains:  []string{fixture.txid},
+			errorArguments:   map[string]any{"path": ""},
+			errorContains:    "database path or replica URL required",
+		},
+		{
+			name:             "litestream_version",
+			successArguments: map[string]any{},
+			successContains:  []string{version},
+			errorArguments:   map[string]any{"unexpected": true},
+			errorContains:    "unexpected",
+		},
+		{
+			name:             "litestream_status",
+			successArguments: map[string]any{},
+			successContains:  []string{fixture.dbPath, "ok"},
+			errorArguments:   map[string]any{"config": fixture.missingConfigPath},
+			errorContains:    fixture.missingConfigPath,
+		},
+		{
+			name:             "litestream_reset",
+			successArguments: map[string]any{"path": fixture.dbPath},
+			successContains:  []string{"Reset complete."},
+			verifySuccess: func(t *testing.T) {
+				if _, err := os.Stat(fixture.localLTXPath); !os.IsNotExist(err) {
+					t.Fatalf("local LTX file still exists after reset: %v", err)
+				}
+			},
+			errorArguments: map[string]any{"path": fixture.missingDBPath},
+			errorContains:  "database does not exist",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+				Name:      test.name,
+				Arguments: test.successArguments,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError {
+				t.Fatalf("tool error: %s", textContent(t, result))
+			}
+			text := textContent(t, result)
+			for _, want := range test.successContains {
+				if !strings.Contains(text, want) {
+					t.Errorf("success content does not contain %q: %q", want, text)
+				}
+			}
+			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
+				t.Errorf("structured content=%v, want %v", got, want)
+			}
+			if test.verifySuccess != nil {
+				test.verifySuccess(t)
+			}
+
+			result, err = session.CallTool(t.Context(), &mcp.CallToolParams{
+				Name:      test.name,
+				Arguments: test.errorArguments,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.IsError {
+				t.Fatalf("tool succeeded, want error: %s", textContent(t, result))
+			}
+			if got := textContent(t, result); !strings.Contains(got, test.errorContains) {
+				t.Fatalf("error content does not contain %q: %q", test.errorContains, got)
+			}
+		})
+	}
+}
+
+func TestMCPCLIProcess(t *testing.T) {
+	if os.Getenv("LITESTREAM_MCP_TEST_CLI") != "1" {
+		t.Skip("helper process only")
+	}
+
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		fmt.Fprintln(os.Stderr, "missing command arguments")
+		os.Exit(2)
+	}
+	if err := NewMain().Run(context.Background(), os.Args[separator+1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
 func TestMCPToolContextCancellation(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires a POSIX shell")
@@ -758,4 +922,126 @@ func TestMCPServerLifecycle(t *testing.T) {
 	if err := listener.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+type mcpToolFixture struct {
+	configPath        string
+	missingConfigPath string
+	dbPath            string
+	missingDBPath     string
+	replicaURL        string
+	missingReplicaURL string
+	restorePath       string
+	failedRestorePath string
+	localLTXPath      string
+	txid              string
+}
+
+func newMCPToolFixture(t *testing.T) mcpToolFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db.sqlite")
+	replicaPath := filepath.Join(dir, "replica")
+
+	db := testingutil.NewDB(t, dbPath)
+	db.MonitorInterval = 0
+	db.ShutdownSyncTimeout = 0
+	db.Replica = litestream.NewReplicaWithClient(db, file.NewReplicaClient(replicaPath))
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb := testingutil.MustOpenSQLDB(t, dbPath)
+	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE test (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO test DEFAULT VALUES`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SyncAndWait(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	pos, err := db.Pos()
+	if err != nil {
+		t.Fatal(err)
+	}
+	localLTXPaths, err := filepath.Glob(filepath.Join(db.LTXDir(), "0", "*.ltx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(localLTXPaths) == 0 {
+		t.Fatal("no local LTX files created")
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := filepath.Join(dir, "litestream.yml")
+	config := fmt.Sprintf("dbs:\n  - path: %s\n    replicas:\n      - url: file://%s\n", dbPath, replicaPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return mcpToolFixture{
+		configPath:        configPath,
+		missingConfigPath: filepath.Join(dir, "missing.yml"),
+		dbPath:            dbPath,
+		missingDBPath:     filepath.Join(dir, "missing.db"),
+		replicaURL:        "file://" + replicaPath,
+		missingReplicaURL: "file://" + filepath.Join(dir, "missing-replica"),
+		restorePath:       filepath.Join(dir, "restored.sqlite"),
+		failedRestorePath: filepath.Join(dir, "failed.sqlite"),
+		localLTXPath:      localLTXPaths[0],
+		txid:              pos.TXID.String(),
+	}
+}
+
+func installLitestreamTestCLI(t *testing.T) {
+	t.Helper()
+
+	testBinary, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "litestream")
+	script := "#!/bin/sh\nexec \"$LITESTREAM_MCP_TEST_BINARY\" -test.run=^TestMCPCLIProcess$ -- \"$@\"\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LITESTREAM_MCP_TEST_BINARY", testBinary)
+	t.Setenv("LITESTREAM_MCP_TEST_CLI", "1")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func connectMCPTestSession(t *testing.T, server *MCPServer) *mcp.ClientSession {
+	t.Helper()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.mcpServer.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := serverSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v1.0.0"}, nil)
+	clientSession, err := client.Connect(t.Context(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := clientSession.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return clientSession
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -662,9 +662,6 @@ func TestMCPToolIntegration(t *testing.T) {
 					t.Errorf("success content does not contain %q: %q", want, text)
 				}
 			}
-			if got, want := result.StructuredContent, map[string]any{"text": text}; !reflect.DeepEqual(got, want) {
-				t.Errorf("structured content=%v, want %v", got, want)
-			}
 			if test.verifySuccess != nil {
 				test.verifySuccess(t)
 			}
@@ -952,8 +949,24 @@ func newMCPToolFixture(t *testing.T) mcpToolFixture {
 	if err := db.Open(); err != nil {
 		t.Fatal(err)
 	}
+	dbClosed := false
+	t.Cleanup(func() {
+		if !dbClosed {
+			if err := db.Close(context.Background()); err != nil {
+				t.Error(err)
+			}
+		}
+	})
 
 	sqldb := testingutil.MustOpenSQLDB(t, dbPath)
+	sqldbClosed := false
+	t.Cleanup(func() {
+		if !sqldbClosed {
+			if err := sqldb.Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	})
 	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE test (id INTEGER PRIMARY KEY)`); err != nil {
 		t.Fatal(err)
 	}
@@ -977,9 +990,11 @@ func newMCPToolFixture(t *testing.T) mcpToolFixture {
 	if err := sqldb.Close(); err != nil {
 		t.Fatal(err)
 	}
+	sqldbClosed = true
 	if err := db.Close(t.Context()); err != nil {
 		t.Fatal(err)
 	}
+	dbClosed = true
 
 	configPath := filepath.Join(dir, "litestream.yml")
 	config := fmt.Sprintf("dbs:\n  - path: %s\n    replicas:\n      - url: file://%s\n", dbPath, replicaPath)


### PR DESCRIPTION
## Summary

Adds focused integration coverage for the seven MCP tools on top of the official Go SDK migration in #1378.

- Connects the official SDK client and server with in-memory transports.
- Exercises success and error paths for every registered tool.
- Uses a temporary SQLite database synced to a real `file://` replica.
- Verifies restore and reset through their filesystem and database side effects.

## Investigation

The `mcp_test.go` added by #1378 already comprehensively covers server identity, capabilities, tool discovery, generated schemas, annotations, structured output, argument preservation, cancellation, panic recovery, and Streamable HTTP transport.

The remaining thin areas were per-tool failures, the SDK's in-process transport, and behavior against real Litestream data. This PR fills those gaps without importing changes from the other MCP branches.

## Scope

**In scope:**
- Per-tool success and error coverage.
- Official SDK in-memory client/server transport.
- Temporary SQLite and `file://` replica fixture.
- Restore-content and reset-removal assertions.

**Not in scope:**
- Replacing subprocess-backed MCP handlers.
- Adding MCP tools or changing tool schemas.
- Changes from sibling MCP branches.

## Test Plan

```bash
go test -race -run '^TestMCPToolIntegration$' -v ./cmd/litestream/
go test -race ./cmd/litestream/
go vet ./...
pre-commit run --all-files
go test -race ./...
```

## Related

- Stacked on #1378
- Closes #1373
