### PR TITLE
fix(replica): return an error for a truncated page index

### DIFF
--- a/replica_client.go
+++ b/replica_client.go
@@ -131,6 +131,13 @@ func fetchPageIndexData(ctx context.Context, client ReplicaClient, info *ltx.Fil
 	if err != nil {
 		return nil, fmt.Errorf("read ltx page index: %w", err)
 	}
+	// The replica may return fewer bytes than a page index footer occupies, for
+	// example if the file is truncated or otherwise corrupt. Slicing the footer
+	// off the end unchecked would index past the start of the buffer and panic.
+	if len(b) < ltx.TrailerSize+8 {
+		return nil, fmt.Errorf("ltx file too short to contain a page index: %d bytes", len(b))
+	}
+
 	size := binary.BigEndian.Uint64(b[len(b)-ltx.TrailerSize-8:])
 	if off := len(b) - int(size) - ltx.TrailerSize - 8; off > 0 {
 		return io.NopCloser(bytes.NewReader(b[off:])), nil

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/internal/testingutil"
+	"github.com/benbjohnson/litestream/mock"
 	"github.com/benbjohnson/litestream/s3"
 )
 
@@ -1071,4 +1072,27 @@ func TestReplicaClient_PITR_CalcRestorePlanWithManyFiles(t *testing.T) {
 			}
 		})
 	})
+}
+
+// A replica can return fewer bytes than a page index footer occupies, for
+// example if the file is truncated. That must surface as an error rather than
+// panicking on a negative slice index.
+func TestFetchPageIndex_ShortRead(t *testing.T) {
+	client := &mock.ReplicaClient{
+		OpenLTXFileFunc: func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("short"))), nil
+		},
+	}
+
+	_, err := litestream.FetchPageIndex(context.Background(), client, &ltx.FileInfo{
+		Level:   0,
+		MinTXID: 1,
+		MaxTXID: 1,
+		Size:    5,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a truncated ltx file")
+	} else if !strings.Contains(err.Error(), "too short") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }


### PR DESCRIPTION
## Problem

`fetchPageIndexData` slices the page index footer off the end of whatever the replica returned, without checking there is enough of it to slice:

```go
b, err := io.ReadAll(f)
...
size := binary.BigEndian.Uint64(b[len(b)-ltx.TrailerSize-8:])
```

If the replica returns fewer than `ltx.TrailerSize+8` bytes — a truncated or corrupt file, or a short read — the index goes negative and the process panics rather than returning an error:

```
--- FAIL: TestFetchPageIndex_ShortRead (0.00s)
panic: runtime error: slice bounds out of range [-19:] [recovered, repanicked]
panic({0x1383a00?, 0x4658339920f0?})
	/usr/local/go/src/runtime/panic.go:860 +0x12c
```

That output is the included test run against `main` without the fix.

This matters more when litestream is embedded than when it is the CLI. We run it inside a long-lived daemon that also hosts other workloads, so a single corrupt backup file takes down considerably more than the replication for that one database.

## Scope

**In scope:**

- A length check in `fetchPageIndexData` before the footer is read, returning an error instead of panicking
- A regression test covering the short-read case

**Not in scope (happy to follow up separately if you want them):**

- The `int(size)` conversion two lines later, which can overflow on 32-bit builds
- The resumable-reader retry paths
- Any other unchecked slice expressions in this file

## Test

```
go test -run TestFetchPageIndex_ShortRead .
```

Passes with the fix, panics as shown above without it. The full package suite also passes:

```
go test .
ok  	github.com/benbjohnson/litestream	20.458s
```

The test uses the existing `mock.ReplicaClient` and goes through the exported `FetchPageIndex`, so it needs no new test infrastructure.
