### PR TITLE
fix(vfs): fix litestream_time() to update with new LTX files

### DIFF
--- a/cmd/litestream-vfs/litestream_time_test.go
+++ b/cmd/litestream-vfs/litestream_time_test.go
@@ -1,0 +1,69 @@
+//go:build vfs
+// +build vfs
+
+package main_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/benbjohnson/litestream/file"
+	"github.com/benbjohnson/litestream/internal/testingutil"
+)
+
+// TestVFS_LitestreamTimeAdvancesOnPoll verifies that litestream_time() advances
+// on a long-lived connection as the backup progresses.
+func TestVFS_LitestreamTimeAdvancesOnPoll(t *testing.T) {
+	client := file.NewReplicaClient(t.TempDir())
+	primaryDB, primary := openReplicatedPrimary(t, client, 50*time.Millisecond, 50*time.Millisecond)
+	defer testingutil.MustCloseSQLDB(t, primary)
+
+	if _, err := primary.Exec("CREATE TABLE t (x)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := primary.Exec("INSERT INTO t VALUES (1)"); err != nil {
+		t.Fatal(err)
+	}
+	waitForLTXFiles(t, client, 10*time.Second, 50*time.Millisecond)
+
+	vfs := newVFS(t, client)
+	vfs.PollInterval = 50 * time.Millisecond
+	name := registerTestVFS(t, vfs)
+	replica := openVFSReplicaDB(t, name)
+	defer replica.Close()
+	// One connection => one VFSFile, so we observe the polling file's time.
+	replica.SetMaxOpenConns(1)
+
+	// Initial data visible, and the initial litestream_time on the held-open
+	// connection (set at open by buildIndex).
+	waitForReplicaValue(t, replica, "SELECT x FROM t", 1, 10*time.Second, 50*time.Millisecond)
+	t0 := readLitestreamTime(t, replica)
+
+	// Ensure the next LTX file gets a strictly-later CreatedAt than the first.
+	time.Sleep(1100 * time.Millisecond)
+
+	// Advance the backup. The VFS poll should apply the new data AND advance
+	// litestream_time — all on the same, never-reset connection.
+	if _, err := primary.Exec("INSERT INTO t VALUES (2)"); err != nil {
+		t.Fatal(err)
+	}
+	forceReplicaSync(t, primaryDB)
+	waitForReplicaValue(t, replica, "SELECT max(x) FROM t", 2, 10*time.Second, 50*time.Millisecond)
+
+	t1 := readLitestreamTime(t, replica)
+
+	require.Truef(t, t1.After(t0),
+		"litestream_time should advance on poll without reset: t0=%s t1=%s", t0, t1)
+}
+
+func readLitestreamTime(t *testing.T, db *sql.DB) time.Time {
+	t.Helper()
+	var s string
+	require.NoError(t, db.QueryRow("PRAGMA litestream_time").Scan(&s))
+	ts, err := time.Parse(time.RFC3339Nano, s)
+	require.NoErrorf(t, err, "parse litestream_time %q", s)
+	return ts
+}

--- a/vfs.go
+++ b/vfs.go
@@ -2511,7 +2511,7 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 	newCommit := baseCommit
 	replaceIndex := false
 
-	maxTXID0, idx0, commit0, replace0, err := f.pollLevel(ctx, 0, pos.TXID, baseCommit)
+	maxTXID0, idx0, commit0, replace0, createdAt0, err := f.pollLevel(ctx, 0, pos.TXID, baseCommit)
 	if err != nil {
 		return fmt.Errorf("poll L0: %w", err)
 	}
@@ -2532,7 +2532,7 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 		}
 	}
 
-	maxTXID1, idx1, commit1, replace1, err := f.pollLevel(ctx, 1, maxTXID1Snapshot, baseCommit)
+	maxTXID1, idx1, commit1, replace1, createdAt1, err := f.pollLevel(ctx, 1, maxTXID1Snapshot, baseCommit)
 	if err != nil {
 		return fmt.Errorf("poll L1: %w", err)
 	}
@@ -2604,8 +2604,10 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 
 	if maxTXID0 > maxTXID1 {
 		f.pos.TXID = maxTXID0
+		f.latestLTXTime = latestTime(f.latestLTXTime, createdAt0)
 	} else {
 		f.pos.TXID = maxTXID1
+		f.latestLTXTime = latestTime(f.latestLTXTime, createdAt1)
 	}
 
 	f.maxTXID1 = maxTXID1
@@ -2621,12 +2623,19 @@ func (f *VFSFile) pollReplicaClient(ctx context.Context) error {
 	return nil
 }
 
+func latestTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+
 // pollLevel fetches LTX files for a specific level and returns the highest TXID seen,
 // any index updates, the latest commit value, and if the index should be replaced.
-func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID, baseCommit uint32) (ltx.TXID, map[uint32]ltx.PageIndexElem, uint32, bool, error) {
+func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID, baseCommit uint32) (ltx.TXID, map[uint32]ltx.PageIndexElem, uint32, bool, time.Time, error) {
 	itr, err := f.client.LTXFiles(ctx, level, prevMaxTXID+1, false)
 	if err != nil {
-		return prevMaxTXID, nil, baseCommit, false, fmt.Errorf("ltx files: %w", err)
+		return prevMaxTXID, nil, baseCommit, false, time.Time{}, fmt.Errorf("ltx files: %w", err)
 	}
 	defer func() { _ = itr.Close() }()
 
@@ -2635,6 +2644,8 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 	lastCommit := baseCommit
 	newCommit := baseCommit
 	replaceIndex := false
+	// CreatedAt of the newest LTX file applied (by TXID); zero if none applied.
+	var latestCreatedAt time.Time
 
 	for itr.Next() {
 		info := itr.Item()
@@ -2647,18 +2658,18 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 				f.logger.Warn("ltx gap detected at L0, deferring to higher levels", "expected", maxTXID+1, "next", info.MinTXID)
 				break
 			}
-			return maxTXID, nil, newCommit, replaceIndex, fmt.Errorf("non-contiguous ltx file: level=%d, current=%s, next=%s-%s", level, maxTXID, info.MinTXID, info.MaxTXID)
+			return maxTXID, nil, newCommit, replaceIndex, time.Time{}, fmt.Errorf("non-contiguous ltx file: level=%d, current=%s, next=%s-%s", level, maxTXID, info.MinTXID, info.MaxTXID)
 		}
 
 		f.logger.Debug("new ltx file", "level", info.Level, "min", info.MinTXID, "max", info.MaxTXID)
 
 		idx, err := FetchPageIndex(ctx, f.client, info)
 		if err != nil {
-			return maxTXID, nil, newCommit, replaceIndex, fmt.Errorf("fetch page index: %w", err)
+			return maxTXID, nil, newCommit, replaceIndex, time.Time{}, fmt.Errorf("fetch page index: %w", err)
 		}
 		hdr, err := FetchLTXHeader(ctx, f.client, info)
 		if err != nil {
-			return maxTXID, nil, newCommit, replaceIndex, fmt.Errorf("fetch header: %w", err)
+			return maxTXID, nil, newCommit, replaceIndex, time.Time{}, fmt.Errorf("fetch header: %w", err)
 		}
 
 		if hdr.Commit < lastCommit {
@@ -2673,9 +2684,10 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 			index[k] = v
 		}
 		maxTXID = info.MaxTXID
+		latestCreatedAt = info.CreatedAt
 	}
 
-	return maxTXID, index, newCommit, replaceIndex, nil
+	return maxTXID, index, newCommit, replaceIndex, latestCreatedAt, nil
 }
 
 func (f *VFSFile) pageSizeBytes() (uint32, error) {


### PR DESCRIPTION
## Description

Fix the value returned by `litestream_time()` to correctly reflect the latest LTX time when it is set to `latest` mode (i.e. the default, without time-travel).

## Motivation and Context

Previous, `f.latestLTXTime` was only on the initial indexing (or when indexes are rebuilt), but not updated with the result of new LTX files after a poll. 

This meant that `litestream_time()` only reflected the first LTX download, but not any updates.

## How Has This Been Tested?

Unit test added

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
