### PR TITLE
chore(deps): bump Go toolchain to 1.25.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/benbjohnson/litestream
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Description

Bump the `toolchain` directive in `go.mod` from `go1.25.12` to `go1.25.13`. One line, no code changes.

`govulncheck` reports 7 **called** standard-library vulnerabilities against `go1.25.12`, every one of them fixed in `go1.25.13`:

| ID | Package | Reached via |
|---|---|---|
| GO-2026-6218 | `net/url` | `HeartbeatClient.Ping` → `http.Client.Do`; `gs.ReplicaClient.WriteLTXFile` → `storage.Writer.Close` |
| GO-2026-6091 | `html/template` | `litestream.Start` → `http.Server.Serve` |
| GO-2026-6090 | `crypto/tls` | `nats.ReplicaClient.connect`; `http.Server.Serve`; `internal.ResumableReader.Read` |
| GO-2026-6089 | `net/http` | `litestream.Start` → `http.Server.Serve` |
| GO-2026-6088 | `encoding/xml` | S3 client response decoding |
| GO-2026-5972 | `encoding/asn1` | certificate parsing under `crypto/tls` |
| GO-2026-5026 | `net/http` | `litestream.Start` → `http.Server.Serve` |

`go1.25.13` is the latest `go1.25.x` patch release, so this also clears the `metrics: go-update` toolchain-freshness flag.

## Motivation and Context

The `analyze-deps` job in `pr-metrics.yml` runs `govulncheck` and labels every PR `metrics: vulns-found`. That label is currently on open PRs because of the toolchain, not because of anything in their diffs — so it carries no signal and any real finding would be lost in it. Bumping the toolchain clears it repo-wide and puts the label back to work.

Every CI job resolves its Go version from `go.mod` via `go-version-file`, and the `Dockerfile` uses the floating `golang:1.25` tag, so the `toolchain` line is the only pin site in the repo (verified: `rg '1\.25\.12'` matches `go.mod:5` and nothing else).

## How Has This Been Tested?

All commands run with `GOTOOLCHAIN=go1.25.13` so they exercise the same toolchain CI will resolve from `go.mod`:

- `go build ./...` — clean.
- `go test -race ./...` — full suite passes.
- `go vet ./...` — clean. Repo pre-commit hooks (`gofmt`, `goimports`, `go vet`, `staticcheck`) passed.
- `govulncheck ./...` — **0 called vulnerabilities**, down from 7:

```
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 1 vulnerability in packages you import and 3
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
```

The 1 imported / 3 required vulnerabilities that remain are not called by Litestream and were equally present before this change; they are out of scope here and would need dependency bumps rather than a toolchain bump.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
