### PR TITLE
fix(restore): sort v3 WAL offsets safely

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -174,6 +174,8 @@ jobs:
       - run: go test -v ./sftp
       - run: go test -v ./cmd/litestream
 
+      - name: Test v0.3 WAL ordering on 32-bit
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=386 go test -v ./file ./s3 -run '^TestReplicaClient_WALSegmentsV3$'
 
   ltx-behavioral-gate:
     name: LTX Behavioral Gate (short)

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -349,7 +350,7 @@ func (c *ReplicaClient) WALSegmentsV3(ctx context.Context, generation string) ([
 		if a.Index != b.Index {
 			return a.Index - b.Index
 		}
-		return int(a.Offset - b.Offset)
+		return cmp.Compare(a.Offset, b.Offset)
 	})
 	return segments, nil
 }

--- a/file/replica_client_test.go
+++ b/file/replica_client_test.go
@@ -454,6 +454,21 @@ func TestReplicaClient_WALSegmentsV3(t *testing.T) {
 		}
 	})
 
+	t.Run("WALPathIsFile", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		walPath := filepath.Join(tmpDir, "generations", gen, "wal")
+		if err := os.MkdirAll(filepath.Dir(walPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(walPath, nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := file.NewReplicaClient(tmpDir).WALSegmentsV3(context.Background(), gen); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
 	t.Run("SingleSegment", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		walDir := filepath.Join(tmpDir, "generations", gen, "wal")
@@ -537,6 +552,45 @@ func TestReplicaClient_WALSegmentsV3(t *testing.T) {
 		}
 	})
 
+	t.Run("LargeOffsets", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			wantOffset int64
+		}{
+			{name: "DifferenceExceedsMaxInt32", wantOffset: 0x80000001},
+			{name: "MaximumOffset", wantOffset: 0x7fffffffffffffff},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tmpDir := t.TempDir()
+				walDir := filepath.Join(tmpDir, "generations", gen, "wal")
+				if err := os.MkdirAll(walDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				for _, offset := range []int64{0, tt.wantOffset} {
+					filename := litestream.FormatWALSegmentFilenameV3(1, offset)
+					if err := os.WriteFile(filepath.Join(walDir, filename), []byte("x"), 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				segments, err := file.NewReplicaClient(tmpDir).WALSegmentsV3(context.Background(), gen)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(segments) != 2 {
+					t.Fatalf("expected 2 segments, got %d", len(segments))
+				}
+				if got, want := segments[0].Offset, int64(0); got != want {
+					t.Errorf("segments[0].Offset = %d, want %d", got, want)
+				}
+				if got, want := segments[1].Offset, tt.wantOffset; got != want {
+					t.Errorf("segments[1].Offset = %d, want %d", got, want)
+				}
+			})
+		}
+	})
+
 	t.Run("SkipsInvalidFilenames", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		walDir := filepath.Join(tmpDir, "generations", gen, "wal")
@@ -555,6 +609,9 @@ func TestReplicaClient_WALSegmentsV3(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(walDir, name), []byte("x"), 0644); err != nil {
 				t.Fatal(err)
 			}
+		}
+		if err := os.Mkdir(filepath.Join(walDir, "subdir"), 0755); err != nil {
+			t.Fatal(err)
 		}
 		c := file.NewReplicaClient(tmpDir)
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/md5"
 	"crypto/tls"
@@ -1420,7 +1421,7 @@ func (c *ReplicaClient) WALSegmentsV3(ctx context.Context, generation string) ([
 		if a.Index != b.Index {
 			return a.Index - b.Index
 		}
-		return int(a.Offset - b.Offset)
+		return cmp.Compare(a.Offset, b.Offset)
 	})
 	return segments, nil
 }

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -567,6 +568,125 @@ func TestReplicaClient_WriteLTXFile_SmallUploadAllocations(t *testing.T) {
 			}()
 			return pr
 		})
+	})
+}
+
+func TestReplicaClient_WALSegmentsV3(t *testing.T) {
+	const generation = "0123456789abcdef"
+	type position struct {
+		index  int
+		offset int64
+	}
+	tests := []struct {
+		name  string
+		input [2]position
+		want  [2]position
+	}{
+		{
+			name:  "OffsetCrossesSignBit",
+			input: [2]position{{index: 1, offset: 0x80000001}, {index: 1}},
+			want:  [2]position{{index: 1}, {index: 1, offset: 0x80000001}},
+		},
+		{
+			name:  "OffsetDifferenceTruncatesToZero",
+			input: [2]position{{index: 1, offset: 0x100000000}, {index: 1}},
+			want:  [2]position{{index: 1}, {index: 1, offset: 0x100000000}},
+		},
+		{
+			name:  "MaximumOffset",
+			input: [2]position{{index: 1, offset: math.MaxInt64}, {index: 1}},
+			want:  [2]position{{index: 1}, {index: 1, offset: math.MaxInt64}},
+		},
+		{
+			name:  "IndexPrecedence",
+			input: [2]position{{index: 2}, {index: 1, offset: math.MaxInt64}},
+			want:  [2]position{{index: 1, offset: math.MaxInt64}, {index: 2}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			firstKey := litestream.WALSegmentPathV3("replica", generation, tt.input[0].index, tt.input[0].offset)
+			secondKey := litestream.WALSegmentPathV3("replica", generation, tt.input[1].index, tt.input[1].offset)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/xml")
+				if _, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+<Name>test-bucket</Name>
+<Prefix>replica/generations/%[1]s/wal/</Prefix>
+<KeyCount>2</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>
+<Contents><Key>%[2]s</Key><LastModified>2026-08-17T00:00:00Z</LastModified><ETag>"first"</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>
+<Contents><Key>%[3]s</Key><LastModified>2026-08-17T00:00:00Z</LastModified><ETag>"second"</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>
+</ListBucketResult>`, generation, firstKey, secondKey); err != nil {
+					t.Errorf("write ListObjectsV2 response: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			segments, err := newTestReplicaClient(t, server).WALSegmentsV3(context.Background(), generation)
+			if err != nil {
+				t.Fatalf("WALSegmentsV3() error: %v", err)
+			}
+			if got, want := len(segments), len(tt.want); got != want {
+				t.Fatalf("len(segments) = %d, want %d", got, want)
+			}
+			for i, want := range tt.want {
+				if got := segments[i]; got.Index != want.index || got.Offset != want.offset {
+					t.Errorf("segments[%d] = index %d offset %d, want index %d offset %d", i, got.Index, got.Offset, want.index, want.offset)
+				}
+			}
+		})
+	}
+
+	t.Run("MissingBucket", func(t *testing.T) {
+		if _, err := NewReplicaClient().WALSegmentsV3(context.Background(), generation); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("ListError", func(t *testing.T) {
+		server := httptest.NewServer(http.NotFoundHandler())
+		t.Cleanup(server.Close)
+		client := newTestReplicaClient(t, server)
+		if err := client.Init(context.Background()); err != nil {
+			t.Fatalf("Init() error: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := client.WALSegmentsV3(ctx, generation); err == nil || !strings.Contains(err.Error(), "s3: list wal segments") {
+			t.Fatalf("WALSegmentsV3() error = %v, want list error", err)
+		}
+	})
+
+	t.Run("SkipsInvalidKeys", func(t *testing.T) {
+		validKey := litestream.WALSegmentPathV3("replica", generation, 1, 2)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/xml")
+			if _, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+<Name>test-bucket</Name><KeyCount>2</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>
+<Contents><Key>replica/generations/%[1]s/wal/invalid.wal.lz4</Key><Size>1</Size></Contents>
+<Contents><Key>%[2]s</Key><Size>1</Size></Contents>
+</ListBucketResult>`, generation, validKey); err != nil {
+				t.Errorf("write ListObjectsV2 response: %v", err)
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		segments, err := newTestReplicaClient(t, server).WALSegmentsV3(context.Background(), generation)
+		if err != nil {
+			t.Fatalf("WALSegmentsV3() error: %v", err)
+		}
+		if got, want := len(segments), 1; got != want {
+			t.Fatalf("len(segments) = %d, want %d", got, want)
+		}
+		if got, want := segments[0].Index, 1; got != want {
+			t.Errorf("segments[0].Index = %d, want %d", got, want)
+		}
+		if got, want := segments[0].Offset, int64(2); got != want {
+			t.Errorf("segments[0].Offset = %d, want %d", got, want)
+		}
 	})
 }
 

--- a/v3.go
+++ b/v3.go
@@ -119,7 +119,10 @@ func ParseSnapshotFilenameV3(filename string) (index int, err error) {
 	if m == nil {
 		return 0, fmt.Errorf("invalid v0.3.x snapshot filename: %q", filename)
 	}
-	idx, _ := strconv.ParseInt(m[1], 16, 64)
+	idx, err := strconv.ParseInt(m[1], 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid snapshot path: %s: %w", filename, err)
+	}
 	return int(idx), nil
 }
 

--- a/v3_test.go
+++ b/v3_test.go
@@ -73,6 +73,7 @@ func TestParseSnapshotFilenameV3(t *testing.T) {
 			{"00000001.snapshot.lz4", 1},
 			{"000000ff.snapshot.lz4", 255},
 			{"12345678.snapshot.lz4", 0x12345678},
+			{"7fffffff.snapshot.lz4", 0x7fffffff},
 		}
 		for _, tt := range tests {
 			index, err := litestream.ParseSnapshotFilenameV3(tt.filename)
@@ -96,6 +97,9 @@ func TestParseSnapshotFilenameV3(t *testing.T) {
 			"0000000g.snapshot.lz4",  // invalid hex
 			"00000001.SNAPSHOT.lz4",  // uppercase
 			"00000001.snapshot.lz4.bak",
+			"80000000.snapshot.lz4",
+			"f2345678.snapshot.lz4",
+			"ffffffff.snapshot.lz4",
 		}
 		for _, filename := range invalids {
 			_, err := litestream.ParseSnapshotFilenameV3(filename)


### PR DESCRIPTION
## Description

- Replace subtraction-and-cast WAL offset comparators with `cmp.Compare()` in the file and S3 v0.3 restore clients.
- Parse v0.3 snapshot indexes as checked signed 32-bit values, matching the WAL filename contract.
- Add focused table-driven ordering and parser boundary tests.
- Run the affected file and S3 tests as Linux/386 binaries in commit CI.

## Motivation and Context

On 32-bit builds, `int(a.Offset - b.Offset)` truncates a 64-bit offset difference. The comparator can report the wrong order—or equality for unequal offsets—which leaves legacy WAL segments out of sequence and causes restore to fail.

Investigation reproduced the old comparator returning `[2147483649, 0]` on Linux/386. The focused regression binaries pass after switching to `cmp.Compare()`.

Snapshot filenames had the same architecture-dependent index behavior because they parsed 64 bits and then converted to `int`. This change rejects values above `0x7fffffff` consistently on every architecture.

Follow-up coverage work is tracked in #1446. Restore parser and ordering fuzzing is tracked in #1447.

Fixes #1443

## How Has This Been Tested?

- `go test -coverprofile=.local/state/coverage.out ./... -count=1`
  - Changed production files: 555/924 statements (60.1%).
- Linux/386 cross-compiled file and S3 regression binaries executed in an Alpine i686 container.
- `go test -race -v ./... -count=1`
- `go build ./...`
- `pre-commit run --all-files`
- `golangci-lint run --new-from-rev=origin/main`
- `go test -tags 'integration,soak' -run '^TestLTXBehavior$' -short -v -timeout 15m ./tests/integration/`
  - Low-volume, high-volume, and burst-volume assertions, restores, and integrity checks passed.
- Independent specification and quality reviews passed with no findings.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (not needed for this behavior-only bug fix)
