### PR TITLE
fix(store): preserve final sync during shutdown

### DIFF
--- a/db.go
+++ b/db.go
@@ -79,6 +79,11 @@ type DB struct {
 	syncState syncState
 	syncDiag  diagState
 
+	snapshotReaders struct {
+		sync.Mutex
+		m map[*snapshotReadCloser]struct{}
+	}
+
 	// last file info for each level
 	maxLTXFileInfos struct {
 		sync.Mutex
@@ -326,6 +331,7 @@ func NewDB(path string) *DB {
 		Logger:               slog.With(LogKeyDB, filepath.Base(path)),
 	}
 	db.maxLTXFileInfos.m = make(map[int]*ltx.FileInfo)
+	db.snapshotReaders.m = make(map[*snapshotReadCloser]struct{})
 	db.openLTXFile = defaultOpenLTXFile
 
 	db.dbSizeGauge = dbSizeGaugeVec.WithLabelValues(db.path)
@@ -828,6 +834,8 @@ func (db *DB) Close(ctx context.Context) (err error) {
 		return err
 	}
 	defer db.execSem.Release(1)
+
+	db.closeSnapshotReaders()
 
 	// Perform a final db sync, if initialized.
 	if db.db != nil {
@@ -2686,12 +2694,15 @@ func (p *snapshotReadPosition) close() {
 
 type snapshotReadCloser struct {
 	*io.PipeReader
-	pos *snapshotReadPosition
+	done      chan struct{}
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func (r *snapshotReadCloser) Close() error {
-	defer r.pos.close()
-	return r.PipeReader.Close()
+	r.closeOnce.Do(func() { r.closeErr = r.PipeReader.Close() })
+	<-r.done
+	return r.closeErr
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
@@ -2699,7 +2710,16 @@ func (r *snapshotReadCloser) Close() error {
 // closed. Callers must close readers they do not fully consume; abandoning a
 // reader blocks checkpoints indefinitely.
 func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.ReadCloser, error) {
-	pos, err := db.snapshotPosition(ctx)
+	if err := db.lockExec(ctx); err != nil {
+		return ltx.Pos{}, nil, err
+	}
+	defer db.execSem.Release(1)
+
+	if !db.IsOpen() {
+		return ltx.Pos{}, nil, ErrDatabaseNotOpen
+	}
+
+	pos, err := db.snapshotPositionLocked()
 	if err != nil {
 		return ltx.Pos{}, nil, err
 	}
@@ -2712,12 +2732,7 @@ func (db *DB) SnapshotReader(ctx context.Context) (ltx.Pos, io.ReadCloser, error
 	return pos.pos, r, nil
 }
 
-func (db *DB) snapshotPosition(ctx context.Context) (*snapshotReadPosition, error) {
-	if err := db.lockExec(ctx); err != nil {
-		return nil, err
-	}
-	defer db.execSem.Release(1)
-
+func (db *DB) snapshotPositionLocked() (*snapshotReadPosition, error) {
 	pageSize := db.PageSize()
 	pos, err := db.Pos()
 
@@ -2792,7 +2807,7 @@ func (db *DB) snapshotWALEndOffset(pos ltx.Pos) (int64, error) {
 	return dec.Header().WALOffset + dec.Header().WALSize, nil
 }
 
-func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io.ReadCloser, error) {
+func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (*snapshotReadCloser, error) {
 	db.Logger.Debug("snapshot", "txid", pos.pos.TXID.String(), "walEndOffset", pos.walEndOffset)
 
 	// TODO(ltx): Read database size from database header.
@@ -2805,8 +2820,14 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 
 	// Execute encoding in a separate goroutine so the caller can initialize before reading.
 	pr, pw := io.Pipe()
+	r := &snapshotReadCloser{PipeReader: pr, done: make(chan struct{})}
+	db.registerSnapshotReader(r)
 	go func() {
-		defer pos.close()
+		defer func() {
+			pos.close()
+			db.unregisterSnapshotReader(r)
+			close(r.done)
+		}()
 
 		walFile, err := os.Open(db.WALPath())
 		if err != nil {
@@ -2886,7 +2907,32 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 		_ = pw.Close()
 	}()
 
-	return &snapshotReadCloser{PipeReader: pr, pos: pos}, nil
+	return r, nil
+}
+
+func (db *DB) registerSnapshotReader(r *snapshotReadCloser) {
+	db.snapshotReaders.Lock()
+	defer db.snapshotReaders.Unlock()
+	db.snapshotReaders.m[r] = struct{}{}
+}
+
+func (db *DB) unregisterSnapshotReader(r *snapshotReadCloser) {
+	db.snapshotReaders.Lock()
+	defer db.snapshotReaders.Unlock()
+	delete(db.snapshotReaders.m, r)
+}
+
+func (db *DB) closeSnapshotReaders() {
+	db.snapshotReaders.Lock()
+	readers := make([]*snapshotReadCloser, 0, len(db.snapshotReaders.m))
+	for r := range db.snapshotReaders.m {
+		readers = append(readers, r)
+	}
+	db.snapshotReaders.Unlock()
+
+	for _, r := range readers {
+		_ = r.Close()
+	}
 }
 
 func snapshotHeaderWALRange(maxOffset, frameSize int64) (offset, size int64) {

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -33,9 +33,16 @@ type testReplicaClient struct {
 
 type earlyReturnSnapshotClient struct {
 	*testReplicaClient
+	reader chan *snapshotReadCloser
 }
 
-func (c *earlyReturnSnapshotClient) WriteLTXFile(_ context.Context, level int, minTXID, maxTXID ltx.TXID, _ io.Reader) (*ltx.FileInfo, error) {
+func (c *earlyReturnSnapshotClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if level != SnapshotLevel {
+		return c.testReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+	}
+	if c.reader != nil {
+		c.reader <- r.(*snapshotReadCloser)
+	}
 	return &ltx.FileInfo{Level: level, MinTXID: minTXID, MaxTXID: maxTXID}, nil
 }
 
@@ -119,6 +126,98 @@ func (c *testReplicaClient) DeleteAll(_ context.Context) error {
 func mustAcquireSemaphore(s *semaphore.Weighted) {
 	if err := s.Acquire(context.Background(), 1); err != nil {
 		panic(err)
+	}
+}
+
+func TestDB_SnapshotJoinsEncoderOnEarlyReplicaReturn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "db")
+	client := &earlyReturnSnapshotClient{
+		testReplicaClient: &testReplicaClient{dir: t.TempDir()},
+		reader:            make(chan *snapshotReadCloser, 1),
+	}
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplicaWithClient(db, client)
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if db.IsOpen() {
+			_ = db.Close(context.Background())
+		}
+	}()
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Snapshot(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	reader := <-client.reader
+
+	select {
+	case <-reader.done:
+	default:
+		t.Fatal("Snapshot returned before its encoder goroutine completed")
+	}
+
+	if !db.chkMu.TryLock() {
+		t.Fatal("snapshot encoder did not release the checkpoint lock")
+	}
+	db.chkMu.Unlock()
+}
+
+func TestSnapshotReadCloser_CloseWaitsForEncoder(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+
+	reader := &snapshotReadCloser{PipeReader: pr, done: make(chan struct{})}
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- reader.Close() }()
+
+	writeResult := make(chan error, 1)
+	go func() {
+		_, err := pw.Write([]byte("x"))
+		writeResult <- err
+	}()
+
+	select {
+	case err := <-writeResult:
+		if !errors.Is(err, io.ErrClosedPipe) {
+			t.Fatalf("write error=%v, want io.ErrClosedPipe", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader close did not close the pipe")
+	}
+
+	select {
+	case err := <-closeResult:
+		t.Fatalf("Close returned before encoder completion: %v", err)
+	default:
+	}
+
+	close(reader.done)
+	select {
+	case err := <-closeResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return after encoder completion")
 	}
 }
 

--- a/store.go
+++ b/store.go
@@ -234,6 +234,9 @@ func (s *Store) Open(ctx context.Context) error {
 }
 
 func (s *Store) Close(ctx context.Context) (err error) {
+	s.cancel()
+	s.wg.Wait()
+
 	s.mu.Lock()
 	dbs := slices.Clone(s.dbs)
 	s.mu.Unlock()
@@ -249,10 +252,6 @@ func (s *Store) Close(ctx context.Context) (err error) {
 			}
 		}
 	}
-
-	// Cancel and wait for background tasks to complete.
-	s.cancel()
-	s.wg.Wait()
 
 	return err
 }

--- a/store.go
+++ b/store.go
@@ -235,7 +235,6 @@ func (s *Store) Open(ctx context.Context) error {
 
 func (s *Store) Close(ctx context.Context) (err error) {
 	s.cancel()
-	s.wg.Wait()
 
 	s.mu.Lock()
 	dbs := slices.Clone(s.dbs)
@@ -253,7 +252,28 @@ func (s *Store) Close(ctx context.Context) (err error) {
 		}
 	}
 
+	if e := s.waitForMonitors(ctx); e != nil && err == nil {
+		err = e
+	}
+
 	return err
+}
+
+func (s *Store) waitForMonitors(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-s.done:
+		return ErrShutdownInterrupted
+	}
 }
 
 func (s *Store) DBs() []*DB {

--- a/store_internal_test.go
+++ b/store_internal_test.go
@@ -2,35 +2,65 @@ package litestream
 
 import (
 	"context"
-	"log/slog"
+	"database/sql"
+	"errors"
+	"io"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/superfly/ltx"
 )
 
-func TestStore_CloseStopsMonitorsBeforeDBClose(t *testing.T) {
-	handler := newBlockingCompactionMonitorHandler()
-	db := NewDB(filepath.Join(t.TempDir(), "db"))
-	db.Replica = NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+func TestStore_CloseFlushesBeforeInterruptibleMonitorWait(t *testing.T) {
+	client := newBlockingSnapshotClient(t.TempDir())
+	dbPath := filepath.Join(t.TempDir(), "db")
+	db := NewDB(dbPath)
+	db.MonitorInterval = 0
+	db.Replica = NewReplicaWithClient(db, client)
+	db.Replica.MonitorEnabled = false
+	if err := db.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqldb.Close()
+	if _, err := sqldb.Exec(`PRAGMA journal_mode = wal`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqldb.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	_, beforeTXID, err := db.MaxLTX()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	store := NewStore([]*DB{db}, CompactionLevels{{Level: 0}})
 	store.L0Retention = 0
-	store.Logger = slog.New(handler)
+	store.SnapshotInterval = time.Hour
+	done := make(chan struct{})
+	store.SetDone(done)
 
 	if err := store.Open(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		handler.unblock()
-		if db.IsOpen() {
-			_ = store.Close(context.Background())
-		}
-	})
 
 	select {
-	case <-handler.started:
+	case <-client.started:
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for compaction monitor")
+		t.Fatal("timed out waiting for snapshot upload")
+	}
+
+	if _, err := sqldb.Exec(`INSERT INTO t DEFAULT VALUES`); err != nil {
+		t.Fatal(err)
 	}
 
 	closeResult := make(chan error, 1)
@@ -38,59 +68,109 @@ func TestStore_CloseStopsMonitorsBeforeDBClose(t *testing.T) {
 		closeResult <- store.Close(context.Background())
 	}()
 
-	var dbOpenAtCancel bool
-	select {
-	case <-store.ctx.Done():
-		dbOpenAtCancel = db.IsOpen()
-	case <-time.After(5 * time.Second):
-		handler.unblock()
-		<-closeResult
-		t.Fatal("timed out waiting for Store cancellation")
+	cleaned := false
+	t.Cleanup(func() {
+		if cleaned {
+			return
+		}
+		client.unblock()
+		select {
+		case <-done:
+		default:
+			close(done)
+		}
+		select {
+		case <-closeResult:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for db.IsOpen() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if db.IsOpen() {
+		t.Fatal("database did not reach final sync while snapshot upload was blocked")
 	}
 
-	handler.unblock()
-	if err := <-closeResult; err != nil {
+	_, afterTXID, err := db.MaxLTX()
+	if err != nil {
 		t.Fatal(err)
 	}
-	if !dbOpenAtCancel {
-		t.Fatal("database closed before Store monitors stopped")
+	if afterTXID <= beforeTXID {
+		t.Fatalf("final sync txid=%s, want greater than %s", afterTXID, beforeTXID)
+	}
+	if got := db.Replica.Pos().TXID; got != afterTXID {
+		t.Fatalf("replica txid=%s, want %s", got, afterTXID)
+	}
+
+	select {
+	case err := <-closeResult:
+		t.Fatalf("Store.Close returned before the second signal: %v", err)
+	default:
+	}
+
+	close(done)
+	select {
+	case err := <-closeResult:
+		if !errors.Is(err, ErrShutdownInterrupted) {
+			t.Fatalf("Store.Close error=%v, want ErrShutdownInterrupted", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Store.Close did not honor the second signal")
+	}
+
+	client.unblock()
+	monitorsDone := make(chan struct{})
+	go func() {
+		store.wg.Wait()
+		close(monitorsDone)
+	}()
+	select {
+	case <-monitorsDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshot monitor did not stop after upload unblocked")
+	}
+	cleaned = true
+}
+
+func TestStore_WaitForMonitorsHonorsContext(t *testing.T) {
+	store := NewStore(nil, nil)
+	store.wg.Add(1)
+	defer store.wg.Done()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := store.waitForMonitors(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v, want context canceled", err)
 	}
 }
 
-type blockingCompactionMonitorHandler struct {
+type blockingSnapshotClient struct {
+	*testReplicaClient
 	started     chan struct{}
 	unblockCh   chan struct{}
 	startedOnce sync.Once
 	unblockOnce sync.Once
 }
 
-func newBlockingCompactionMonitorHandler() *blockingCompactionMonitorHandler {
-	return &blockingCompactionMonitorHandler{
-		started:   make(chan struct{}),
-		unblockCh: make(chan struct{}),
+func newBlockingSnapshotClient(dir string) *blockingSnapshotClient {
+	return &blockingSnapshotClient{
+		testReplicaClient: &testReplicaClient{dir: dir},
+		started:           make(chan struct{}),
+		unblockCh:         make(chan struct{}),
 	}
 }
 
-func (h *blockingCompactionMonitorHandler) Enabled(context.Context, slog.Level) bool {
-	return true
-}
-
-func (h *blockingCompactionMonitorHandler) Handle(_ context.Context, record slog.Record) error {
-	if record.Message == "starting compaction monitor" {
-		h.startedOnce.Do(func() { close(h.started) })
-		<-h.unblockCh
+func (c *blockingSnapshotClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if level != SnapshotLevel {
+		return c.testReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
 	}
-	return nil
+	c.startedOnce.Do(func() { close(c.started) })
+	<-c.unblockCh
+	return nil, context.Canceled
 }
 
-func (h *blockingCompactionMonitorHandler) WithAttrs([]slog.Attr) slog.Handler {
-	return h
-}
-
-func (h *blockingCompactionMonitorHandler) WithGroup(string) slog.Handler {
-	return h
-}
-
-func (h *blockingCompactionMonitorHandler) unblock() {
-	h.unblockOnce.Do(func() { close(h.unblockCh) })
+func (c *blockingSnapshotClient) unblock() {
+	c.unblockOnce.Do(func() { close(c.unblockCh) })
 }

--- a/store_internal_test.go
+++ b/store_internal_test.go
@@ -1,0 +1,96 @@
+package litestream
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStore_CloseStopsMonitorsBeforeDBClose(t *testing.T) {
+	handler := newBlockingCompactionMonitorHandler()
+	db := NewDB(filepath.Join(t.TempDir(), "db"))
+	db.Replica = NewReplicaWithClient(db, &testReplicaClient{dir: t.TempDir()})
+	store := NewStore([]*DB{db}, CompactionLevels{{Level: 0}})
+	store.L0Retention = 0
+	store.Logger = slog.New(handler)
+
+	if err := store.Open(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		handler.unblock()
+		if db.IsOpen() {
+			_ = store.Close(context.Background())
+		}
+	})
+
+	select {
+	case <-handler.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for compaction monitor")
+	}
+
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- store.Close(context.Background())
+	}()
+
+	var dbOpenAtCancel bool
+	select {
+	case <-store.ctx.Done():
+		dbOpenAtCancel = db.IsOpen()
+	case <-time.After(5 * time.Second):
+		handler.unblock()
+		<-closeResult
+		t.Fatal("timed out waiting for Store cancellation")
+	}
+
+	handler.unblock()
+	if err := <-closeResult; err != nil {
+		t.Fatal(err)
+	}
+	if !dbOpenAtCancel {
+		t.Fatal("database closed before Store monitors stopped")
+	}
+}
+
+type blockingCompactionMonitorHandler struct {
+	started     chan struct{}
+	unblockCh   chan struct{}
+	startedOnce sync.Once
+	unblockOnce sync.Once
+}
+
+func newBlockingCompactionMonitorHandler() *blockingCompactionMonitorHandler {
+	return &blockingCompactionMonitorHandler{
+		started:   make(chan struct{}),
+		unblockCh: make(chan struct{}),
+	}
+}
+
+func (h *blockingCompactionMonitorHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *blockingCompactionMonitorHandler) Handle(_ context.Context, record slog.Record) error {
+	if record.Message == "starting compaction monitor" {
+		h.startedOnce.Do(func() { close(h.started) })
+		<-h.unblockCh
+	}
+	return nil
+}
+
+func (h *blockingCompactionMonitorHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *blockingCompactionMonitorHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *blockingCompactionMonitorHandler) unblock() {
+	h.unblockOnce.Do(func() { close(h.unblockCh) })
+}


### PR DESCRIPTION
## Description

Preserves the final database flush when Store-owned monitors are slow or ignore cancellation, while eliminating the snapshot encoder race with database handle cleanup.

- cancels Store monitors immediately, then lets each database complete its final WAL-to-LTX sync, replica sync, and handle cleanup before waiting for those monitors
- makes the post-flush monitor wait interruptible by `Close(ctx)` or the CLI second-signal channel
- registers snapshot readers while holding the DB execution semaphore
- closes and joins every active snapshot encoder before final sync and before `DB.Close()` clears `db.f`
- closes and joins the encoder when a snapshot backend returns early, whether it returns success or failure

## Motivation and Context

A full race sweep while validating PR #1396 caught `DB.Close()` clearing database fields while `monitorCompactionLevel()` was still taking a snapshot. The initial fix moved `s.wg.Wait()` before `DB.Close()`, but cold review found that ordering introduced a durability regression: file fsync and SFTP operations can ignore cancellation, so shutdown could block before the final WAL-to-LTX and replica sync. A second signal could not interrupt that wait.

The review also found that waiting for the Store monitor did not completely eliminate the original race. `snapshotReader` launches an encoder goroutine that was not joined when a backend returned early; the monitor could finish while that encoder still used `db.f`.

Both major findings and the test-coverage finding were confirmed. The revised design does not make final-flush correctness depend on a backend monitor stopping:

1. Store cancellation prevents normal new work.
2. `DB.Close()` acquires the DB execution semaphore, closes all registered snapshot pipes, and joins their encoders.
3. The database performs its final local and replica sync and clears its handles.
4. Store waits for any remaining backend monitor work only after the durability work is complete; caller cancellation or a second signal can interrupt that wait.

This deliberately avoids placing an unbounded backend wait in front of the final flush. Discovered while validating #1396.

## How Has This Been Tested?

The regressions fail on the previous PR head `4364eab`:

- an early-success snapshot backend lets `Snapshot` return while its encoder still holds the checkpoint lock
- a non-cancelable snapshot upload prevents `Store.Close()` from reaching the final sync

The replacement Store regression runs through the real snapshot monitor and `snapshotReader`, leaves the backend blocked after cancellation, writes pending WAL data, and verifies that shutdown still advances both the local and replica TXIDs before a second signal interrupts the remaining monitor wait.

```bash
go test -race -count=10 -run '^(TestDB_SnapshotJoinsEncoderOnEarlyReplicaReturn|TestStore_CloseFlushesBeforeInterruptibleMonitorWait|TestStore_WaitForMonitorsHonorsContext)$' .
go test -race -count=10 -timeout 45m ./...
pre-commit run --all-files
go build -o bin/litestream ./cmd/litestream
go build -o bin/litestream-test ./cmd/litestream-test
go test -tags 'integration,soak' -run '^TestLTXBehavior$' -short -v -timeout 10m ./tests/integration/
```

The low-, high-, and burst-volume behavioral profiles all passed shutdown, restoration, and integrity validation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (not needed; shutdown contract is unchanged)
