### PR TITLE
config: warn about unrecognized YAML keys

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -7,14 +7,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"math"
 	"net/url"
 	"os"
 	"os/user"
 	"path"
 	"path/filepath"
-	"reflect"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -700,116 +698,24 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	}
 	internal.InitLog(logOutput, config.Logging.Level, config.Logging.Type, config.Logging.Source)
 
-	// The YAML decoder silently drops keys that do not map to a Config field,
-	// so a misspelled or nonexistent setting looks like it took effect. Warn
-	// about each one; this is intentionally not an error so that existing
-	// deployments with a stray key keep starting.
-	for _, key := range unrecognizedConfigKeys(buf) {
-		slog.Warn("unrecognized config key, ignoring", "key", key)
+	// The lenient decode above silently drops keys that do not map to a Config
+	// field, so a misspelled or nonexistent setting looks like it took effect.
+	// Decode again in strict mode into a scratch value purely for diagnostics:
+	// yaml.UnmarshalStrict reports both unrecognized and duplicate mapping keys.
+	// These are warnings rather than errors so that existing deployments with a
+	// stray key keep starting.
+	var strictConfig Config
+	if err := yaml.UnmarshalStrict(buf, &strictConfig); err != nil {
+		var typeErr *yaml.TypeError
+		if !errors.As(err, &typeErr) {
+			return config, fmt.Errorf("strictly decode config: %w", err)
+		}
+		for _, detail := range typeErr.Errors {
+			slog.Warn("configuration contains unrecognized or duplicate key", "detail", detail)
+		}
 	}
 
 	return config, nil
-}
-
-// yamlUnmarshalerType is the interface implemented by types with custom YAML decoding.
-var yamlUnmarshalerType = reflect.TypeOf((*yaml.Unmarshaler)(nil)).Elem()
-
-// unrecognizedConfigKeys returns the paths of the YAML keys in buf that do not
-// correspond to any field of Config, in document order. Paths are written as
-// they appear in the config, e.g. "dbs[0].replica.retention".
-//
-// yaml.v2's strict mode reports the same keys, but only as "field X not found
-// in type Y" with no path, so the decoded document is walked against the
-// Config field tags instead.
-func unrecognizedConfigKeys(buf []byte) []string {
-	var doc yaml.MapSlice
-	if err := yaml.Unmarshal(buf, &doc); err != nil {
-		return nil
-	}
-	return unrecognizedKeys(doc, reflect.TypeOf(Config{}), "")
-}
-
-// unrecognizedKeys compares the mapping m against the YAML fields of struct type t.
-func unrecognizedKeys(m yaml.MapSlice, t reflect.Type, prefix string) []string {
-	fields := yamlFields(t)
-	if fields == nil {
-		return nil // struct accepts arbitrary keys
-	}
-
-	var keys []string
-	for _, item := range m {
-		name := fmt.Sprint(item.Key)
-		if name == "<<" {
-			continue // merge key; the decoder expands it
-		}
-		typ, ok := fields[name]
-		if !ok {
-			keys = append(keys, prefix+name)
-			continue
-		}
-		keys = append(keys, unrecognizedValueKeys(item.Value, typ, prefix+name)...)
-	}
-	return keys
-}
-
-// unrecognizedValueKeys descends into nested mappings, and sequences of
-// mappings, whose Go type is a struct with known fields.
-func unrecognizedValueKeys(v interface{}, t reflect.Type, path string) []string {
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-	if reflect.PointerTo(t).Implements(yamlUnmarshalerType) {
-		return nil // custom decoding; keys are not known here
-	}
-
-	switch t.Kind() {
-	case reflect.Struct:
-		if m, ok := v.(yaml.MapSlice); ok {
-			return unrecognizedKeys(m, t, path+".")
-		}
-	case reflect.Slice, reflect.Array:
-		if items, ok := v.([]interface{}); ok {
-			var keys []string
-			for i, item := range items {
-				keys = append(keys, unrecognizedValueKeys(item, t.Elem(), fmt.Sprintf("%s[%d]", path, i))...)
-			}
-			return keys
-		}
-	}
-	return nil
-}
-
-// yamlFields maps the YAML key of each field of struct type t to the field's
-// type, following the gopkg.in/yaml.v2 tag rules including ",inline" structs.
-// It returns nil if t has an inline map and therefore accepts any key.
-func yamlFields(t reflect.Type) map[string]reflect.Type {
-	fields := make(map[string]reflect.Type)
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-		if f.PkgPath != "" && !f.Anonymous {
-			continue // unexported
-		}
-		name, opts, _ := strings.Cut(f.Tag.Get("yaml"), ",")
-		if name == "-" {
-			continue
-		}
-		if strings.Contains(","+opts+",", ",inline,") {
-			if f.Type.Kind() != reflect.Struct {
-				return nil
-			}
-			inner := yamlFields(f.Type)
-			if inner == nil {
-				return nil
-			}
-			maps.Copy(fields, inner)
-			continue
-		}
-		if name == "" {
-			name = strings.ToLower(f.Name)
-		}
-		fields[name] = f.Type
-	}
-	return fields
 }
 
 // CompactionLevelConfig the configuration for a single level of compaction.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"math"
 	"net/url"
 	"os"
 	"os/user"
 	"path"
 	"path/filepath"
+	"reflect"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -698,7 +700,116 @@ func ParseConfig(r io.Reader, expandEnv bool) (_ Config, err error) {
 	}
 	internal.InitLog(logOutput, config.Logging.Level, config.Logging.Type, config.Logging.Source)
 
+	// The YAML decoder silently drops keys that do not map to a Config field,
+	// so a misspelled or nonexistent setting looks like it took effect. Warn
+	// about each one; this is intentionally not an error so that existing
+	// deployments with a stray key keep starting.
+	for _, key := range unrecognizedConfigKeys(buf) {
+		slog.Warn("unrecognized config key, ignoring", "key", key)
+	}
+
 	return config, nil
+}
+
+// yamlUnmarshalerType is the interface implemented by types with custom YAML decoding.
+var yamlUnmarshalerType = reflect.TypeOf((*yaml.Unmarshaler)(nil)).Elem()
+
+// unrecognizedConfigKeys returns the paths of the YAML keys in buf that do not
+// correspond to any field of Config, in document order. Paths are written as
+// they appear in the config, e.g. "dbs[0].replica.retention".
+//
+// yaml.v2's strict mode reports the same keys, but only as "field X not found
+// in type Y" with no path, so the decoded document is walked against the
+// Config field tags instead.
+func unrecognizedConfigKeys(buf []byte) []string {
+	var doc yaml.MapSlice
+	if err := yaml.Unmarshal(buf, &doc); err != nil {
+		return nil
+	}
+	return unrecognizedKeys(doc, reflect.TypeOf(Config{}), "")
+}
+
+// unrecognizedKeys compares the mapping m against the YAML fields of struct type t.
+func unrecognizedKeys(m yaml.MapSlice, t reflect.Type, prefix string) []string {
+	fields := yamlFields(t)
+	if fields == nil {
+		return nil // struct accepts arbitrary keys
+	}
+
+	var keys []string
+	for _, item := range m {
+		name := fmt.Sprint(item.Key)
+		if name == "<<" {
+			continue // merge key; the decoder expands it
+		}
+		typ, ok := fields[name]
+		if !ok {
+			keys = append(keys, prefix+name)
+			continue
+		}
+		keys = append(keys, unrecognizedValueKeys(item.Value, typ, prefix+name)...)
+	}
+	return keys
+}
+
+// unrecognizedValueKeys descends into nested mappings, and sequences of
+// mappings, whose Go type is a struct with known fields.
+func unrecognizedValueKeys(v interface{}, t reflect.Type, path string) []string {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if reflect.PointerTo(t).Implements(yamlUnmarshalerType) {
+		return nil // custom decoding; keys are not known here
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		if m, ok := v.(yaml.MapSlice); ok {
+			return unrecognizedKeys(m, t, path+".")
+		}
+	case reflect.Slice, reflect.Array:
+		if items, ok := v.([]interface{}); ok {
+			var keys []string
+			for i, item := range items {
+				keys = append(keys, unrecognizedValueKeys(item, t.Elem(), fmt.Sprintf("%s[%d]", path, i))...)
+			}
+			return keys
+		}
+	}
+	return nil
+}
+
+// yamlFields maps the YAML key of each field of struct type t to the field's
+// type, following the gopkg.in/yaml.v2 tag rules including ",inline" structs.
+// It returns nil if t has an inline map and therefore accepts any key.
+func yamlFields(t reflect.Type) map[string]reflect.Type {
+	fields := make(map[string]reflect.Type)
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" && !f.Anonymous {
+			continue // unexported
+		}
+		name, opts, _ := strings.Cut(f.Tag.Get("yaml"), ",")
+		if name == "-" {
+			continue
+		}
+		if strings.Contains(","+opts+",", ",inline,") {
+			if f.Type.Kind() != reflect.Struct {
+				return nil
+			}
+			inner := yamlFields(f.Type)
+			if inner == nil {
+				return nil
+			}
+			maps.Copy(fields, inner)
+			continue
+		}
+		if name == "" {
+			name = strings.ToLower(f.Name)
+		}
+		fields[name] = f.Type
+	}
+	return fields
 }
 
 // CompactionLevelConfig the configuration for a single level of compaction.

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/benbjohnson/litestream"
 	main "github.com/benbjohnson/litestream/cmd/litestream"
 	"github.com/benbjohnson/litestream/file"
@@ -205,6 +207,150 @@ dbs:
 			t.Fatalf("DB.MetaDir=%v, want %v", got, want)
 		}
 	})
+}
+
+// Ensure keys that do not map to any config field are reported as warnings
+// naming the key's path, while the config still parses successfully.
+func TestParseConfig_UnrecognizedKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		config string
+		want   []string
+	}{
+		{
+			name: "TopLevel",
+			config: `
+definitely-not-a-setting: true
+dbs:
+  - path: /tmp/x.db
+    replica:
+      path: /tmp/xrep
+`,
+			want: []string{"definitely-not-a-setting"},
+		},
+		{
+			name: "ReplicaRetention",
+			config: `
+dbs:
+  - path: /tmp/x.db
+    replica:
+      path: /tmp/xrep
+      retention: 72h
+`,
+			want: []string{"dbs[0].replica.retention"},
+		},
+		{
+			name: "LevelsRetention",
+			config: `
+levels:
+  - interval: 5m
+    retention: 1h
+  - interval: 1h
+dbs:
+  - path: /tmp/x.db
+    replica:
+      path: /tmp/xrep
+`,
+			want: []string{"levels[0].retention"},
+		},
+		{
+			name: "MultipleNested",
+			config: `
+dbs:
+  - path: /tmp/x.db
+    snapshot:
+      intervall: 1h
+    replica:
+      path: /tmp/xrep
+      age:
+        bogus: 1
+  - path: /tmp/y.db
+    replicas:
+      - path: /tmp/yrep
+        typo-here: 1
+logging:
+  lvl: debug
+`,
+			want: []string{
+				"dbs[0].snapshot.intervall",
+				"dbs[0].replica.age.bogus",
+				"dbs[1].replicas[0].typo-here",
+				"logging.lvl",
+			},
+		},
+		{
+			name: "Valid",
+			config: `
+access-key-id: XXX
+sync-interval: 5s
+levels:
+  - interval: 5m
+snapshot:
+  interval: 1h
+  retention: 24h
+logging:
+  level: info
+dbs:
+  - path: /tmp/x.db
+    snapshot:
+      interval: 2h
+    replica:
+      url: s3://foo/bar
+      part-size: 5MB
+      age:
+        identities: []
+`,
+			want: nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var config main.Config
+			output := captureStdout(t, func() {
+				var err error
+				if config, err = main.ParseConfig(strings.NewReader(tt.config), false); err != nil {
+					t.Fatalf("ParseConfig: %v", err)
+				}
+			})
+
+			// The config must still load; unknown keys are not an error.
+			if got, want := config.DBs[0].Path, "/tmp/x.db"; got != want {
+				t.Fatalf("DBs[0].Path=%v, want %v", got, want)
+			}
+
+			var got []string
+			for _, line := range strings.Split(output, "\n") {
+				if !strings.Contains(line, `msg="unrecognized config key, ignoring"`) {
+					continue
+				}
+				_, key, ok := strings.Cut(line, " key=")
+				if !ok {
+					t.Fatalf("warning has no key attribute: %s", line)
+				}
+				got = append(got, key)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("warned keys=%q, want %q\noutput:\n%s", got, tt.want, output)
+			}
+
+			// The set of unknown keys must agree with the YAML decoder's own
+			// strict mode, which reports the same keys without their paths.
+			var strictErr *yaml.TypeError
+			if err := yaml.UnmarshalStrict([]byte(tt.config), &main.Config{}); err != nil && !errors.As(err, &strictErr) {
+				t.Fatalf("UnmarshalStrict: %v", err)
+			}
+			var strictN int
+			if strictErr != nil {
+				for _, msg := range strictErr.Errors {
+					if strings.Contains(msg, "not found in type") {
+						strictN++
+					}
+				}
+			}
+			if strictN != len(tt.want) {
+				t.Fatalf("strict decode reports %d unknown keys, want %d: %v", strictN, len(tt.want), strictErr)
+			}
+		})
+	}
 }
 
 func TestNewDBFromConfig_MetaPathExpansion(t *testing.T) {

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -12,11 +12,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"gopkg.in/yaml.v2"
 
 	"github.com/benbjohnson/litestream"
 	main "github.com/benbjohnson/litestream/cmd/litestream"
@@ -209,9 +208,11 @@ dbs:
 	})
 }
 
-// Ensure keys that do not map to any config field are reported as warnings
-// naming the key's path, while the config still parses successfully.
-func TestParseConfig_UnrecognizedKeys(t *testing.T) {
+// Ensure keys the decoder cannot map to a config field, and duplicate mapping
+// keys, are reported as warnings while the configuration still parses.
+func TestParseConfig_StrictWarnings(t *testing.T) {
+	const warnMsg = `msg="configuration contains unrecognized or duplicate key"`
+
 	for _, tt := range []struct {
 		name   string
 		config string
@@ -226,10 +227,10 @@ dbs:
     replica:
       path: /tmp/xrep
 `,
-			want: []string{"definitely-not-a-setting"},
+			want: []string{"line 2: field definitely-not-a-setting not found in type main.Config"},
 		},
 		{
-			name: "ReplicaRetention",
+			name: "UnrecognizedKey",
 			config: `
 dbs:
   - path: /tmp/x.db
@@ -237,7 +238,7 @@ dbs:
       path: /tmp/xrep
       retention: 72h
 `,
-			want: []string{"dbs[0].replica.retention"},
+			want: []string{"line 6: field retention not found in type main.ReplicaConfig"},
 		},
 		{
 			name: "LevelsRetention",
@@ -251,7 +252,7 @@ dbs:
     replica:
       path: /tmp/xrep
 `,
-			want: []string{"levels[0].retention"},
+			want: []string{"line 4: field retention not found in type main.CompactionLevelConfig"},
 		},
 		{
 			name: "MultipleNested",
@@ -262,8 +263,6 @@ dbs:
       intervall: 1h
     replica:
       path: /tmp/xrep
-      age:
-        bogus: 1
   - path: /tmp/y.db
     replicas:
       - path: /tmp/yrep
@@ -272,13 +271,27 @@ logging:
   lvl: debug
 `,
 			want: []string{
-				"dbs[0].snapshot.intervall",
-				"dbs[0].replica.age.bogus",
-				"dbs[1].replicas[0].typo-here",
-				"logging.lvl",
+				"line 5: field intervall not found in type main.SnapshotConfig",
+				"line 11: field typo-here not found in type main.ReplicaConfig",
+				"line 13: field lvl not found in type internal.LoggingConfig",
 			},
 		},
 		{
+			name: "DuplicateKey",
+			config: `
+dbs:
+  - path: /tmp/x.db
+    replica:
+      path: /tmp/xrep
+      path: /tmp/other
+`,
+			want: []string{"line 6: field path already set in type main.ReplicaConfig"},
+		},
+		{
+			// Strict decoding's failure mode is warning about keys that are
+			// in fact valid, so this exercises the shapes the decoder has to
+			// resolve itself: an inline struct, a custom unmarshaler
+			// (part-size), and a nested anonymous struct (age).
 			name: "Valid",
 			config: `
 access-key-id: XXX
@@ -306,48 +319,34 @@ dbs:
 		t.Run(tt.name, func(t *testing.T) {
 			var config main.Config
 			output := captureStdout(t, func() {
+				// Unrecognized and duplicate keys warn; they are never errors.
 				var err error
 				if config, err = main.ParseConfig(strings.NewReader(tt.config), false); err != nil {
 					t.Fatalf("ParseConfig: %v", err)
 				}
 			})
 
-			// The config must still load; unknown keys are not an error.
+			// Parsing continues, so the rest of the config is still applied.
 			if got, want := config.DBs[0].Path, "/tmp/x.db"; got != want {
 				t.Fatalf("DBs[0].Path=%v, want %v", got, want)
 			}
 
 			var got []string
 			for _, line := range strings.Split(output, "\n") {
-				if !strings.Contains(line, `msg="unrecognized config key, ignoring"`) {
+				if !strings.Contains(line, warnMsg) {
 					continue
 				}
-				_, key, ok := strings.Cut(line, " key=")
+				_, detail, ok := strings.Cut(line, " detail=")
 				if !ok {
-					t.Fatalf("warning has no key attribute: %s", line)
+					t.Fatalf("warning has no detail attribute: %s", line)
 				}
-				got = append(got, key)
+				if unquoted, err := strconv.Unquote(detail); err == nil {
+					detail = unquoted
+				}
+				got = append(got, detail)
 			}
 			if !slices.Equal(got, tt.want) {
-				t.Fatalf("warned keys=%q, want %q\noutput:\n%s", got, tt.want, output)
-			}
-
-			// The set of unknown keys must agree with the YAML decoder's own
-			// strict mode, which reports the same keys without their paths.
-			var strictErr *yaml.TypeError
-			if err := yaml.UnmarshalStrict([]byte(tt.config), &main.Config{}); err != nil && !errors.As(err, &strictErr) {
-				t.Fatalf("UnmarshalStrict: %v", err)
-			}
-			var strictN int
-			if strictErr != nil {
-				for _, msg := range strictErr.Errors {
-					if strings.Contains(msg, "not found in type") {
-						strictN++
-					}
-				}
-			}
-			if strictN != len(tt.want) {
-				t.Fatalf("strict decode reports %d unknown keys, want %d: %v", strictN, len(tt.want), strictErr)
+				t.Fatalf("warned details=%q, want %q\noutput:\n%s", got, tt.want, output)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Log a WARN for every YAML key in the config file that the decoder cannot map to a known setting, and for every duplicate mapping key. The config still loads; these are warnings, not errors.

## Problem
`ParseConfig()` decodes with plain `yaml.Unmarshal` (gopkg.in/yaml.v2), so unknown keys are silently dropped and the user believes they took effect. On origin/main (63225f1):

```
$ cat c.yml
definitely-not-a-setting: true
dbs:
  - path: /tmp/x.db
    replica:
      path: /tmp/xrep
      retention: 72h
$ litestream databases -config c.yml
path       replica
/tmp/x.db  file
$ echo $?
0
```

Real cases from #1403: `replica.retention` (no such field, but the v0.3 -> v0.5 migration guide shows it) and `levels[].retention` (`CompactionLevelConfig` only has `interval`).

## Solution
After the existing lenient decode and validation succeed, and after `InitLog` has configured the logger, `ParseConfig` runs `yaml.UnmarshalStrict` a second time into a scratch `Config` used only for diagnostics. The live configuration is still the lenient decode, so behavior is unchanged for every config that loads today. Each `yaml.TypeError` detail is logged:

```
$ litestream databases -config c.yml
time=... level=WARN msg="configuration contains unrecognized or duplicate key" detail="line 1: field definitely-not-a-setting not found in type main.Config"
time=... level=WARN msg="configuration contains unrecognized or duplicate key" detail="line 6: field retention not found in type main.ReplicaConfig"
path       replica
/tmp/x.db  file
$ echo $?
0
```

This relies on the YAML library as the source of truth for tags, inline structs, custom unmarshalling and duplicate keys, rather than a second implementation of field resolution that has to stay synchronized with it. An earlier revision of this PR walked the decoded document against the `Config` field tags to produce a dotted path (`dbs[0].replica.retention`); the production code for that was 111 lines against 11 here, and the tradeoff is that the detail names the line, field and destination type instead of the path.

The preliminary snapshot-only decode pass is untouched. The returned `Config` and all error paths are unchanged. Warnings go through the configured logger, so they follow `logging.type`, `logging.stderr` and `LOG_LEVEL` like every other startup message.

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Unknown top-level key | silently ignored, exit 0 | WARN with the detail, exit 0 |
| `replica.retention` / `levels[].retention` | silently ignored | WARN naming the line, field and type |
| Duplicate mapping key | last value silently wins | WARN, last value still wins |
| Valid config | no output | no output (unchanged) |
| Known key with wrong type | hard error | hard error (unchanged) |

## Scope
**In scope:**
- Strict second decode in `ParseConfig`, warning per `yaml.TypeError` detail
- Tests for top-level, `dbs[].replica`, `levels[]`, nested/multiple, a duplicate key, and a valid config

**Not in scope:**
- Making unknown keys a hard error, or a `--strict` / `--strict-config` flag (per the issue this should stay a warning; an opt-in strict mode could be a follow-up)
- Fixing the migration guide text that shows `replica.retention` (website repo)

## Test Plan
```bash
go test -race -v -run 'TestParseConfig_StrictWarnings' ./cmd/litestream/...
go test -race -run 'TestParseConfig|TestReadConfigFile|TestConfig_' ./cmd/litestream/...
go test -race ./cmd/litestream/...
go vet ./cmd/litestream/...
```
All pass locally (macOS, Go 1.26; gofmt, goimports and staticcheck clean).

## Related
- Fixes #1403
- Related to #1400

This change was made with AI assistance (Claude Code) and reviewed by the author.
