### PR TITLE
fix(config): accept l0-retention: 0 as disabled

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -54,7 +54,7 @@ var (
 	ErrInvalidSnapshotRetention        = errors.New("snapshot retention must be greater than 0")
 	ErrInvalidCompactionInterval       = errors.New("compaction interval must be greater than 0")
 	ErrInvalidSyncInterval             = errors.New("sync interval must be greater than 0")
-	ErrInvalidL0Retention              = errors.New("l0 retention must be greater than 0")
+	ErrInvalidL0Retention              = errors.New("l0 retention must not be negative")
 	ErrInvalidL0RetentionCheckInterval = errors.New("l0 retention check interval must be greater than 0")
 	ErrInvalidShutdownSyncTimeout      = errors.New("shutdown-sync-timeout must be >= 0")
 	ErrInvalidShutdownSyncInterval     = errors.New("shutdown sync interval must be greater than 0")
@@ -432,7 +432,7 @@ func (c *Config) Validate() error {
 			Value: *c.Snapshot.Retention,
 		}
 	}
-	if c.L0Retention != nil && *c.L0Retention <= 0 {
+	if c.L0Retention != nil && *c.L0Retention < 0 {
 		return &ConfigValidationError{
 			Err:   ErrInvalidL0Retention,
 			Field: "l0-retention",

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -875,7 +875,7 @@ func TestParseReplicaURL_AccessPoint(t *testing.T) {
 }
 
 func TestConfig_Validate_L0Retention(t *testing.T) {
-	t.Run("ZeroRetention", func(t *testing.T) {
+	t.Run("ZeroRetentionDisables", func(t *testing.T) {
 		yaml := `
 l0-retention: 0s
 dbs:
@@ -883,9 +883,29 @@ dbs:
     replica:
       url: file:///tmp/replica
 `
+		config, err := main.ParseConfig(strings.NewReader(yaml), false)
+		if err != nil {
+			t.Fatalf("expected zero l0 retention to be accepted: %v", err)
+		}
+		if config.L0Retention == nil {
+			t.Fatal("expected l0 retention to be set")
+		}
+		if *config.L0Retention != 0 {
+			t.Errorf("expected l0 retention of 0, got %v", *config.L0Retention)
+		}
+	})
+
+	t.Run("NegativeRetention", func(t *testing.T) {
+		yaml := `
+l0-retention: -1s
+dbs:
+  - path: /tmp/test.db
+    replica:
+      url: file:///tmp/replica
+`
 		_, err := main.ParseConfig(strings.NewReader(yaml), false)
 		if err == nil {
-			t.Fatal("expected error for zero l0 retention")
+			t.Fatal("expected error for negative l0 retention")
 		}
 		if !errors.Is(err, main.ErrInvalidL0Retention) {
 			t.Errorf("expected ErrInvalidL0Retention, got %v", err)


### PR DESCRIPTION
## Summary
Allow `l0-retention: 0` in config to disable L0 retention, matching the runtime semantics where the Store and Compactor already treat `0` as disabled.

## Problem
Config validation rejects `l0-retention: 0` with `ErrInvalidL0Retention`, even though the engine already implements "0 = disabled":

- `store.go:236` starts the L0 retention monitor only when `L0Retention > 0`
- `compactor.go:343` `EnforceL0Retention` returns early when `retention <= 0` ("retention disabled")

Before this fix:
```
$ litestream replicate -config ls.yml
Error: l0-retention: l0 retention must be greater than 0 (got 0s)
```

So a user who wants "never delete compacted L0 files" cannot express it in YAML despite the engine fully supporting it. The codebase also disagreed with itself: `compactor_test.go` titled "Enforce L0 retention with 0 duration (delete immediately)" while the code path no-ops.

## Solution
Relax the validation from `<= 0` to `< 0` for `l0-retention` (only negative values are invalid), matching the existing precedent of `shutdown-sync-timeout` which allows `0` (`main.go`). Update the sentinel error message to reflect the new contract and rewrite the tests to codify "0 = disabled".

After this fix:
```
$ litestream replicate -config ls.yml
... "initialized db" path=/tmp/opencode/test.db
... "replicating to" type=file sync-interval=1s
... "starting compaction monitor" system=store level=1 interval=30s
... "snapshot complete" ...
(no "starting L0 retention monitor" log line — monitor disabled)
```

## Scope
**In scope:**
- Config validation change for `l0-retention`
- Tests codifying `0` = disabled, negative = invalid

**Not in scope:**
- `l0-retention-check-interval` semantics (still requires > 0)
- `snapshot.retention` semantics

## Test Plan
```bash
go test -v ./cmd/litestream/ -run TestConfig_Validate_L0Retention
go test -race ./...
```
Both pass. E2E verified manually: replicate with `l0-retention: 0s` starts and does not start the L0 retention monitor.

## Related
- Fixes #1406
