### PR TITLE
fix: resumable LTX reader aborts restore on transient S3 connection resets

### DIFF
--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -45,9 +45,16 @@ type ResumableReader struct {
 	size    int64 // expected total file size from FileInfo; 0 means unknown
 	offset  int64
 	rc      io.ReadCloser
-	retryN  int
-	err     error
-	logger  *slog.Logger
+	// retryN counts consecutive failures since the last forward progress, so a
+	// stream that periodically drops but keeps advancing is not limited by it;
+	// only a stream stuck at one offset trips resumableReaderMaxRetries.
+	retryN int
+	err    error
+	logger *slog.Logger
+
+	// backoff is defaulted from resumableReaderBackoff by NewResumableReader and
+	// overridable in tests to keep reconnect-heavy cases fast.
+	backoff time.Duration
 }
 
 // NewResumableReader creates a ResumableReader. Primarily exposed for testing.
@@ -61,9 +68,14 @@ func NewResumableReader(ctx context.Context, client LTXFileOpener, level int, mi
 		size:    size,
 		rc:      rc,
 		logger:  logger,
+		backoff: resumableReaderBackoff,
 	}
 }
 
+// resumableReaderMaxRetries bounds *consecutive* failed reads at a single
+// offset — a stream making no forward progress. It resets every time a Read
+// returns bytes, so a connection that periodically drops but keeps advancing
+// (the common S3/Tigris case during a large restore) is not limited by it.
 const resumableReaderMaxRetries = 3
 
 // resumableReaderBackoff is the base delay between retry attempts, doubling
@@ -98,6 +110,12 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 
 		n, err := r.rc.Read(p)
 		r.offset += int64(n)
+		if n > 0 {
+			// Forward progress: the connection recovered, so clear the
+			// consecutive-failure budget. Only reads that advance zero bytes
+			// count against resumableReaderMaxRetries.
+			r.retryN = 0
+		}
 
 		if err == nil {
 			return n, nil
@@ -174,7 +192,7 @@ func (r *ResumableReader) retry(err error) error {
 	case <-r.ctx.Done():
 		r.err = r.ctx.Err()
 		return r.err
-	case <-time.After(resumableReaderBackoff << (r.retryN - 1)):
+	case <-time.After(r.backoff << (r.retryN - 1)):
 	}
 	return nil
 }

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -271,7 +271,12 @@ func TestResumableReader(t *testing.T) {
 	})
 }
 
-func TestResumableReader_BoundsConnectionsAcrossPartialReads(t *testing.T) {
+func TestResumableReader_CompletesAcrossPartialReads(t *testing.T) {
+	// A backend that returns one byte per connection (closing early each time)
+	// used to exhaust the retry budget and fail. Now, because forward progress
+	// resets the consecutive-failure counter, the reader reconnects as many
+	// times as needed and delivers the whole file — one reconnect per byte of
+	// progress, naturally bounded by the file size.
 	data := []byte("0123456789abcdef")
 	var connectionN atomic.Int64
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -308,12 +313,56 @@ func TestResumableReader_BoundsConnectionsAcrossPartialReads(t *testing.T) {
 	}
 
 	r := newTestResumableReader(opener, int64(len(data)), data)
-	_, err := io.ReadAll(r)
-	if err == nil {
-		t.Error("ReadAll() error=nil, want retry limit error")
+	r.backoff = 0 // keep the test fast; correctness does not depend on the delay
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll() error=%v, want nil: one reconnect per byte of progress should complete", err)
 	}
-	if got, max := connectionN.Load(), int64(resumableReaderMaxRetries+1); got > max {
-		t.Errorf("connections=%d, want at most %d", got, max)
+	if !bytes.Equal(got, data) {
+		t.Fatalf("ReadAll() = %q, want %q", got, data)
+	}
+	// Each reset costs one reopen; progress guarantees completion, so the
+	// connection count is bounded by the file size, not the retry limit.
+	if got, max := connectionN.Load(), int64(len(data)); got > max {
+		t.Errorf("connections=%d, want at most %d (one per byte)", got, max)
+	}
+}
+
+func TestResumableReader_ResetsRetriesOnForwardProgress(t *testing.T) {
+	// The production restore failure: a stream that resets many more times than
+	// resumableReaderMaxRetries, but delivers a chunk of data between each reset
+	// (S3 dropping a connection at ~1.2MB, then again at ~25MB, with megabytes
+	// of progress in between). Forward progress must reset the consecutive
+	// failure budget so the read completes instead of aborting the restore.
+	data := []byte("the quick brown fox jumps over the lazy dog")
+	const chunk = 4
+	callCount := 0
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			callCount++
+			if int(offset)+chunk >= len(data) {
+				// Final segment: serve the rest cleanly.
+				return io.NopCloser(bytes.NewReader(data[offset:])), nil
+			}
+			// Serve `chunk` bytes from the offset, then drop the connection.
+			return io.NopCloser(&errorAfterN{data: data[offset:], n: chunk, err: fmt.Errorf("read: connection reset by peer")}), nil
+		},
+	}
+
+	r := newTestResumableReader(client, int64(len(data)), data)
+	r.backoff = 0 // keep the test fast
+
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q, want %q", got, data)
+	}
+	// len(data)=43 with chunk=4 forces ~10 resets, far more than maxRetries=3;
+	// the old lifetime-3 budget would have failed after the fourth.
+	if callCount <= resumableReaderMaxRetries+1 {
+		t.Fatalf("test did not exercise more than maxRetries resets; callCount=%d", callCount)
 	}
 }
 


### PR DESCRIPTION
## Description

The `ResumableReader` used to wrap LTX file streams during restore treated its retry budget as a **lifetime** cap rather than a **consecutive-failure** cap. `retryN` was incremented on every reconnect and never reset, so "3 retries" meant "3 reconnects total for the file's entire transfer" instead of "3 consecutive failures without progress."

This change resets `retryN` to 0 whenever a `Read` returns bytes, so the cap now counts consecutive failures at a stuck offset. A connection that periodically drops but keeps advancing recovers instead of aborting; a stream genuinely stalled at one offset still fails after 3 tries.

No lifetime cap is added: termination is guaranteed by the storage backend returning EOF at the true end of a finite object, backstopped by the 3-consecutive-no-progress limit. (A fixed lifetime cap would be actively harmful — a legitimately large file over a flaky link could exceed it while making perfect progress, reproducing this same bug at a higher threshold.)

The reconnect backoff is now a struct field defaulted from the package constant, purely as a test seam so reconnect-heavy cases can run without the real delay.

## Motivation and Context

Our process crash-looped indefinitely, never completing its litestream restore (disk/memory see-sawing, pod restarting every ~30–40 min). The underlying error:

```
Error: decode database: decode page 30201904: read page header 69: read compressed data:
  max retries exceeded reading ltx file (level=0, min=0000000000000046, max=0000000000000046,
  offset=25141595): read tcp ...:443: read: connection reset by peer
```

The connection reset at `offset 1210312` (attempt 2) and again at `offset 25141595` (attempt 4) on the same file — ~24 MB of successful progress between the two resets, yet the counter climbed to 4 and tripped the limit of 3. The network path is healthy (S3 egresses via the VPC S3 gateway endpoint); these are ordinary transient resets the reader is designed to recover from. Because each restore restarts from scratch, any file large enough to see a few resets means the restore never converges.

## How Has This Been Tested?

`go test ./...`, `go vet ./...`, and `gofmt` all clean. Focused coverage in `internal/resumable_reader_test.go`:

- **`ResetsRetriesOnForwardProgress`** — a stream that resets ~10× with a chunk of progress between each now completes; would have failed at the 4th reset under the old code (direct regression for the reported failure).
- **`CompletesAcrossPartialReads`** (reworked from `BoundsConnectionsAcrossPartialReads`) — a one-byte-per-connection backend now succeeds, with reconnects bounded by file size. The old assertion ("fail after `maxRetries+1` connections") was the bug encoded as expected behavior, so it was inverted.
- All existing subtests (normal read, reconnect-on-error, premature-EOF, backoff, context-cancel, max-retries-exceeded, etc.) pass unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)