### PR TITLE
fix(packaging): omit Homebrew sample config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,7 +91,6 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     install: |
       bin.install "litestream"
-      etc.install "etc/litestream.yml" => "litestream.yml"
     test: |
       system "#{bin}/litestream", "version"
     commit_author:


### PR DESCRIPTION
## Description
Stop the Homebrew formula from installing the sample configuration into Homebrew's prefix. Homebrew installations now install only the Litestream binary, while release archives and Debian/RPM packages retain their existing configuration behavior.

## Motivation and Context
Homebrew installs configuration files under its own prefix, such as `/opt/homebrew/etc`, while Litestream defaults to `/etc/litestream.yml`. The installed sample was therefore never discovered automatically, leaving users with an unused file while the CLI referenced a different location.

Fixes #1412

## How Has This Been Tested?
- `pre-commit run --all-files`
- `go test -race -v ./...`
- `git diff --check origin/main...HEAD`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (no documentation change is needed for this packaging-only fix)
