### PR TITLE
fix(restore): correctly restore v3 wal segments that exceed 4GB

### DIFF
--- a/v3.go
+++ b/v3.go
@@ -108,7 +108,7 @@ func FormatWALSegmentFilenameV3(index int, offset int64) string {
 
 var (
 	snapshotRegexV3   = regexp.MustCompile(`^([0-9a-f]{8})\.snapshot\.lz4$`)
-	walSegmentRegexV3 = regexp.MustCompile(`^([0-9a-f]{8})_([0-9a-f]{8})\.wal\.lz4$`)
+	walSegmentRegexV3 = regexp.MustCompile(`^([0-9a-f]{8})_([0-9a-f]{8,16})\.wal\.lz4$`)
 	generationRegexV3 = regexp.MustCompile(`^[0-9a-f]{16}$`)
 )
 
@@ -130,8 +130,14 @@ func ParseWALSegmentFilenameV3(filename string) (index int, offset int64, err er
 	if m == nil {
 		return 0, 0, fmt.Errorf("invalid v0.3.x WAL segment filename: %q", filename)
 	}
-	idx, _ := strconv.ParseInt(m[1], 16, 64)
-	off, _ := strconv.ParseInt(m[2], 16, 64)
+	idx, err := strconv.ParseInt(m[1], 16, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid wal segment path: %s: %w", filename, err)
+	}
+	off, err := strconv.ParseInt(m[2], 16, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid wal segment path: %s: %w", filename, err)
+	}
 	return int(idx), off, nil
 }
 

--- a/v3_test.go
+++ b/v3_test.go
@@ -133,6 +133,9 @@ func TestParseWALSegmentFilenameV3(t *testing.T) {
 			{"00000000_00000000.wal.lz4", 0, 0},
 			{"00000001_00001000.wal.lz4", 1, 4096},
 			{"000000ff_12345678.wal.lz4", 255, 0x12345678},
+			{"000000ff_f2345678.wal.lz4", 255, 0xf2345678},
+			{"000000ff_123456789.wal.lz4", 255, 0x123456789},
+			{"000000ff_123456789012345.wal.lz4", 255, 0x123456789012345},
 		}
 		for _, tt := range tests {
 			index, offset, err := litestream.ParseWALSegmentFilenameV3(tt.filename)
@@ -151,10 +154,13 @@ func TestParseWALSegmentFilenameV3(t *testing.T) {
 		invalids := []string{
 			"",
 			"invalid.wal",
-			"00000001.wal.lz4",         // missing offset
-			"00000001_00001000.wal",    // missing .lz4
-			"0000001_00001000.wal.lz4", // 7 chars index
-			"00000001_0001000.wal.lz4", // 7 chars offset
+			"00000001.wal.lz4",                   // missing offset
+			"00000001_00001000.wal",              // missing .lz4
+			"0000001_00001000.wal.lz4",           // 7 chars index
+			"00000001_0001000.wal.lz4",           // 7 chars offset
+			"00000001_12345678123456789.wal.lz4", // 17 chars offset
+			"f2345678_00000001.wal.lz4",          // index out of range
+			"00000001_f234567812345678.wal.lz4",  // offset out of range
 		}
 		for _, filename := range invalids {
 			_, _, err := litestream.ParseWALSegmentFilenameV3(filename)


### PR DESCRIPTION
## Description

Allow the legacy WAL reader (v3 restore logic) to handle segment filenames whose offsets grow beyond eight hexadecimal digits.

This fixes v0.3-format backups where a single WAL index exceeds 4 GiB. Existing eight-digit filenames remain valid, while offsets up to the maximum non-negative signed 64-bit value are accepted.

## Motivation and Context

litestream v3 can write wal segments with more than 8 hex characters; the writer formats offsets with %08x, which means a minimum width of eight digits and therefore legally emits these nine-digit names above 0xffffffff. The reader regex required exactly eight digits. Replica-client iterators treat a parser failure as an unrelated object and skip it, resulting in corruption.

Examples:

```
000012c3_11a6bfa58.wal.lz4
000012c3_1251faff8.wal.lz4
000012c3_12632ba20.wal.lz4
```

## How Has This Been Tested?

Unit tests, as well as vetted on our (v3) fork in production: https://github.com/rocicorp/litestream/pull/18

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
