### PR TITLE
config: reject duplicate dbs[].path at load

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -489,6 +489,7 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate database configs
+	seenPaths := make(map[string]int) // cleaned path -> 1-based config index
 	for idx, db := range c.DBs {
 		// Validate that either path or dir is specified, but not both
 		if db.Path != "" && db.Dir != "" {
@@ -496,6 +497,17 @@ func (c *Config) Validate() error {
 		}
 		if db.Path == "" && db.Dir == "" {
 			return fmt.Errorf("database config #%d: must specify either 'path' or 'dir'", idx+1)
+		}
+
+		// Reject the same database path listed twice. The metadata directory is
+		// derived from the path, so two entries would share it and race on the
+		// same LTX temp files.
+		if db.Path != "" {
+			key := filepath.Clean(db.Path)
+			if first, ok := seenPaths[key]; ok {
+				return fmt.Errorf("database config #%d: duplicate path %q (already used by database config #%d); each database can be listed only once", idx+1, db.Path, first)
+			}
+			seenPaths[key] = idx + 1
 		}
 
 		// When using dir, pattern must be specified

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -2306,6 +2306,56 @@ func TestDBConfigValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate path", func(t *testing.T) {
+		config := main.DefaultConfig()
+		config.DBs = []*main.DBConfig{
+			{Path: "/path/to/db.sqlite", Replica: &main.ReplicaConfig{Path: "/path/to/rep-a"}},
+			{Path: "/path/to/db.sqlite", Replica: &main.ReplicaConfig{Path: "/path/to/rep-b"}},
+		}
+
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("expected validation error when the same path is listed twice")
+		}
+		if !strings.Contains(err.Error(), `database config #2: duplicate path "/path/to/db.sqlite"`) {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+		if !strings.Contains(err.Error(), "already used by database config #1") {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("duplicate path after cleaning", func(t *testing.T) {
+		config := main.DefaultConfig()
+		config.DBs = []*main.DBConfig{
+			{Path: "/path/to/db.sqlite"},
+			{Path: "/path/to/../to/db.sqlite"},
+		}
+
+		err := config.Validate()
+		if err == nil {
+			t.Fatal("expected validation error when the same path is listed twice in different spellings")
+		}
+		if !strings.Contains(err.Error(), "duplicate path") {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("distinct paths", func(t *testing.T) {
+		config := main.DefaultConfig()
+		config.DBs = []*main.DBConfig{
+			{Path: "/path/to/a.sqlite"},
+			{Path: "/path/to/b.sqlite"},
+			{Dir: "/path/to/dir", Pattern: "*.db"},
+			{Dir: "/path/to/dir", Pattern: "*.sqlite"},
+		}
+
+		err := config.Validate()
+		if err != nil {
+			t.Errorf("unexpected validation error for distinct paths: %v", err)
+		}
+	})
+
 	t.Run("valid directory configuration", func(t *testing.T) {
 		config := main.DefaultConfig()
 		config.DBs = []*main.DBConfig{


### PR DESCRIPTION
## Summary
Reject a config that lists the same `dbs[].path` more than once, with an error that names both entries, instead of silently starting two managers on one metadata directory.

## Problem
As described in #1411, two `dbs:` entries for the same path each get their own manager but derive the same `.<name>-litestream` metadata directory, so they race on the same LTX temp files:

```
level=ERROR msg="sync error" system=store db=app.db error="sync: rename ltx file: rename /tmp/ls-race-repro/.app.db-litestream/ltx/0/0000000000000001-0000000000000001.ltx.tmp ...: no such file or directory" consecutive_errors=1 backoff=1s
```

Reproduced on `main` (63225f1) with a binary built from this tree before the fix. The config below loads with exit 0 and `litestream databases` prints the path twice:

```yaml
dbs:
  - path: /tmp/ls-race-repro/app.db
    replica:
      path: /tmp/ls-race-repro/rep-a
  - path: /tmp/ls-race-repro/app.db
    replica:
      path: /tmp/ls-race-repro/rep-b
```

`Config.Validate()` in `cmd/litestream/main.go` checks path/dir, pattern, watch, meta-dir, snapshot and sync-interval settings per entry, but never compares entries against each other.

## Solution
`Validate()` now keeps a map of cleaned paths seen so far and fails on the first repeat:

```
$ litestream databases -config dup.yml
Error: database config #2: duplicate path "/tmp/ls-race-repro/app.db" (already used by database config #1); each database can be listed only once
$ echo $?
1
```

`ParseConfig()` already expands every path to an absolute path before calling `Validate()`, so different spellings of one file (`./app.db`, `/tmp/x/../x/app.db`) are caught too; `filepath.Clean` keeps that true for callers that build a `Config` directly.

One note on the message: the issue suggests pointing users at the `replicas:` list, but `NewDBFromConfig` rejects more than one replica per database in v0.5 ("multiple replicas on a single database are no longer supported"), so the error just says each database can be listed once rather than recommending a shape that is also rejected.

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Same `path` listed twice | Accepted, two managers race on one metadata dir | Config error naming both entries, exit 1 |
| Same `path` in two spellings that resolve to one file | Accepted | Config error |
| Distinct paths, or the same `dir` with different patterns | Accepted | Accepted (unchanged) |

## Scope
**In scope:**
- Duplicate detection for `dbs[].path` in `Config.Validate()`
- Unit tests for the duplicate, cleaned-duplicate and distinct cases

**Not in scope:**
- Duplicate `dir` entries (the same directory with two different `pattern`s is legitimate, and overlapping patterns are a separate question)
- Detecting two different paths that are hard links or symlinks to one file

## Test Plan
```bash
go test -race -v -run TestDBConfigValidation ./cmd/litestream/
go test -race ./cmd/litestream/
go vet ./cmd/litestream/
```
All pass locally (macOS, Go 1.26).

## Related
- Fixes #1411

This change was made with AI assistance (Claude Code) and reviewed by the author.
