### PR TITLE
fix(replica): honor LTX file seek contract

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -383,9 +383,6 @@ func newLTXFileIterator(ctx context.Context, client *ReplicaClient, level int, s
 	// Create paginator for listing blobs with level prefix
 	dir := litestream.LTXLevelDir(client.Path, level)
 	prefix := dir + "/"
-	if seek != 0 {
-		prefix += seek.String()
-	}
 
 	itr.pager = client.client.NewListBlobsFlatPager(client.Bucket, &azblob.ListBlobsFlatOptions{
 		Prefix:  &prefix,

--- a/abs/replica_client_test.go
+++ b/abs/replica_client_test.go
@@ -1,0 +1,116 @@
+package abs
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream"
+)
+
+func TestReplicaClient_LTXFilesSeek(t *testing.T) {
+	names := []string{
+		litestream.LTXFilePath("integration", 0, 1, 1),
+		litestream.LTXFilePath("integration", 0, 3, 3),
+		litestream.LTXFilePath("integration", 0, 5, 5),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPrefix := r.URL.Query().Get("prefix")
+		response := listBlobsResponse{
+			ServiceEndpoint: serverURL(r),
+			ContainerName:   "litestream-test",
+		}
+		for _, name := range names {
+			if strings.HasPrefix(name, requestedPrefix) {
+				response.Blobs = append(response.Blobs, newListBlob(name))
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+		if err := xml.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := azblob.NewClientWithNoCredential(server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+	rc := NewReplicaClient()
+	rc.client = client
+	rc.Bucket = "litestream-test"
+	rc.Path = "integration"
+
+	for _, tt := range []struct {
+		name string
+		seek ltx.TXID
+		want []ltx.TXID
+	}{
+		{name: "exact", seek: 3, want: []ltx.TXID{3, 5}},
+		{name: "next available", seek: 2, want: []ltx.TXID{3, 5}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			itr, err := rc.LTXFiles(t.Context(), 0, tt.seek, false)
+			if err != nil {
+				t.Fatalf("LTXFiles: %v", err)
+			}
+
+			var got []ltx.TXID
+			for itr.Next() {
+				got = append(got, itr.Item().MinTXID)
+			}
+			if err := itr.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("MinTXIDs=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type listBlobsResponse struct {
+	XMLName         xml.Name   `xml:"EnumerationResults"`
+	ServiceEndpoint string     `xml:"ServiceEndpoint,attr"`
+	ContainerName   string     `xml:"ContainerName,attr"`
+	Blobs           []listBlob `xml:"Blobs>Blob"`
+	NextMarker      string     `xml:"NextMarker"`
+}
+
+type listBlob struct {
+	Name       string             `xml:"Name"`
+	Properties listBlobProperties `xml:"Properties"`
+}
+
+type listBlobProperties struct {
+	ETag          string `xml:"Etag"`
+	LastModified  string `xml:"Last-Modified"`
+	CreationTime  string `xml:"Creation-Time"`
+	ContentLength int64  `xml:"Content-Length"`
+}
+
+func newListBlob(name string) listBlob {
+	timestamp := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC).Format(http.TimeFormat)
+	return listBlob{
+		Name: name,
+		Properties: listBlobProperties{
+			ETag:          `"etag"`,
+			LastModified:  timestamp,
+			CreationTime:  timestamp,
+			ContentLength: 1,
+		},
+	}
+}
+
+func serverURL(r *http.Request) string {
+	return "http://" + r.Host
+}

--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -129,12 +129,12 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 	}
 
 	dir := litestream.LTXLevelDir(c.Path, level)
-	prefix := dir + "/"
+	query := &storage.Query{Prefix: dir + "/"}
 	if seek != 0 {
-		prefix += seek.String()
+		query.StartOffset = query.Prefix + seek.String()
 	}
 
-	return newLTXFileIterator(c.bkt.Objects(ctx, &storage.Query{Prefix: prefix}), c, level), nil
+	return newLTXFileIterator(c.bkt.Objects(ctx, query), c, level), nil
 }
 
 // WriteLTXFile writes an LTX file from rd to a remote path.

--- a/gs/replica_client_test.go
+++ b/gs/replica_client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"slices"
 	"testing"
 	"time"
 
@@ -77,5 +78,45 @@ func TestReplicaClient_OpenLTXFileReadsFullObject(t *testing.T) {
 
 	if !bytes.Equal(out, data) {
 		t.Fatalf("unexpected replica content: got %q, want %q", out, data)
+	}
+}
+
+func TestReplicaClient_LTXFilesSeek(t *testing.T) {
+	rc, server := setupTestClient(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	for _, txID := range []ltx.TXID{1, 3, 5} {
+		data := ltxTestData(t, txID, txID, nil)
+		if _, err := rc.WriteLTXFile(ctx, 0, txID, txID, bytes.NewReader(data)); err != nil {
+			t.Fatalf("WriteLTXFile(%s): %v", txID, err)
+		}
+	}
+
+	for _, tt := range []struct {
+		name string
+		seek ltx.TXID
+		want []ltx.TXID
+	}{
+		{name: "exact", seek: 3, want: []ltx.TXID{3, 5}},
+		{name: "next available", seek: 2, want: []ltx.TXID{3, 5}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			itr, err := rc.LTXFiles(ctx, 0, tt.seek, false)
+			if err != nil {
+				t.Fatalf("LTXFiles: %v", err)
+			}
+
+			var got []ltx.TXID
+			for itr.Next() {
+				got = append(got, itr.Item().MinTXID)
+			}
+			if err := itr.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("MinTXIDs=%v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Make Azure Blob Storage and Google Cloud Storage return every LTX file at or after the requested seek TXID. GCS now combines the level prefix with `storage.Query.StartOffset`; Azure lists the level prefix and applies its existing `MinTXID >= seek` filter client-side.

Scope is limited to the two storage clients and their seek regression tests. Compaction and replica orchestration are unchanged.

## Motivation and Context

Both clients previously appended the full fixed-width seek TXID to the listing prefix. That restricted results to filenames beginning with exactly that TXID, so an exact seek returned only one file and a gap seek returned none.

The regression tests produced this evidence before the fix:

```text
abs exact: MinTXIDs=[0000000000000003], want [0000000000000003 0000000000000005]
abs next available: MinTXIDs=[], want [0000000000000003 0000000000000005]
gs exact: MinTXIDs=[0000000000000003], want [0000000000000003 0000000000000005]
gs next available: MinTXIDs=[], want [0000000000000003 0000000000000005]
```

Fixes #1456

## How Has This Been Tested?

```bash
GOTOOLCHAIN=go1.25.13 go test -race -count=1 ./abs/... ./gs/...
GOTOOLCHAIN=go1.25.13 go test -race -count=1 .
GOTOOLCHAIN=go1.25.13 pre-commit run --all-files
```

The provider tests cover both an exact seek and a missing seek TXID whose next available files must be returned.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
