### PR TITLE
Log the resolved repica type when unknown

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1393,7 +1393,7 @@ func NewReplicaFromConfig(c *ReplicaConfig, db *litestream.DB) (_ *litestream.Re
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown replica type in config: %q", c.Type)
+		return nil, fmt.Errorf("unknown replica type in config: %q", c.ReplicaType())
 	}
 
 	r.Client.SetLogger(r.Logger())


### PR DESCRIPTION
## Description
Seeing `Error: unknown replica type in config: ""` when running in zero.

## Motivation and Context

Unable to see what the actual value is that's being used in the switch and causing the error. `ReplicaType()` is used in the switch, but `c.Type` is logged directly in the error.

```go
// ReplicaType returns the type based on the type field or extracted from the URL.
func (c *ReplicaConfig) ReplicaType() string {
	if replicaType := litestream.ReplicaTypeFromURL(c.URL); replicaType != "" {
		return replicaType
	} else if c.Type != "" {
		return c.Type
	}
	return "file"
}
```

I think in our case the url is being resolved from `litestream.ReplicaTypeFromURL(c.URL)` which is not logged

## How Has This Been Tested?

It hasn't 😅, but should be fine?

I don't have an env setup to run this yet. I may end up compiling and running a build in zero later to debug further. Will updat this if I do.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] My code follows the code style of this project (`go fmt`, `go vet`)
- [ ] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)
