### PR TITLE
perf(vfs): batch hydration page fetches

### DIFF
--- a/cmd/litestream-vfs/main_test.go
+++ b/cmd/litestream-vfs/main_test.go
@@ -1002,6 +1002,7 @@ func TestVFS_SortingLargeResultSet(t *testing.T) {
 	}
 
 	seedSortedDataset(t, primary, 25000)
+	forceReplicaSync(t, db)
 	if err := db.Replica.Stop(false); err != nil {
 		t.Fatalf("stop replica: %v", err)
 	}

--- a/vfs.go
+++ b/vfs.go
@@ -4,10 +4,13 @@
 package litestream
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash"
 	"hash/fnv"
 	"io"
 	"log/slog"
@@ -590,7 +593,7 @@ type hydrationLTXKey struct {
 
 type hydrationUpdateGroup struct {
 	info          *ltx.FileInfo
-	updates       map[uint32]ltx.PageIndexElem
+	pageN         int
 	requestedSize int64
 }
 
@@ -601,6 +604,35 @@ func (g *hydrationUpdateGroup) shouldFetchWholeFile() bool {
 type hydrationPage struct {
 	pgno uint32
 	data []byte
+}
+
+type hydrationCountingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (r *hydrationCountingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.n += int64(n)
+	return n, err
+}
+
+type hydrationHashingByteReader struct {
+	r io.ByteReader
+	h hash.Hash64
+	n int64
+	b [1]byte
+}
+
+func (r *hydrationHashingByteReader) ReadByte() (byte, error) {
+	b, err := r.r.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	r.b[0] = b
+	_, _ = r.h.Write(r.b[:])
+	r.n++
+	return b, nil
 }
 
 // NewHydrator creates a new Hydrator instance.
@@ -860,60 +892,73 @@ func (h *Hydrator) applyUpdates(ctx context.Context, updates map[uint32]ltx.Page
 	}
 
 	groups := make(map[hydrationLTXKey]*hydrationUpdateGroup)
-	for pgno, elem := range updates {
+	for _, elem := range updates {
 		key := hydrationLTXKey{level: elem.Level, minTXID: elem.MinTXID, maxTXID: elem.MaxTXID}
 		group := groups[key]
 		if group == nil {
 			group = &hydrationUpdateGroup{
-				info:    infoByKey[key],
-				updates: make(map[uint32]ltx.PageIndexElem),
+				info: infoByKey[key],
 			}
 			groups[key] = group
 		}
-		group.updates[pgno] = elem
+		group.pageN++
 		group.requestedSize += elem.Size
 	}
 
-	for _, group := range groups {
+	for key, group := range groups {
 		if group.shouldFetchWholeFile() {
-			if err := h.applyWholeLTX(ctx, group.info, group.updates); err != nil {
+			if err := h.applyWholeLTX(ctx, key, group, updates); err != nil {
 				return err
 			}
+		}
+	}
+
+	for pgno, elem := range updates {
+		key := hydrationLTXKey{level: elem.Level, minTXID: elem.MinTXID, maxTXID: elem.MaxTXID}
+		if groups[key].shouldFetchWholeFile() {
 			continue
 		}
-
-		for pgno, elem := range group.updates {
-			_, data, err := FetchPage(ctx, h.client, elem.Level, elem.MinTXID, elem.MaxTXID, elem.Offset, elem.Size)
-			if err != nil {
-				return fmt.Errorf("fetch updated page %d: %w", pgno, err)
-			}
-			if err := h.writePages([]hydrationPage{{pgno: pgno, data: data}}); err != nil {
-				return err
-			}
+		_, data, err := FetchPage(ctx, h.client, elem.Level, elem.MinTXID, elem.MaxTXID, elem.Offset, elem.Size)
+		if err != nil {
+			return fmt.Errorf("fetch updated page %d: %w", pgno, err)
+		}
+		if err := h.writePages([]hydrationPage{{pgno: pgno, data: data}}); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func (h *Hydrator) applyWholeLTX(ctx context.Context, info *ltx.FileInfo, updates map[uint32]ltx.PageIndexElem) error {
+func (h *Hydrator) applyWholeLTX(ctx context.Context, key hydrationLTXKey, group *hydrationUpdateGroup, updates map[uint32]ltx.PageIndexElem) error {
+	info := group.info
 	rc, err := h.client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
 	if err != nil {
 		return fmt.Errorf("open ltx file: %w", err)
 	}
 	defer rc.Close()
 
-	dec := ltx.NewDecoder(rc)
+	r := &hydrationCountingReader{r: rc}
+	dec := ltx.NewDecoder(r)
 	if err := dec.DecodeHeader(); err != nil {
 		return fmt.Errorf("decode header: %w", err)
 	}
-	if dec.Header().PageSize != h.pageSize {
-		return fmt.Errorf("ltx page size %d does not match hydration page size %d", dec.Header().PageSize, h.pageSize)
+	hdr := dec.Header()
+	if hdr.PageSize != h.pageSize {
+		return fmt.Errorf("ltx page size %d does not match hydration page size %d", hdr.PageSize, h.pageSize)
 	}
 
-	pending := make(map[uint32]struct{}, len(updates))
-	for pgno := range updates {
-		pending[pgno] = struct{}{}
+	fileHash := ltx.NewHasher()
+	headerData, err := hdr.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal ltx header: %w", err)
+	}
+	_, _ = fileHash.Write(headerData)
+
+	var postApplyChecksum ltx.Checksum
+	pageHash := ltx.NewHasher()
+	if hdr.IsSnapshot() && !hdr.NoChecksum() {
+		postApplyChecksum = ltx.ChecksumFlag
 	}
 
 	batchPageN := hydrationWriteBatchSize / int(h.pageSize)
@@ -922,21 +967,39 @@ func (h *Hydrator) applyWholeLTX(ctx context.Context, info *ltx.FileInfo, update
 	}
 	batch := make([]hydrationPage, 0, batchPageN)
 	data := make([]byte, h.pageSize)
+	matchedPageN := 0
+	var prevPgno uint32
 
 	for {
-		var hdr ltx.PageHeader
-		if err := dec.DecodePage(&hdr, data); err == io.EOF {
+		var pageHdr ltx.PageHeader
+		if err := dec.DecodePage(&pageHdr, data); err == io.EOF {
 			break
 		} else if err != nil {
 			return fmt.Errorf("decode page: %w", err)
 		}
 
-		if _, ok := pending[hdr.Pgno]; !ok {
+		if pageHdr.Pgno <= prevPgno {
+			return fmt.Errorf("out-of-order ltx page numbers: %d,%d", prevPgno, pageHdr.Pgno)
+		}
+		prevPgno = pageHdr.Pgno
+
+		pageHeaderData, err := pageHdr.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("marshal ltx page header: %w", err)
+		}
+		_, _ = fileHash.Write(pageHeaderData)
+		_, _ = fileHash.Write(data)
+		if hdr.IsSnapshot() && !hdr.NoChecksum() && pageHdr.Pgno != hdr.LockPgno() {
+			postApplyChecksum = ltx.ChecksumFlag | (postApplyChecksum ^ ltx.ChecksumPageWithHasher(pageHash, pageHdr.Pgno, data))
+		}
+
+		elem, ok := updates[pageHdr.Pgno]
+		if !ok || (hydrationLTXKey{level: elem.Level, minTXID: elem.MinTXID, maxTXID: elem.MaxTXID}) != key {
 			continue
 		}
 
-		batch = append(batch, hydrationPage{pgno: hdr.Pgno, data: data})
-		delete(pending, hdr.Pgno)
+		batch = append(batch, hydrationPage{pgno: pageHdr.Pgno, data: data})
+		matchedPageN++
 		data = make([]byte, h.pageSize)
 
 		if len(batch) == cap(batch) {
@@ -947,16 +1010,82 @@ func (h *Hydrator) applyWholeLTX(ctx context.Context, info *ltx.FileInfo, update
 		}
 	}
 
-	if err := dec.Close(); err != nil {
-		return fmt.Errorf("close ltx decoder: %w", err)
+	zeroPageHeader, err := (&ltx.PageHeader{}).MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal ltx page block terminator: %w", err)
 	}
-	if len(pending) != 0 {
-		return fmt.Errorf("ltx file missing %d hydration pages", len(pending))
+	_, _ = fileHash.Write(zeroPageHeader)
+
+	if err := validateHydrationLTXTail(r, info.Size, hdr, fileHash, postApplyChecksum); err != nil {
+		return fmt.Errorf("validate ltx tail: %w", err)
+	}
+	if matchedPageN != group.pageN {
+		return fmt.Errorf("ltx file missing %d hydration pages", group.pageN-matchedPageN)
 	}
 	if err := h.writePages(batch); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func validateHydrationLTXTail(r *hydrationCountingReader, fileSize int64, hdr ltx.Header, fileHash hash.Hash64, postApplyChecksum ltx.Checksum) error {
+	br := bufio.NewReader(r)
+	indexReader := &hydrationHashingByteReader{r: br, h: fileHash}
+	for {
+		pgno, err := binary.ReadUvarint(indexReader)
+		if err != nil {
+			return fmt.Errorf("read page index pgno: %w", err)
+		}
+		if pgno == 0 {
+			break
+		}
+		if _, err := binary.ReadUvarint(indexReader); err != nil {
+			return fmt.Errorf("read page index offset: %w", err)
+		}
+		if _, err := binary.ReadUvarint(indexReader); err != nil {
+			return fmt.Errorf("read page index size: %w", err)
+		}
+	}
+
+	var pageIndexSizeData [8]byte
+	if _, err := io.ReadFull(br, pageIndexSizeData[:]); err != nil {
+		return fmt.Errorf("read page index byte size: %w", err)
+	}
+	_, _ = fileHash.Write(pageIndexSizeData[:])
+	if got, want := binary.BigEndian.Uint64(pageIndexSizeData[:]), uint64(indexReader.n); got != want {
+		return fmt.Errorf("page index size=%d, want %d", got, want)
+	}
+
+	var trailerData [ltx.TrailerSize]byte
+	if _, err := io.ReadFull(br, trailerData[:]); err != nil {
+		return fmt.Errorf("read ltx trailer: %w", err)
+	}
+	_, _ = fileHash.Write(trailerData[:ltx.TrailerChecksumOffset])
+
+	var trailer ltx.Trailer
+	if err := trailer.UnmarshalBinary(trailerData[:]); err != nil {
+		return fmt.Errorf("unmarshal ltx trailer: %w", err)
+	}
+	if err := trailer.Validate(hdr); err != nil {
+		return fmt.Errorf("validate ltx trailer: %w", err)
+	}
+	if got, want := ltx.ChecksumFlag|ltx.Checksum(fileHash.Sum64()), trailer.FileChecksum; got != want {
+		return ltx.ErrChecksumMismatch
+	}
+	if hdr.IsSnapshot() && !hdr.NoChecksum() && trailer.PostApplyChecksum != postApplyChecksum {
+		return fmt.Errorf("post-apply checksum in trailer (%s) does not match calculated checksum (%s)", trailer.PostApplyChecksum, postApplyChecksum)
+	}
+
+	var extra [1]byte
+	if _, err := io.ReadFull(br, extra[:]); err == nil {
+		return fmt.Errorf("unexpected data after ltx trailer")
+	} else if err != io.EOF {
+		return fmt.Errorf("read after ltx trailer: %w", err)
+	}
+	if r.n != fileSize {
+		return fmt.Errorf("ltx stream size=%d, want %d", r.n, fileSize)
+	}
 	return nil
 }
 
@@ -1603,10 +1732,12 @@ func (f *VFSFile) ReadAt(p []byte, off int64) (n int, err error) {
 			return n, nil
 		}
 	}
+	hydrator := f.hydrator
+	hydrationCurrent := len(f.pending) == 0 && !f.pendingReplace
 	f.mu.Unlock()
 
-	if f.hydrator != nil && f.hydrator.Complete() {
-		if n, ok, err := f.hydrator.tryReadAt(p, off); ok {
+	if hydrationCurrent && hydrator != nil && hydrator.Complete() {
+		if n, ok, err := hydrator.tryReadAt(p, off); ok {
 			return n, err
 		}
 	}

--- a/vfs.go
+++ b/vfs.go
@@ -34,6 +34,8 @@ const (
 
 	pageFetchRetryAttempts = 6
 	pageFetchRetryDelay    = 15 * time.Millisecond
+
+	hydrationWriteBatchSize = 4 * 1024 * 1024
 )
 
 // ErrConflict is returned when the remote replica has newer transactions than expected.
@@ -566,17 +568,39 @@ type VFSFile struct {
 
 // Hydrator handles background hydration of the database to a local file.
 type Hydrator struct {
-	path       string         // Full path to hydration file
-	persistent bool           // True when file should survive across restarts
-	file       *os.File       // Local database file
-	complete   atomic.Bool    // True when restore completes
-	txid       ltx.TXID       // TXID the hydrated file is at
+	path       string      // Full path to hydration file
+	persistent bool        // True when file should survive across restarts
+	file       *os.File    // Local database file
+	complete   atomic.Bool // True when restore completes
+	txid       ltx.TXID    // TXID the hydrated file is at
+	applyMu    sync.Mutex
 	mu         sync.Mutex     // Protects hydration file writes
 	err        error          // Stores fatal hydration error
 	compactor  *ltx.Compactor // Tracks compaction progress during restore
 	pageSize   uint32         // Page size of the database
 	client     ReplicaClient
 	logger     *slog.Logger
+}
+
+type hydrationLTXKey struct {
+	level   int
+	minTXID ltx.TXID
+	maxTXID ltx.TXID
+}
+
+type hydrationUpdateGroup struct {
+	info          *ltx.FileInfo
+	updates       map[uint32]ltx.PageIndexElem
+	requestedSize int64
+}
+
+func (g *hydrationUpdateGroup) shouldFetchWholeFile() bool {
+	return g.info != nil && g.info.Size > 0 && g.requestedSize >= (g.info.Size+1)/2
+}
+
+type hydrationPage struct {
+	pgno uint32
+	data []byte
 }
 
 // NewHydrator creates a new Hydrator instance.
@@ -810,26 +834,140 @@ func (h *Hydrator) ReadAt(p []byte, off int64) (int, error) {
 
 // ApplyUpdates fetches updated pages and writes them to the hydration file.
 func (h *Hydrator) ApplyUpdates(ctx context.Context, updates map[uint32]ltx.PageIndexElem) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	return h.applyUpdateSet(ctx, updates, nil)
+}
 
+func (h *Hydrator) applyUpdateSet(ctx context.Context, updates map[uint32]ltx.PageIndexElem, infos []*ltx.FileInfo) error {
+	h.applyMu.Lock()
+	defer h.applyMu.Unlock()
+	return h.applyUpdates(ctx, updates, infos)
+}
+
+func (h *Hydrator) applyUpdates(ctx context.Context, updates map[uint32]ltx.PageIndexElem, infos []*ltx.FileInfo) error {
+	infoByKey := make(map[hydrationLTXKey]*ltx.FileInfo, len(infos))
+	for _, info := range infos {
+		infoByKey[hydrationLTXKey{level: info.Level, minTXID: info.MinTXID, maxTXID: info.MaxTXID}] = info
+	}
+
+	groups := make(map[hydrationLTXKey]*hydrationUpdateGroup)
 	for pgno, elem := range updates {
-		_, data, err := FetchPage(ctx, h.client, elem.Level, elem.MinTXID, elem.MaxTXID, elem.Offset, elem.Size)
-		if err != nil {
-			return fmt.Errorf("fetch updated page %d: %w", pgno, err)
+		key := hydrationLTXKey{level: elem.Level, minTXID: elem.MinTXID, maxTXID: elem.MaxTXID}
+		group := groups[key]
+		if group == nil {
+			group = &hydrationUpdateGroup{
+				info:    infoByKey[key],
+				updates: make(map[uint32]ltx.PageIndexElem),
+			}
+			groups[key] = group
+		}
+		group.updates[pgno] = elem
+		group.requestedSize += elem.Size
+	}
+
+	for _, group := range groups {
+		if group.shouldFetchWholeFile() {
+			if err := h.applyWholeLTX(ctx, group.info, group.updates); err != nil {
+				return err
+			}
+			continue
 		}
 
-		off := int64(pgno-1) * int64(h.pageSize)
-		if _, err := h.file.WriteAt(data, off); err != nil {
-			return fmt.Errorf("write updated page %d: %w", pgno, err)
+		for pgno, elem := range group.updates {
+			_, data, err := FetchPage(ctx, h.client, elem.Level, elem.MinTXID, elem.MaxTXID, elem.Offset, elem.Size)
+			if err != nil {
+				return fmt.Errorf("fetch updated page %d: %w", pgno, err)
+			}
+			if err := h.writePages([]hydrationPage{{pgno: pgno, data: data}}); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
 }
 
+func (h *Hydrator) applyWholeLTX(ctx context.Context, info *ltx.FileInfo, updates map[uint32]ltx.PageIndexElem) error {
+	rc, err := h.client.OpenLTXFile(ctx, info.Level, info.MinTXID, info.MaxTXID, 0, 0)
+	if err != nil {
+		return fmt.Errorf("open ltx file: %w", err)
+	}
+	defer rc.Close()
+
+	dec := ltx.NewDecoder(rc)
+	if err := dec.DecodeHeader(); err != nil {
+		return fmt.Errorf("decode header: %w", err)
+	}
+	if dec.Header().PageSize != h.pageSize {
+		return fmt.Errorf("ltx page size %d does not match hydration page size %d", dec.Header().PageSize, h.pageSize)
+	}
+
+	pending := make(map[uint32]struct{}, len(updates))
+	for pgno := range updates {
+		pending[pgno] = struct{}{}
+	}
+
+	batchPageN := hydrationWriteBatchSize / int(h.pageSize)
+	if batchPageN == 0 {
+		batchPageN = 1
+	}
+	batch := make([]hydrationPage, 0, batchPageN)
+	data := make([]byte, h.pageSize)
+
+	for {
+		var hdr ltx.PageHeader
+		if err := dec.DecodePage(&hdr, data); err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("decode page: %w", err)
+		}
+
+		if _, ok := pending[hdr.Pgno]; !ok {
+			continue
+		}
+
+		batch = append(batch, hydrationPage{pgno: hdr.Pgno, data: data})
+		delete(pending, hdr.Pgno)
+		data = make([]byte, h.pageSize)
+
+		if len(batch) == cap(batch) {
+			if err := h.writePages(batch); err != nil {
+				return err
+			}
+			batch = batch[:0]
+		}
+	}
+
+	if err := dec.Close(); err != nil {
+		return fmt.Errorf("close ltx decoder: %w", err)
+	}
+	if len(pending) != 0 {
+		return fmt.Errorf("ltx file missing %d hydration pages", len(pending))
+	}
+	if err := h.writePages(batch); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Hydrator) writePages(pages []hydrationPage) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, page := range pages {
+		off := int64(page.pgno-1) * int64(h.pageSize)
+		if _, err := h.file.WriteAt(page.data, off); err != nil {
+			return fmt.Errorf("write updated page %d: %w", page.pgno, err)
+		}
+	}
+	return nil
+}
+
 // WritePage writes a single page to the hydration file.
 func (h *Hydrator) WritePage(pgno uint32, data []byte) error {
+	h.applyMu.Lock()
+	defer h.applyMu.Unlock()
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -842,6 +980,9 @@ func (h *Hydrator) WritePage(pgno uint32, data []byte) error {
 
 // Truncate truncates the hydration file to the specified size.
 func (h *Hydrator) Truncate(size int64) error {
+	h.applyMu.Lock()
+	defer h.applyMu.Unlock()
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.file.Truncate(size)
@@ -2511,7 +2652,7 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 	newCommit := baseCommit
 	replaceIndex := false
 
-	maxTXID0, idx0, commit0, replace0, err := f.pollLevel(ctx, 0, pos.TXID, baseCommit)
+	maxTXID0, idx0, infos0, commit0, replace0, err := f.pollLevel(ctx, 0, pos.TXID, baseCommit)
 	if err != nil {
 		return fmt.Errorf("poll L0: %w", err)
 	}
@@ -2532,7 +2673,7 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 		}
 	}
 
-	maxTXID1, idx1, commit1, replace1, err := f.pollLevel(ctx, 1, maxTXID1Snapshot, baseCommit)
+	maxTXID1, idx1, infos1, commit1, replace1, err := f.pollLevel(ctx, 1, maxTXID1Snapshot, baseCommit)
 	if err != nil {
 		return fmt.Errorf("poll L1: %w", err)
 	}
@@ -2552,11 +2693,11 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 
 	// Send updates to a pending list if there are active readers.
 	f.mu.Lock()
-	defer f.mu.Unlock()
 
 	if f.targetTime != nil {
 		// Skip applying updates while time travel is active to avoid
 		// overwriting the historical snapshot state.
+		f.mu.Unlock()
 		return nil
 	}
 
@@ -2611,10 +2752,20 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 	f.maxTXID1 = maxTXID1
 	f.logger.Debug("txid updated", "txid", f.pos.TXID.String(), "maxTXID1", f.maxTXID1.String())
 
-	// Apply updates to hydrated file if hydration is complete
-	if f.hydrator != nil && f.hydrator.Complete() && len(combined) > 0 {
-		if err := f.hydrator.ApplyUpdates(f.ctx, combined); err != nil {
-			f.logger.Error("failed to apply updates to hydrated file", "error", err)
+	hydrator := f.hydrator
+	applyHydration := hydrator != nil && hydrator.Complete() && len(combined) > 0
+	if applyHydration {
+		hydrator.applyMu.Lock()
+	}
+	f.mu.Unlock()
+
+	if applyHydration {
+		defer hydrator.applyMu.Unlock()
+		infos := append(infos0, infos1...)
+		if err := hydrator.applyUpdates(ctx, combined, infos); err != nil {
+			hydrator.SetErr(err)
+			hydrator.Disable()
+			return fmt.Errorf("apply updates to hydrated file: %w", err)
 		}
 	}
 
@@ -2623,14 +2774,15 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 
 // pollLevel fetches LTX files for a specific level and returns the highest TXID seen,
 // any index updates, the latest commit value, and if the index should be replaced.
-func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID, baseCommit uint32) (ltx.TXID, map[uint32]ltx.PageIndexElem, uint32, bool, error) {
+func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID, baseCommit uint32) (ltx.TXID, map[uint32]ltx.PageIndexElem, []*ltx.FileInfo, uint32, bool, error) {
 	itr, err := f.client.LTXFiles(ctx, level, prevMaxTXID+1, false)
 	if err != nil {
-		return prevMaxTXID, nil, baseCommit, false, fmt.Errorf("ltx files: %w", err)
+		return prevMaxTXID, nil, nil, baseCommit, false, fmt.Errorf("ltx files: %w", err)
 	}
 	defer func() { _ = itr.Close() }()
 
 	index := make(map[uint32]ltx.PageIndexElem)
+	var infos []*ltx.FileInfo
 	maxTXID := prevMaxTXID
 	lastCommit := baseCommit
 	newCommit := baseCommit
@@ -2647,18 +2799,18 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 				f.logger.Warn("ltx gap detected at L0, deferring to higher levels", "expected", maxTXID+1, "next", info.MinTXID)
 				break
 			}
-			return maxTXID, nil, newCommit, replaceIndex, fmt.Errorf("non-contiguous ltx file: level=%d, current=%s, next=%s-%s", level, maxTXID, info.MinTXID, info.MaxTXID)
+			return maxTXID, nil, infos, newCommit, replaceIndex, fmt.Errorf("non-contiguous ltx file: level=%d, current=%s, next=%s-%s", level, maxTXID, info.MinTXID, info.MaxTXID)
 		}
 
 		f.logger.Debug("new ltx file", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
 
 		idx, err := FetchPageIndex(ctx, f.client, info)
 		if err != nil {
-			return maxTXID, nil, newCommit, replaceIndex, fmt.Errorf("fetch page index: %w", err)
+			return maxTXID, nil, infos, newCommit, replaceIndex, fmt.Errorf("fetch page index: %w", err)
 		}
 		hdr, err := FetchLTXHeader(ctx, f.client, info)
 		if err != nil {
-			return maxTXID, nil, newCommit, replaceIndex, fmt.Errorf("fetch header: %w", err)
+			return maxTXID, nil, infos, newCommit, replaceIndex, fmt.Errorf("fetch header: %w", err)
 		}
 
 		if hdr.Commit < lastCommit {
@@ -2672,10 +2824,11 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 			f.logger.Debug("adding new page index", "page", k, "elem", v)
 			index[k] = v
 		}
+		infos = append(infos, info)
 		maxTXID = info.MaxTXID
 	}
 
-	return maxTXID, index, newCommit, replaceIndex, nil
+	return maxTXID, index, infos, newCommit, replaceIndex, nil
 }
 
 func (f *VFSFile) pageSizeBytes() (uint32, error) {

--- a/vfs.go
+++ b/vfs.go
@@ -573,7 +573,7 @@ type Hydrator struct {
 	file       *os.File    // Local database file
 	complete   atomic.Bool // True when restore completes
 	txid       ltx.TXID    // TXID the hydrated file is at
-	applyMu    sync.Mutex
+	applyMu    sync.RWMutex
 	mu         sync.Mutex     // Protects hydration file writes
 	err        error          // Stores fatal hydration error
 	compactor  *ltx.Compactor // Tracks compaction progress during restore
@@ -830,6 +830,16 @@ func (h *Hydrator) ReadAt(p []byte, off int64) (int, error) {
 	}
 
 	return n, nil
+}
+
+func (h *Hydrator) tryReadAt(p []byte, off int64) (int, bool, error) {
+	if !h.applyMu.TryRLock() {
+		return 0, false, nil
+	}
+	defer h.applyMu.RUnlock()
+
+	n, err := h.ReadAt(p, off)
+	return n, true, err
 }
 
 // ApplyUpdates fetches updated pages and writes them to the hydration file.
@@ -1595,9 +1605,10 @@ func (f *VFSFile) ReadAt(p []byte, off int64) (n int, err error) {
 	}
 	f.mu.Unlock()
 
-	// If hydration complete, read from local file
 	if f.hydrator != nil && f.hydrator.Complete() {
-		return f.hydrator.ReadAt(p, off)
+		if n, ok, err := f.hydrator.tryReadAt(p, off); ok {
+			return n, err
+		}
 	}
 
 	// Check cache (cache is thread-safe)

--- a/vfs.go
+++ b/vfs.go
@@ -687,7 +687,7 @@ func (h *Hydrator) SetComplete() {
 	h.complete.Store(true)
 }
 
-// Disable temporarily disables hydrated reads (used during time travel).
+// Disable disables hydrated reads during time travel or permanently after an apply failure.
 func (h *Hydrator) Disable() {
 	h.complete.Store(false)
 }
@@ -864,16 +864,6 @@ func (h *Hydrator) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
-func (h *Hydrator) tryReadAt(p []byte, off int64) (int, bool, error) {
-	if !h.applyMu.TryRLock() {
-		return 0, false, nil
-	}
-	defer h.applyMu.RUnlock()
-
-	n, err := h.ReadAt(p, off)
-	return n, true, err
-}
-
 // ApplyUpdates fetches updated pages and writes them to the hydration file.
 func (h *Hydrator) ApplyUpdates(ctx context.Context, updates map[uint32]ltx.PageIndexElem) error {
 	return h.applyUpdateSet(ctx, updates, nil)
@@ -944,6 +934,9 @@ func (h *Hydrator) applyWholeLTX(ctx context.Context, key hydrationLTXKey, group
 		return fmt.Errorf("decode header: %w", err)
 	}
 	hdr := dec.Header()
+	if hdr.MinTXID != info.MinTXID || hdr.MaxTXID != info.MaxTXID {
+		return fmt.Errorf("ltx transaction range %s-%s does not match requested %s-%s", hdr.MinTXID, hdr.MaxTXID, info.MinTXID, info.MaxTXID)
+	}
 	if hdr.PageSize != h.pageSize {
 		return fmt.Errorf("ltx page size %d does not match hydration page size %d", hdr.PageSize, h.pageSize)
 	}
@@ -1733,13 +1726,13 @@ func (f *VFSFile) ReadAt(p []byte, off int64) (n int, err error) {
 		}
 	}
 	hydrator := f.hydrator
-	hydrationCurrent := len(f.pending) == 0 && !f.pendingReplace
+	hydrationReadLocked := len(f.pending) == 0 && !f.pendingReplace &&
+		hydrator != nil && hydrator.Complete() && hydrator.applyMu.TryRLock()
 	f.mu.Unlock()
 
-	if hydrationCurrent && hydrator != nil && hydrator.Complete() {
-		if n, ok, err := hydrator.tryReadAt(p, off); ok {
-			return n, err
-		}
+	if hydrationReadLocked {
+		defer hydrator.applyMu.RUnlock()
+		return hydrator.ReadAt(p, off)
 	}
 
 	// Check cache (cache is thread-safe)

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -113,6 +113,69 @@ func TestVFSFile_PendingIndexIsolation(t *testing.T) {
 	}
 }
 
+func TestVFSFile_Hydration_PendingIndexIsolation(t *testing.T) {
+	client := newMockReplicaClient()
+	client.addFixture(t, buildLTXFixtureWithPages(t, 1, 4096, []uint32{1, 2}, 'a'))
+
+	f := NewVFSFile(client, "test.db", slog.Default())
+	f.hydrationPath = filepath.Join(t.TempDir(), "hydration.db")
+	f.PollInterval = time.Hour
+	if err := f.Open(); err != nil {
+		t.Fatalf("open vfs file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for !f.hydrator.Complete() {
+		select {
+		case <-deadline.C:
+			t.Fatal("hydration did not complete")
+		case <-ticker.C:
+		}
+	}
+
+	if err := f.Lock(sqlite3vfs.LockShared); err != nil {
+		t.Fatalf("lock shared: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		t.Fatalf("read before poll: %v", err)
+	}
+	if buf[0] != 'a' {
+		t.Fatalf("read before poll=%q, want %q", buf[0], 'a')
+	}
+
+	client.addFixture(t, buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2}, 'b'))
+	if err := f.pollReplicaClient(t.Context()); err != nil {
+		t.Fatalf("poll replica: %v", err)
+	}
+
+	if _, err := f.ReadAt(buf, 4096); err != nil {
+		t.Fatalf("read during shared lock: %v", err)
+	}
+	if buf[0] != 'a' {
+		t.Fatalf("read during shared lock=%q, want %q", buf[0], 'a')
+	}
+
+	if err := f.Unlock(sqlite3vfs.LockNone); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+	if _, err := f.ReadAt(buf, 4096); err != nil {
+		t.Fatalf("read after unlock: %v", err)
+	}
+	if buf[0] != 'b' {
+		t.Fatalf("read after unlock=%q, want %q", buf[0], 'b')
+	}
+}
+
 func TestVFSFile_PendingIndexRace(t *testing.T) {
 	client := newMockReplicaClient()
 	client.addFixture(t, buildLTXFixture(t, 1, 'a'))
@@ -856,6 +919,18 @@ type failingWholeOpenReplicaClient struct {
 	err  error
 }
 
+type boundedWholeReadReplicaClient struct {
+	*mockReplicaClient
+	maxReadSize int
+	largestRead atomic.Int64
+}
+
+type boundedReadCloser struct {
+	io.ReadCloser
+	maxReadSize int
+	largestRead *atomic.Int64
+}
+
 type countingReplicaClient struct {
 	calls atomic.Uint64
 }
@@ -991,6 +1066,30 @@ func (c *failingWholeOpenReplicaClient) OpenLTXFile(ctx context.Context, level i
 		return nil, c.err
 	}
 	return c.mockReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+}
+
+func (c *boundedWholeReadReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	rc, err := c.mockReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+	if err != nil {
+		return nil, err
+	}
+	if offset != 0 || size != 0 {
+		return rc, nil
+	}
+	return &boundedReadCloser{ReadCloser: rc, maxReadSize: c.maxReadSize, largestRead: &c.largestRead}, nil
+}
+
+func (r *boundedReadCloser) Read(p []byte) (int, error) {
+	n := int64(len(p))
+	for current := r.largestRead.Load(); n > current; current = r.largestRead.Load() {
+		if r.largestRead.CompareAndSwap(current, n) {
+			break
+		}
+	}
+	if len(p) > r.maxReadSize {
+		return 0, fmt.Errorf("read buffer size %d exceeds limit %d", len(p), r.maxReadSize)
+	}
+	return r.ReadCloser.Read(p)
 }
 
 func (c *blockingReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
@@ -1314,6 +1413,94 @@ func TestHydrator_ApplyUpdates_WholeFile(t *testing.T) {
 	}
 	if !bytes.Equal(buf, bytes.Repeat([]byte{'x'}, 4096)) {
 		t.Fatalf("excluded page was overwritten")
+	}
+}
+
+func TestHydrator_ApplyUpdates_WholeFileTruncatedTail(t *testing.T) {
+	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'g')
+	baseClient := newMockReplicaClient()
+	baseClient.addFixture(t, fixture)
+	index, err := FetchPageIndex(t.Context(), baseClient, fixture.info)
+	if err != nil {
+		t.Fatalf("fetch page index: %v", err)
+	}
+
+	var pageBlockEnd int64
+	for _, elem := range index {
+		if end := elem.Offset + elem.Size; end > pageBlockEnd {
+			pageBlockEnd = end
+		}
+	}
+	truncatedSize := pageBlockEnd + ltx.PageHeaderSize + 4
+	if truncatedSize >= int64(len(fixture.data)) {
+		t.Fatalf("truncated size=%d, fixture size=%d", truncatedSize, len(fixture.data))
+	}
+
+	client := newMockReplicaClient()
+	client.addFixture(t, &ltxFixture{
+		info: fixture.info,
+		data: append([]byte(nil), fixture.data[:truncatedSize]...),
+	})
+	h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+	if err := h.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	if err := h.applyUpdateSet(t.Context(), index, []*ltx.FileInfo{fixture.info}); err == nil {
+		t.Fatal("expected truncated tail error")
+	}
+}
+
+func TestHydrator_ApplyUpdates_WholeFileBoundedTailRead(t *testing.T) {
+	const maxReadSize = 16 * 1024
+
+	pgnos := make([]uint32, 16384)
+	for i := range pgnos {
+		pgnos[i] = uint32(i + 1)
+	}
+	fixture := buildLTXFixtureWithPages(t, 2, 512, pgnos, 'g')
+	baseClient := newMockReplicaClient()
+	baseClient.addFixture(t, fixture)
+	index, err := FetchPageIndex(t.Context(), baseClient, fixture.info)
+	if err != nil {
+		t.Fatalf("fetch page index: %v", err)
+	}
+
+	var pageBlockEnd int64
+	for _, elem := range index {
+		if end := elem.Offset + elem.Size; end > pageBlockEnd {
+			pageBlockEnd = end
+		}
+	}
+	tailSize := fixture.info.Size - pageBlockEnd - ltx.PageHeaderSize
+	if tailSize <= maxReadSize {
+		t.Fatalf("tail size=%d, want greater than %d", tailSize, maxReadSize)
+	}
+
+	client := &boundedWholeReadReplicaClient{
+		mockReplicaClient: baseClient,
+		maxReadSize:       maxReadSize,
+	}
+	h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 512, client, slog.Default())
+	if err := h.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	if err := h.applyUpdateSet(t.Context(), index, []*ltx.FileInfo{fixture.info}); err != nil {
+		t.Fatalf("apply updates: %v", err)
+	}
+	if got := client.largestRead.Load(); got > maxReadSize {
+		t.Fatalf("largest read=%d, want at most %d", got, maxReadSize)
 	}
 }
 

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -1416,6 +1416,48 @@ func TestHydrator_ApplyUpdates_WholeFile(t *testing.T) {
 	}
 }
 
+func TestHydrator_ApplyUpdates_WholeFileTXIDMismatch(t *testing.T) {
+	object := buildLTXFixtureWithPages(t, 3, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'x')
+	for _, tt := range []struct {
+		name    string
+		minTXID ltx.TXID
+		maxTXID ltx.TXID
+	}{
+		{name: "min", minTXID: 2, maxTXID: 3},
+		{name: "max", minTXID: 3, maxTXID: 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockReplicaClient()
+			info := *object.info
+			info.MinTXID = tt.minTXID
+			info.MaxTXID = tt.maxTXID
+			client.data[client.key(&info)] = object.data
+
+			index, err := FetchPageIndex(t.Context(), client, &info)
+			if err != nil {
+				t.Fatalf("fetch page index: %v", err)
+			}
+
+			h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+			if err := h.Init(); err != nil {
+				t.Fatalf("init: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := h.Close(); err != nil {
+					t.Errorf("close: %v", err)
+				}
+			})
+
+			err = h.applyUpdateSet(t.Context(), index, []*ltx.FileInfo{&info})
+			want := fmt.Sprintf("ltx transaction range %s-%s does not match requested %s-%s",
+				object.info.MinTXID, object.info.MaxTXID, info.MinTXID, info.MaxTXID)
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("apply error=%v", err)
+			}
+		})
+	}
+}
+
 func TestHydrator_ApplyUpdates_WholeFileTruncatedTail(t *testing.T) {
 	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'g')
 	baseClient := newMockReplicaClient()

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -850,6 +850,12 @@ type blockingOpenReplicaClient struct {
 	release chan struct{}
 }
 
+type failingWholeOpenReplicaClient struct {
+	*mockReplicaClient
+	fail atomic.Bool
+	err  error
+}
+
 type countingReplicaClient struct {
 	calls atomic.Uint64
 }
@@ -976,6 +982,13 @@ func (c *blockingOpenReplicaClient) OpenLTXFile(ctx context.Context, level int, 
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
+	}
+	return c.mockReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+}
+
+func (c *failingWholeOpenReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	if offset == 0 && size == 0 && c.fail.Load() {
+		return nil, c.err
 	}
 	return c.mockReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
 }
@@ -1304,6 +1317,49 @@ func TestHydrator_ApplyUpdates_WholeFile(t *testing.T) {
 	}
 }
 
+func TestHydrator_ApplyUpdates_WholeFileBeyondLockPage(t *testing.T) {
+	client := newMockReplicaClient()
+	pgno := ltx.LockPgno(4096) + 1
+	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, pgno}, 'n')
+	client.addFixture(t, fixture)
+
+	index, err := FetchPageIndex(t.Context(), client, fixture.info)
+	if err != nil {
+		t.Fatalf("fetch page index: %v", err)
+	}
+	client.openCount.Store(0)
+	client.wholeOpenCount.Store(0)
+
+	h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+	if err := h.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	if err := h.applyUpdateSet(t.Context(), index, []*ltx.FileInfo{fixture.info}); err != nil {
+		t.Fatalf("apply updates: %v", err)
+	}
+	if got, want := client.openCount.Load(), uint64(1); got != want {
+		t.Fatalf("open count=%d, want %d", got, want)
+	}
+	if got, want := client.wholeOpenCount.Load(), uint64(1); got != want {
+		t.Fatalf("whole open count=%d, want %d", got, want)
+	}
+
+	buf := make([]byte, 4096)
+	off := int64(pgno-1) * 4096
+	if _, err := h.ReadAt(buf, off); err != nil {
+		t.Fatalf("read page beyond lock page: %v", err)
+	}
+	if !bytes.Equal(buf, bytes.Repeat([]byte{'n'}, 4096)) {
+		t.Fatal("page beyond lock page data mismatch")
+	}
+}
+
 func TestHydrator_ApplyUpdates_SparseFile(t *testing.T) {
 	client := newMockReplicaClient()
 	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'h')
@@ -1454,10 +1510,11 @@ func TestVFSFile_Hydration_ReadDuringIncrementalFetch(t *testing.T) {
 		t.Fatal("poll did not start hydration fetch")
 	}
 
+	readData := make([]byte, 4096)
 	readErr := make(chan error, 1)
 	off := int64(pgnos[len(pgnos)-1]-1) * 4096
 	go func() {
-		_, err := f.ReadAt(make([]byte, 4096), off)
+		_, err := f.ReadAt(readData, off)
 		readErr <- err
 	}()
 
@@ -1468,6 +1525,9 @@ func TestVFSFile_Hydration_ReadDuringIncrementalFetch(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("read blocked during hydration fetch")
+	}
+	if !bytes.Equal(readData, bytes.Repeat([]byte{'k'}, 4096)) {
+		t.Fatal("read during hydration fetch returned stale data")
 	}
 
 	close(client.release)
@@ -1484,6 +1544,65 @@ func TestVFSFile_Hydration_ReadDuringIncrementalFetch(t *testing.T) {
 	}
 	if got, want := client.wholeOpenCount.Load(), uint64(1); got != want {
 		t.Fatalf("whole open count=%d, want %d", got, want)
+	}
+}
+
+func TestVFSFile_Hydration_ApplyFailureFallsBackToRemote(t *testing.T) {
+	baseClient := newMockReplicaClient()
+	pgnos := make([]uint32, 2048)
+	for i := range pgnos {
+		pgnos[i] = uint32(i + 1)
+	}
+	baseClient.addFixture(t, buildLTXFixtureWithPages(t, 1, 4096, pgnos, 'l'))
+	openErr := errors.New("whole file unavailable")
+	client := &failingWholeOpenReplicaClient{
+		mockReplicaClient: baseClient,
+		err:               openErr,
+	}
+
+	f := NewVFSFile(client, "test.db", slog.Default())
+	f.hydrationPath = filepath.Join(t.TempDir(), "hydration.db")
+	f.PollInterval = time.Hour
+	if err := f.Open(); err != nil {
+		t.Fatalf("open vfs file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for !f.hydrator.Complete() {
+		select {
+		case <-deadline.C:
+			t.Fatal("hydration did not complete")
+		case <-ticker.C:
+		}
+	}
+
+	baseClient.addFixture(t, buildLTXFixtureWithPages(t, 2, 4096, pgnos, 'm'))
+	client.fail.Store(true)
+	if err := f.pollReplicaClient(f.ctx); !errors.Is(err, openErr) {
+		t.Fatalf("poll error=%v, want %v", err, openErr)
+	}
+	if f.hydrator.Complete() {
+		t.Fatal("hydrated reads remained enabled after apply failure")
+	}
+	if err := f.hydrator.Err(); !errors.Is(err, openErr) {
+		t.Fatalf("hydration error=%v, want %v", err, openErr)
+	}
+
+	buf := make([]byte, 4096)
+	off := int64(pgnos[len(pgnos)-1]-1) * 4096
+	if _, err := f.ReadAt(buf, off); err != nil {
+		t.Fatalf("read remote fallback: %v", err)
+	}
+	if !bytes.Equal(buf, bytes.Repeat([]byte{'m'}, 4096)) {
+		t.Fatal("remote fallback data mismatch")
 	}
 }
 

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -828,9 +828,11 @@ func TestVFSFile_PollingCancelsBlockedLTXFiles(t *testing.T) {
 
 // mockReplicaClient implements ReplicaClient for deterministic LTX fixtures.
 type mockReplicaClient struct {
-	mu    sync.Mutex
-	files []*ltx.FileInfo
-	data  map[string][]byte
+	mu             sync.Mutex
+	files          []*ltx.FileInfo
+	data           map[string][]byte
+	openCount      atomic.Uint64
+	wholeOpenCount atomic.Uint64
 }
 
 type blockingReplicaClient struct {
@@ -841,6 +843,13 @@ type blockingReplicaClient struct {
 	once      sync.Once
 }
 
+type blockingOpenReplicaClient struct {
+	*mockReplicaClient
+	block   atomic.Bool
+	started chan struct{}
+	release chan struct{}
+}
+
 type countingReplicaClient struct {
 	calls atomic.Uint64
 }
@@ -848,6 +857,8 @@ type countingReplicaClient struct {
 func newCountingReplicaClient() *countingReplicaClient { return &countingReplicaClient{} }
 
 func (c *countingReplicaClient) Type() string { return "count" }
+
+func (c *countingReplicaClient) SetLogger(*slog.Logger) {}
 
 func (c *countingReplicaClient) Init(context.Context) error { return nil }
 
@@ -881,6 +892,8 @@ func newBlockingReplicaClient() *blockingReplicaClient {
 
 func (c *mockReplicaClient) Type() string { return "mock" }
 
+func (c *mockReplicaClient) SetLogger(*slog.Logger) {}
+
 func (c *mockReplicaClient) Init(context.Context) error { return nil }
 
 func (c *mockReplicaClient) addFixture(tb testing.TB, fx *ltxFixture) {
@@ -904,6 +917,10 @@ func (c *mockReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TX
 }
 
 func (c *mockReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	c.openCount.Add(1)
+	if offset == 0 && size == 0 {
+		c.wholeOpenCount.Add(1)
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	key := c.makeKey(level, minTXID, maxTXID)
@@ -948,6 +965,18 @@ func (c *blockingReplicaClient) LTXFiles(ctx context.Context, level int, seek lt
 }
 
 func (c *blockingReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	return c.mockReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+}
+
+func (c *blockingOpenReplicaClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	if offset == 0 && size == 0 && c.block.CompareAndSwap(true, false) {
+		close(c.started)
+		select {
+		case <-c.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return c.mockReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
 }
 
@@ -1215,6 +1244,246 @@ func TestVFSFile_Hydration_IncrementalUpdates(t *testing.T) {
 		if buf[i] != 'f' {
 			t.Fatalf("expected byte 'f' at position %d, got %q", i, buf[i])
 		}
+	}
+}
+
+func TestHydrator_ApplyUpdates_WholeFile(t *testing.T) {
+	client := newMockReplicaClient()
+	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'g')
+	client.addFixture(t, fixture)
+
+	index, err := FetchPageIndex(t.Context(), client, fixture.info)
+	if err != nil {
+		t.Fatalf("fetch page index: %v", err)
+	}
+	updates := make(map[uint32]ltx.PageIndexElem)
+	for pgno := uint32(1); pgno <= 7; pgno++ {
+		updates[pgno] = index[pgno]
+	}
+	client.openCount.Store(0)
+	client.wholeOpenCount.Store(0)
+
+	h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+	if err := h.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	for pgno := uint32(1); pgno <= 8; pgno++ {
+		if err := h.WritePage(pgno, bytes.Repeat([]byte{'x'}, 4096)); err != nil {
+			t.Fatalf("write page %d: %v", pgno, err)
+		}
+	}
+
+	if err := h.applyUpdateSet(t.Context(), updates, []*ltx.FileInfo{fixture.info}); err != nil {
+		t.Fatalf("apply updates: %v", err)
+	}
+	if got, want := client.openCount.Load(), uint64(1); got != want {
+		t.Fatalf("open count=%d, want %d", got, want)
+	}
+	if got, want := client.wholeOpenCount.Load(), uint64(1); got != want {
+		t.Fatalf("whole open count=%d, want %d", got, want)
+	}
+
+	buf := make([]byte, 4096)
+	if _, err := h.ReadAt(buf, 6*4096); err != nil {
+		t.Fatalf("read updated page: %v", err)
+	}
+	if !bytes.Equal(buf, bytes.Repeat([]byte{'g'}, 4096)) {
+		t.Fatalf("updated page data mismatch")
+	}
+	if _, err := h.ReadAt(buf, 7*4096); err != nil {
+		t.Fatalf("read excluded page: %v", err)
+	}
+	if !bytes.Equal(buf, bytes.Repeat([]byte{'x'}, 4096)) {
+		t.Fatalf("excluded page was overwritten")
+	}
+}
+
+func TestHydrator_ApplyUpdates_SparseFile(t *testing.T) {
+	client := newMockReplicaClient()
+	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'h')
+	client.addFixture(t, fixture)
+
+	index, err := FetchPageIndex(t.Context(), client, fixture.info)
+	if err != nil {
+		t.Fatalf("fetch page index: %v", err)
+	}
+	updates := map[uint32]ltx.PageIndexElem{2: index[2]}
+	client.openCount.Store(0)
+	client.wholeOpenCount.Store(0)
+
+	h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+	if err := h.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	if err := h.ApplyUpdates(t.Context(), updates); err != nil {
+		t.Fatalf("apply updates: %v", err)
+	}
+	if got, want := client.openCount.Load(), uint64(1); got != want {
+		t.Fatalf("open count=%d, want %d", got, want)
+	}
+	if got := client.wholeOpenCount.Load(); got != 0 {
+		t.Fatalf("whole open count=%d, want 0", got)
+	}
+}
+
+func TestHydrator_ApplyUpdates_ReadDuringFetch(t *testing.T) {
+	baseClient := newMockReplicaClient()
+	fixture := buildLTXFixtureWithPages(t, 2, 4096, []uint32{1, 2, 3, 4, 5, 6, 7, 8}, 'i')
+	baseClient.addFixture(t, fixture)
+
+	index, err := FetchPageIndex(t.Context(), baseClient, fixture.info)
+	if err != nil {
+		t.Fatalf("fetch page index: %v", err)
+	}
+
+	client := &blockingOpenReplicaClient{
+		mockReplicaClient: baseClient,
+		started:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+	if err := h.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+	if err := h.WritePage(1, bytes.Repeat([]byte{'x'}, 4096)); err != nil {
+		t.Fatalf("write page: %v", err)
+	}
+
+	client.block.Store(true)
+	applyErr := make(chan error, 1)
+	go func() {
+		applyErr <- h.applyUpdateSet(t.Context(), index, []*ltx.FileInfo{fixture.info})
+	}()
+
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("apply did not start remote fetch")
+	}
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := h.ReadAt(make([]byte, 4096), 0)
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		if err != nil {
+			t.Fatalf("read during fetch: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("read blocked during remote fetch")
+	}
+
+	close(client.release)
+	if err := <-applyErr; err != nil {
+		t.Fatalf("apply updates: %v", err)
+	}
+}
+
+func TestVFSFile_Hydration_ReadDuringIncrementalFetch(t *testing.T) {
+	baseClient := newMockReplicaClient()
+	pgnos := make([]uint32, 2048)
+	for i := range pgnos {
+		pgnos[i] = uint32(i + 1)
+	}
+	initial := buildLTXFixtureWithPages(t, 1, 4096, pgnos, 'j')
+	if initial.info.Size <= DefaultEstimatedPageIndexSize {
+		t.Fatalf("fixture size=%d, want greater than %d", initial.info.Size, DefaultEstimatedPageIndexSize)
+	}
+	baseClient.addFixture(t, initial)
+	client := &blockingOpenReplicaClient{
+		mockReplicaClient: baseClient,
+		started:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+
+	f := NewVFSFile(client, "test.db", slog.Default())
+	f.hydrationPath = filepath.Join(t.TempDir(), "hydration.db")
+	f.PollInterval = time.Hour
+	if err := f.Open(); err != nil {
+		t.Fatalf("open vfs file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	})
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for !f.hydrator.Complete() {
+		select {
+		case <-deadline.C:
+			t.Fatal("hydration did not complete")
+		case <-ticker.C:
+		}
+	}
+
+	client.wholeOpenCount.Store(0)
+	baseClient.addFixture(t, buildLTXFixtureWithPages(t, 2, 4096, pgnos, 'k'))
+	client.block.Store(true)
+	pollErr := make(chan error, 1)
+	go func() {
+		pollErr <- f.pollReplicaClient(f.ctx)
+	}()
+
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("poll did not start hydration fetch")
+	}
+
+	readErr := make(chan error, 1)
+	off := int64(pgnos[len(pgnos)-1]-1) * 4096
+	go func() {
+		_, err := f.ReadAt(make([]byte, 4096), off)
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		if err != nil {
+			t.Fatalf("read during fetch: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("read blocked during hydration fetch")
+	}
+
+	close(client.release)
+	if err := <-pollErr; err != nil {
+		t.Fatalf("poll replica client: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	if _, err := f.ReadAt(buf, off); err != nil {
+		t.Fatalf("read updated page: %v", err)
+	}
+	if !bytes.Equal(buf, bytes.Repeat([]byte{'k'}, 4096)) {
+		t.Fatal("updated page data mismatch")
+	}
+	if got, want := client.wholeOpenCount.Load(), uint64(1); got != want {
+		t.Fatalf("whole open count=%d, want %d", got, want)
 	}
 }
 

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -37,6 +37,8 @@ func newWriteTestReplicaClient() *writeTestReplicaClient {
 
 func (c *writeTestReplicaClient) Type() string { return "test" }
 
+func (c *writeTestReplicaClient) SetLogger(*slog.Logger) {}
+
 func (c *writeTestReplicaClient) Init(ctx context.Context) error { return nil }
 
 func (c *writeTestReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error) {


### PR DESCRIPTION
## Description
Groups steady-state hydration winners by source LTX file and switches dense groups to one whole-file stream when winner ranges cover at least half of the file. The stream decodes every page but applies only current winners in bounded 4 MiB write batches.

Sparse groups retain per-page ranged reads. Remote I/O runs outside the hydrated-read and VFS state mutexes, while a separate apply mutex preserves ordering with local writes and truncation. Apply failures now disable hydrated reads and return the error so the VFS falls back to remote data instead of serving a partially applied file.

The tagged root VFS test doubles also implement the current `ReplicaClient.SetLogger` contract so the regression suite compiles.

## Motivation and Context
The existing steady-state path performs one ranged object request per winning page while holding locks needed by hydrated reads. The issue report measured 13,904 object requests for 23 LTX files (about 600 requests per file), roughly 21 serialized fetches per second against a workload producing about 390 changed pages per second, and only 2 reader queries completing in 11 minutes.

A focused baseline fixture confirmed 8 remote opens for 8 dense winners before this change. The regression now asserts one whole-file open for the same dense shape, while a sparse one-page winner still uses exactly one ranged open and does not fetch the whole file.

Fixes #1387

## How Has This Been Tested?
- `go test -race ./...`
- `go test -race -tags=vfs -count=1 .`
- `go test -tags=vfs ./cmd/litestream-vfs`
- `go vet ./...`
- `pre-commit run --all-files`

The VFS regressions also block the whole-file request deliberately and verify reads complete while network I/O is in progress, excluded pages are not overwritten, and dense updates issue exactly one whole-file request.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
