### PR TITLE
feat(mcp): add optional bearer-token auth

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -55,6 +55,7 @@ var (
 	ErrInvalidShutdownSyncInterval     = errors.New("shutdown sync interval must be greater than 0")
 	ErrInvalidHeartbeatURL             = errors.New("heartbeat URL must be a valid HTTP or HTTPS URL")
 	ErrInvalidHeartbeatInterval        = errors.New("heartbeat interval must be at least 1 minute")
+	ErrInvalidMCPAuthToken             = errors.New("mcp auth token must not be empty")
 	ErrConfigFileNotFound              = errors.New("config file not found")
 )
 
@@ -308,8 +309,8 @@ type Config struct {
 	Logging internal.LoggingConfig `yaml:"logging"`
 
 	// MCP server options
-	MCPAddr      string `yaml:"mcp-addr"`
-	MCPAuthToken string `yaml:"mcp-auth-token"`
+	MCPAddr      string  `yaml:"mcp-addr"`
+	MCPAuthToken *string `yaml:"mcp-auth-token"`
 
 	// Shutdown sync retry settings
 	ShutdownSyncTimeout  *time.Duration `yaml:"shutdown-sync-timeout"`
@@ -413,6 +414,13 @@ func DefaultConfig() Config {
 
 // Validate returns an error if config contains invalid settings.
 func (c *Config) Validate() error {
+	if c.MCPAuthToken != nil && *c.MCPAuthToken == "" {
+		return &ConfigValidationError{
+			Err:   ErrInvalidMCPAuthToken,
+			Field: "mcp-auth-token",
+		}
+	}
+
 	// Validate snapshot intervals
 	if c.Snapshot.Interval != nil && *c.Snapshot.Interval <= 0 {
 		return &ConfigValidationError{
@@ -636,6 +644,11 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	if err := yaml.Unmarshal(buf, &raw); err != nil {
 		return config, err
 	}
+	var rawValues map[string]any
+	if err := yaml.Unmarshal(buf, &rawValues); err != nil {
+		return config, err
+	}
+	_, mcpAuthTokenSet := rawValues["mcp-auth-token"]
 	globalSnapshotIntervalSet := raw.Snapshot != nil && raw.Snapshot.Interval != nil
 	globalSnapshotRetentionSet := raw.Snapshot != nil && raw.Snapshot.Retention != nil
 
@@ -647,6 +660,9 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 
 	if err := yaml.Unmarshal(buf, &config); err != nil {
 		return config, err
+	}
+	if mcpAuthTokenSet && config.MCPAuthToken == nil {
+		config.MCPAuthToken = new(string)
 	}
 
 	// Restore defaults if they were overwritten with nil by empty YAML sections

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -308,7 +308,8 @@ type Config struct {
 	Logging internal.LoggingConfig `yaml:"logging"`
 
 	// MCP server options
-	MCPAddr string `yaml:"mcp-addr"`
+	MCPAddr      string `yaml:"mcp-addr"`
+	MCPAuthToken string `yaml:"mcp-auth-token"`
 
 	// Shutdown sync retry settings
 	ShutdownSyncTimeout  *time.Duration `yaml:"shutdown-sync-timeout"`

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/dustin/go-humanize"
 	"github.com/superfly/ltx"
@@ -60,7 +61,7 @@ var (
 	ErrInvalidShutdownSyncInterval     = errors.New("shutdown sync interval must be greater than 0")
 	ErrInvalidHeartbeatURL             = errors.New("heartbeat URL must be a valid HTTP or HTTPS URL")
 	ErrInvalidHeartbeatInterval        = errors.New("heartbeat interval must be at least 1 minute")
-	ErrInvalidMCPAuthToken             = errors.New("mcp auth token must not be empty")
+	ErrInvalidMCPAuthToken             = errors.New("mcp auth token must not be empty or contain whitespace or control characters")
 	ErrConfigFileNotFound              = errors.New("config file not found")
 )
 
@@ -426,7 +427,9 @@ func DefaultConfig() Config {
 
 // Validate returns an error if config contains invalid settings.
 func (c *Config) Validate() error {
-	if c.MCPAuthToken != nil && *c.MCPAuthToken == "" {
+	if c.MCPAuthToken != nil && (*c.MCPAuthToken == "" || strings.ContainsFunc(*c.MCPAuthToken, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	})) {
 		return &ConfigValidationError{
 			Err:   ErrInvalidMCPAuthToken,
 			Field: "mcp-auth-token",

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -60,6 +60,7 @@ var (
 	ErrInvalidShutdownSyncInterval     = errors.New("shutdown sync interval must be greater than 0")
 	ErrInvalidHeartbeatURL             = errors.New("heartbeat URL must be a valid HTTP or HTTPS URL")
 	ErrInvalidHeartbeatInterval        = errors.New("heartbeat interval must be at least 1 minute")
+	ErrInvalidMCPAuthToken             = errors.New("mcp auth token must not be empty")
 	ErrConfigFileNotFound              = errors.New("config file not found")
 )
 
@@ -320,8 +321,8 @@ type Config struct {
 	Logging internal.LoggingConfig `yaml:"logging"`
 
 	// MCP server options
-	MCPAddr      string `yaml:"mcp-addr"`
-	MCPAuthToken string `yaml:"mcp-auth-token"`
+	MCPAddr      string  `yaml:"mcp-addr"`
+	MCPAuthToken *string `yaml:"mcp-auth-token"`
 
 	// Shutdown sync retry settings
 	ShutdownSyncTimeout  *time.Duration `yaml:"shutdown-sync-timeout"`
@@ -425,6 +426,13 @@ func DefaultConfig() Config {
 
 // Validate returns an error if config contains invalid settings.
 func (c *Config) Validate() error {
+	if c.MCPAuthToken != nil && *c.MCPAuthToken == "" {
+		return &ConfigValidationError{
+			Err:   ErrInvalidMCPAuthToken,
+			Field: "mcp-auth-token",
+		}
+	}
+
 	// Validate snapshot intervals
 	if c.Snapshot.Interval != nil && *c.Snapshot.Interval <= 0 {
 		return &ConfigValidationError{
@@ -660,6 +668,11 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	if err := yaml.Unmarshal(buf, &raw); err != nil {
 		return config, err
 	}
+	var rawValues map[string]any
+	if err := yaml.Unmarshal(buf, &rawValues); err != nil {
+		return config, err
+	}
+	_, mcpAuthTokenSet := rawValues["mcp-auth-token"]
 	globalSnapshotIntervalSet := raw.Snapshot != nil && raw.Snapshot.Interval != nil
 	globalSnapshotRetentionSet := raw.Snapshot != nil && raw.Snapshot.Retention != nil
 
@@ -671,6 +684,9 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 
 	if err := yaml.Unmarshal(buf, &config); err != nil {
 		return config, err
+	}
+	if mcpAuthTokenSet && config.MCPAuthToken == nil {
+		config.MCPAuthToken = new(string)
 	}
 
 	// Restore defaults if they were overwritten with nil by empty YAML sections

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -320,7 +320,8 @@ type Config struct {
 	Logging internal.LoggingConfig `yaml:"logging"`
 
 	// MCP server options
-	MCPAddr string `yaml:"mcp-addr"`
+	MCPAddr      string `yaml:"mcp-addr"`
+	MCPAuthToken string `yaml:"mcp-auth-token"`
 
 	// Shutdown sync retry settings
 	ShutdownSyncTimeout  *time.Duration `yaml:"shutdown-sync-timeout"`

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -155,7 +155,9 @@ dbs:
 			t.Fatalf("Replica[0].URL=%v, want %v", got, want)
 		} else if got, want := config.DBs[0].Replicas[1].URL, ``; got != want {
 			t.Fatalf("Replica[1].URL=%v, want %v", got, want)
-		} else if got, want := config.MCPAuthToken, `secret`; got != want {
+		} else if config.MCPAuthToken == nil {
+			t.Fatal("MCPAuthToken is nil")
+		} else if got, want := *config.MCPAuthToken, `secret`; got != want {
 			t.Fatalf("MCPAuthToken=%v, want %v", got, want)
 		}
 	})

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -132,9 +132,11 @@ dbs:
 	t.Run("ExpandEnv", func(t *testing.T) {
 		os.Setenv("LITESTREAM_TEST_0129380", "/path/to/db")
 		os.Setenv("LITESTREAM_TEST_1872363", "s3://foo/bar")
+		t.Setenv("LITESTREAM_TEST_MCP_AUTH_TOKEN", "secret")
 
 		filename := filepath.Join(t.TempDir(), "litestream.yml")
 		if err := os.WriteFile(filename, []byte(`
+mcp-auth-token: ${LITESTREAM_TEST_MCP_AUTH_TOKEN}
 dbs:
   - path: $LITESTREAM_TEST_0129380
     replicas:
@@ -153,6 +155,8 @@ dbs:
 			t.Fatalf("Replica[0].URL=%v, want %v", got, want)
 		} else if got, want := config.DBs[0].Replicas[1].URL, ``; got != want {
 			t.Fatalf("Replica[1].URL=%v, want %v", got, want)
+		} else if got, want := config.MCPAuthToken, `secret`; got != want {
+			t.Fatalf("MCPAuthToken=%v, want %v", got, want)
 		}
 	})
 

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -157,7 +157,9 @@ dbs:
 			t.Fatalf("Replica[0].URL=%v, want %v", got, want)
 		} else if got, want := config.DBs[0].Replicas[1].URL, ``; got != want {
 			t.Fatalf("Replica[1].URL=%v, want %v", got, want)
-		} else if got, want := config.MCPAuthToken, `secret`; got != want {
+		} else if config.MCPAuthToken == nil {
+			t.Fatal("MCPAuthToken is nil")
+		} else if got, want := *config.MCPAuthToken, `secret`; got != want {
 			t.Fatalf("MCPAuthToken=%v, want %v", got, want)
 		}
 	})

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -134,9 +134,11 @@ dbs:
 	t.Run("ExpandEnv", func(t *testing.T) {
 		os.Setenv("LITESTREAM_TEST_0129380", "/path/to/db")
 		os.Setenv("LITESTREAM_TEST_1872363", "s3://foo/bar")
+		t.Setenv("LITESTREAM_TEST_MCP_AUTH_TOKEN", "secret")
 
 		filename := filepath.Join(t.TempDir(), "litestream.yml")
 		if err := os.WriteFile(filename, []byte(`
+mcp-auth-token: ${LITESTREAM_TEST_MCP_AUTH_TOKEN}
 dbs:
   - path: $LITESTREAM_TEST_0129380
     replicas:
@@ -155,6 +157,8 @@ dbs:
 			t.Fatalf("Replica[0].URL=%v, want %v", got, want)
 		} else if got, want := config.DBs[0].Replicas[1].URL, ``; got != want {
 			t.Fatalf("Replica[1].URL=%v, want %v", got, want)
+		} else if got, want := config.MCPAuthToken, `secret`; got != want {
+			t.Fatalf("MCPAuthToken=%v, want %v", got, want)
 		}
 	})
 

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -63,13 +63,13 @@ func NewMCP(ctx context.Context, configPath, authToken string) (*MCPServer, erro
 }
 
 func newMCPHandler(mcpServer *mcp.Server, authToken string) http.Handler {
-	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+	transportHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return mcpServer
 	}, &mcp.StreamableHTTPOptions{
 		Stateless:                    true,
 		PropagateRequestCancellation: true,
 	})
-	handler = bearerAuthMiddleware(authToken, handler)
+	authHandler := bearerAuthMiddleware(authToken, transportHandler)
 	protection := http.NewCrossOriginProtection()
 	originHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Origin") != "" {
@@ -80,7 +80,7 @@ func newMCPHandler(mcpServer *mcp.Server, authToken string) http.Handler {
 				return
 			}
 		}
-		handler.ServeHTTP(w, r)
+		authHandler.ServeHTTP(w, r)
 	})
 	return httplog.Logger(protection.Handler(originHandler))
 }

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -27,7 +28,7 @@ type MCPServer struct {
 	configPath string
 }
 
-func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
+func NewMCP(ctx context.Context, configPath, authToken string) (*MCPServer, error) {
 	s := &MCPServer{
 		ctx:        ctx,
 		configPath: configPath,
@@ -56,17 +57,18 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcp.AddTool(mcpServer, resetTool, resetHandler)
 
 	s.mux = http.NewServeMux()
-	s.mux.Handle("/", newMCPHandler(mcpServer))
+	s.mux.Handle("/", newMCPHandler(mcpServer, authToken))
 	return s, nil
 }
 
-func newMCPHandler(mcpServer *mcp.Server) http.Handler {
+func newMCPHandler(mcpServer *mcp.Server, authToken string) http.Handler {
 	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return mcpServer
 	}, &mcp.StreamableHTTPOptions{
 		Stateless:                    true,
 		PropagateRequestCancellation: true,
 	})
+	handler = bearerAuthMiddleware(authToken, handler)
 	protection := http.NewCrossOriginProtection()
 	originHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Origin") != "" {
@@ -80,6 +82,22 @@ func newMCPHandler(mcpServer *mcp.Server) http.Handler {
 		handler.ServeHTTP(w, r)
 	})
 	return httplog.Logger(protection.Handler(originHandler))
+}
+
+func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
+	if token == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme, credential, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare([]byte(credential), []byte(token)) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *MCPServer) Start(addr string) {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"fmt"
 	"log/slog"
@@ -88,10 +89,12 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 	if token == "" {
 		return next
 	}
+	tokenHash := sha256.Sum256([]byte(token))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		scheme, credential, ok := strings.Cut(r.Header.Get("Authorization"), " ")
-		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare([]byte(credential), []byte(token)) != 1 {
+		credentialHash := sha256.Sum256([]byte(credential))
+		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(credentialHash[:], tokenHash[:]) != 1 {
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -93,8 +93,9 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		scheme, credential, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		credential = strings.TrimLeft(credential, " ")
 		credentialHash := sha256.Sum256([]byte(credential))
-		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(credentialHash[:], tokenHash[:]) != 1 {
+		if !ok || credential == "" || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(credentialHash[:], tokenHash[:]) != 1 {
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -99,8 +99,9 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		scheme, credential, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		credential = strings.TrimLeft(credential, " ")
 		credentialHash := sha256.Sum256([]byte(credential))
-		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(credentialHash[:], tokenHash[:]) != 1 {
+		if !ok || credential == "" || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(credentialHash[:], tokenHash[:]) != 1 {
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -94,10 +95,12 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 	if token == "" {
 		return next
 	}
+	tokenHash := sha256.Sum256([]byte(token))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		scheme, credential, ok := strings.Cut(r.Header.Get("Authorization"), " ")
-		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare([]byte(credential), []byte(token)) != 1 {
+		credentialHash := sha256.Sum256([]byte(credential))
+		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare(credentialHash[:], tokenHash[:]) != 1 {
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -33,7 +34,7 @@ type MCPServer struct {
 	configPath string
 }
 
-func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
+func NewMCP(ctx context.Context, configPath, authToken string) (*MCPServer, error) {
 	s := &MCPServer{
 		ctx:        ctx,
 		configPath: configPath,
@@ -62,17 +63,18 @@ func NewMCP(ctx context.Context, configPath string) (*MCPServer, error) {
 	mcp.AddTool(mcpServer, resetTool, resetHandler)
 
 	s.mux = http.NewServeMux()
-	s.mux.Handle("/", newMCPHandler(mcpServer))
+	s.mux.Handle("/", newMCPHandler(mcpServer, authToken))
 	return s, nil
 }
 
-func newMCPHandler(mcpServer *mcp.Server) http.Handler {
+func newMCPHandler(mcpServer *mcp.Server, authToken string) http.Handler {
 	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return mcpServer
 	}, &mcp.StreamableHTTPOptions{
 		Stateless:                    true,
 		PropagateRequestCancellation: true,
 	})
+	handler = bearerAuthMiddleware(authToken, handler)
 	protection := http.NewCrossOriginProtection()
 	originHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Origin") != "" {
@@ -86,6 +88,22 @@ func newMCPHandler(mcpServer *mcp.Server) http.Handler {
 		handler.ServeHTTP(w, r)
 	})
 	return httplog.Logger(protection.Handler(originHandler))
+}
+
+func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
+	if token == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme, credential, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") || subtle.ConstantTimeCompare([]byte(credential), []byte(token)) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *MCPServer) Start(addr string) error {

--- a/cmd/litestream/mcp.go
+++ b/cmd/litestream/mcp.go
@@ -69,13 +69,13 @@ func NewMCP(ctx context.Context, configPath, authToken string) (*MCPServer, erro
 }
 
 func newMCPHandler(mcpServer *mcp.Server, authToken string) http.Handler {
-	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+	transportHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return mcpServer
 	}, &mcp.StreamableHTTPOptions{
 		Stateless:                    true,
 		PropagateRequestCancellation: true,
 	})
-	handler = bearerAuthMiddleware(authToken, handler)
+	authHandler := bearerAuthMiddleware(authToken, transportHandler)
 	protection := http.NewCrossOriginProtection()
 	originHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Origin") != "" {
@@ -86,7 +86,7 @@ func newMCPHandler(mcpServer *mcp.Server, authToken string) http.Handler {
 				return
 			}
 		}
-		handler.ServeHTTP(w, r)
+		authHandler.ServeHTTP(w, r)
 	})
 	return httplog.Logger(protection.Handler(originHandler))
 }

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -259,7 +259,7 @@ func TestMCPServerAbandonedSession(t *testing.T) {
 }
 
 func TestMCPServerCrossOriginProtection(t *testing.T) {
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,11 +324,42 @@ func TestMCPServerCrossOriginProtection(t *testing.T) {
 	}
 }
 
+func TestMCPServerCrossOriginProtectionPrecedesBearerAuth(t *testing.T) {
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		authorization string
+	}{
+		{name: "without credential"},
+		{name: "with correct credential", authorization: "Bearer secret"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := newMCPInitializeRequest(test.authorization)
+			request.Header.Set("Origin", "https://attacker.example")
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			if got, want := response.Code, http.StatusForbidden; got != want {
+				t.Fatalf("status=%d, want %d", got, want)
+			}
+			if got := response.Header().Get("WWW-Authenticate"); got != "" {
+				t.Fatalf("WWW-Authenticate=%q, want empty", got)
+			}
+		})
+	}
+}
+
 func TestMCPServerRequestCancellation(t *testing.T) {
 	handlerStarted := make(chan struct{})
 	handlerCanceled := make(chan error, 1)
 
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -25,7 +25,7 @@ func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
 	setVersion(t, version)
 
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +421,7 @@ func TestMCPToolBehavior(t *testing.T) {
 	setVersion(t, "v1.2.3-mcp-test")
 	installFakeLitestream(t)
 
-	server, err := NewMCP(t.Context(), "/default/litestream.yml")
+	server, err := NewMCP(t.Context(), "/default/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -567,6 +567,49 @@ func TestMCPRecoveryMiddleware(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "panic recovered in tools/call handler: test panic") {
 		t.Fatalf("error=%v, want recovered panic", err)
+	}
+}
+
+func TestMCPServerBearerAuth(t *testing.T) {
+	tests := []struct {
+		name          string
+		token         string
+		authorization string
+		wantStatus    int
+	}{
+		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
+		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
+		{name: "wrong token", token: "secret", authorization: "Bearer wrong", wantStatus: http.StatusUnauthorized},
+		{name: "unset token", wantStatus: http.StatusOK},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, err := NewMCP(t.Context(), "/etc/litestream.yml", test.token)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"v1.0.0"}}}`
+			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Accept", "application/json, text/event-stream")
+			if test.authorization != "" {
+				request.Header.Set("Authorization", test.authorization)
+			}
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			if got := response.Code; got != test.wantStatus {
+				t.Fatalf("status=%d, want %d", got, test.wantStatus)
+			}
+			if test.wantStatus == http.StatusUnauthorized {
+				if got, want := response.Header().Get("WWW-Authenticate"), "Bearer"; got != want {
+					t.Fatalf("WWW-Authenticate=%q, want %q", got, want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -238,7 +238,7 @@ func assertMCPResultCaching(t *testing.T, result map[string]any) {
 }
 
 func TestMCPServerAbandonedSession(t *testing.T) {
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,7 +578,11 @@ func TestMCPServerBearerAuth(t *testing.T) {
 		wantStatus    int
 	}{
 		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
+		{name: "case-insensitive scheme", token: "secret", authorization: "bEaReR secret", wantStatus: http.StatusOK},
+		{name: "authorized with multiple spaces", token: "secret", authorization: "Bearer  secret", wantStatus: http.StatusOK},
 		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
+		{name: "missing credential", token: "secret", authorization: "Bearer", wantStatus: http.StatusUnauthorized},
+		{name: "incorrect scheme", token: "secret", authorization: "Basic secret", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token", token: "secret", authorization: "Bearer wrongx", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token length", token: "secret", authorization: "Bearer incorrect", wantStatus: http.StatusUnauthorized},
 		{name: "unset token", wantStatus: http.StatusOK},
@@ -591,13 +595,7 @@ func TestMCPServerBearerAuth(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"v1.0.0"}}}`
-			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
-			request.Header.Set("Content-Type", "application/json")
-			request.Header.Set("Accept", "application/json, text/event-stream")
-			if test.authorization != "" {
-				request.Header.Set("Authorization", test.authorization)
-			}
+			request := newMCPInitializeRequest(test.authorization)
 			response := httptest.NewRecorder()
 
 			server.ServeHTTP(response, request)
@@ -612,6 +610,75 @@ func TestMCPServerBearerAuth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMCPServerBearerAuthConfig(t *testing.T) {
+	const envName = "LITESTREAM_TEST_MCP_AUTH_TOKEN_MISSING"
+	oldEnv, envSet := os.LookupEnv(envName)
+	if err := os.Unsetenv(envName); err != nil {
+		t.Fatal(err)
+	}
+	if envSet {
+		t.Cleanup(func() {
+			if err := os.Setenv(envName, oldEnv); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+
+	tests := []struct {
+		name       string
+		config     string
+		wantErr    error
+		wantStatus int
+	}{
+		{name: "token absent", wantStatus: http.StatusOK},
+		{name: "token configured", config: "mcp-auth-token: secret\n", wantStatus: http.StatusUnauthorized},
+		{name: "token environment missing", config: "mcp-auth-token: ${" + envName + "}\n", wantErr: ErrInvalidMCPAuthToken},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := ParseConfig(strings.NewReader(test.config), true)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("error=%v, want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			authToken := ""
+			if config.MCPAuthToken != nil {
+				authToken = *config.MCPAuthToken
+			}
+			server, err := NewMCP(t.Context(), "/etc/litestream.yml", authToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			request := newMCPInitializeRequest("")
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, request)
+
+			if got := response.Code; got != test.wantStatus {
+				t.Fatalf("status=%d, want %d", got, test.wantStatus)
+			}
+		})
+	}
+}
+
+func newMCPInitializeRequest(authorization string) *http.Request {
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"v1.0.0"}}}`
+	request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+	return request
 }
 
 func jsonObject(t *testing.T, value any) map[string]any {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -579,7 +579,7 @@ func TestMCPServerBearerAuth(t *testing.T) {
 	}{
 		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
 		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
-		{name: "wrong token", token: "secret", authorization: "Bearer wrong", wantStatus: http.StatusUnauthorized},
+		{name: "wrong token", token: "secret", authorization: "Bearer wrongx", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token length", token: "secret", authorization: "Bearer incorrect", wantStatus: http.StatusUnauthorized},
 		{name: "unset token", wantStatus: http.StatusOK},
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -580,6 +580,7 @@ func TestMCPServerBearerAuth(t *testing.T) {
 		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
 		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token", token: "secret", authorization: "Bearer wrong", wantStatus: http.StatusUnauthorized},
+		{name: "wrong token length", token: "secret", authorization: "Bearer incorrect", wantStatus: http.StatusUnauthorized},
 		{name: "unset token", wantStatus: http.StatusOK},
 	}
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -260,7 +260,7 @@ func TestMCPServerAbandonedSession(t *testing.T) {
 }
 
 func TestMCPServerCrossOriginProtection(t *testing.T) {
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,11 +325,42 @@ func TestMCPServerCrossOriginProtection(t *testing.T) {
 	}
 }
 
+func TestMCPServerCrossOriginProtectionPrecedesBearerAuth(t *testing.T) {
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		authorization string
+	}{
+		{name: "without credential"},
+		{name: "with correct credential", authorization: "Bearer secret"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := newMCPInitializeRequest(test.authorization)
+			request.Header.Set("Origin", "https://attacker.example")
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			if got, want := response.Code, http.StatusForbidden; got != want {
+				t.Fatalf("status=%d, want %d", got, want)
+			}
+			if got := response.Header().Get("WWW-Authenticate"); got != "" {
+				t.Fatalf("WWW-Authenticate=%q, want empty", got)
+			}
+		})
+	}
+}
+
 func TestMCPServerRequestCancellation(t *testing.T) {
 	handlerStarted := make(chan struct{})
 	handlerCanceled := make(chan error, 1)
 
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -666,6 +666,14 @@ func TestMCPServerBearerAuthConfig(t *testing.T) {
 	}{
 		{name: "token absent", wantStatus: http.StatusOK},
 		{name: "token configured", config: "mcp-auth-token: secret\n", wantStatus: http.StatusUnauthorized},
+		{name: "token empty", config: "mcp-auth-token: ''\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token null", config: "mcp-auth-token: null\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token blank", config: "mcp-auth-token: '   '\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token leading space", config: "mcp-auth-token: ' secret'\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token trailing space", config: "mcp-auth-token: 'secret '\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token multiline", config: "mcp-auth-token: |\n  secret\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token control", config: "mcp-auth-token: \"secret\\u0001\"\n", wantErr: ErrInvalidMCPAuthToken},
+		{name: "token unicode space", config: "mcp-auth-token: 'secret\u00a0'\n", wantErr: ErrInvalidMCPAuthToken},
 		{name: "token environment missing", config: "mcp-auth-token: ${" + envName + "}\n", wantErr: ErrInvalidMCPAuthToken},
 	}
 
@@ -675,6 +683,9 @@ func TestMCPServerBearerAuthConfig(t *testing.T) {
 			if test.wantErr != nil {
 				if !errors.Is(err, test.wantErr) {
 					t.Fatalf("error=%v, want %v", err, test.wantErr)
+				}
+				if strings.Contains(err.Error(), "secret") {
+					t.Fatal("validation error exposes the token")
 				}
 				return
 			}
@@ -859,7 +870,7 @@ func setVersion(t *testing.T, version string) {
 
 func TestMCPServerLifecycle(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
-	server, err := NewMCP(ctx, "")
+	server, err := NewMCP(ctx, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -874,7 +885,7 @@ func TestMCPServerLifecycle(t *testing.T) {
 			t.Error(err)
 		}
 	})
-	other, err := NewMCP(ctx, "")
+	other, err := NewMCP(ctx, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -580,7 +580,7 @@ func TestMCPServerBearerAuth(t *testing.T) {
 	}{
 		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
 		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
-		{name: "wrong token", token: "secret", authorization: "Bearer wrong", wantStatus: http.StatusUnauthorized},
+		{name: "wrong token", token: "secret", authorization: "Bearer wrongx", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token length", token: "secret", authorization: "Bearer incorrect", wantStatus: http.StatusUnauthorized},
 		{name: "unset token", wantStatus: http.StatusOK},
 	}

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -239,7 +239,7 @@ func assertMCPResultCaching(t *testing.T, result map[string]any) {
 }
 
 func TestMCPServerAbandonedSession(t *testing.T) {
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,11 @@ func TestMCPServerBearerAuth(t *testing.T) {
 		wantStatus    int
 	}{
 		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
+		{name: "case-insensitive scheme", token: "secret", authorization: "bEaReR secret", wantStatus: http.StatusOK},
+		{name: "authorized with multiple spaces", token: "secret", authorization: "Bearer  secret", wantStatus: http.StatusOK},
 		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
+		{name: "missing credential", token: "secret", authorization: "Bearer", wantStatus: http.StatusUnauthorized},
+		{name: "incorrect scheme", token: "secret", authorization: "Basic secret", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token", token: "secret", authorization: "Bearer wrongx", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token length", token: "secret", authorization: "Bearer incorrect", wantStatus: http.StatusUnauthorized},
 		{name: "unset token", wantStatus: http.StatusOK},
@@ -592,13 +596,7 @@ func TestMCPServerBearerAuth(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"v1.0.0"}}}`
-			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
-			request.Header.Set("Content-Type", "application/json")
-			request.Header.Set("Accept", "application/json, text/event-stream")
-			if test.authorization != "" {
-				request.Header.Set("Authorization", test.authorization)
-			}
+			request := newMCPInitializeRequest(test.authorization)
 			response := httptest.NewRecorder()
 
 			server.ServeHTTP(response, request)
@@ -613,6 +611,75 @@ func TestMCPServerBearerAuth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMCPServerBearerAuthConfig(t *testing.T) {
+	const envName = "LITESTREAM_TEST_MCP_AUTH_TOKEN_MISSING"
+	oldEnv, envSet := os.LookupEnv(envName)
+	if err := os.Unsetenv(envName); err != nil {
+		t.Fatal(err)
+	}
+	if envSet {
+		t.Cleanup(func() {
+			if err := os.Setenv(envName, oldEnv); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+
+	tests := []struct {
+		name       string
+		config     string
+		wantErr    error
+		wantStatus int
+	}{
+		{name: "token absent", wantStatus: http.StatusOK},
+		{name: "token configured", config: "mcp-auth-token: secret\n", wantStatus: http.StatusUnauthorized},
+		{name: "token environment missing", config: "mcp-auth-token: ${" + envName + "}\n", wantErr: ErrInvalidMCPAuthToken},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := ParseConfig(strings.NewReader(test.config), true)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("error=%v, want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			authToken := ""
+			if config.MCPAuthToken != nil {
+				authToken = *config.MCPAuthToken
+			}
+			server, err := NewMCP(t.Context(), "/etc/litestream.yml", authToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			request := newMCPInitializeRequest("")
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, request)
+
+			if got := response.Code; got != test.wantStatus {
+				t.Fatalf("status=%d, want %d", got, test.wantStatus)
+			}
+		})
+	}
+}
+
+func newMCPInitializeRequest(authorization string) *http.Request {
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"v1.0.0"}}}`
+	request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+	return request
 }
 
 func jsonObject(t *testing.T, value any) map[string]any {

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -581,6 +581,7 @@ func TestMCPServerBearerAuth(t *testing.T) {
 		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
 		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
 		{name: "wrong token", token: "secret", authorization: "Bearer wrong", wantStatus: http.StatusUnauthorized},
+		{name: "wrong token length", token: "secret", authorization: "Bearer incorrect", wantStatus: http.StatusUnauthorized},
 		{name: "unset token", wantStatus: http.StatusOK},
 	}
 

--- a/cmd/litestream/mcp_test.go
+++ b/cmd/litestream/mcp_test.go
@@ -26,7 +26,7 @@ func TestMCPServerTools(t *testing.T) {
 	const version = "v1.2.3-mcp-test"
 	setVersion(t, version)
 
-	server, err := NewMCP(t.Context(), "/etc/litestream.yml")
+	server, err := NewMCP(t.Context(), "/etc/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func TestMCPToolBehavior(t *testing.T) {
 	setVersion(t, "v1.2.3-mcp-test")
 	installFakeLitestream(t)
 
-	server, err := NewMCP(t.Context(), "/default/litestream.yml")
+	server, err := NewMCP(t.Context(), "/default/litestream.yml", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -568,6 +568,49 @@ func TestMCPRecoveryMiddleware(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "panic recovered in tools/call handler: test panic") {
 		t.Fatalf("error=%v, want recovered panic", err)
+	}
+}
+
+func TestMCPServerBearerAuth(t *testing.T) {
+	tests := []struct {
+		name          string
+		token         string
+		authorization string
+		wantStatus    int
+	}{
+		{name: "authorized", token: "secret", authorization: "Bearer secret", wantStatus: http.StatusOK},
+		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
+		{name: "wrong token", token: "secret", authorization: "Bearer wrong", wantStatus: http.StatusUnauthorized},
+		{name: "unset token", wantStatus: http.StatusOK},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, err := NewMCP(t.Context(), "/etc/litestream.yml", test.token)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"v1.0.0"}}}`
+			request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Accept", "application/json, text/event-stream")
+			if test.authorization != "" {
+				request.Header.Set("Authorization", test.authorization)
+			}
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			if got := response.Code; got != test.wantStatus {
+				t.Fatalf("status=%d, want %d", got, test.wantStatus)
+			}
+			if test.wantStatus == http.StatusUnauthorized {
+				if got, want := response.Header().Get("WWW-Authenticate"), "Bearer"; got != want {
+					t.Fatalf("WWW-Authenticate=%q, want %q", got, want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -181,7 +181,7 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 
 	// Start MCP server if enabled
 	if c.Config.MCPAddr != "" {
-		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath)
+		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath, c.Config.MCPAuthToken)
 		if err != nil {
 			return err
 		}

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -181,7 +181,11 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 
 	// Start MCP server if enabled
 	if c.Config.MCPAddr != "" {
-		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath, c.Config.MCPAuthToken)
+		authToken := ""
+		if c.Config.MCPAuthToken != nil {
+			authToken = *c.Config.MCPAuthToken
+		}
+		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath, authToken)
 		if err != nil {
 			return err
 		}

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -182,7 +182,7 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 
 	// Start MCP server if enabled
 	if c.Config.MCPAddr != "" {
-		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath)
+		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath, c.Config.MCPAuthToken)
 		if err != nil {
 			return err
 		}

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -182,7 +182,11 @@ func (c *ReplicateCommand) Run(ctx context.Context) (err error) {
 
 	// Start MCP server if enabled
 	if c.Config.MCPAddr != "" {
-		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath, c.Config.MCPAuthToken)
+		authToken := ""
+		if c.Config.MCPAuthToken != nil {
+			authToken = *c.Config.MCPAuthToken
+		}
+		c.MCP, err = NewMCP(ctx, c.Config.ConfigPath, authToken)
 		if err != nil {
 			return err
 		}

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -18,6 +18,10 @@ This file tracks open issues on [benbjohnson/litestream.io](https://github.com/b
 | [#249](https://github.com/benbjohnson/litestream.io/issues/249) | Automatic v0.3.x backup restore | #1074, #1075 | Restore |
 | [#250](https://github.com/benbjohnson/litestream.io/issues/250) | MCP tools for v0.5.x changes | — | MCP |
 
+## MCP HTTP Bearer-Token Authentication
+
+User-facing documentation for #1384 must cover the optional `mcp-auth-token` setting and its environment variable expansion. Omitting the setting leaves the HTTP endpoint unauthenticated, while a configured token that expands to an empty value is invalid. Because bearer tokens sent over plaintext can be intercepted, an authenticated TLS reverse proxy, SSH tunnel, VPN, or private network should remain the primary access control.
+
 ## AI Documentation Status
 
 Internal AI documentation (this repo) is tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106).

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -22,6 +22,8 @@ This file tracks open issues on [benbjohnson/litestream.io](https://github.com/b
 
 User-facing documentation for #1384 must cover the optional `mcp-auth-token` setting and its environment variable expansion. Omitting the setting leaves the HTTP endpoint unauthenticated, while a configured token that expands to an empty value is invalid. Because bearer tokens sent over plaintext can be intercepted, an authenticated TLS reverse proxy, SSH tunnel, VPN, or private network should remain the primary access control.
 
+The token is a pre-shared secret that the operator configures on both the server and client; it is not OAuth, and Litestream provides no authorization discovery. Clients must explicitly send `Authorization: Bearer <token>`. MCP clients that expect automatic authorization discovery cannot connect without manual configuration, and the resulting 401 is expected rather than a bug. Full OAuth resource-server support—including RFC 9728 protected resource metadata, audience validation, and scope challenges—is possible future work and is not provided by this setting.
+
 ## AI Documentation Status
 
 Internal AI documentation (this repo) is tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106).

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -11,6 +11,10 @@ Add a row when a new Litestream feature lands that still needs user-facing docs 
 | Issue | Title | Related Litestream PR | Category |
 |-------|-------|-----------------------|----------|
 
+## MCP HTTP Bearer-Token Authentication
+
+User-facing documentation for #1384 must cover the optional `mcp-auth-token` setting and its environment variable expansion. Omitting the setting leaves the HTTP endpoint unauthenticated, while a configured token that expands to an empty value is invalid. Because bearer tokens sent over plaintext can be intercepted, an authenticated TLS reverse proxy, SSH tunnel, VPN, or private network should remain the primary access control.
+
 ## AI Documentation Status
 
 Internal AI documentation (this repo) was tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106), now closed.

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -13,9 +13,11 @@ Add a row when a new Litestream feature lands that still needs user-facing docs 
 
 ## MCP HTTP Bearer-Token Authentication
 
-User-facing documentation for #1384 must cover the optional `mcp-auth-token` setting and its environment variable expansion. Omitting the setting leaves the HTTP endpoint unauthenticated, while a configured token that expands to an empty value is invalid. Because bearer tokens sent over plaintext can be intercepted, an authenticated TLS reverse proxy, SSH tunnel, VPN, or private network should remain the primary access control.
+User-facing documentation for #1384 must cover the optional `mcp-auth-token` setting and its environment variable expansion. Omitting the setting leaves the HTTP endpoint unauthenticated, while a configured token that expands to an empty value or contains whitespace or control characters is invalid. Because bearer tokens sent over plaintext can be intercepted, an authenticated TLS reverse proxy, SSH tunnel, VPN, or private network should remain the primary access control.
 
 The token is a pre-shared secret that the operator configures on both the server and client; it is not OAuth, and Litestream provides no authorization discovery. Clients must explicitly send `Authorization: Bearer <token>`. MCP clients that expect automatic authorization discovery cannot connect without manual configuration, and the resulting 401 is expected rather than a bug. Full OAuth resource-server support—including RFC 9728 protected resource metadata, audience validation, and scope challenges—is possible future work and is not provided by this setting.
+
+When integrating with the standalone MCP command in #1380, the HTTP command must load and validate `mcp-auth-token` from its selected config and pass it to `NewMCP`. Passing an empty token to resolve the constructor change would silently disable configured authentication. Stdio does not use HTTP bearer authentication.
 
 ## AI Documentation Status
 

--- a/docs/PENDING_USER_DOCS.md
+++ b/docs/PENDING_USER_DOCS.md
@@ -15,6 +15,8 @@ Add a row when a new Litestream feature lands that still needs user-facing docs 
 
 User-facing documentation for #1384 must cover the optional `mcp-auth-token` setting and its environment variable expansion. Omitting the setting leaves the HTTP endpoint unauthenticated, while a configured token that expands to an empty value is invalid. Because bearer tokens sent over plaintext can be intercepted, an authenticated TLS reverse proxy, SSH tunnel, VPN, or private network should remain the primary access control.
 
+The token is a pre-shared secret that the operator configures on both the server and client; it is not OAuth, and Litestream provides no authorization discovery. Clients must explicitly send `Authorization: Bearer <token>`. MCP clients that expect automatic authorization discovery cannot connect without manual configuration, and the resulting 401 is expected rather than a bug. Full OAuth resource-server support—including RFC 9728 protected resource metadata, audience validation, and scope challenges—is possible future work and is not provided by this setting.
+
 ## AI Documentation Status
 
 Internal AI documentation (this repo) was tracked in [#1106](https://github.com/benbjohnson/litestream/issues/1106), now closed.


### PR DESCRIPTION
## Description

Adds optional bearer-token authentication to the MCP Streamable HTTP transport on top of #1378.

- Adds the top-level `mcp-auth-token` configuration setting, including existing YAML environment expansion support.
- Wraps only the official SDK Streamable HTTP handler with bearer authentication.
- Returns `401 Unauthorized` and `WWW-Authenticate: Bearer` for missing or incorrect credentials when configured.
- Preserves the current open HTTP behavior when the token is unset.
- Leaves transport-neutral MCP middleware, and therefore stdio behavior, unchanged.

Example configuration:

```yaml
mcp-addr: "127.0.0.1:3001"
mcp-auth-token: ${LITESTREAM_MCP_AUTH_TOKEN}
```

## Motivation and Context

Before this change, `NewMCP` registered the official SDK HTTP handler directly on the server mux, and `Config` had no MCP authentication setting. Anyone able to reach `mcp-addr` could access tools including the mutating restore and reset operations.

| Configuration/request | Before | After |
|---|---|---|
| Token unset | Open | Open |
| Correct bearer token | Open | `200 OK` |
| Missing or incorrect token | Open | `401 Unauthorized` |

The token is a defense-in-depth option. SSH tunneling, an authenticated TLS reverse proxy, VPN, or private networking remain the primary controls for the MCP endpoint. Bearer tokens should not be sent over an untrusted plaintext connection.

## Scope

**In scope:**

- Optional static bearer authentication for Streamable HTTP.
- Configuration and environment expansion wiring.
- HTTP authorization behavior tests.

**Not in scope:**

- Authentication changes to stdio.
- OAuth or token rotation.
- Changes from sibling MCP branches.

## How Has This Been Tested?

```bash
go test -race -run '^TestMCPServerBearerAuth$' -v ./cmd/litestream/
go test -race -run '^TestReadConfigFile$/^ExpandEnv$' -v ./cmd/litestream/
go test -race ./cmd/litestream/
go vet ./...
pre-commit run --all-files
go test -race ./...
go build -o /tmp/litestream-issue-1374 ./cmd/litestream
go mod verify
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have documented the configuration and retained the primary reverse-proxy/SSH guidance above

## Related

- Stacked on #1378
- Closes #1374
