### PR TITLE
docs(readme): document internal lock table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ instructions and documentation.
 If you find this project interesting, please consider starring the project on
 GitHub.
 
+Source database changes
+-----------------------
+
+When Litestream begins replicating a database, it creates an internal
+`_litestream_lock` table in the source SQLite database. This is expected and
+safe to leave in place. Litestream uses the table to acquire SQLite's write
+lock while coordinating synchronization around WAL checkpoints. The writes
+occur in transactions that are rolled back, so Litestream does not leave rows
+in the table.
+
+The table is part of the source database, not a separate table in the replica
+destination. Because the source schema is backed up, restored databases also
+contain it. Its creation changes the source database schema and can change its
+page count or bytes, so a database under Litestream should not be expected to
+remain byte-identical to its pre-Litestream state.
+
+Do not drop `_litestream_lock` while Litestream is running. Synchronization
+around a checkpoint can fail until Litestream reinitializes the database.
+Restarting Litestream recreates the missing table automatically.
+
 Contributing
 ------------
 


### PR DESCRIPTION
## Description

Documents the expected `_litestream_lock` table that Litestream creates in each source database.

- Explains that rolled-back writes to the table acquire SQLite's writer lock while coordinating synchronization around WAL checkpoints.
- Clarifies that the table is safe to leave in place, lives in the source database rather than as a separate replica-storage table, and is included in restored database state.
- Calls out schema and byte-level changes plus the failure and automatic recreation behavior when the table is dropped.

This is documentation only; it does not change locking or replication behavior.

## Motivation and Context

Issue #1428 reports that a first-time user was surprised to find `_litestream_lock` in the source database and could not find documentation for it.

The implementation creates the table with `CREATE TABLE IF NOT EXISTS` during source database initialization. Checkpoint coordination inserts into it only inside transactions that are rolled back. A manual reproduction confirmed that dropping it while Litestream is running causes checkpoint errors and restarting Litestream recreates the empty table.

Fixes #1428

## How Has This Been Tested?

- `pre-commit run --all-files`
- `go test -race ./...`
- Replicated a temporary SQLite database to a file replica and confirmed the source table existed with zero rows.
- Dropped the table, generated a checkpoint-sized WAL, and observed `checkpoint: _litestream_lock: SQL logic error: no such table`.
- Restarted Litestream and confirmed the source and restored databases contained the recreated empty table.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)
- [x] Documentation

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)