### PR TITLE
fix(restore): retry through provider throttle responses

### DIFF
--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -64,6 +65,11 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 }
 
 const resumableReaderMaxRetries = 3
+
+// resumableReaderBackoff is the base delay between retry attempts, doubling
+// per attempt. Zero-delay retries land every attempt inside the same provider
+// throttle window (e.g. Tigris 408 load shedding), guaranteeing exhaustion.
+const resumableReaderBackoff = 250 * time.Millisecond
 
 func (r *ResumableReader) Read(p []byte) (int, error) {
 	if r.err != nil {
@@ -155,10 +161,20 @@ func (r *ResumableReader) close() {
 
 func (r *ResumableReader) retry(err error) error {
 	r.retryN++
-	if r.retryN <= resumableReaderMaxRetries {
-		return nil
+	if r.retryN > resumableReaderMaxRetries {
+		r.err = fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d): %w",
+			r.level, r.minTXID, r.maxTXID, r.offset, err)
+		return r.err
 	}
-	r.err = fmt.Errorf("max retries exceeded reading ltx file (level=%d, min=%s, max=%s, offset=%d): %w",
-		r.level, r.minTXID, r.maxTXID, r.offset, err)
-	return r.err
+
+	// Wait before the caller reopens. Retrying with no delay lands every
+	// attempt inside the same provider throttle window, so the attempts are
+	// spent without the provider ever getting a chance to recover.
+	select {
+	case <-r.ctx.Done():
+		r.err = r.ctx.Err()
+		return r.err
+	case <-time.After(resumableReaderBackoff << (r.retryN - 1)):
+	}
+	return nil
 }

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/superfly/ltx"
 )
@@ -360,4 +362,87 @@ func (r *errorAfterN) Read(p []byte) (int, error) {
 	n := copy(p, r.data[r.pos:r.pos+len(p)])
 	r.pos += n
 	return n, nil
+}
+
+func TestResumableReader_BackoffBetweenReopens(t *testing.T) {
+	// Burst-retrying a throttling provider (e.g. Tigris load-shedding with
+	// 408 RequestCanceled) lands every reopen attempt inside the same
+	// throttle window. Reopens must back off between attempts.
+	data := []byte("hello world")
+	var callTimes []time.Time
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			callTimes = append(callTimes, time.Now())
+			if len(callTimes) <= 2 {
+				return nil, fmt.Errorf("operation error S3: GetObject, api error RequestCanceled: Request is canceled.")
+			}
+			return io.NopCloser(bytes.NewReader(data[offset:])), nil
+		},
+	}
+
+	r := NewResumableReader(context.Background(), client, 2, 1, 2, int64(len(data)), nil, slog.Default())
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q, want %q", got, data)
+	}
+	if len(callTimes) != 3 {
+		t.Fatalf("expected 3 OpenLTXFile calls, got %d", len(callTimes))
+	}
+	for i := 1; i < len(callTimes); i++ {
+		if gap := callTimes[i].Sub(callTimes[i-1]); gap < 100*time.Millisecond {
+			t.Fatalf("reopen attempt %d fired %v after attempt %d; want >= 100ms backoff", i+1, gap, i)
+		}
+	}
+}
+
+func TestResumableReader_ContextCancelAbortsBackoff(t *testing.T) {
+	// Cancellation has to interrupt the backoff itself, not just be noticed
+	// before the next attempt. Read() already returns early when the context
+	// is done at reopen time, so the wait is cancelled from another goroutine
+	// while it is in progress.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opened := make(chan struct{}, 1)
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			select {
+			case opened <- struct{}{}:
+			default:
+			}
+			return nil, fmt.Errorf("connection reset")
+		},
+	}
+
+	go func() {
+		<-opened
+		cancel()
+	}()
+
+	r := NewResumableReader(ctx, client, 2, 1, 2, 11, nil, slog.Default())
+	start := time.Now()
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want an error wrapping context.Canceled", err)
+	}
+	// Full backoff without cancellation would be 250ms+500ms+1s.
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("read blocked %v after cancellation; backoff must abort on ctx.Done", elapsed)
+	}
+
+	// The cancellation is terminal, matching how the reader treats its other
+	// terminal errors: a later Read must not reopen the file.
+	before := len(opened)
+	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("read after cancellation returned %v, want context.Canceled", err)
+	}
+	if len(opened) != before {
+		t.Fatal("read after cancellation reopened the file; cancellation must be sticky")
+	}
 }

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -570,6 +570,19 @@ func newTransportRetryer() aws.Retryer {
 	return retry.NewStandard(func(o *retry.StandardOptions) {
 		o.MaxAttempts = transportRetryMaxAttempts
 		o.RateLimiter = ratelimit.None
+		// S3-compatible providers (observed: Tigris) load-shed with HTTP 408
+		// and api error code "RequestCanceled", neither of which the SDK
+		// classifies as retryable by default. Genuine client-side context
+		// cancellation stays non-retryable via the standard retryer's
+		// canceled-context check, which runs before these.
+		o.Retryables = append(o.Retryables,
+			retry.RetryableHTTPStatusCode{Codes: map[int]struct{}{
+				http.StatusRequestTimeout: {},
+			}},
+			retry.RetryableErrorCode{Codes: map[string]struct{}{
+				"RequestCanceled": {},
+			}},
+		)
 	})
 }
 

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -2932,3 +2932,35 @@ func TestReplicaClient_RetryerSurvivesSustainedFailures(t *testing.T) {
 		}
 	}
 }
+
+// TestTransportRetryer_RetriesProviderThrottleResponses covers S3-compatible
+// providers that load-shed with HTTP 408 / api error "RequestCanceled"
+// (observed from Tigris during soak testing). The SDK defaults treat neither
+// as retryable, so restores failed after effectively zero patience.
+func TestTransportRetryer_RetriesProviderThrottleResponses(t *testing.T) {
+	retryer := newTransportRetryer()
+
+	status408 := &smithyhttp.ResponseError{Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusRequestTimeout}}, Err: fmt.Errorf("request timeout")}
+	if !retryer.IsErrorRetryable(status408) {
+		t.Fatal("HTTP 408 must be retryable for S3-compatible providers")
+	}
+
+	canceledCode := &smithy.GenericAPIError{Code: "RequestCanceled", Message: "Request is canceled."}
+	if !retryer.IsErrorRetryable(canceledCode) {
+		t.Fatal(`api error code "RequestCanceled" (server-side load shed) must be retryable`)
+	}
+
+	// A bare wrapped context.Canceled proves little: every classifier returns
+	// "unknown" for it, so it would come back non-retryable even without the
+	// canceled-error guard. Wrapping a RequestCanceled API error in a real
+	// smithy.CanceledError is the case that actually exercises precedence --
+	// the guard must win over the RequestCanceled classifier added above.
+	clientCanceled := &smithy.CanceledError{Err: &smithy.GenericAPIError{Code: "RequestCanceled", Message: "Request is canceled."}}
+	if retryer.IsErrorRetryable(clientCanceled) {
+		t.Fatal("genuine client-side cancellation must NOT be retryable, even wrapping a RequestCanceled api error")
+	}
+
+	if retryer.IsErrorRetryable(fmt.Errorf("wrapped: %w", context.Canceled)) {
+		t.Fatal("genuine client-side context cancellation must NOT be retryable")
+	}
+}


### PR DESCRIPTION
## Description

S3-compatible providers load-shed with HTTP `408` and api error code `RequestCanceled`. The AWS SDK classifies neither as retryable by default, so a restore gives up on the first throttled response. `ResumableReader` compounds this by retrying with no delay at all, so all three attempts land inside the same throttle window and are spent before the provider has any chance to recover.

Two changes:

- `s3/replica_client.go` — append `RetryableHTTPStatusCode{408}` and `RetryableErrorCode{"RequestCanceled"}` to the transport retryer.
- `internal/resumable_reader.go` — wait between reopen attempts, 250ms base doubling per attempt (250ms, 500ms, 1s; 1.75s worst case per reader). Cancellation interrupts the wait rather than blocking on it, and is terminal in the same way the reader's other terminal errors are.

## Motivation and Context

This fix was already written and **approved by @benbjohnson** in #1306, but that PR merged into `fix-s3-retry-quota-exhaustion` rather than `main`, so it never reached `main` or any release. That branch is now 2 ahead / 33 behind and its other commit duplicates work already squashed onto main via #1305, so it should not be merged — hence this fresh PR off current `main`.

**The `s3/` change here is #1306 verbatim.** The `internal/resumable_reader.go` change is a **re-port and wants fresh review**: #1306 placed the wait at the top of a bounded `for attempt := 0; attempt <= resumableReaderMaxRetries; attempt++` loop, which no longer exists — `Read` was since restructured into `for {}` plus a `retry()` helper. The wait now lives in `retry()`, which is the equivalent single choke point for all three retry sites.

Found by continuous soak testing against Tigris. Field evidence across ~1 month: 95 failures on two `syd` workers and 9 on two `ams` workers, e.g.

```
Error: get LTX time bounds: operation error S3: ListObjectsV2,
https response error StatusCode: 408, api error RequestCanceled: Request is canceled.
```

It is not only a cross-region problem. An `ord` worker restoring a large database failed with `main`'s own exhaustion message, which is the zero-delay retry path being spent inside one throttle window:

```
max retries exceeded reading ltx file (level=9, min=..., max=..., offset=2544884736): unexpected EOF
```

Refs #1306

## How Has This Been Tested?

- `go test -race ./...` — full suite passes.
- `go vet`, `gofmt`, `goimports`, `staticcheck` clean (repo pre-commit hooks passed).

Both reproducers were confirmed to **fail without the fix**:

| Test | Without the fix |
|---|---|
| `TestResumableReader_BackoffBetweenReopens` | `reopen attempt 2 fired 3.083µs after attempt 1; want >= 100ms backoff` |
| `TestTransportRetryer_RetriesProviderThrottleResponses` | `HTTP 408 must be retryable for S3-compatible providers` |

`TestResumableReader_ContextCancelAbortsBackoff` is a guard for the new behaviour rather than a reproducer — it passes either way and is not offered as evidence of the bug. It cancels from another goroutine while the wait is in progress, since `Read` returns early when `r.ctx.Err() != nil` and would otherwise never reach the wait.

The retryer test asserts precedence explicitly: a real `smithy.CanceledError` wrapping a `RequestCanceled` api error stays **non**-retryable, so genuine client-side cancellation is not caught by the new classifier. Verified against `aws-sdk-go-v2` v1.41.5, where `NoRetryCanceledError` is evaluated before the appended classifiers and evaluation stops at the first known result.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)