### PR TITLE
docs(security): document private vulnerability reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Contributing
 
 We welcome bug reports, fixes, and patches! Please see our [Contributing Guide](CONTRIBUTING.md) for details on how to contribute.
 
+Security
+--------
+
+Please do not open a public issue for security vulnerabilities. Report them
+privately through GitHub's [private vulnerability reporting](https://github.com/benbjohnson/litestream/security/advisories/new),
+which keeps the report visible only to you and the maintainers until a fix is
+released. See our [Security Policy](SECURITY.md) for what to include and what to
+expect.
+
 Acknowledgements
 ----------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,9 @@ We take security issues seriously. If you discover a security vulnerability in L
 
 **Please DO NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please report security issues via email to the maintainers. This allows us to assess the issue and release a fix before the vulnerability is publicly disclosed.
+Instead, use GitHub's [private vulnerability reporting](https://github.com/benbjohnson/litestream/security/advisories/new) to open a report that only you and the maintainers can see. This allows us to assess the issue and release a fix before the vulnerability is publicly disclosed.
+
+You can also reach the form from the [Security tab](https://github.com/benbjohnson/litestream/security/advisories) of the repository.
 
 ## What to Include
 


### PR DESCRIPTION
## Description

Replaces the dead "email the maintainers" instruction with GitHub private vulnerability reporting, which is now enabled on this repository.

- `SECURITY.md`: the reporting section pointed people at email but never gave an address. It now links the private advisory form and the Security tab.
- `README.md`: had no security section at all. Adds a short `Security` section between `Contributing` and `Acknowledgements` directing reporters to the private form and to `SECURITY.md` for details.

Docs only — no code, config, or workflow changes.

## Motivation and Context

A security engineer opened #1388 saying he had found what may be a vulnerability but could not report it: the policy told him to email a maintainer and listed no contact address. Private vulnerability reporting has since been turned on in the repository settings, but the docs still described the old, unusable channel. This makes the documentation match reality so the next reporter is not blocked the same way.

Related to #1388 (left open until the original reporter confirms his report went through).

## How Has This Been Tested?

- Confirmed private vulnerability reporting is live: `gh api repos/benbjohnson/litestream/private-vulnerability-reporting` returns `{"enabled":true}`.
- Verified both advisory URLs resolve for the repository.
- Markdown link syntax and section ordering reviewed in the rendered diff.

No automated tests apply; no Go source is touched.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`) — N/A, docs only; pre-commit hooks passed
- [x] I have tested my changes (`go test ./...`) — N/A, no code changed
- [x] I have updated the documentation accordingly (if needed)