### PR TITLE
fix(restore): resume follow mode when saved TXID is ahead of latest s…

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -652,8 +652,20 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 				if latestSnapshot.MinTXID > txid {
 					return fmt.Errorf("cannot resume follow mode: saved TXID %s is behind the earliest snapshot (min TXID %s); replica history has been pruned -- delete %s and %s-txid to re-restore", txid, latestSnapshot.MinTXID, opt.OutputPath, opt.OutputPath)
 				}
-				if txid > latestSnapshot.MaxTXID {
-					return fmt.Errorf("cannot resume follow mode: saved TXID %s is ahead of latest snapshot (max TXID %s); delete %s and %s-txid to re-restore", txid, latestSnapshot.MaxTXID, opt.OutputPath, opt.OutputPath)
+
+				// A follow file legitimately runs ahead of the latest snapshot, so bound the check by the newest TXID across all levels.
+				var maxTXID ltx.TXID
+				for level := 0; level <= SnapshotLevel; level++ {
+					info, infoErr := r.MaxLTXFileInfo(ctx, level)
+					if infoErr != nil {
+						return fmt.Errorf("cannot validate saved TXID for crash recovery: %w", infoErr)
+					}
+					if info.MaxTXID > maxTXID {
+						maxTXID = info.MaxTXID
+					}
+				}
+				if txid > maxTXID {
+					return fmt.Errorf("cannot resume follow mode: saved TXID %s is ahead of the replica's latest TXID %s; delete %s and %s-txid to re-restore", txid, maxTXID, opt.OutputPath, opt.OutputPath)
 				}
 			}
 

--- a/replica_test.go
+++ b/replica_test.go
@@ -2490,6 +2490,145 @@ func TestReplica_Restore_Follow_CrashRecovery(t *testing.T) {
 	}
 }
 
+// TestReplica_Restore_Follow_ResumeAheadOfSnapshot resumes a follow file whose saved
+// TXID is ahead of the latest snapshot, which must succeed since the deltas still exist.
+func TestReplica_Restore_Follow_ResumeAheadOfSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	db, sqldb := testingutil.MustOpenDBs(t)
+	defer testingutil.MustCloseDBs(t, db, sqldb)
+
+	c := file.NewReplicaClient(t.TempDir())
+	r := litestream.NewReplicaWithClient(db, c)
+
+	// Replicate several transactions as level-0 deltas (no snapshot).
+	if _, err := sqldb.ExecContext(ctx, `CREATE TABLE test(id INTEGER PRIMARY KEY, value TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 5; i++ {
+		if _, err := sqldb.ExecContext(ctx, `INSERT INTO test VALUES (?, ?)`, i, fmt.Sprintf("v%d", i)); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Sync(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := r.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the follow file, let it catch up, then crash it.
+	outputPath := filepath.Join(t.TempDir(), "follower.db")
+	followCtx, followCancel := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.Restore(followCtx, litestream.RestoreOptions{
+			OutputPath:     outputPath,
+			Follow:         true,
+			FollowInterval: 50 * time.Millisecond,
+		})
+	}()
+
+	var savedTXID ltx.TXID
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cur, err := litestream.ReadTXIDFile(outputPath); err == nil && cur > 1 {
+			savedTXID = cur
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if savedTXID <= 1 {
+		t.Fatalf("follow file did not advance past TXID 1 (saved=%s)", savedTXID)
+	}
+
+	followCancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("initial follow returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial follow did not shut down within timeout")
+	}
+
+	// Add a transaction while the follower is down.
+	if _, err := sqldb.ExecContext(ctx, `INSERT INTO test VALUES (100, 'post-crash')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Put a snapshot marker behind the follow position. Validation reads only its TXID
+	// range, and follow applies from levels 0..8, so the marker's content is never read.
+	snapshotDir := c.LTXLevelDir(litestream.SnapshotLevel)
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(snapshotDir, ltx.FormatFilename(1, 1)), []byte("snapshot-marker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Precondition: the saved TXID is ahead of the latest snapshot.
+	snap, err := r.MaxLTXFileInfo(ctx, litestream.SnapshotLevel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if savedTXID <= snap.MaxTXID {
+		t.Fatalf("precondition: saved TXID %s must be ahead of latest snapshot %s", savedTXID, snap.MaxTXID)
+	}
+
+	// Restart follow mode: must resume and apply the new transaction.
+	followCtx2, followCancel2 := context.WithCancel(ctx)
+	defer followCancel2()
+	errCh2 := make(chan error, 1)
+	go func() {
+		errCh2 <- r.Restore(followCtx2, litestream.RestoreOptions{
+			OutputPath:     outputPath,
+			Follow:         true,
+			FollowInterval: 50 * time.Millisecond,
+		})
+	}()
+
+	var found bool
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		// A rejected resume returns immediately.
+		select {
+		case err := <-errCh2:
+			t.Fatalf("resume ahead of snapshot was rejected: %v", err)
+		default:
+		}
+
+		followerDB := testingutil.MustOpenSQLDB(t, outputPath)
+		var count int
+		err := followerDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM test WHERE value = 'post-crash'`).Scan(&count)
+		followerDB.Close()
+		if err == nil && count > 0 {
+			found = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !found {
+		t.Fatal("resume ahead of snapshot did not apply new data within timeout")
+	}
+
+	followCancel2()
+	select {
+	case err := <-errCh2:
+		if err != nil {
+			t.Fatalf("follow returned error after resume: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("follow did not shut down within timeout after resume")
+	}
+}
+
 func TestReplica_Restore_Follow_NoTXIDFile(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)


### PR DESCRIPTION
## Description

Follow-mode crash-recovery resume validated the saved `-txid` against the latest snapshot's `MaxTXID` and refused to resume when the saved TXID was greater. Compare against the newest TXID across *all* levels instead, so a follow file that is ahead of the last snapshot but still backed by existing deltas resumes correctly. A stale/foreign `-txid` past all replicated data is still rejected; the "behind the earliest snapshot" check is unchanged.

## Motivation and Context

A live follow file continuously applies level-0 deltas past the latest snapshot, while snapshots are only written every `SnapshotInterval` (default 24h). So the saved `-txid` is almost always ahead of the last snapshot, and resume was rejected in the normal case — including `litestream restore -follow` crash recovery — forcing a full re-restore instead of an incremental catch-up.

## How Has This Been Tested?

New regression test `TestReplica_Restore_Follow_ResumeAheadOfSnapshot` (fails before this change with `saved TXID … is ahead of latest snapshot`, passes after):

```
go test -race -run 'TestReplica_Restore_Follow' .
```

All pass locally (full race suite green across all packages; `go fmt`, `go vet`, `goimports`, `staticcheck` on the changed files clean).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
