### PR TITLE
fix(s3): allow disabling accept encoding signing

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1124,18 +1124,19 @@ type ReplicaSettings struct {
 	AutoRecover *bool `yaml:"auto-recover"`
 
 	// S3 settings
-	AccessKeyID       string    `yaml:"access-key-id"`
-	SecretAccessKey   string    `yaml:"secret-access-key"`
-	Region            string    `yaml:"region"`
-	Bucket            string    `yaml:"bucket"`
-	Endpoint          string    `yaml:"endpoint"`
-	ForcePathStyle    *bool     `yaml:"force-path-style"`
-	SignPayload       *bool     `yaml:"sign-payload"`
-	RequireContentMD5 *bool     `yaml:"require-content-md5"`
-	SkipVerify        bool      `yaml:"skip-verify"`
-	StorageClass      string    `yaml:"storage-class"`
-	PartSize          *ByteSize `yaml:"part-size"`
-	Concurrency       *int      `yaml:"concurrency"`
+	AccessKeyID        string    `yaml:"access-key-id"`
+	SecretAccessKey    string    `yaml:"secret-access-key"`
+	Region             string    `yaml:"region"`
+	Bucket             string    `yaml:"bucket"`
+	Endpoint           string    `yaml:"endpoint"`
+	ForcePathStyle     *bool     `yaml:"force-path-style"`
+	SignPayload        *bool     `yaml:"sign-payload"`
+	SignAcceptEncoding *bool     `yaml:"sign-accept-encoding"`
+	RequireContentMD5  *bool     `yaml:"require-content-md5"`
+	SkipVerify         bool      `yaml:"skip-verify"`
+	StorageClass       string    `yaml:"storage-class"`
+	PartSize           *ByteSize `yaml:"part-size"`
+	Concurrency        *int      `yaml:"concurrency"`
 
 	// S3 Server-Side Encryption (SSE-C: Customer-provided keys)
 	SSECustomerAlgorithm string `yaml:"sse-customer-algorithm"`
@@ -1229,6 +1230,9 @@ func (rs *ReplicaSettings) SetDefaults(src *ReplicaSettings) {
 	}
 	if rs.SignPayload == nil {
 		rs.SignPayload = src.SignPayload
+	}
+	if rs.SignAcceptEncoding == nil {
+		rs.SignAcceptEncoding = src.SignAcceptEncoding
 	}
 	if rs.RequireContentMD5 == nil {
 		rs.RequireContentMD5 = src.RequireContentMD5
@@ -1461,6 +1465,10 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 	if v := c.SignPayload; v != nil {
 		signSetting.Set(*v)
 	}
+	signAcceptEncodingSetting := newBoolSetting(true)
+	if v := c.SignAcceptEncoding; v != nil {
+		signAcceptEncodingSetting.Set(*v)
+	}
 	requireSetting := newBoolSetting(true)
 	if v := c.RequireContentMD5; v != nil {
 		requireSetting.Set(*v)
@@ -1475,16 +1483,18 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 
 	// Apply settings from URL, if specified.
 	var (
-		endpointWasSet        bool
-		usignPayload          bool
-		usignPayloadSet       bool
-		urequireContentMD5    bool
-		urequireContentMD5Set bool
-		ustorageClass         string
-		upartSize             int64
-		upartSizeSet          bool
-		uconcurrency          int64
-		uconcurrencySet       bool
+		endpointWasSet         bool
+		usignPayload           bool
+		usignPayloadSet        bool
+		usignAcceptEncoding    bool
+		usignAcceptEncodingSet bool
+		urequireContentMD5     bool
+		urequireContentMD5Set  bool
+		ustorageClass          string
+		upartSize              int64
+		upartSizeSet           bool
+		uconcurrency           int64
+		uconcurrencySet        bool
 	)
 	if endpoint != "" {
 		endpointWasSet = true
@@ -1534,6 +1544,10 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 			usignPayload = v
 			usignPayloadSet = true
 		}
+		if v, ok := litestream.BoolQueryValue(query, "signAcceptEncoding", "sign-accept-encoding"); ok {
+			usignAcceptEncoding = v
+			usignAcceptEncodingSet = true
+		}
 		if v, ok := litestream.BoolQueryValue(query, "requireContentMD5", "require-content-md5"); ok {
 			urequireContentMD5 = v
 			urequireContentMD5Set = true
@@ -1577,6 +1591,9 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 		}
 		if !signSetting.set && usignPayloadSet {
 			signSetting.Set(usignPayload)
+		}
+		if !signAcceptEncodingSetting.set && usignAcceptEncodingSet {
+			signAcceptEncodingSetting.Set(usignAcceptEncoding)
 		}
 		if !requireSetting.set && urequireContentMD5Set {
 			requireSetting.Set(urequireContentMD5)
@@ -1637,6 +1654,7 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 	client.StorageClass = storageClass
 
 	client.SignPayload = signSetting.value
+	client.SignAcceptEncoding = signAcceptEncodingSetting.value
 	client.RequireContentMD5 = requireSetting.value
 
 	if isCloudflareR2 {

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -507,6 +507,47 @@ dbs:
 	}
 }
 
+func TestNewS3ReplicaFromConfig_SignAcceptEncodingInheritance(t *testing.T) {
+	config, err := main.ParseConfig(strings.NewReader(`
+sign-accept-encoding: false
+dbs:
+  - path: /tmp/db-inherits
+    replica:
+      type: s3
+      bucket: bucket
+      path: db
+  - path: /tmp/db-overrides
+    replica:
+      type: s3
+      bucket: bucket
+      path: db
+      sign-accept-encoding: true
+`), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		index int
+		want  bool
+	}{
+		{name: "InheritedFalse", index: 0},
+		{name: "ExplicitTrue", index: 1, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := main.NewS3ReplicaClientFromConfig(config.DBs[tt.index].Replica, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if client.SignAcceptEncoding != tt.want {
+				t.Fatalf("SignAcceptEncoding=%v, want %v", client.SignAcceptEncoding, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewSFTPReplicaFromConfig(t *testing.T) {
 	hostKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAnK0+GdwOelXlAXdqLx/qvS7WHMr3rH7zW2+0DtmK5r"
 	r, err := main.NewReplicaFromConfig(&main.ReplicaConfig{
@@ -3255,7 +3296,7 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 
 	t.Run("QuerySigningOptions", func(t *testing.T) {
 		config := &main.ReplicaConfig{
-			URL: "s3://bucket/db?sign-payload=true&require-content-md5=false",
+			URL: "s3://bucket/db?sign-payload=true&sign-accept-encoding=false&require-content-md5=false",
 		}
 
 		client, err := main.NewS3ReplicaClientFromConfig(config, nil)
@@ -3265,19 +3306,40 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		if !client.SignPayload {
 			t.Error("expected SignPayload to be true when query parameter is set")
 		}
+		if client.SignAcceptEncoding {
+			t.Error("expected SignAcceptEncoding to be false when disabled via query")
+		}
 		if client.RequireContentMD5 {
 			t.Error("expected RequireContentMD5 to be false when disabled via query")
 		}
 	})
 
+	t.Run("QuerySignAcceptEncodingAliases", func(t *testing.T) {
+		for _, param := range []string{"signAcceptEncoding", "sign-accept-encoding"} {
+			t.Run(param, func(t *testing.T) {
+				client, err := main.NewS3ReplicaClientFromConfig(&main.ReplicaConfig{
+					URL: "s3://bucket/db?" + param + "=false",
+				}, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if client.SignAcceptEncoding {
+					t.Error("expected SignAcceptEncoding to be false")
+				}
+			})
+		}
+	})
+
 	t.Run("ConfigOverridesQuerySigning", func(t *testing.T) {
 		signTrue := true
+		signAcceptEncodingTrue := true
 		requireFalse := false
 		config := &main.ReplicaConfig{
-			URL: "s3://bucket/db?sign-payload=false&require-content-md5=true",
+			URL: "s3://bucket/db?sign-payload=false&sign-accept-encoding=false&require-content-md5=true",
 			ReplicaSettings: main.ReplicaSettings{
-				SignPayload:       &signTrue,
-				RequireContentMD5: &requireFalse,
+				SignPayload:        &signTrue,
+				SignAcceptEncoding: &signAcceptEncodingTrue,
+				RequireContentMD5:  &requireFalse,
 			},
 		}
 
@@ -3287,6 +3349,9 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		}
 		if !client.SignPayload {
 			t.Error("expected config SignPayload to override query parameter")
+		}
+		if !client.SignAcceptEncoding {
+			t.Error("expected config SignAcceptEncoding to override query parameter")
 		}
 		if client.RequireContentMD5 {
 			t.Error("expected config RequireContentMD5=false to override query parameter")

--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -125,6 +125,35 @@ replicas:
 - Works well with default settings
 - Force path style recommended for single-server deployments
 
+### Garage
+
+**Status**: Supported with configuration when an intermediary rewrites `Accept-Encoding`
+
+```yaml
+dbs:
+  - path: /path/to/database.db
+    replica:
+      type: s3
+      bucket: bucket-name
+      path: database-name
+      endpoint: https://your-garage-server
+      region: garage
+      force-path-style: true
+      sign-accept-encoding: false
+      access-key-id: your-access-key
+      secret-access-key: your-secret-key
+```
+
+`sign-accept-encoding` defaults to `true`. Set it to `false` when a reverse
+proxy or other intermediary removes or rewrites `Accept-Encoding`, which would
+otherwise invalidate the SigV4 signature. Litestream removes the header before
+signing, although Go's HTTP transport may still add an unsigned header on the
+wire.
+
+Disabling this setting improves compatibility but removes `Accept-Encoding`
+from SigV4 integrity protection, so changes to that header are no longer
+detected during signature validation. Reported by @ahgraber in #1424.
+
 ### Scaleway Object Storage
 
 **Status**: Supported with configuration
@@ -340,6 +369,7 @@ Parameters with an alias accept both camelCase and hyphenated forms
 | `forcePathStyle` | `force-path-style` | Use path-style URLs | `false` (auto for custom endpoints) |
 | `skipVerify` | `skip-verify` | Skip TLS verification | `false` |
 | `signPayload` | `sign-payload` | Sign request payloads | `true` |
+| `signAcceptEncoding` | `sign-accept-encoding` | Include Accept-Encoding in SigV4 signatures | `true` |
 | `requireContentMD5` | `require-content-md5` | Require Content-MD5 header | `true` |
 | `concurrency` | | Multipart upload concurrency | `5` (`2` for R2/Tigris) |
 | `partSize` | `part-size` | Multipart upload part size | `5242880` (5MB) (`16MiB` for Tigris) |
@@ -381,6 +411,12 @@ Litestream automatically detects certain providers and applies appropriate defau
 - Try `sign-payload=true` in the URL
 - Verify credentials are correct
 - Check endpoint URL format
+
+**`signed header accept-encoding is not present`**
+
+- An intermediary removed or rewrote `Accept-Encoding` after request signing
+- Set `sign-accept-encoding=false` in the replica URL or configuration
+- This trades signature coverage of that header for intermediary compatibility
 
 **`MissingContentLength`**
 

--- a/etc/litestream.yml
+++ b/etc/litestream.yml
@@ -15,6 +15,8 @@
 #      url:  s3://my.bucket.com/db        # S3-based replication
 #      # Example Fly.io Tigris setup (signing/no-Content-MD5 are auto-enabled for this endpoint)
 #      # url: s3://my-tigris-bucket/db.sqlite?endpoint=fly.storage.tigris.dev&region=auto
+#      # Disable Accept-Encoding signing for proxies that rewrite the header (default: true)
+#      # sign-accept-encoding: false
 #      type: nats                         # NATS JetStream replication
 #      url: nats://nats.example.com:4222
 #      bucket: litestream-backups

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -95,15 +95,16 @@ type ReplicaClient struct {
 	SecretAccessKey string
 
 	// S3 bucket information
-	Region            string
-	Bucket            string
-	Path              string
-	Endpoint          string
-	ForcePathStyle    bool
-	SkipVerify        bool
-	SignPayload       bool
-	RequireContentMD5 bool
-	StorageClass      string
+	Region             string
+	Bucket             string
+	Path               string
+	Endpoint           string
+	ForcePathStyle     bool
+	SkipVerify         bool
+	SignPayload        bool
+	SignAcceptEncoding bool
+	RequireContentMD5  bool
+	StorageClass       string
 
 	// Upload configuration
 	PartSize    int64 // Part size for multipart uploads (default: 5MB)
@@ -128,9 +129,10 @@ type ReplicaClient struct {
 // NewReplicaClient returns a new instance of ReplicaClient.
 func NewReplicaClient() *ReplicaClient {
 	return &ReplicaClient{
-		logger:            slog.Default().WithGroup(ReplicaClientType),
-		RequireContentMD5: true,
-		SignPayload:       true,
+		logger:             slog.Default().WithGroup(ReplicaClientType),
+		RequireContentMD5:  true,
+		SignPayload:        true,
+		SignAcceptEncoding: true,
 	}
 }
 
@@ -144,19 +146,21 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 	client := NewReplicaClient()
 
 	var (
-		bucket         string
-		region         string
-		endpoint       string
-		forcePathStyle bool
-		skipVerify     bool
-		signPayload    bool
-		signPayloadSet bool
-		requireMD5     bool
-		requireMD5Set  bool
-		concurrency    int
-		concurrencySet bool
-		partSize       int64
-		storageClass   string
+		bucket                string
+		region                string
+		endpoint              string
+		forcePathStyle        bool
+		skipVerify            bool
+		signPayload           bool
+		signPayloadSet        bool
+		signAcceptEncoding    bool
+		signAcceptEncodingSet bool
+		requireMD5            bool
+		requireMD5Set         bool
+		concurrency           int
+		concurrencySet        bool
+		partSize              int64
+		storageClass          string
 	)
 
 	// Parse host for bucket and region
@@ -189,6 +193,10 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 	if v, ok := litestream.BoolQueryValue(query, "signPayload", "sign-payload"); ok {
 		signPayload = v
 		signPayloadSet = true
+	}
+	if v, ok := litestream.BoolQueryValue(query, "signAcceptEncoding", "sign-accept-encoding"); ok {
+		signAcceptEncoding = v
+		signAcceptEncodingSet = true
 	}
 	if v, ok := litestream.BoolQueryValue(query, "requireContentMD5", "require-content-md5"); ok {
 		requireMD5 = v
@@ -293,6 +301,9 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 
 	if signPayloadSet {
 		client.SignPayload = signPayload
+	}
+	if signAcceptEncodingSet {
+		client.SignAcceptEncoding = signAcceptEncoding
 	}
 	if requireMD5Set {
 		client.RequireContentMD5 = requireMD5
@@ -949,10 +960,10 @@ func (c *ReplicaClient) middlewareOption() func(*middleware.Stack) error {
 			}
 		}
 
-		if litestream.IsGoogleCloudStorageEndpoint(c.Endpoint) {
+		if !c.SignAcceptEncoding || litestream.IsGoogleCloudStorageEndpoint(c.Endpoint) {
 			if err := stack.Finalize.Insert(
 				middleware.FinalizeMiddlewareFunc(
-					"LitestreamGCSRemoveAcceptEncoding",
+					"LitestreamRemoveAcceptEncoding",
 					func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (
 						out middleware.FinalizeOutput, metadata middleware.Metadata, err error,
 					) {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -102,6 +101,9 @@ func TestReplicaClient_DefaultSignPayload(t *testing.T) {
 	client := NewReplicaClient()
 	if !client.SignPayload {
 		t.Error("expected default SignPayload to be true for AWS S3 compatibility")
+	}
+	if !client.SignAcceptEncoding {
+		t.Error("expected default SignAcceptEncoding to be true")
 	}
 	if !client.RequireContentMD5 {
 		t.Error("expected default RequireContentMD5 to be true for AWS S3 compatibility")
@@ -568,125 +570,6 @@ func TestReplicaClient_WriteLTXFile_SmallUploadAllocations(t *testing.T) {
 			}()
 			return pr
 		})
-	})
-}
-
-func TestReplicaClient_WALSegmentsV3(t *testing.T) {
-	const generation = "0123456789abcdef"
-	type position struct {
-		index  int
-		offset int64
-	}
-	tests := []struct {
-		name  string
-		input [2]position
-		want  [2]position
-	}{
-		{
-			name:  "OffsetCrossesSignBit",
-			input: [2]position{{index: 1, offset: 0x80000001}, {index: 1}},
-			want:  [2]position{{index: 1}, {index: 1, offset: 0x80000001}},
-		},
-		{
-			name:  "OffsetDifferenceTruncatesToZero",
-			input: [2]position{{index: 1, offset: 0x100000000}, {index: 1}},
-			want:  [2]position{{index: 1}, {index: 1, offset: 0x100000000}},
-		},
-		{
-			name:  "MaximumOffset",
-			input: [2]position{{index: 1, offset: math.MaxInt64}, {index: 1}},
-			want:  [2]position{{index: 1}, {index: 1, offset: math.MaxInt64}},
-		},
-		{
-			name:  "IndexPrecedence",
-			input: [2]position{{index: 2}, {index: 1, offset: math.MaxInt64}},
-			want:  [2]position{{index: 1, offset: math.MaxInt64}, {index: 2}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			firstKey := litestream.WALSegmentPathV3("replica", generation, tt.input[0].index, tt.input[0].offset)
-			secondKey := litestream.WALSegmentPathV3("replica", generation, tt.input[1].index, tt.input[1].offset)
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/xml")
-				if _, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
-<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-<Name>test-bucket</Name>
-<Prefix>replica/generations/%[1]s/wal/</Prefix>
-<KeyCount>2</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>
-<Contents><Key>%[2]s</Key><LastModified>2026-08-17T00:00:00Z</LastModified><ETag>"first"</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>
-<Contents><Key>%[3]s</Key><LastModified>2026-08-17T00:00:00Z</LastModified><ETag>"second"</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>
-</ListBucketResult>`, generation, firstKey, secondKey); err != nil {
-					t.Errorf("write ListObjectsV2 response: %v", err)
-				}
-			}))
-			t.Cleanup(server.Close)
-
-			segments, err := newTestReplicaClient(t, server).WALSegmentsV3(context.Background(), generation)
-			if err != nil {
-				t.Fatalf("WALSegmentsV3() error: %v", err)
-			}
-			if got, want := len(segments), len(tt.want); got != want {
-				t.Fatalf("len(segments) = %d, want %d", got, want)
-			}
-			for i, want := range tt.want {
-				if got := segments[i]; got.Index != want.index || got.Offset != want.offset {
-					t.Errorf("segments[%d] = index %d offset %d, want index %d offset %d", i, got.Index, got.Offset, want.index, want.offset)
-				}
-			}
-		})
-	}
-
-	t.Run("MissingBucket", func(t *testing.T) {
-		if _, err := NewReplicaClient().WALSegmentsV3(context.Background(), generation); err == nil {
-			t.Fatal("expected error")
-		}
-	})
-
-	t.Run("ListError", func(t *testing.T) {
-		server := httptest.NewServer(http.NotFoundHandler())
-		t.Cleanup(server.Close)
-		client := newTestReplicaClient(t, server)
-		if err := client.Init(context.Background()); err != nil {
-			t.Fatalf("Init() error: %v", err)
-		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		if _, err := client.WALSegmentsV3(ctx, generation); err == nil || !strings.Contains(err.Error(), "s3: list wal segments") {
-			t.Fatalf("WALSegmentsV3() error = %v, want list error", err)
-		}
-	})
-
-	t.Run("SkipsInvalidKeys", func(t *testing.T) {
-		validKey := litestream.WALSegmentPathV3("replica", generation, 1, 2)
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/xml")
-			if _, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
-<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-<Name>test-bucket</Name><KeyCount>2</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>
-<Contents><Key>replica/generations/%[1]s/wal/invalid.wal.lz4</Key><Size>1</Size></Contents>
-<Contents><Key>%[2]s</Key><Size>1</Size></Contents>
-</ListBucketResult>`, generation, validKey); err != nil {
-				t.Errorf("write ListObjectsV2 response: %v", err)
-			}
-		}))
-		t.Cleanup(server.Close)
-
-		segments, err := newTestReplicaClient(t, server).WALSegmentsV3(context.Background(), generation)
-		if err != nil {
-			t.Fatalf("WALSegmentsV3() error: %v", err)
-		}
-		if got, want := len(segments), 1; got != want {
-			t.Fatalf("len(segments) = %d, want %d", got, want)
-		}
-		if got, want := segments[0].Index, 1; got != want {
-			t.Errorf("segments[0].Index = %d, want %d", got, want)
-		}
-		if got, want := segments[0].Offset, int64(2); got != want {
-			t.Errorf("segments[0].Offset = %d, want %d", got, want)
-		}
 	})
 }
 
@@ -2033,59 +1916,11 @@ func TestReplicaClient_TigrisConsistentHeader(t *testing.T) {
 	}
 }
 
-// TestReplicaClient_ProviderUploadDefaults verifies provider-specific upload
-// defaults for S3-compatible endpoints with known concurrency limits.
-func TestReplicaClient_ProviderUploadDefaults(t *testing.T) {
-	tests := []struct {
-		name            string
-		url             string
-		wantConcurrency int
-		wantPartSize    int64
-	}{
-		{
-			name:            "R2_DefaultConcurrency",
-			url:             "s3://mybucket/path?endpoint=https://account123.r2.cloudflarestorage.com",
-			wantConcurrency: 2,
-		},
-		{
-			name:            "Tigris_DefaultUploadShape",
-			url:             "s3://mybucket/path?endpoint=https://fly.storage.tigris.dev",
-			wantConcurrency: DefaultTigrisConcurrency,
-			wantPartSize:    DefaultTigrisPartSize,
-		},
-		{
-			name:            "Tigris_ExplicitUploadShape",
-			url:             "s3://mybucket/path?endpoint=https://fly.storage.tigris.dev&concurrency=4&part-size=33554432",
-			wantConcurrency: 4,
-			wantPartSize:    33554432,
-		},
-		{
-			name: "AWS_NoConcurrencyOverride",
-			url:  "s3://mybucket/path",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client, err := litestream.NewReplicaClientFromURL(tt.url)
-			if err != nil {
-				t.Fatalf("NewReplicaClientFromURL() error: %v", err)
-			}
-			c := client.(*ReplicaClient)
-			if c.Concurrency != tt.wantConcurrency {
-				t.Errorf("Concurrency = %d, want %d", c.Concurrency, tt.wantConcurrency)
-			}
-			if c.PartSize != tt.wantPartSize {
-				t.Errorf("PartSize = %d, want %d", c.PartSize, tt.wantPartSize)
-			}
-		})
-	}
-}
-
-func TestReplicaClient_GCSAcceptEncodingNotSigned(t *testing.T) {
+func TestReplicaClient_AcceptEncodingSigning(t *testing.T) {
 	tests := []struct {
 		name                     string
 		endpoint                 string
+		disableSigning           bool
 		wantAcceptEncodingSigned bool
 	}{
 		{
@@ -2160,6 +1995,11 @@ func TestReplicaClient_GCSAcceptEncodingNotSigned(t *testing.T) {
 			endpoint:                 "https://s3.example.com",
 			wantAcceptEncodingSigned: true,
 		},
+		{
+			name:           "ExplicitOptOut",
+			endpoint:       "https://s3.example.com",
+			disableSigning: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2192,6 +2032,7 @@ func TestReplicaClient_GCSAcceptEncodingNotSigned(t *testing.T) {
 
 			c := NewReplicaClient()
 			c.Endpoint = tt.endpoint
+			c.SignAcceptEncoding = !tt.disableSigning
 			c.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 			client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 				o.BaseEndpoint = aws.String("https://example.com")
@@ -2203,6 +2044,30 @@ func TestReplicaClient_GCSAcceptEncodingNotSigned(t *testing.T) {
 				Bucket: aws.String("test-bucket"),
 			}); err != nil {
 				t.Fatalf("ListObjectsV2() error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewReplicaClientFromURL_SignAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "Default", url: "s3://mybucket/path", want: true},
+		{name: "CamelCase", url: "s3://mybucket/path?signAcceptEncoding=false"},
+		{name: "Hyphenated", url: "s3://mybucket/path?sign-accept-encoding=false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := litestream.NewReplicaClientFromURL(tt.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := client.(*ReplicaClient).SignAcceptEncoding; got != tt.want {
+				t.Fatalf("SignAcceptEncoding=%v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Add `sign-accept-encoding`, a boolean S3 replica setting that defaults to `true`. Setting it to `false` removes `Accept-Encoding` before SigV4 signing so S3-compatible endpoints behind header-altering intermediaries can validate requests.

The setting participates in YAML default inheritance, is applied by configuration-based and direct replica URL construction, and accepts both `signAcceptEncoding` and `sign-accept-encoding` URL parameters. Existing Google Cloud Storage endpoint detection continues to exclude the header without configuration, while all other endpoints retain the current signed-header default.

Garage configuration and the signature-coverage compatibility tradeoff are documented using the singular `replica:` form.

## Motivation and Context

Garage rejects every S3 operation with `signed header accept-encoding is not present` when an intermediary changes or removes the header after the AWS SDK includes it in SigV4 `SignedHeaders`. The existing fix in #1394 only applies to detected Google Cloud Storage endpoints, and the generic S3-compatible regression case deliberately keeps the header signed.

This change makes that behavior explicitly configurable without adding a provider allowlist or changing defaults for existing Tigris, Filebase, Hetzner, Backblaze, or other S3-compatible users. When disabled, Go may still add an unsigned `Accept-Encoding` header on the wire; changes to that header are no longer covered by SigV4 integrity validation.

Reported by @ahgraber. The `sign-accept-encoding` key name is still pending Cory's final confirmation.

Fixes #1424

## How Has This Been Tested?

- `go test ./s3 -run 'TestReplicaClient_(DefaultSignPayload|AcceptEncodingSigning)$|TestNewReplicaClientFromURL_SignAcceptEncoding$' -count=1`
- `go test ./cmd/litestream -run 'TestNewS3ReplicaFromConfig_SignAcceptEncodingInheritance$|TestNewS3ReplicaClientFromConfig$' -count=1`
- `go test -race -v ./...`
- `go build ./cmd/litestream`
- `pre-commit run --all-files`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
