### PR TITLE
docs(retention): explain snapshot floor

### DIFF
--- a/db.go
+++ b/db.go
@@ -2982,8 +2982,8 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 
 	// Use the last deleted snapshot's MaxTXID, rather than the first retained
 	// snapshot's MaxTXID, to preserve lower-level files in an in-flight restore
-	// plan (issue #1307). TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles
-	// in db_test.go guards this; issue #1333 tracks the idle database tradeoff.
+	// plan. TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles
+	// guards this conservative floor.
 	for i, info := range snapshots {
 		if slices.Contains(deleted, info) {
 			continue

--- a/db.go
+++ b/db.go
@@ -2980,6 +2980,10 @@ func (db *DB) EnforceSnapshotRetention(ctx context.Context, timestamp time.Time)
 		deleted = deleted[:len(deleted)-1]
 	}
 
+	// Use the last deleted snapshot's MaxTXID, rather than the first retained
+	// snapshot's MaxTXID, to preserve lower-level files in an in-flight restore
+	// plan (issue #1307). TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles
+	// in db_test.go guards this; issue #1333 tracks the idle database tradeoff.
 	for i, info := range snapshots {
 		if slices.Contains(deleted, info) {
 			continue


### PR DESCRIPTION
## Description

Documents why `DB.EnforceSnapshotRetention` sets the lower-level retention floor to the last deleted snapshot MaxTXID rather than the first retained snapshot MaxTXID. The source comment records the in-flight restore-plan hazard and points to the regression guard and the idle-database tradeoff.

## Motivation and Context

The conservative floor is intentional behavior introduced by #1325 for #1307: a restore plans its LTX files once, and concurrent retention must not delete a lower-level file already selected by that plan. Without this rationale next to the loop, the behavior described in #1418 looks like an off-by-one error.

`TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles` guards the invariant. #1333 tracks the opposite edge, where the conservative floor can prevent retention from converging on write-idle databases.

No retention logic, tests, or runtime behavior change in this PR.

## How Has This Been Tested?

- `go test -race -run "^TestStore_EnforceSnapshotRetention_RetainsInFlightRestorePlanFiles$" .`
- `go test -race ./...`
- `pre-commit run --all-files`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)
- [x] Documentation/comment only

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly