### PR TITLE
fix(vfs): tolerate L1 files that straddle the poll watermark

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -380,12 +380,13 @@ func newLTXFileIterator(ctx context.Context, client *ReplicaClient, level int, s
 		seek:   seek,
 	}
 
-	// Create paginator for listing blobs with level prefix
+	// Create paginator for listing blobs with level prefix. List the whole
+	// level and filter by seek in the iterator (like the s3 backend). We can't
+	// narrow the list with a seek-derived key prefix: a file whose range
+	// straddles the seek has a MinTXID below it, so a prefix on the seek value
+	// would exclude the very file that covers the next needed TXID.
 	dir := litestream.LTXLevelDir(client.Path, level)
 	prefix := dir + "/"
-	if seek != 0 {
-		prefix += seek.String()
-	}
 
 	itr.pager = client.client.NewListBlobsFlatPager(client.Bucket, &azblob.ListBlobsFlatOptions{
 		Prefix:  &prefix,
@@ -457,8 +458,10 @@ func (itr *ltxFileIterator) loadNextPage() bool {
 			Size:    *item.Properties.ContentLength,
 		}
 
-		// Skip if below seek TXID
-		if info.MinTXID < itr.seek {
+		// Skip only if the file's whole range is below the seek TXID. A file
+		// whose range straddles the seek (MinTXID < seek <= MaxTXID) still
+		// covers the next TXID a follower needs, so it must be returned.
+		if info.MaxTXID < itr.seek {
 			continue
 		}
 

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -114,7 +114,8 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 		minTXID, maxTXID, err := ltx.ParseFilename(fi.Name())
 		if err != nil {
 			continue
-		} else if minTXID < seek {
+		} else if maxTXID < seek {
+			// Skip if the whole range is below seek.
 			continue
 		}
 

--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -130,11 +130,11 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 
 	dir := litestream.LTXLevelDir(c.Path, level)
 	prefix := dir + "/"
-	if seek != 0 {
-		prefix += seek.String()
-	}
-
-	return newLTXFileIterator(c.bkt.Objects(ctx, &storage.Query{Prefix: prefix}), c, level), nil
+	// List the whole level and filter by seek in the iterator (like the s3
+	// backend). We can't narrow the list with a seek-derived key prefix: a file
+	// whose range straddles the seek has a MinTXID below it, so a prefix on the
+	// seek value would exclude the very file that covers the next needed TXID.
+	return newLTXFileIterator(c.bkt.Objects(ctx, &storage.Query{Prefix: prefix}), c, level, seek), nil
 }
 
 // WriteLTXFile writes an LTX file from rd to a remote path.
@@ -240,15 +240,17 @@ type ltxFileIterator struct {
 	it     *storage.ObjectIterator
 	client *ReplicaClient
 	level  int
+	seek   ltx.TXID
 	info   *ltx.FileInfo
 	err    error
 }
 
-func newLTXFileIterator(it *storage.ObjectIterator, client *ReplicaClient, level int) *ltxFileIterator {
+func newLTXFileIterator(it *storage.ObjectIterator, client *ReplicaClient, level int, seek ltx.TXID) *ltxFileIterator {
 	return &ltxFileIterator{
 		it:     it,
 		client: client,
 		level:  level,
+		seek:   seek,
 	}
 }
 
@@ -275,6 +277,13 @@ func (itr *ltxFileIterator) Next() bool {
 		// Parse index & offset, otherwise skip to the next object.
 		minTXID, maxTXID, err := ltx.ParseFilename(path.Base(attrs.Name))
 		if err != nil {
+			continue
+		}
+
+		// Skip only if the file's whole range is below the seek TXID. A file
+		// whose range straddles the seek (minTXID < seek <= maxTXID) still
+		// covers the next TXID a follower needs, so it must be returned.
+		if maxTXID < itr.seek {
 			continue
 		}
 

--- a/nats/replica_client.go
+++ b/nats/replica_client.go
@@ -317,8 +317,8 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 			continue
 		}
 
-		// Apply seek filter
-		if minTXID < seek {
+		// Apply seek filter. Skip if the whole range is below seek.
+		if maxTXID < seek {
 			continue
 		}
 

--- a/oss/replica_client.go
+++ b/oss/replica_client.go
@@ -578,8 +578,8 @@ func (itr *fileIterator) Next() bool {
 				MaxTXID: maxTXID,
 			}
 
-			// Skip if below seek TXID
-			if info.MinTXID < itr.seek {
+			// Skip if the file's whole range is below the seek TXID.
+			if info.MaxTXID < itr.seek {
 				continue
 			}
 

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -1680,8 +1680,8 @@ func (itr *fileIterator) Next() bool {
 				MaxTXID: maxTXID,
 			}
 
-			// Skip if below seek TXID
-			if info.MinTXID < itr.seek {
+			// Skip if the file's whole range is below the seek TXID.
+			if info.MaxTXID < itr.seek {
 				continue
 			}
 

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -247,7 +247,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 		minTXID, maxTXID, err := ltx.ParseFilename(path.Base(fi.Name()))
 		if err != nil {
 			continue
-		} else if minTXID < seek {
+		} else if maxTXID < seek {
 			continue
 		}
 

--- a/vfs.go
+++ b/vfs.go
@@ -2641,9 +2641,10 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 
 		// Position this file relative to the highest TXID applied so far:
 		//
-		//   1. Already covered (MaxTXID <= maxTXID): nothing new — skip. Handles
-		//      narrower files listed alongside a wider one that supersedes them
-		//      (e.g. from L1->L1 re-compaction).
+		//   1. Already covered (MaxTXID <= maxTXID): nothing new — skip. Defends
+		//      against a narrower file listed alongside a wider one that overlaps
+		//      it. litestream does not rewrite files within a level today, so this
+		//      is robustness, not a path exercised in normal operation.
 		//   2. Contiguous continuation, including a *straddling* compacted file
 		//      whose range starts at or below maxTXID but extends past it
 		//      (MinTXID <= maxTXID+1 <= MaxTXID): apply it and advance to its

--- a/vfs.go
+++ b/vfs.go
@@ -2639,11 +2639,27 @@ func (f *VFSFile) pollLevel(ctx context.Context, level int, prevMaxTXID ltx.TXID
 	for itr.Next() {
 		info := itr.Item()
 
-		f.mu.Lock()
-		isNextTXID := info.MinTXID == maxTXID+1
-		f.mu.Unlock()
-		if !isNextTXID {
-			if level == 0 && info.MinTXID > maxTXID+1 {
+		// Position this file relative to the highest TXID applied so far:
+		//
+		//   1. Already covered (MaxTXID <= maxTXID): nothing new — skip. Handles
+		//      narrower files listed alongside a wider one that supersedes them
+		//      (e.g. from L1->L1 re-compaction).
+		//   2. Contiguous continuation, including a *straddling* compacted file
+		//      whose range starts at or below maxTXID but extends past it
+		//      (MinTXID <= maxTXID+1 <= MaxTXID): apply it and advance to its
+		//      MaxTXID. Re-applying the already-covered portion is an idempotent
+		//      page-index overwrite.
+		//   3. Real gap (MinTXID > maxTXID+1): at L0 defer to higher levels;
+		//      above L0 it is an error.
+		//
+		// Case 2 keeps a follower from wedging when compaction merges files into
+		// wider ranges: seeking by TXID must not reject a file that actually
+		// covers the next TXID we need (e.g. resuming at 6 and meeting a 1-b file).
+		if info.MaxTXID <= maxTXID {
+			continue
+		}
+		if info.MinTXID > maxTXID+1 {
+			if level == 0 {
 				f.logger.Warn("ltx gap detected at L0, deferring to higher levels", "expected", maxTXID+1, "next", info.MinTXID)
 				break
 			}

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -435,12 +435,13 @@ func TestVFSFile_StraddlingL1FileAfterSeed(t *testing.T) {
 	}
 }
 
-// TestVFSFile_MergedWiderL1FileAfterConsume covers the L1->L1 re-compaction
-// variant of the straddle bug. After a follower has consumed an L1 file up to
-// some boundary (here b), compaction can merge that range with later ones into a
-// *wider* L1 file whose MinTXID is below the follower's watermark (7..1d covers
-// b). The follower must ingest that wider file rather than reject it as
-// non-contiguous — the same defect as the seed case, reached a different way.
+// TestVFSFile_MergedWiderL1FileAfterConsume is a defensive test for overlapping
+// files within a level. litestream compacts level N into level N+1 and does not
+// rewrite files within a level, so this exact state should not arise in normal
+// operation — but pollLevel must not wedge if it ever encounters a wider file
+// whose range overlaps what a follower has already consumed. Here a follower at
+// watermark b meets a wider 7..1d file (MinTXID 7 < b); it must be ingested and
+// advance the watermark to 1d rather than be rejected as non-contiguous.
 func TestVFSFile_MergedWiderL1FileAfterConsume(t *testing.T) {
 	client := newMockReplicaClient()
 	client.addFixture(t, buildLTXRangeFixture(t, SnapshotLevel, 1, 6, 's'))
@@ -460,10 +461,10 @@ func TestVFSFile_MergedWiderL1FileAfterConsume(t *testing.T) {
 		t.Fatalf("aligned L1 file not ingested: maxTXID1=%s, want b", got)
 	}
 
-	// L1->L1 re-compaction merges 7..b with c..1d into a wider 7..1d file, whose
-	// MinTXID (7) is below the current watermark (b). seek=c naturally excludes
-	// the superseded 7..b (MaxTXID b < c), so the wider file is what must be
-	// ingested; it straddles b and advances the watermark to 1d.
+	// A wider 7..1d file appears whose MinTXID (7) is below the current watermark
+	// (b) — a within-level overlap. seek=c naturally excludes the narrower 7..b
+	// (MaxTXID b < c), so the wider file is what must be ingested; it straddles b
+	// and advances the watermark to 1d.
 	client.addFixture(t, buildLTXRangeFixture(t, 1, 7, 0x1d, 'B'))
 	if err := f.pollReplicaClient(context.Background()); err != nil {
 		t.Fatalf("poll after merged wider L1 file: %v", err)

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -384,6 +384,95 @@ func TestVFSFile_OpenSeedsLevel1PositionFromPos(t *testing.T) {
 	}
 }
 
+// TestVFSFile_StraddlingL1FileAfterSeed reproduces the permanent
+// "non-contiguous ltx file" wedge at L1.
+//
+// When the index is built while L1 is empty, maxTXID1 is seeded from pos.TXID
+// (an L0/snapshot position) — here TXID 6 — which need not fall on an L1 file
+// boundary. When the writer's first L1 compaction then emits a file whose range
+// *straddles* that seed (1..b covers 6), the level-1 seek (seek=maxTXID1+1=7)
+// skips it because its MinTXID (1) < seek, and the following L1 file (c..1d)
+// then trips the strict MinTXID==maxTXID+1 contiguity check — wedging the
+// follower forever even though the data on disk is fully contiguous.
+//
+// Correct behavior: the straddling 1..b file is ingested (advancing maxTXID1 to
+// b), after which c..1d continues contiguously.
+func TestVFSFile_StraddlingL1FileAfterSeed(t *testing.T) {
+	client := newMockReplicaClient()
+
+	// Snapshot covering TXIDs 1..6, no L1 files yet. On open this makes
+	// pos.TXID = 6 and — since L1 is empty — seeds maxTXID1 = 6.
+	client.addFixture(t, buildLTXRangeFixture(t, SnapshotLevel, 1, 6, 's'))
+
+	f := NewVFSFile(client, "straddle.db", slog.Default())
+	if err := f.Open(); err != nil {
+		t.Fatalf("open vfs file: %v", err)
+	}
+	defer f.Close()
+
+	if got := f.maxTXID1; got != 6 {
+		t.Fatalf("precondition: maxTXID1 seeded to %s, want 6", got)
+	}
+
+	// The first L1 compaction emits 1..b — a range that straddles the seed (6).
+	// It must be ingested; today it is silently skipped (MinTXID 1 < seek 7).
+	client.addFixture(t, buildLTXRangeFixture(t, 1, 1, 0xb, 'A'))
+	if err := f.pollReplicaClient(context.Background()); err != nil {
+		t.Fatalf("poll after straddling L1 file: %v", err)
+	}
+	if got := f.maxTXID1; got != 0xb {
+		t.Fatalf("straddling L1 file 1-b was not ingested: maxTXID1=%s, want b", got)
+	}
+
+	// The next L1 file continues contiguously from b: c..1d. Without ingesting
+	// 1..b above, this is where the wedge surfaces as a non-contiguous error.
+	client.addFixture(t, buildLTXRangeFixture(t, 1, 0xc, 0x1d, 'B'))
+	if err := f.pollReplicaClient(context.Background()); err != nil {
+		t.Fatalf("poll after following L1 file: %v", err)
+	}
+	if got := f.maxTXID1; got != 0x1d {
+		t.Fatalf("following L1 file c-1d not ingested: maxTXID1=%s, want 1d", got)
+	}
+}
+
+// TestVFSFile_MergedWiderL1FileAfterConsume covers the L1->L1 re-compaction
+// variant of the straddle bug. After a follower has consumed an L1 file up to
+// some boundary (here b), compaction can merge that range with later ones into a
+// *wider* L1 file whose MinTXID is below the follower's watermark (7..1d covers
+// b). The follower must ingest that wider file rather than reject it as
+// non-contiguous — the same defect as the seed case, reached a different way.
+func TestVFSFile_MergedWiderL1FileAfterConsume(t *testing.T) {
+	client := newMockReplicaClient()
+	client.addFixture(t, buildLTXRangeFixture(t, SnapshotLevel, 1, 6, 's'))
+
+	f := NewVFSFile(client, "merge.db", slog.Default())
+	if err := f.Open(); err != nil {
+		t.Fatalf("open vfs file: %v", err)
+	}
+	defer f.Close()
+
+	// Consume an aligned L1 file 7..b, advancing maxTXID1 to b.
+	client.addFixture(t, buildLTXRangeFixture(t, 1, 7, 0xb, 'A'))
+	if err := f.pollReplicaClient(context.Background()); err != nil {
+		t.Fatalf("poll after aligned L1 file: %v", err)
+	}
+	if got := f.maxTXID1; got != 0xb {
+		t.Fatalf("aligned L1 file not ingested: maxTXID1=%s, want b", got)
+	}
+
+	// L1->L1 re-compaction merges 7..b with c..1d into a wider 7..1d file, whose
+	// MinTXID (7) is below the current watermark (b). seek=c naturally excludes
+	// the superseded 7..b (MaxTXID b < c), so the wider file is what must be
+	// ingested; it straddles b and advances the watermark to 1d.
+	client.addFixture(t, buildLTXRangeFixture(t, 1, 7, 0x1d, 'B'))
+	if err := f.pollReplicaClient(context.Background()); err != nil {
+		t.Fatalf("poll after merged wider L1 file: %v", err)
+	}
+	if got := f.maxTXID1; got != 0x1d {
+		t.Fatalf("merged wider L1 file not ingested: maxTXID1=%s, want 1d", got)
+	}
+}
+
 func TestVFSFile_HeaderForcesDeleteJournal(t *testing.T) {
 	client := newMockReplicaClient()
 	client.addFixture(t, buildLTXFixture(t, 1, 'h'))
@@ -868,6 +957,8 @@ func (c *countingReplicaClient) DeleteLTXFiles(context.Context, []*ltx.FileInfo)
 
 func (c *countingReplicaClient) DeleteAll(context.Context) error { return nil }
 
+func (c *countingReplicaClient) SetLogger(*slog.Logger) {}
+
 func newMockReplicaClient() *mockReplicaClient {
 	return &mockReplicaClient{data: make(map[string][]byte)}
 }
@@ -883,6 +974,8 @@ func (c *mockReplicaClient) Type() string { return "mock" }
 
 func (c *mockReplicaClient) Init(context.Context) error { return nil }
 
+func (c *mockReplicaClient) SetLogger(*slog.Logger) {}
+
 func (c *mockReplicaClient) addFixture(tb testing.TB, fx *ltxFixture) {
 	tb.Helper()
 	c.mu.Lock()
@@ -896,7 +989,9 @@ func (c *mockReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TX
 	defer c.mu.Unlock()
 	var out []*ltx.FileInfo
 	for _, info := range c.files {
-		if info.Level == level && info.MinTXID >= seek {
+		// Mirror the real backends: return a file whose range reaches the seek
+		// (MaxTXID >= seek), including one that straddles it (MinTXID < seek).
+		if info.Level == level && info.MaxTXID >= seek {
 			out = append(out, info)
 		}
 	}
@@ -1042,6 +1137,49 @@ func buildLTXFixtureWithPages(tb testing.TB, txid ltx.TXID, pageSize uint32, pgn
 		CreatedAt: time.Now().UTC(),
 	}
 
+	return &ltxFixture{info: info, data: buf.Bytes()}
+}
+
+// buildLTXRangeFixture builds an LTX fixture spanning [minTXID, maxTXID] at the
+// given level, so tests can model a compacted file (snapshot/L1/L2+) whose range
+// covers multiple transactions — including one that straddles a poll watermark.
+// The existing builders only produce single-TXID (MinTXID==MaxTXID) files.
+func buildLTXRangeFixture(tb testing.TB, level int, minTXID, maxTXID ltx.TXID, fill byte) *ltxFixture {
+	tb.Helper()
+	const pageSize = 4096
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		tb.Fatalf("new encoder: %v", err)
+	}
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		PageSize:  pageSize,
+		Commit:    1, // single-page db; page contents are irrelevant to poll-watermark tests
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Timestamp: time.Now().UnixMilli(),
+		Flags:     ltx.HeaderFlagNoChecksum,
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		tb.Fatalf("encode header: %v", err)
+	}
+	page := bytes.Repeat([]byte{fill}, pageSize)
+	if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page); err != nil {
+		tb.Fatalf("encode page: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		tb.Fatalf("close encoder: %v", err)
+	}
+
+	info := &ltx.FileInfo{
+		Level:     level,
+		MinTXID:   minTXID,
+		MaxTXID:   maxTXID,
+		Size:      int64(buf.Len()),
+		CreatedAt: time.Now().UTC(),
+	}
 	return &ltxFixture{info: info, data: buf.Bytes()}
 }
 

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -39,6 +39,8 @@ func (c *writeTestReplicaClient) Type() string { return "test" }
 
 func (c *writeTestReplicaClient) Init(ctx context.Context) error { return nil }
 
+func (c *writeTestReplicaClient) SetLogger(*slog.Logger) {}
+
 func (c *writeTestReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/webdav/replica_client.go
+++ b/webdav/replica_client.go
@@ -157,7 +157,7 @@ func (c *ReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, 
 		minTXID, maxTXID, err := ltx.ParseFilename(path.Base(fi.Name()))
 		if err != nil {
 			continue
-		} else if minTXID < seek {
+		} else if maxTXID < seek {
 			continue
 		}
 


### PR DESCRIPTION
## Description

The VFS live-tailer's incremental poll (`pollLevel`) and every `ReplicaClient`
backend's `LTXFiles(seek)` implementation assumed a resumed watermark always
falls exactly on a compaction-level file boundary (`file.MinTXID == watermark+1`).
That assumption breaks whenever a file's range *straddles* the watermark —
`MinTXID <= watermark < MaxTXID` — which happens:

* on open, `maxTXID1` is seeded from `pos.TXID` (an L0/snapshot position) when
   L1 is still empty. That seed is correct and necessary (L1 files get pruned by
   retention, so L1 doesn't generally start at TXID 1) — but it need not land on
   a future L1 file's boundary.

In both cases, every backend's seek filter (`MinTXID < seek` -> skip) makes the
straddling file invisible, and `pollLevel`'s exact-match contiguity check
(`MinTXID == watermark+1`) then rejects the *next* file as non-contiguous. At L1
and above this returns a hard error; nothing retries or recovers, so a follower
wedges permanently at the stale watermark — polling forever, logging
"non-contiguous ltx file", and serving stale reads with no indication to
callers.

This PR makes the seek + contiguity logic straddle-tolerant:

- `pollLevel` (`vfs.go`) now classifies each candidate file against the current
  watermark instead of requiring an exact match:
  1. Already covered (`MaxTXID <= watermark`) -> skip (defends against within-level 
   overlap; not produced by litestream today)).
  2. Covers the next TXID, including straddling (`MinTXID <= watermark+1 <=
     MaxTXID`) -> apply and advance the watermark to `MaxTXID`. Re-applying the
     already-covered portion of the page index is an idempotent overwrite, so
     this is safe.
  3. Real gap (`MinTXID > watermark+1`) -> unchanged: defer at L0, error above.
- Every backend's `LTXFiles` seek filter changes from `MinTXID < seek` to
  `MaxTXID < seek`, so a straddling file is returned instead of silently
  dropped: `s3`, `file`, `sftp`, `webdav`, `nats`, `oss`.
- `gs` and `abs` additionally used `seek` as a *list-key prefix*
  (`prefix += seek.String()`), which excludes a straddling file at the listing
  level regardless of the post-filter. Both now list the full level directory
  and filter by `MaxTXID < seek` in the iterator, matching `s3`/`oss`. This
  trades a narrower list for correctness — same list volume `s3`/`oss` already
  have.
- `mock` needs no change; it delegates entirely to a caller-supplied func.

The LTXFiles seek-semantics change is a no-op for every existing caller except pollLevel: seek==0 callers are unaffected by definition, L0 callers only ever see single-TXID files (MinTXID==MaxTXID), and compaction always seeks on a level-aligned boundary. Only pollLevel passes a seek that can fall inside a file's range.

## Motivation and Context

Found via a production incident: a read-only VFS follower tailing S3 wedged
permanently on 

`poll L1: non-contiguous ltx file: level=1, current=...6, next=...c-...1d`

even though the backup data in object storage was fully intact and contiguous. 
Root-caused to the seed-vs-boundary mismatch above (case 1) — the L1 file that
would have bridged the gap (`1-b`, covering the missing range) was present in
storage the whole time but permanently invisible to the seek. 

Fixes Issue #1460 

## How Has This Been Tested?

- Added `TestVFSFile_StraddlingL1FileAfterSeed`, which reproduces the exact
  production sequence (snapshot seeds `maxTXID1=6`, first L1 compaction emits a
  straddling `1-b`, next L1 file is `c-1d`) — fails on the old code
  (`maxTXID1` stuck at 6) and passes with this fix.
- Added `TestVFSFile_MergedWiderL1FileAfterConsume`, a defensive test that 
pollLevel doesn't wedge on within-level overlap; not a state litestream produces today.
- Updated `mockReplicaClient.LTXFiles` in tests to mirror the fixed backend
  seek semantics (`MaxTXID >= seek`).
- Full existing `-tags vfs` suite passes with no regressions:
  `go test -tags vfs ./...`.
- `go build -tags vfs ./...`, `go vet` clean on all backend packages.
- Per-backend package tests (`s3`, `gs`, `oss`, `nats`, `webdav`, `file`) pass;
  `abs`/`sftp`/`mock` have no existing test files to run.
- `gofmt -l` clean on all touched files.

Note: this also fixes a latent, unrelated compile break in the `-tags vfs` test
suite — `ReplicaClient` gained `SetLogger` in a prior commit but the VFS test
doubles (`mockReplicaClient`, `countingReplicaClient`, `writeTestReplicaClient`)
were never updated, so `go test -tags vfs ./...` hasn't built since. Added
no-op `SetLogger` implementations to unblock running (and adding to) these
tests; worth wiring `-tags vfs` into CI separately so this doesn't recur.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
