### PR TITLE
Propagate AWS_SESSION_TOKEN to AWS client

### DIFF
--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -86,6 +86,7 @@ type ReplicaClient struct {
 	// AWS authentication keys.
 	AccessKeyID     string
 	SecretAccessKey string
+	SessionToken    string
 
 	// S3 bucket information
 	Region            string
@@ -226,6 +227,11 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 		client.SecretAccessKey = v
 	} else if v := os.Getenv("LITESTREAM_SECRET_ACCESS_KEY"); v != "" {
 		client.SecretAccessKey = v
+	}
+	if v := os.Getenv("AWS_SESSION_TOKEN"); v != "" {
+		client.SessionToken = v
+	} else if v := os.Getenv("LITESTREAM_SESSION_TOKEN"); v != "" {
+		client.SessionToken = v
 	}
 
 	if endpoint == "" {
@@ -407,7 +413,7 @@ func (c *ReplicaClient) Init(ctx context.Context) (err error) {
 	// - Web Identity Token credentials (for EKS)
 	if c.AccessKeyID != "" && c.SecretAccessKey != "" {
 		configOpts = append(configOpts, config.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(c.AccessKeyID, c.SecretAccessKey, ""),
+			credentials.NewStaticCredentialsProvider(c.AccessKeyID, c.SecretAccessKey, c.SessionToken),
 		))
 	}
 
@@ -588,7 +594,7 @@ func (c *ReplicaClient) findBucketRegion(ctx context.Context, bucket string) (st
 	// Add static credentials if provided
 	if c.AccessKeyID != "" && c.SecretAccessKey != "" {
 		configOpts = append(configOpts, config.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(c.AccessKeyID, c.SecretAccessKey, ""),
+			credentials.NewStaticCredentialsProvider(c.AccessKeyID, c.SecretAccessKey, c.SessionToken),
 		))
 	}
 


### PR DESCRIPTION
## Description
AWS can issue temporary credentials (see [the docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html)). However, the current implementation doesn't pass-through AWS_SESSION_TOKEN, which is required when using temporary credentials.

## Motivation and Context
Since some users may be using AWS temporary credentials, `litestream` should propagate `AWS_SESSION_TOKEN` alongside ACCESS_KEY_ID and SECRET_ACCESS_KEY.

## How Has This Been Tested?
I have tested this in an AWS Lambda that uses temp credentials to provision

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
