### PR TITLE
fix(ci): stabilize nightly workflow

### DIFF
--- a/.github/scripts/nightly-stability-jobs.js
+++ b/.github/scripts/nightly-stability-jobs.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const failedConclusions = new Set([
+  'failure',
+  'neutral',
+  'timed_out',
+  'action_required',
+  'cancelled',
+  'stale',
+  'startup_failure',
+]);
+const successfulConclusions = new Set(['success', 'skipped']);
+
+function classifyJobs(jobs) {
+  if (!Array.isArray(jobs)) {
+    return [malformedFailure(0, null, ['jobs response must be an array'])];
+  }
+
+  const failures = [];
+  let monitoredJobCount = 0;
+
+  jobs.forEach((job, index) => {
+    if (!isRecord(job)) {
+      failures.push(malformedFailure(index, job, ['job must be an object']));
+      return;
+    }
+    if (job.name === 'Notify on Failure') {
+      return;
+    }
+
+    monitoredJobCount += 1;
+    const problems = validateJob(job);
+    if (problems.length > 0) {
+      failures.push(malformedFailure(index, job, problems));
+      return;
+    }
+
+    if (successfulConclusions.has(job.conclusion)) {
+      return;
+    }
+    if (!failedConclusions.has(job.conclusion)) {
+      failures.push(malformedFailure(index, job, [`unsupported conclusion ${JSON.stringify(job.conclusion)}`]));
+      return;
+    }
+
+    failures.push({
+      id: job.id,
+      name: job.name,
+      url: job.html_url || job.url || '',
+      failedSteps: job.steps
+        .filter(step => step.conclusion === 'failure')
+        .map(step => step.name),
+      classificationError: '',
+    });
+  });
+
+  if (monitoredJobCount === 0 && failures.length === 0) {
+    failures.push(malformedFailure(0, null, ['no monitored job records']));
+  }
+
+  return failures;
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateJob(job) {
+  const problems = [];
+
+  if (!Number.isSafeInteger(job.id) || job.id <= 0) {
+    problems.push('id must be a positive integer');
+  }
+  if (typeof job.name !== 'string' || job.name.trim() === '') {
+    problems.push('name must be a non-empty string');
+  }
+  if (typeof job.conclusion !== 'string' || job.conclusion.trim() === '') {
+    problems.push('conclusion must be a non-empty string');
+  }
+  if (!Array.isArray(job.steps)) {
+    problems.push('steps must be an array');
+  } else {
+    job.steps.forEach((step, index) => {
+      if (!isRecord(step)) {
+        problems.push(`steps[${index}] must be an object`);
+        return;
+      }
+      if (typeof step.name !== 'string' || step.name.trim() === '') {
+        problems.push(`steps[${index}].name must be a non-empty string`);
+      }
+      if (typeof step.conclusion !== 'string' || step.conclusion.trim() === '') {
+        problems.push(`steps[${index}].conclusion must be a non-empty string`);
+      }
+    });
+  }
+
+  return problems;
+}
+
+function malformedFailure(index, job, problems) {
+  const validName = isRecord(job) && typeof job.name === 'string' && job.name.trim() !== '';
+  const validID = isRecord(job) && Number.isSafeInteger(job.id) && job.id > 0;
+  const validURL = isRecord(job) && typeof (job.html_url || job.url) === 'string';
+
+  return {
+    id: validID ? job.id : null,
+    name: validName ? job.name : `Malformed job record #${index + 1}`,
+    url: validURL ? job.html_url || job.url : '',
+    failedSteps: [],
+    classificationError: `Malformed job record #${index + 1}: ${problems.join('; ')}`,
+  };
+}
+
+module.exports = { classifyJobs };

--- a/.github/scripts/nightly-stability-jobs.test.js
+++ b/.github/scripts/nightly-stability-jobs.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { classifyJobs } = require('./nightly-stability-jobs');
+
+test('classifies malformed failed jobs without throwing', () => {
+  const failures = classifyJobs([
+    {
+      id: 1,
+      name: 'Race Detector Sweep',
+      conclusion: 'failure',
+      steps: {},
+    },
+  ]);
+
+  assert.equal(failures.length, 1);
+  assert.match(failures[0].classificationError, /steps must be an array/);
+});
+
+test('classifies malformed jobs alongside recognized failures', () => {
+  const failures = classifyJobs([
+    {
+      id: 1,
+      name: 'Race Detector Sweep',
+      conclusion: 'failure',
+      steps: [],
+    },
+    {
+      id: 2,
+      name: 'MinIO Soak',
+      steps: [],
+    },
+  ]);
+
+  assert.equal(failures.length, 2);
+  assert.equal(failures[0].name, 'Race Detector Sweep');
+  assert.equal(failures[1].name, 'MinIO Soak');
+  assert.match(failures[1].classificationError, /conclusion must be a non-empty string/);
+});
+
+test('ignores successful and notifier jobs', () => {
+  const failures = classifyJobs([
+    {
+      id: 1,
+      name: 'Race Detector Sweep',
+      conclusion: 'success',
+      steps: [],
+    },
+    {
+      id: 2,
+      name: 'Notify on Failure',
+      conclusion: '',
+      steps: [],
+    },
+  ]);
+
+  assert.deepEqual(failures, []);
+});
+
+test('creates a tracking issue for malformed job objects', async () => {
+  const jobs = [
+    {
+      id: 1,
+      name: 'Race Detector Sweep',
+      conclusion: 'failure',
+      steps: {},
+    },
+    {
+      id: 2,
+      name: 'MinIO Soak',
+      steps: [],
+    },
+  ];
+  const createdIssues = [];
+  const listForRepo = () => {};
+  const github = {
+    paginate: async route => (typeof route === 'string' ? jobs : []),
+    rest: {
+      issues: {
+        listForRepo,
+        create: async input => {
+          createdIssues.push(input);
+          return {
+            data: {
+              number: 123,
+              html_url: 'https://github.com/benbjohnson/litestream/issues/123',
+            },
+          };
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: 'benbjohnson', repo: 'litestream' },
+    runId: 456,
+    serverUrl: 'https://github.com',
+    ref: 'refs/heads/test',
+    sha: '1234567890abcdef',
+  };
+
+  const originalWorkspace = process.env.GITHUB_WORKSPACE;
+  process.env.GITHUB_WORKSPACE = process.cwd();
+  try {
+    await runNotifierScript({
+      context,
+      github,
+      core: {},
+      fetch: async () => {
+        throw new Error('malformed records must not fetch job logs');
+      },
+    });
+  } finally {
+    if (originalWorkspace === undefined) {
+      delete process.env.GITHUB_WORKSPACE;
+    } else {
+      process.env.GITHUB_WORKSPACE = originalWorkspace;
+    }
+  }
+
+  assert.equal(createdIssues.length, 1);
+  assert.match(createdIssues[0].body, /Race Detector Sweep/);
+  assert.match(createdIssues[0].body, /steps must be an array/);
+  assert.match(createdIssues[0].body, /MinIO Soak/);
+  assert.match(createdIssues[0].body, /conclusion must be a non-empty string/);
+});
+
+async function runNotifierScript({ context, github, core, fetch }) {
+  const workflowPath = path.join(process.cwd(), '.github/workflows/nightly-stability.yml');
+  const lines = fs.readFileSync(workflowPath, 'utf8').split('\n');
+  const markerIndex = lines.findIndex(line => line.trim() === 'script: |');
+  assert.notEqual(markerIndex, -1);
+
+  const markerIndent = lines[markerIndex].length - lines[markerIndex].trimStart().length;
+  const scriptLines = [];
+  for (const line of lines.slice(markerIndex + 1)) {
+    const indent = line.length - line.trimStart().length;
+    if (line.trim() !== '' && indent <= markerIndent) {
+      break;
+    }
+    scriptLines.push(line.slice(markerIndent + 2));
+  }
+
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+  const execute = new AsyncFunction('require', 'context', 'github', 'core', 'fetch', scriptLines.join('\n'));
+  await execute(require, context, github, core, fetch);
+}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Test nightly notifier classification
+        run: node --test .github/scripts/nightly-stability-jobs.test.js
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/nightly-stability.yml
+++ b/.github/workflows/nightly-stability.yml
@@ -453,16 +453,34 @@ jobs:
                 run_id: runId,
                 attempt_number: runAttempt,
                 per_page: 100,
-              },
-              response => response.data.jobs
+              }
             );
 
+            if (!Array.isArray(jobs)) {
+              core.setFailed('Unable to classify nightly stability run: jobs response was not an array');
+              return;
+            }
+
+            const validJobs = jobs.filter(job => job && typeof job === 'object');
+            const malformedJobCount = jobs.length - validJobs.length;
             const failedConclusions = new Set(['failure', 'timed_out', 'action_required', 'cancelled', 'startup_failure']);
-            const failedJobs = jobs.filter(job => failedConclusions.has(job.conclusion || ''));
+            const failedJobs = validJobs.filter(job => failedConclusions.has(job.conclusion || ''));
 
             if (failedJobs.length === 0) {
+              const monitoredJobs = validJobs.filter(job => job.name !== 'Notify on Failure');
+              const unclassifiedJobs = monitoredJobs.filter(job => !job.conclusion);
+              if (malformedJobCount > 0 || unclassifiedJobs.length > 0 || monitoredJobs.length === 0) {
+                core.setFailed(
+                  `Unable to classify nightly stability run: ${malformedJobCount} malformed and ${unclassifiedJobs.length} incomplete job records`
+                );
+                return;
+              }
               console.log('No failed jobs found for this run');
               return;
+            }
+
+            if (malformedJobCount > 0) {
+              console.warn(`Ignoring ${malformedJobCount} malformed job records`);
             }
 
             const failures = [];

--- a/.github/workflows/nightly-stability.yml
+++ b/.github/workflows/nightly-stability.yml
@@ -264,6 +264,8 @@ jobs:
     needs: [race-detector-sweep, ltx-behavioral-soak, ltx-snapshot-regression, minio-soak, replicate-restore-soak, comprehensive-soak]
     if: failure()
     steps:
+      - uses: actions/checkout@v4
+
       - name: Create or update failure issue
         uses: actions/github-script@v7
         env:
@@ -272,6 +274,9 @@ jobs:
           script: |
             const fs = require('fs');
             const crypto = require('crypto');
+            const { classifyJobs } = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/nightly-stability-jobs`
+            );
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -456,69 +461,47 @@ jobs:
               }
             );
 
-            if (!Array.isArray(jobs)) {
-              core.setFailed('Unable to classify nightly stability run: jobs response was not an array');
-              return;
-            }
-
-            const validJobs = jobs.filter(job => job && typeof job === 'object');
-            const malformedJobCount = jobs.length - validJobs.length;
-            const failedConclusions = new Set(['failure', 'timed_out', 'action_required', 'cancelled', 'startup_failure']);
-            const failedJobs = validJobs.filter(job => failedConclusions.has(job.conclusion || ''));
+            const failedJobs = classifyJobs(jobs);
 
             if (failedJobs.length === 0) {
-              const monitoredJobs = validJobs.filter(job => job.name !== 'Notify on Failure');
-              const unclassifiedJobs = monitoredJobs.filter(job => !job.conclusion);
-              if (malformedJobCount > 0 || unclassifiedJobs.length > 0 || monitoredJobs.length === 0) {
-                core.setFailed(
-                  `Unable to classify nightly stability run: ${malformedJobCount} malformed and ${unclassifiedJobs.length} incomplete job records`
-                );
-                return;
-              }
               console.log('No failed jobs found for this run');
               return;
             }
 
-            if (malformedJobCount > 0) {
-              console.warn(`Ignoring ${malformedJobCount} malformed job records`);
-            }
-
             const failures = [];
             for (const job of failedJobs) {
-              const failedSteps = (job.steps || [])
-                .filter(step => step.conclusion === 'failure')
-                .map(step => step.name);
+              let logText = job.classificationError;
+              if (!job.classificationError) {
+                try {
+                  const response = await fetch(
+                    `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${job.id}/logs`,
+                    {
+                      headers: {
+                        Accept: 'application/vnd.github+json',
+                        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                        'X-GitHub-Api-Version': '2022-11-28',
+                      },
+                    }
+                  );
 
-              let logText = '';
-              try {
-                const response = await fetch(
-                  `https://api.github.com/repos/${owner}/${repo}/actions/jobs/${job.id}/logs`,
-                  {
-                    headers: {
-                      Accept: 'application/vnd.github+json',
-                      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-                      'X-GitHub-Api-Version': '2022-11-28',
-                    },
+                  if (!response.ok) {
+                    throw new Error(`Unable to fetch logs (${response.status})`);
                   }
-                );
 
-                if (!response.ok) {
-                  throw new Error(`Unable to fetch logs (${response.status})`);
+                  logText = await response.text();
+                } catch (error) {
+                  logText = `Log download failed: ${error.message}`;
                 }
-
-                logText = await response.text();
-              } catch (error) {
-                logText = `Log download failed: ${error.message}`;
               }
 
               const snippets = extractFailureSnippets(logText);
-              const primarySource = snippets[0] || failedSteps[0] || `${job.name} failed`;
+              const primarySource = snippets[0] || job.failedSteps[0] || job.classificationError || `${job.name} failed`;
               const primarySignature = summarizeSnippet(primarySource, job.name);
 
               failures.push({
                 name: job.name,
-                url: job.html_url || job.url,
-                failedSteps,
+                url: job.url || runUrl,
+                failedSteps: job.failedSteps,
                 snippets: snippets.length > 0 ? snippets : [sanitizeSnippet(primarySource)],
                 primarySignature,
                 fingerprintKey: `${job.name}:${normalizeForFingerprint(primarySignature)}`,

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -506,12 +506,18 @@ func TestReplicaClient_SFTP_HostKeyValidation(t *testing.T) {
 		}
 	})
 	t.Run("IgnoreHostKey", func(t *testing.T) {
+		previousLogger := slog.Default()
+		t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+		var capturedMu sync.Mutex
 		var captured []string
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
 			Level: slog.LevelWarn,
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				if a.Key == slog.MessageKey {
+					capturedMu.Lock()
 					captured = append(captured, a.Value.String())
+					capturedMu.Unlock()
 				}
 				return a
 			},
@@ -528,9 +534,12 @@ func TestReplicaClient_SFTP_HostKeyValidation(t *testing.T) {
 			t.Fatalf("SFTP connection failed: %v", err)
 		}
 
-		if !slices.ContainsFunc(captured, func(msg string) bool {
+		capturedMu.Lock()
+		foundWarning := slices.ContainsFunc(captured, func(msg string) bool {
 			return strings.Contains(msg, "sftp host key not verified")
-		}) {
+		})
+		capturedMu.Unlock()
+		if !foundWarning {
 			t.Errorf("Expected warning not found")
 		}
 	})

--- a/restore_fuzz_test.go
+++ b/restore_fuzz_test.go
@@ -34,12 +34,6 @@ func FuzzRestoreWithMissingCompactedFile(f *testing.F) {
 		client := file.NewReplicaClient(t.TempDir())
 		db.Replica.Client = client
 
-		if err := db.Open(); err != nil {
-			t.Fatal(err)
-		}
-		sqldb := testingutil.MustOpenSQLDB(t, db.Path())
-		defer testingutil.MustCloseDBs(t, db, sqldb)
-
 		store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{
 			{Level: 0},
 			{Level: 1, Interval: 50 * time.Millisecond},
@@ -50,6 +44,9 @@ func FuzzRestoreWithMissingCompactedFile(f *testing.F) {
 			t.Fatal(err)
 		}
 		defer store.Close(ctx)
+
+		sqldb := testingutil.MustOpenSQLDB(t, db.Path())
+		defer testingutil.MustCloseSQLDB(t, sqldb)
 
 		if _, err := sqldb.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);`); err != nil {
 			t.Fatal(err)

--- a/store_test.go
+++ b/store_test.go
@@ -176,11 +176,6 @@ func TestStore_Integration(t *testing.T) {
 	db.MonitorInterval = factor * 100 * time.Millisecond
 	db.Replica = litestream.NewReplica(db)
 	db.Replica.Client = file.NewReplicaClient(t.TempDir())
-	if err := db.Open(); err != nil {
-		t.Fatal(err)
-	}
-	sqldb := testingutil.MustOpenSQLDB(t, db.Path())
-	defer testingutil.MustCloseSQLDB(t, sqldb)
 
 	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{
 		{Level: 0},
@@ -192,6 +187,9 @@ func TestStore_Integration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer store.Close(t.Context())
+
+	sqldb := testingutil.MustOpenSQLDB(t, db.Path())
+	defer testingutil.MustCloseSQLDB(t, sqldb)
 
 	// Create initial table
 	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);`); err != nil {

--- a/tests/integration/load_profiles.go
+++ b/tests/integration/load_profiles.go
@@ -74,7 +74,7 @@ func HighVolumeProfile() LoadProfile {
 		Description:     "High traffic: 500 writes/sec, wave pattern. Catches performance regressions under sustained load.",
 		WriteRate:       500,
 		Pattern:         "wave",
-		PayloadSize:     4096,
+		PayloadSize:     1024,
 		Workers:         8,
 		MaxL0Pages:      500,
 		MaxWALSizeMB:    500,

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -444,6 +444,8 @@ func invalidCheckpointReason(ev LTXEvent) string {
 		return "missing or malformed timestamp and missing mode"
 	case ev.Time.IsZero():
 		return "missing or malformed timestamp"
+	case ev.Database == "":
+		return "missing database"
 	case !isCheckpointMode(ev.CheckpointMode):
 		return fmt.Sprintf("invalid mode %q", ev.CheckpointMode)
 	default:

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -369,10 +369,10 @@ func AssertWALBounded(t *testing.T, walPath string, maxWALSizeMB float64, peakWA
 func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	t.Helper()
 
-	snapSyncEvents := make([]LTXEvent, 0)
-	for _, ev := range report.Events {
+	snapSyncIndexes := make([]int, 0)
+	for i, ev := range report.Events {
 		if ev.Type == "sync" && ev.IsSnap {
-			snapSyncEvents = append(snapSyncEvents, ev)
+			snapSyncIndexes = append(snapSyncIndexes, i)
 		}
 	}
 
@@ -390,7 +390,8 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 		}
 	}
 
-	for _, snapEv := range snapSyncEvents {
+	for _, snapshotIndex := range snapSyncIndexes {
+		snapEv := report.Events[snapshotIndex]
 		if snapEv.Time.IsZero() {
 			t.Errorf("  [no-snap-on-checkpoint] FAIL: snapshot sync has a missing or malformed timestamp (reason: %s)",
 				snapEv.Reason)
@@ -398,7 +399,7 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 			continue
 		}
 
-		checkpointEv, ok := precedingCheckpoint(report.Events, snapEv.Time, checkpointWindow)
+		checkpointEv, ok := precedingCheckpoint(report.Events[:snapshotIndex], snapEv.Time, checkpointWindow)
 		if !ok {
 			if snapEv.Reason == "checkpoint boundary snapshot" {
 				t.Errorf("  [no-snap-on-checkpoint] FAIL: checkpoint boundary snapshot at %v has no attributable preceding checkpoint",
@@ -426,7 +427,7 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 
 	if violations == 0 {
 		msg := fmt.Sprintf("no snapshot-on-checkpoint detected (%d checkpoints, %d snap-syncs checked",
-			len(report.CheckpointTimes), len(snapSyncEvents))
+			len(report.CheckpointTimes), len(snapSyncIndexes))
 		if expectedSnapshots > 0 {
 			msg += fmt.Sprintf(", %d expected snapshots", expectedSnapshots)
 		}

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -18,6 +18,7 @@ import (
 // LTXEvent represents a parsed log event related to LTX operations.
 type LTXEvent struct {
 	Time           time.Time
+	Database       string
 	Type           string // "sync", "snapshot", "compaction", "checkpoint"
 	CheckpointMode string
 	Level          int // compaction level (-1 if N/A)
@@ -399,7 +400,7 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 			continue
 		}
 
-		checkpointEv, ok := precedingCheckpoint(report.Events[:snapshotIndex], snapEv.Time, checkpointWindow)
+		checkpointEv, ok := precedingCheckpoint(report.Events[:snapshotIndex], snapEv.Database, snapEv.Time, checkpointWindow)
 		if !ok {
 			if snapEv.Reason == "checkpoint boundary snapshot" {
 				t.Errorf("  [no-snap-on-checkpoint] FAIL: checkpoint boundary snapshot at %v has no attributable preceding checkpoint",
@@ -459,11 +460,11 @@ func isCheckpointMode(mode string) bool {
 	}
 }
 
-func precedingCheckpoint(events []LTXEvent, snapshotTime time.Time, window time.Duration) (LTXEvent, bool) {
+func precedingCheckpoint(events []LTXEvent, snapshotDatabase string, snapshotTime time.Time, window time.Duration) (LTXEvent, bool) {
 	var checkpoint LTXEvent
 	var ok bool
 	for _, ev := range events {
-		if ev.Type != "checkpoint" {
+		if ev.Type != "checkpoint" || snapshotDatabase == "" || ev.Database != snapshotDatabase {
 			continue
 		}
 
@@ -619,9 +620,10 @@ func parseSnapshotComplete(line string) (LTXEvent, bool) {
 
 	t, _ := parseLogTime(line)
 	ev := LTXEvent{
-		Time:  t,
-		Type:  "snapshot",
-		Level: 9,
+		Time:     t,
+		Database: parseLogDatabase(line),
+		Type:     "snapshot",
+		Level:    9,
 	}
 
 	if v := extractField(line, "txid="); v != "" {
@@ -641,8 +643,9 @@ func parseCompactionComplete(line string) (LTXEvent, bool) {
 
 	t, _ := parseLogTime(line)
 	ev := LTXEvent{
-		Time: t,
-		Type: "compaction",
+		Time:     t,
+		Database: parseLogDatabase(line),
+		Type:     "compaction",
 	}
 
 	// Extract compaction level — skip past msg= to avoid matching log level=INFO
@@ -690,6 +693,7 @@ func parseCheckpoint(line string) (LTXEvent, bool) {
 	t, _ := parseLogTime(line)
 	return LTXEvent{
 		Time:           t,
+		Database:       parseLogDatabase(line),
 		Type:           "checkpoint",
 		Level:          -1,
 		CheckpointMode: mode,
@@ -707,9 +711,10 @@ func parseSyncWithSnap(line string) (LTXEvent, bool) {
 
 	t, _ := parseLogTime(line)
 	ev := LTXEvent{
-		Time:  t,
-		Type:  "sync",
-		Level: 0,
+		Time:     t,
+		Database: parseLogDatabase(line),
+		Type:     "sync",
+		Level:    0,
 	}
 
 	// Check for snap field in both text and JSON formats
@@ -732,8 +737,9 @@ func parseLTXFileUploaded(line string) (LTXEvent, bool) {
 
 	t, _ := parseLogTime(line)
 	ev := LTXEvent{
-		Time: t,
-		Type: "upload",
+		Time:     t,
+		Database: parseLogDatabase(line),
+		Type:     "upload",
 	}
 
 	// Search for the replica level field AFTER the message text to avoid
@@ -762,6 +768,13 @@ func parseLTXFileUploaded(line string) (LTXEvent, bool) {
 	}
 
 	return ev, true
+}
+
+func parseLogDatabase(line string) string {
+	if database := extractField(line, "db="); database != "" {
+		return database
+	}
+	return extractJSONField(line, "db")
 }
 
 func extractField(line, prefix string) string {

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -17,15 +17,16 @@ import (
 
 // LTXEvent represents a parsed log event related to LTX operations.
 type LTXEvent struct {
-	Time      time.Time
-	Type      string // "sync", "snapshot", "compaction", "checkpoint"
-	Level     int    // compaction level (-1 if N/A)
-	MinTXID   string
-	MaxTXID   string
-	Size      int64
-	IsSnap    bool   // true if sync created a snapshot-sized LTX
-	Reason    string // snapshot reason from log
-	PageCount int    // number of pages (estimated from size)
+	Time           time.Time
+	Type           string // "sync", "snapshot", "compaction", "checkpoint"
+	CheckpointMode string
+	Level          int // compaction level (-1 if N/A)
+	MinTXID        string
+	MaxTXID        string
+	Size           int64
+	IsSnap         bool   // true if sync created a snapshot-sized LTX
+	Reason         string // snapshot reason from log
+	PageCount      int    // number of pages (estimated from size)
 }
 
 // LTXBehaviorReport holds all behavioral metrics from a test run.
@@ -386,20 +387,23 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	expectedSnapshots := 0
 	checkpointWindow := 5 * time.Second
 
-	for _, chkTime := range report.CheckpointTimes {
-		for _, snapEv := range snapSyncEvents {
-			diff := snapEv.Time.Sub(chkTime)
-			if diff >= 0 && diff <= checkpointWindow {
-				if isExpectedSnapshot(snapEv.Reason) {
-					expectedSnapshots++
-					continue
-				}
-				t.Errorf("  [no-snap-on-checkpoint] Snapshot sync at %v occurred %v after checkpoint at %v (reason: %s)",
-					snapEv.Time.Format("15:04:05"), diff.Round(time.Millisecond),
-					chkTime.Format("15:04:05"), snapEv.Reason)
-				violations++
-			}
+	for _, snapEv := range snapSyncEvents {
+		checkpointEv, ok := precedingCheckpoint(report.Events, snapEv.Time, checkpointWindow)
+		if !ok {
+			continue
 		}
+
+		if isExpectedRecoverySnapshot(snapEv.Reason) ||
+			isExpectedTruncateBoundarySnapshot(checkpointEv, snapEv) {
+			expectedSnapshots++
+			continue
+		}
+
+		diff := snapEv.Time.Sub(checkpointEv.Time)
+		t.Errorf("  [no-snap-on-checkpoint] Snapshot sync at %v occurred %v after %s checkpoint at %v (reason: %s)",
+			snapEv.Time.Format("15:04:05"), diff.Round(time.Millisecond),
+			checkpointEv.CheckpointMode, checkpointEv.Time.Format("15:04:05"), snapEv.Reason)
+		violations++
 	}
 
 	if violations == 0 {
@@ -414,16 +418,39 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	}
 }
 
-// isExpectedSnapshot returns true if the snapshot reason indicates an
-// intentional recovery mechanism or checkpoint safety boundary rather than the
-// checkpoint-triggers-unwanted-snapshot bug. NOTE: "full or restart checkpoint
-// detected" is intentionally NOT in this list — that is the exact bug this
-// assertion catches.
-func isExpectedSnapshot(reason string) bool {
+func precedingCheckpoint(events []LTXEvent, snapshotTime time.Time, window time.Duration) (LTXEvent, bool) {
+	var checkpoint LTXEvent
+	var ok bool
+	for _, ev := range events {
+		if ev.Type != "checkpoint" {
+			continue
+		}
+
+		diff := snapshotTime.Sub(ev.Time)
+		if diff < 0 || diff > window {
+			continue
+		}
+		if !ok || !ev.Time.Before(checkpoint.Time) {
+			checkpoint, ok = ev, true
+		}
+	}
+	return checkpoint, ok
+}
+
+// isExpectedRecoverySnapshot returns true if the snapshot reason indicates an
+// intentional recovery mechanism rather than the checkpoint-triggers-unwanted-
+// snapshot bug.
+func isExpectedRecoverySnapshot(reason string) bool {
 	return strings.Contains(reason, "repair snapshot") ||
 		strings.Contains(reason, "compaction detected missing") ||
-		strings.Contains(reason, "wal header salt reset") ||
-		strings.Contains(reason, "checkpoint boundary snapshot")
+		strings.Contains(reason, "wal header salt reset")
+}
+
+// PR #1292 requires emergency TRUNCATE checkpoints to take a boundary snapshot;
+// issue #1198 tracks the remaining cost of those full L0 snapshots.
+func isExpectedTruncateBoundarySnapshot(checkpoint, snapshot LTXEvent) bool {
+	return strings.EqualFold(checkpoint.CheckpointMode, "TRUNCATE") &&
+		snapshot.Reason == "checkpoint boundary snapshot"
 }
 
 // PrintBehaviorReport prints a human-readable summary of the behavioral report.
@@ -607,17 +634,27 @@ func parseCheckpoint(line string) (LTXEvent, bool) {
 		return LTXEvent{}, false
 	}
 
-	isCheckpoint := (strings.Contains(line, "msg=checkpoint") || strings.Contains(line, `msg="checkpoint"`)) &&
-		strings.Contains(line, "mode=")
+	isCheckpoint := strings.Contains(line, "msg=checkpoint") ||
+		strings.Contains(line, `msg="checkpoint"`) ||
+		strings.Contains(line, `"msg":"checkpoint"`)
 	if !isCheckpoint {
+		return LTXEvent{}, false
+	}
+
+	mode := extractField(line, "mode=")
+	if mode == "" {
+		mode = extractJSONField(line, "mode")
+	}
+	if mode == "" {
 		return LTXEvent{}, false
 	}
 
 	t, _ := parseLogTime(line)
 	return LTXEvent{
-		Time:  t,
-		Type:  "checkpoint",
-		Level: -1,
+		Time:           t,
+		Type:           "checkpoint",
+		Level:          -1,
+		CheckpointMode: mode,
 	}, true
 }
 

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -369,13 +369,6 @@ func AssertWALBounded(t *testing.T, walPath string, maxWALSizeMB float64, peakWA
 func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	t.Helper()
 
-	if len(report.CheckpointTimes) == 0 || report.SnapSyncCount == 0 {
-		t.Logf("  [no-snap-on-checkpoint] PASS: no checkpoint+snapshot overlap to check (checkpoints=%d, snap-syncs=%d)",
-			len(report.CheckpointTimes), report.SnapSyncCount)
-		return
-	}
-
-	// Build timeline: check if any snap-sync events coincide with checkpoint events
 	snapSyncEvents := make([]LTXEvent, 0)
 	for _, ev := range report.Events {
 		if ev.Type == "sync" && ev.IsSnap {
@@ -387,9 +380,34 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	expectedSnapshots := 0
 	checkpointWindow := 5 * time.Second
 
+	for _, ev := range report.Events {
+		if ev.Type != "checkpoint" {
+			continue
+		}
+		if reason := invalidCheckpointReason(ev); reason != "" {
+			t.Errorf("  [no-snap-on-checkpoint] FAIL: unclassifiable checkpoint: %s", reason)
+			violations++
+		}
+	}
+
 	for _, snapEv := range snapSyncEvents {
+		if snapEv.Time.IsZero() {
+			t.Errorf("  [no-snap-on-checkpoint] FAIL: snapshot sync has a missing or malformed timestamp (reason: %s)",
+				snapEv.Reason)
+			violations++
+			continue
+		}
+
 		checkpointEv, ok := precedingCheckpoint(report.Events, snapEv.Time, checkpointWindow)
 		if !ok {
+			if snapEv.Reason == "checkpoint boundary snapshot" {
+				t.Errorf("  [no-snap-on-checkpoint] FAIL: checkpoint boundary snapshot at %v has no attributable preceding checkpoint",
+					snapEv.Time.Format("15:04:05"))
+				violations++
+			}
+			continue
+		}
+		if invalidCheckpointReason(checkpointEv) != "" {
 			continue
 		}
 
@@ -415,6 +433,28 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 		t.Logf("  [no-snap-on-checkpoint] PASS: %s)", msg)
 	} else {
 		t.Errorf("  [no-snap-on-checkpoint] FAIL: %d snapshot-on-checkpoint violations detected", violations)
+	}
+}
+
+func invalidCheckpointReason(ev LTXEvent) string {
+	switch {
+	case ev.Time.IsZero() && ev.CheckpointMode == "":
+		return "missing or malformed timestamp and missing mode"
+	case ev.Time.IsZero():
+		return "missing or malformed timestamp"
+	case !isCheckpointMode(ev.CheckpointMode):
+		return fmt.Sprintf("invalid mode %q", ev.CheckpointMode)
+	default:
+		return ""
+	}
+}
+
+func isCheckpointMode(mode string) bool {
+	switch strings.ToUpper(mode) {
+	case "PASSIVE", "FULL", "RESTART", "TRUNCATE":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -644,9 +684,6 @@ func parseCheckpoint(line string) (LTXEvent, bool) {
 	mode := extractField(line, "mode=")
 	if mode == "" {
 		mode = extractJSONField(line, "mode")
-	}
-	if mode == "" {
-		return LTXEvent{}, false
 	}
 
 	t, _ := parseLogTime(line)

--- a/tests/integration/ltx_assertions.go
+++ b/tests/integration/ltx_assertions.go
@@ -383,15 +383,15 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	}
 
 	violations := 0
-	expectedRecoveries := 0
+	expectedSnapshots := 0
 	checkpointWindow := 5 * time.Second
 
 	for _, chkTime := range report.CheckpointTimes {
 		for _, snapEv := range snapSyncEvents {
 			diff := snapEv.Time.Sub(chkTime)
 			if diff >= 0 && diff <= checkpointWindow {
-				if isExpectedRecoverySnapshot(snapEv.Reason) {
-					expectedRecoveries++
+				if isExpectedSnapshot(snapEv.Reason) {
+					expectedSnapshots++
 					continue
 				}
 				t.Errorf("  [no-snap-on-checkpoint] Snapshot sync at %v occurred %v after checkpoint at %v (reason: %s)",
@@ -405,8 +405,8 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	if violations == 0 {
 		msg := fmt.Sprintf("no snapshot-on-checkpoint detected (%d checkpoints, %d snap-syncs checked",
 			len(report.CheckpointTimes), len(snapSyncEvents))
-		if expectedRecoveries > 0 {
-			msg += fmt.Sprintf(", %d expected gap recoveries", expectedRecoveries)
+		if expectedSnapshots > 0 {
+			msg += fmt.Sprintf(", %d expected snapshots", expectedSnapshots)
 		}
 		t.Logf("  [no-snap-on-checkpoint] PASS: %s)", msg)
 	} else {
@@ -414,14 +414,16 @@ func AssertNoSnapshotOnCheckpoint(t *testing.T, report *LTXBehaviorReport) {
 	}
 }
 
-// isExpectedRecoverySnapshot returns true if the snapshot reason indicates an
-// intentional recovery mechanism rather than the checkpoint-triggers-unwanted-
-// snapshot bug. NOTE: "full or restart checkpoint detected" is intentionally
-// NOT in this list — that is the exact bug this assertion catches.
-func isExpectedRecoverySnapshot(reason string) bool {
+// isExpectedSnapshot returns true if the snapshot reason indicates an
+// intentional recovery mechanism or checkpoint safety boundary rather than the
+// checkpoint-triggers-unwanted-snapshot bug. NOTE: "full or restart checkpoint
+// detected" is intentionally NOT in this list — that is the exact bug this
+// assertion catches.
+func isExpectedSnapshot(reason string) bool {
 	return strings.Contains(reason, "repair snapshot") ||
 		strings.Contains(reason, "compaction detected missing") ||
-		strings.Contains(reason, "wal header salt reset")
+		strings.Contains(reason, "wal header salt reset") ||
+		strings.Contains(reason, "checkpoint boundary snapshot")
 }
 
 // PrintBehaviorReport prints a human-readable summary of the behavioral report.

--- a/tests/integration/ltx_assertions_test.go
+++ b/tests/integration/ltx_assertions_test.go
@@ -1,0 +1,90 @@
+//go:build integration && soak
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAssertNoSnapshotOnCheckpointFailsClosed(t *testing.T) {
+	if logText := os.Getenv("LITESTREAM_ASSERTION_LOG"); logText != "" {
+		logPath := filepath.Join(t.TempDir(), "litestream.log")
+		if err := os.WriteFile(logPath, []byte(logText), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		events, err := ParseLTXEvents(logPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		AssertNoSnapshotOnCheckpoint(t, BuildBehaviorReport(events, 0))
+		return
+	}
+
+	tests := map[string]string{
+		"missing checkpoint mode": `
+time=2026-07-25T01:00:00Z level=DEBUG msg=checkpoint mode=TRUNCATE
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint result=0,10,10
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
+`,
+		"malformed checkpoint timestamp": `
+time=2026-07-25T01:00:00Z level=DEBUG msg=checkpoint mode=TRUNCATE
+time=invalid level=DEBUG msg=checkpoint mode=PASSIVE
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
+`,
+		"unsupported checkpoint mode": `
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint mode=UNKNOWN
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
+`,
+		"no preceding checkpoint": `
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
+`,
+	}
+
+	for name, logText := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestAssertNoSnapshotOnCheckpointFailsClosed$")
+			cmd.Env = append(os.Environ(), "LITESTREAM_ASSERTION_LOG="+logText)
+			if output, err := cmd.CombinedOutput(); err == nil {
+				t.Fatalf("assertion passed unclassifiable input:\n%s", output)
+			}
+		})
+	}
+}
+
+func TestAssertNoSnapshotOnCheckpointAllowsStartupAndTruncateSnapshots(t *testing.T) {
+	events := []LTXEvent{
+		{
+			Time:   mustParseLogTime(t, "time=2026-07-25T01:00:00Z"),
+			Type:   "sync",
+			IsSnap: true,
+		},
+		{
+			Time:           mustParseLogTime(t, "time=2026-07-25T01:00:02Z"),
+			Type:           "checkpoint",
+			CheckpointMode: "TRUNCATE",
+		},
+		{
+			Time:   mustParseLogTime(t, "time=2026-07-25T01:00:03Z"),
+			Type:   "sync",
+			IsSnap: true,
+			Reason: "checkpoint boundary snapshot",
+		},
+	}
+
+	AssertNoSnapshotOnCheckpoint(t, BuildBehaviorReport(events, 0))
+}
+
+func mustParseLogTime(t *testing.T, line string) time.Time {
+	t.Helper()
+
+	value, ok := parseLogTime(line)
+	if !ok {
+		t.Fatalf("parse log time: %q", line)
+	}
+	return value
+}

--- a/tests/integration/ltx_assertions_test.go
+++ b/tests/integration/ltx_assertions_test.go
@@ -47,6 +47,14 @@ time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boun
 time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
 time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint mode=TRUNCATE
 `,
+		"checkpoint later in log for same database": `
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync db=test.db snap=true reason="checkpoint boundary snapshot"
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint db=test.db mode=TRUNCATE
+`,
+		"checkpoint from another database": `
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint db=alpha.db mode=TRUNCATE
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync db=beta.db snap=true reason="checkpoint boundary snapshot"
+`,
 	}
 
 	for name, logText := range tests {
@@ -69,14 +77,16 @@ func TestAssertNoSnapshotOnCheckpointAllowsStartupAndTruncateSnapshots(t *testin
 		},
 		{
 			Time:           mustParseLogTime(t, "time=2026-07-25T01:00:02Z"),
+			Database:       "test.db",
 			Type:           "checkpoint",
 			CheckpointMode: "TRUNCATE",
 		},
 		{
-			Time:   mustParseLogTime(t, "time=2026-07-25T01:00:03Z"),
-			Type:   "sync",
-			IsSnap: true,
-			Reason: "checkpoint boundary snapshot",
+			Time:     mustParseLogTime(t, "time=2026-07-25T01:00:03Z"),
+			Database: "test.db",
+			Type:     "sync",
+			IsSnap:   true,
+			Reason:   "checkpoint boundary snapshot",
 		},
 	}
 

--- a/tests/integration/ltx_assertions_test.go
+++ b/tests/integration/ltx_assertions_test.go
@@ -55,6 +55,16 @@ time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint db=test.db mode=TRUNCATE
 time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint db=alpha.db mode=TRUNCATE
 time=2026-07-25T01:00:03Z level=DEBUG msg=sync db=beta.db snap=true reason="checkpoint boundary snapshot"
 `,
+		"missing checkpoint database launders older truncate": `
+time=2026-07-25T01:00:00Z level=DEBUG msg=checkpoint db=beta.db mode=TRUNCATE
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint mode=PASSIVE
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync db=beta.db snap=true reason="checkpoint boundary snapshot"
+`,
+		"empty checkpoint database launders older truncate": `
+time=2026-07-25T01:00:00Z level=DEBUG msg=checkpoint db=beta.db mode=TRUNCATE
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint db="" mode=PASSIVE
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync db=beta.db snap=true reason="checkpoint boundary snapshot"
+`,
 	}
 
 	for name, logText := range tests {

--- a/tests/integration/ltx_assertions_test.go
+++ b/tests/integration/ltx_assertions_test.go
@@ -43,6 +43,10 @@ time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boun
 		"no preceding checkpoint": `
 time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
 `,
+		"checkpoint later in log": `
+time=2026-07-25T01:00:03Z level=DEBUG msg=sync snap=true reason="checkpoint boundary snapshot"
+time=2026-07-25T01:00:02Z level=DEBUG msg=checkpoint mode=TRUNCATE
+`,
 	}
 
 	for name, logText := range tests {

--- a/tests/integration/soak_helpers.go
+++ b/tests/integration/soak_helpers.go
@@ -140,12 +140,15 @@ func StartMinIOContainer(t *testing.T) (containerID string, endpoint string, vol
 		"-e", "MINIO_ROOT_PASSWORD=minioadmin",
 		"minio/minio", "server", "/data", "--console-address", ":9001")
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to start MinIO container: %v\nOutput: %s", err, string(output))
+	_, stdoutBuf, stderrBuf := configureCmdIO(cmd)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to start MinIO container: %v\nOutput: %s", err, combinedOutput(stdoutBuf, stderrBuf))
 	}
 
-	containerID = strings.TrimSpace(string(output))
+	containerID = strings.TrimSpace(stdoutBuf.String())
+	if containerID == "" {
+		t.Fatal("MinIO container returned an empty container ID")
+	}
 	endpoint = fmt.Sprintf("http://localhost:%s", minioPort)
 
 	// Wait for MinIO to be ready
@@ -153,7 +156,7 @@ func StartMinIOContainer(t *testing.T) (containerID string, endpoint string, vol
 
 	// Verify container is running
 	cmd = exec.Command("docker", "ps", "-q", "-f", "name="+containerName)
-	output, err = cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if err != nil || len(strings.TrimSpace(string(output))) == 0 {
 		t.Fatalf("MinIO container failed to start properly")
 	}
@@ -197,10 +200,7 @@ func CreateMinIOBucket(t *testing.T, containerID, bucket string) {
 	}
 
 	// Use mc (MinIO Client) via docker to create bucket
-	cmd := exec.Command("docker", "run", "--rm",
-		"--link", containerID+":minio",
-		"-e", "MC_HOST_minio=http://minioadmin:minioadmin@minio:9000",
-		"minio/mc", "mb", "minio/"+bucket)
+	cmd := minioClientCommand(containerID, "mb", "minio/"+bucket)
 
 	_, stdoutBuf, stderrBuf := configureCmdIO(cmd)
 	if err := cmd.Run(); err != nil {
@@ -221,11 +221,18 @@ func CreateMinIOBucket(t *testing.T, containerID, bucket string) {
 	t.Logf("MinIO bucket '%s' ready", bucket)
 }
 
+func minioClientCommand(containerID string, args ...string) *exec.Cmd {
+	dockerArgs := []string{
+		"run", "--rm",
+		"--network", "container:" + containerID,
+		"-e", "MC_HOST_minio=http://minioadmin:minioadmin@localhost:9000",
+		"minio/mc",
+	}
+	return exec.Command("docker", append(dockerArgs, args...)...)
+}
+
 func minioBucketExists(containerID, bucket string) bool {
-	cmd := exec.Command("docker", "run", "--rm",
-		"--link", containerID+":minio",
-		"-e", "MC_HOST_minio=http://minioadmin:minioadmin@minio:9000",
-		"minio/mc", "ls", "minio/"+bucket+"/")
+	cmd := minioClientCommand(containerID, "ls", "minio/"+bucket+"/")
 	_, _, _ = configureCmdIO(cmd)
 	if err := cmd.Run(); err != nil {
 		return false
@@ -234,10 +241,7 @@ func minioBucketExists(containerID, bucket string) bool {
 }
 
 func clearMinIOBucket(containerID, bucket string) error {
-	cmd := exec.Command("docker", "run", "--rm",
-		"--link", containerID+":minio",
-		"-e", "MC_HOST_minio=http://minioadmin:minioadmin@minio:9000",
-		"minio/mc", "rm", "--recursive", "--force", "minio/"+bucket)
+	cmd := minioClientCommand(containerID, "rm", "--recursive", "--force", "minio/"+bucket)
 	_, stdoutBuf, stderrBuf := configureCmdIO(cmd)
 	if err := cmd.Run(); err != nil {
 		output := combinedOutput(stdoutBuf, stderrBuf)
@@ -267,10 +271,7 @@ func waitForMinIOBucket(containerID, bucket string, timeout time.Duration) error
 func CountMinIOObjects(t *testing.T, containerID, bucket string) int {
 	t.Helper()
 
-	cmd := exec.Command("docker", "run", "--rm",
-		"--link", containerID+":minio",
-		"-e", "MC_HOST_minio=http://minioadmin:minioadmin@minio:9000",
-		"minio/mc", "ls", "minio/"+bucket+"/", "--recursive")
+	cmd := minioClientCommand(containerID, "ls", "minio/"+bucket+"/", "--recursive")
 
 	_, stdoutBuf, stderrBuf := configureCmdIO(cmd)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Description

Stabilizes the nightly workflow by fixing its accumulated race-test, MinIO harness, high-volume disk-growth, snapshot-classification, and failure-notification problems.

- restores the prior default logger after the SFTP host-key test and synchronizes captured log access
- configures each test Store before opening its DB so logger configuration cannot race the DB monitor
- captures the MinIO container ID from stdout only and runs `minio/mc` in the MinIO container's network namespace
- retains the 500 writes/sec high-volume profile while reducing its payload from 4KB to 1KB
- records checkpoint mode and database identity in behavioral events and fails closed on malformed or unattributable checkpoint-boundary snapshots
- requires a valid same-database `TRUNCATE` checkpoint to precede a boundary snapshot in log order and fall within the five-second attribution window
- validates every paginated job independently so malformed jobs become synthetic failures without hiding recognized failures or throwing from the notifier

The snapshot exception is deliberately narrow. PR #1292 made a full L0 `checkpoint boundary snapshot` required for emergency `TRUNCATE` checkpoints. The assertion permits that reason only when an earlier log event is a valid `TRUNCATE` checkpoint for the same database and its timestamp is within five seconds. Missing database identity, cross-database checkpoints, later-in-log checkpoints, missing modes, malformed timestamps, unsupported modes, `PASSIVE` checkpoints, missing preceding checkpoints, and differently reasoned checkpoint-adjacent snapshots still fail. Issue #1198 remains open for the cost of those intentional full L0 snapshots.

## Motivation and Context

The 25 most recent `nightly-stability` runs were failing. Evidence run [30065650568](https://github.com/benbjohnson/litestream/actions/runs/30065650568) showed four independent harness failures:

- the SFTP host-key test left a mutable global slog handler installed, and later background logging raced on its captured slice
- MinIO startup combined Docker pull stderr with stdout, producing an invalid container ID that was passed to the legacy `--link` flag
- the 500 writes/sec high-volume profile used 4KB payloads, growing the source, replica, and restore working set until the runner ran out of disk
- the notifier's `github.paginate()` mapping callback returned an undefined jobs collection, then dereferenced `job.conclusion`

Once disk exhaustion was fixed, the high-volume lane also exposed that its older snapshot assertion did not distinguish PR #1292's intentional emergency-TRUNCATE boundary from the unwanted snapshot-on-checkpoint behavior tracked by #1198.

Cold review found additional fail-open paths. Red-first regressions proved that malformed checkpoint records could launder a boundary snapshot through an older `TRUNCATE`, a checkpoint later in log order could launder an earlier snapshot when timestamps were out of order, and a checkpoint from another database could authorize the snapshot. The assertion now requires valid mode, timestamp window, log order, and matching database identity. The review's broader reading that every startup snapshot needs a preceding checkpoint was refuted against a known-green nightly artifact: legitimate startup `snap=true` events precede the first checkpoint and are not labeled `checkpoint boundary snapshot`.

The notifier review likewise proved that malformed job objects could throw or disappear beside a recognized failure. Malformed entries are now reported as synthetic failures without suppressing valid job failures.

Validation also exposed a separate production Store shutdown race. That production-code concern and its dedicated regressions were deliberately split into PR #1397; this PR remains CI and test-harness only.

Fixes #1392
Related to #1198, #1212, #1216, #1219, and #1397

## How Has This Been Tested?

- Full Nightly Stability workflow at final commit `728b7eb`: [run 30152582978](https://github.com/benbjohnson/litestream/actions/runs/30152582978) — all eight test jobs passed
- Red-first checkpoint attribution regressions for missing modes, malformed timestamps, unsupported modes, missing preceding checkpoints, stale-TRUNCATE laundering, later-in-log checkpoints, cross-database checkpoints, `PASSIVE` rejection, and valid same-database `TRUNCATE` acceptance
- Notifier regressions that execute the committed workflow script with malformed and recognized failures together and verify one tracking issue contains both failures
- Real low-, high-, burst-volume, and dedicated snapshot-regression behavioral profiles with successful restore and integrity validation

```bash
node --test .github/scripts/nightly-stability-jobs.test.js
go test -tags 'integration,soak' -race -count=10 -run '^TestAssertNoSnapshotOnCheckpoint' ./tests/integration/
go test -tags 'integration,soak' -run '^TestLTXBehavior$' -short -v -timeout 10m ./tests/integration/
go test -tags 'integration,soak' -run '^TestLTXBehavior_NoExcessiveSnapshots$' -short -v -timeout 5m ./tests/integration/
go test -race -count=3 -timeout 45m ./...
go test -count=1 ./...
pre-commit run --all-files
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
