### PR TITLE
fix(ci): always report test summary

### DIFF
--- a/.github/scripts/integration-test-paths.js
+++ b/.github/scripts/integration-test-paths.js
@@ -1,0 +1,55 @@
+'use strict';
+
+function hasRelevantIntegrationTestChanges(files, totalChangedFiles) {
+  if (!Array.isArray(files)) {
+    throw new TypeError('files must be an array');
+  }
+  if (!Number.isSafeInteger(totalChangedFiles) || totalChangedFiles < 0) {
+    throw new TypeError('totalChangedFiles must be a nonnegative safe integer');
+  }
+
+  const filenames = [];
+  files.forEach((file, index) => {
+    if (file === null || typeof file !== 'object' || Array.isArray(file)) {
+      throw new TypeError(`files[${index}] must be an object`);
+    }
+    if (typeof file.filename !== 'string' || file.filename.trim() === '') {
+      throw new TypeError(`files[${index}].filename must be a non-empty string`);
+    }
+
+    filenames.push(file.filename);
+    if (file.previous_filename !== undefined) {
+      if (
+        typeof file.previous_filename !== 'string' ||
+        file.previous_filename.trim() === ''
+      ) {
+        throw new TypeError(
+          `files[${index}].previous_filename must be a non-empty string`
+        );
+      }
+      filenames.push(file.previous_filename);
+    }
+  });
+
+  if (totalChangedFiles < files.length) {
+    throw new TypeError('totalChangedFiles must not be less than files.length');
+  }
+  if (totalChangedFiles > files.length) {
+    return true;
+  }
+
+  return filenames.some(isRelevantIntegrationTestPath);
+}
+
+function isRelevantIntegrationTestPath(filename) {
+  return (
+    filename.endsWith('.go') ||
+    filename === 'go.mod' ||
+    filename === 'go.sum' ||
+    filename.startsWith('tests/integration/') ||
+    filename === '.github/scripts/integration-test-paths.js' ||
+    filename === '.github/workflows/integration-tests.yml'
+  );
+}
+
+module.exports = { hasRelevantIntegrationTestChanges };

--- a/.github/scripts/integration-test-paths.test.js
+++ b/.github/scripts/integration-test-paths.test.js
@@ -1,0 +1,423 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+const { hasRelevantIntegrationTestChanges } = require('./integration-test-paths');
+
+const workflow = fs.readFileSync(
+  path.join(__dirname, '..', 'workflows', 'integration-tests.yml'),
+  'utf8'
+);
+const commitWorkflow = fs.readFileSync(
+  path.join(__dirname, '..', 'workflows', 'commit.yml'),
+  'utf8'
+);
+
+test('runs the integration workflow for every pull request', () => {
+  const pullRequestTrigger = workflow.match(/  pull_request:\n([\s\S]*?)  workflow_dispatch:/);
+
+  assert.ok(pullRequestTrigger);
+  assert.doesNotMatch(pullRequestTrigger[1], /^    paths:/m);
+  assert.match(workflow, /  workflow_dispatch:\n    inputs:\n      test_type:/);
+});
+
+test('detects relevant pull request changes with least privilege', () => {
+  const changes = jobBlock('changes', 'quick-tests');
+  const workflowPermissions = workflow.match(/^permissions:\n([\s\S]*?)(?=^jobs:)/m);
+
+  assert.ok(workflowPermissions);
+  assert.match(workflowPermissions[1], /^  contents: read$/m);
+  assert.doesNotMatch(workflowPermissions[1], /^  pull-requests:/m);
+  assert.match(
+    changes,
+    /^    permissions:\n      contents: read\n      pull-requests: read$/m
+  );
+  assert.match(changes, /^    if: github\.event_name == 'pull_request'$/m);
+  assert.match(changes, /^      relevant: \$\{\{ steps\.paths\.outputs\.relevant \}\}$/m);
+  assert.match(changes, /uses: actions\/checkout@v4/);
+  assert.match(changes, /uses: actions\/github-script@v7/);
+  assert.match(changes, /github\.paginate\(github\.rest\.pulls\.listFiles/);
+  assert.match(changes, /hasRelevantIntegrationTestChanges/);
+  assert.match(changes, /context\.payload\.pull_request\.changed_files/);
+  assert.match(changes, /String\(relevant\)/);
+});
+
+test('does not load a pull-request-modified matcher', async () => {
+  const changesScript = extractRunScript(
+    jobBlock('changes', 'quick-tests'),
+    'Check changed paths',
+    'script: |'
+  );
+  const matcherGuardIndex = changesScript.indexOf('const matcherPath');
+  const requireIndex = changesScript.indexOf('require(');
+
+  assert.notEqual(matcherGuardIndex, -1);
+  assert.ok(matcherGuardIndex < requireIndex);
+
+  const matcherPath = '.github/scripts/integration-test-paths.js';
+  const scenarios = [
+    {
+      name: 'incomplete response',
+      files: [{ filename: 'README.md' }],
+      totalChangedFiles: 2,
+    },
+    {
+      name: 'malformed declared count',
+      files: [{ filename: 'README.md' }],
+      totalChangedFiles: '1',
+    },
+    {
+      name: 'matcher current filename',
+      files: [{ filename: matcherPath }],
+      totalChangedFiles: 1,
+    },
+    {
+      name: 'matcher previous filename',
+      files: [
+        {
+          filename: 'docs/integration-test-paths.js',
+          previous_filename: matcherPath,
+        },
+      ],
+      totalChangedFiles: 1,
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const result = await runChangesScript({
+      files: scenario.files,
+      totalChangedFiles: scenario.totalChangedFiles,
+      requireImpl: () => assert.fail(`${scenario.name} loaded the matcher`),
+    });
+
+    assert.deepEqual(result.outputs, [['relevant', 'true']], scenario.name);
+    assert.equal(result.requireCalls, 0, scenario.name);
+  }
+});
+
+test('gates quick tests on successful relevant changes or manual selection', () => {
+  const quickTests = jobBlock('quick-tests', 'scenario-tests');
+
+  assert.match(quickTests, /^    needs: changes$/m);
+  assert.match(quickTests, /^    if: always\(\)/m);
+  assert.match(quickTests, /needs\.changes\.result == 'success'/);
+  assert.match(quickTests, /needs\.changes\.outputs\.relevant == 'true'/);
+  assert.match(quickTests, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(quickTests, /inputs\.test_type == 'quick'/);
+  assert.match(quickTests, /inputs\.test_type == 'all'/);
+});
+
+test('excludes manual long runs from quick tests and the summary', () => {
+  const quickTests = jobBlock('quick-tests', 'scenario-tests');
+  const summary = finalJobBlock('summary');
+  const quickCondition = quickTests.match(/^    if: (.*)$/m);
+  const summaryCondition = summary.match(/^    if: (.*)$/m);
+
+  assert.ok(quickCondition);
+  assert.ok(summaryCondition);
+  assert.doesNotMatch(quickCondition[1], /inputs\.test_type == 'long'/);
+  assert.doesNotMatch(summaryCondition[1], /inputs\.test_type == 'long'/);
+});
+
+test('runs the summary after change detection and quick tests', () => {
+  const summary = finalJobBlock('summary');
+
+  assert.match(summary, /^    needs: \[changes, quick-tests\]$/m);
+  assert.match(summary, /^    if: always\(\)/m);
+  assert.match(summary, /github\.event_name == 'pull_request'/);
+  assert.match(summary, /inputs\.test_type == 'quick'/);
+  assert.match(summary, /inputs\.test_type == 'all'/);
+  assert.match(summary, /CHANGES_RESULT: \$\{\{ needs\.changes\.result \}\}/);
+  assert.match(summary, /RELEVANT_CHANGES: \$\{\{ needs\.changes\.outputs\.relevant \}\}/);
+  assert.match(summary, /QUICK_TESTS_RESULT: \$\{\{ needs\.quick-tests\.result \}\}/);
+});
+
+test('fails the summary closed for required detection and test results', () => {
+  const scenarios = [
+    {
+      name: 'irrelevant pull request',
+      env: pullRequestResults('success', 'false', 'skipped'),
+      status: 0,
+    },
+    {
+      name: 'successful relevant pull request',
+      env: pullRequestResults('success', 'true', 'success'),
+      status: 0,
+    },
+    {
+      name: 'failed change detection',
+      env: pullRequestResults('failure', '', 'skipped'),
+      status: 1,
+    },
+    {
+      name: 'cancelled change detection',
+      env: pullRequestResults('cancelled', '', 'skipped'),
+      status: 1,
+    },
+    {
+      name: 'unexpected skipped change detection',
+      env: pullRequestResults('skipped', '', 'skipped'),
+      status: 1,
+    },
+    {
+      name: 'malformed change detection output',
+      env: pullRequestResults('success', '', 'skipped'),
+      status: 1,
+    },
+    {
+      name: 'failed required quick tests',
+      env: pullRequestResults('success', 'true', 'failure'),
+      status: 1,
+    },
+    {
+      name: 'cancelled required quick tests',
+      env: pullRequestResults('success', 'true', 'cancelled'),
+      status: 1,
+    },
+    {
+      name: 'unexpected skipped required quick tests',
+      env: pullRequestResults('success', 'true', 'skipped'),
+      status: 1,
+    },
+    {
+      name: 'successful manual quick tests',
+      env: manualResults('quick', 'success'),
+      status: 0,
+    },
+    {
+      name: 'successful manual all tests',
+      env: manualResults('all', 'success'),
+      status: 0,
+    },
+    {
+      name: 'failed manual quick tests',
+      env: manualResults('quick', 'failure'),
+      status: 1,
+    },
+    {
+      name: 'cancelled manual quick tests',
+      env: manualResults('quick', 'cancelled'),
+      status: 1,
+    },
+    {
+      name: 'unexpected skipped manual quick tests',
+      env: manualResults('quick', 'skipped'),
+      status: 1,
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const result = runSummary(scenario.env);
+    assert.equal(
+      result.status,
+      scenario.status,
+      `${scenario.name}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+});
+
+test('runs every script test from the commit workflow', () => {
+  assert.match(
+    commitWorkflow,
+    /^\s+run: node --test \.github\/scripts\/\*\.test\.js$/m
+  );
+});
+
+test('includes paths that affect quick integration tests', () => {
+  const relevantPaths = [
+    'main.go',
+    'internal/db/replica.go',
+    'go.mod',
+    'go.sum',
+    'tests/integration/restore_testdata.sql',
+    '.github/workflows/integration-tests.yml',
+    '.github/scripts/integration-test-paths.js',
+  ];
+
+  for (const filename of relevantPaths) {
+    assert.equal(hasRelevantIntegrationTestChanges([{ filename }], 1), true, filename);
+  }
+});
+
+test('excludes paths that do not affect quick integration tests', () => {
+  const irrelevantPaths = [
+    'README.md',
+    'docs/config.md',
+    'internal/db/replica.js',
+    'tools/go.mod',
+    'tests/unit/database_testdata.sql',
+    '.github/workflows/commit.yml',
+    '.github/workflows/integration-tests.yml.disabled',
+  ];
+
+  for (const filename of irrelevantPaths) {
+    assert.equal(hasRelevantIntegrationTestChanges([{ filename }], 1), false, filename);
+  }
+});
+
+test('includes relevant previous paths for renamed files', () => {
+  assert.equal(
+    hasRelevantIntegrationTestChanges([
+      { filename: 'docs/removed-code.md', previous_filename: 'db.go' },
+    ], 1),
+    true
+  );
+  assert.equal(
+    hasRelevantIntegrationTestChanges([
+      {
+        filename: 'tests/archive/restore_testdata.sql',
+        previous_filename: 'tests/integration/restore_testdata.sql',
+      },
+    ], 1),
+    true
+  );
+});
+
+test('excludes an empty file list', () => {
+  assert.equal(hasRelevantIntegrationTestChanges([], 0), false);
+});
+
+test('includes changes when the returned file list is incomplete', () => {
+  assert.equal(
+    hasRelevantIntegrationTestChanges([{ filename: 'README.md' }], 2),
+    true
+  );
+});
+
+test('rejects malformed file lists and changed-file counts', () => {
+  const malformedInputs = [
+    [null, 0],
+    [{}, 0],
+    [[null], 1],
+    [[{}], 1],
+    [[{ filename: '' }], 1],
+    [[{ filename: 42 }], 1],
+    [[{ filename: 'README.md', previous_filename: '' }], 1],
+    [[{ filename: 'README.md', previous_filename: 42 }], 1],
+    [[], undefined],
+    [[], null],
+    [[], -1],
+    [[], 1.5],
+    [[], Number.MAX_SAFE_INTEGER + 1],
+    [[], '0'],
+    [[{ filename: 'README.md' }], 0],
+  ];
+
+  for (const [files, totalChangedFiles] of malformedInputs) {
+    assert.throws(
+      () => hasRelevantIntegrationTestChanges(files, totalChangedFiles),
+      TypeError
+    );
+  }
+});
+
+function jobBlock(name, nextName) {
+  const block = workflow.match(
+    new RegExp(`^  ${name}:\\n([\\s\\S]*?)(?=^  ${nextName}:)`, 'm')
+  );
+
+  assert.ok(block, `${name} job must precede ${nextName}`);
+  return block[1];
+}
+
+function finalJobBlock(name) {
+  const block = workflow.match(new RegExp(`^  ${name}:\\n([\\s\\S]*)$`, 'm'));
+
+  assert.ok(block, `${name} job must exist`);
+  return block[1];
+}
+
+function pullRequestResults(changesResult, relevantChanges, quickTestsResult) {
+  return {
+    EVENT_NAME: 'pull_request',
+    TEST_TYPE: '',
+    CHANGES_RESULT: changesResult,
+    RELEVANT_CHANGES: relevantChanges,
+    QUICK_TESTS_RESULT: quickTestsResult,
+  };
+}
+
+function manualResults(testType, quickTestsResult) {
+  return {
+    EVENT_NAME: 'workflow_dispatch',
+    TEST_TYPE: testType,
+    CHANGES_RESULT: 'skipped',
+    RELEVANT_CHANGES: '',
+    QUICK_TESTS_RESULT: quickTestsResult,
+  };
+}
+
+function runSummary(env) {
+  const summaryScript = extractRunScript(finalJobBlock('summary'), 'Generate summary');
+
+  return spawnSync('/bin/bash', ['-c', summaryScript], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env,
+      GITHUB_STEP_SUMMARY: '/dev/null',
+    },
+  });
+}
+
+async function runChangesScript({ files, totalChangedFiles, requireImpl }) {
+  const changesScript = extractRunScript(
+    jobBlock('changes', 'quick-tests'),
+    'Check changed paths',
+    'script: |'
+  );
+  const outputs = [];
+  let requireCalls = 0;
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+  await new AsyncFunction('require', 'context', 'github', 'core', changesScript)(
+    modulePath => {
+      requireCalls += 1;
+      return requireImpl(modulePath);
+    },
+    {
+      repo: { owner: 'benbjohnson', repo: 'litestream' },
+      payload: {
+        pull_request: {
+          number: 1473,
+          changed_files: totalChangedFiles,
+        },
+      },
+    },
+    {
+      paginate: async () => files,
+      rest: { pulls: { listFiles: () => {} } },
+    },
+    {
+      setOutput: (name, value) => outputs.push([name, value]),
+    }
+  );
+
+  return { outputs, requireCalls };
+}
+
+function extractRunScript(job, stepName, marker = 'run: |') {
+  const lines = job.split('\n');
+  const stepIndex = lines.findIndex(line => line.trim() === `- name: ${stepName}`);
+  assert.notEqual(stepIndex, -1, `${stepName} step must exist`);
+
+  const markerIndex = lines.findIndex(
+    (line, index) => index > stepIndex && line.trim() === marker
+  );
+  assert.notEqual(markerIndex, -1, `${stepName} step must have ${marker}`);
+
+  const markerIndent = lines[markerIndex].length - lines[markerIndex].trimStart().length;
+  const scriptLines = [];
+  for (const line of lines.slice(markerIndex + 1)) {
+    const indent = line.length - line.trimStart().length;
+    if (line.trim() !== '' && indent <= markerIndent) {
+      break;
+    }
+    scriptLines.push(line.slice(markerIndent + 2));
+  }
+
+  return scriptLines.join('\n');
+}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test nightly notifier classification
-        run: node --test .github/scripts/nightly-stability-jobs.test.js
+      - name: Test workflow scripts
+        run: node --test .github/scripts/*.test.js
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,12 +2,6 @@ name: Integration Tests
 
 on:
   pull_request:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'tests/integration/**'
-      - '.github/workflows/integration-tests.yml'
   workflow_dispatch:
     inputs:
       test_type:
@@ -24,10 +18,70 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Integration Test Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.paths.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check changed paths
+        id: paths
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const totalChangedFiles = context.payload.pull_request.changed_files;
+            const matcherPath = '.github/scripts/integration-test-paths.js';
+            const completeResponse =
+              Array.isArray(files) &&
+              Number.isSafeInteger(totalChangedFiles) &&
+              totalChangedFiles >= 0 &&
+              totalChangedFiles === files.length &&
+              files.every(file =>
+                file !== null &&
+                typeof file === 'object' &&
+                !Array.isArray(file) &&
+                typeof file.filename === 'string' &&
+                file.filename.trim() !== '' &&
+                (file.previous_filename === undefined ||
+                  (typeof file.previous_filename === 'string' &&
+                    file.previous_filename.trim() !== ''))
+              );
+            const matcherChanged =
+              completeResponse &&
+              files.some(
+                file =>
+                  file.filename === matcherPath ||
+                  file.previous_filename === matcherPath
+              );
+            if (!completeResponse || matcherChanged) {
+              core.setOutput('relevant', 'true');
+              return;
+            }
+            const { hasRelevantIntegrationTestChanges } = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/integration-test-paths`
+            );
+            const relevant = hasRelevantIntegrationTestChanges(
+              files,
+              totalChangedFiles
+            );
+            core.setOutput('relevant', String(relevant));
+
   quick-tests:
     name: Quick Integration Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || inputs.test_type == 'quick' || inputs.test_type == 'all'
+    needs: changes
+    if: always() && ((github.event_name == 'pull_request' && needs.changes.result == 'success' && needs.changes.outputs.relevant == 'true') || (github.event_name == 'workflow_dispatch' && (inputs.test_type == 'quick' || inputs.test_type == 'all')))
     steps:
       - uses: actions/checkout@v4
 
@@ -124,25 +178,52 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [quick-tests]
+    needs: [changes, quick-tests]
     if: always() && (github.event_name == 'pull_request' || inputs.test_type == 'quick' || inputs.test_type == 'all')
     steps:
       - name: Generate summary
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_TYPE: ${{ inputs.test_type }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          RELEVANT_CHANGES: ${{ needs.changes.outputs.relevant }}
+          QUICK_TESTS_RESULT: ${{ needs.quick-tests.result }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "## Integration Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          status=0
+          {
+            echo "## Integration Test Results"
+            echo ""
 
-          if [ "${{ needs.quick-tests.result }}" == "success" ]; then
-            echo "✅ **Quick Tests:** Passed" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.quick-tests.result }}" == "failure" ]; then
-            echo "❌ **Quick Tests:** Failed" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.quick-tests.result }}" == "skipped" ]; then
-            echo "⏭️ **Quick Tests:** Skipped" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              if [ "$CHANGES_RESULT" != "success" ]; then
+                echo "❌ **Change Detection:** $CHANGES_RESULT"
+                status=1
+              elif [ "$RELEVANT_CHANGES" = "false" ]; then
+                echo "⏭️ **Quick Tests:** Skipped for irrelevant changes"
+              elif [ "$RELEVANT_CHANGES" != "true" ]; then
+                echo "❌ **Change Detection:** Invalid output"
+                status=1
+              elif [ "$QUICK_TESTS_RESULT" = "success" ]; then
+                echo "✅ **Quick Tests:** Passed"
+              else
+                echo "❌ **Quick Tests:** $QUICK_TESTS_RESULT"
+                status=1
+              fi
+            elif [ "$EVENT_NAME" = "workflow_dispatch" ] && { [ "$TEST_TYPE" = "quick" ] || [ "$TEST_TYPE" = "all" ]; }; then
+              if [ "$QUICK_TESTS_RESULT" = "success" ]; then
+                echo "✅ **Quick Tests:** Passed"
+              else
+                echo "❌ **Quick Tests:** $QUICK_TESTS_RESULT"
+                status=1
+              fi
+            else
+              echo "❌ **Workflow:** Unexpected invocation"
+              status=1
+            fi
 
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "**Triggered by:** @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-
-          # Note: Scenario and long-running tests run independently on workflow_dispatch.
-          # Check individual job results for those test suites.
+            echo ""
+            echo "---"
+            echo "**Triggered by:** @$ACTOR"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"


### PR DESCRIPTION
## Description

- Run the Integration Tests workflow for every pull request so the required Test Summary check always reports.
- Detect relevant code changes in a fail-closed gate and skip expensive quick integration tests for unrelated changes.
- Preserve manual quick, all, and long dispatch behavior while propagating detector and required-test failures through Test Summary.
- Add executable regression coverage for path matching, renamed files, truncated API responses, matcher trust boundaries, manual dispatch, and summary outcomes.

## Motivation and Context

Documentation- and configuration-only pull requests never started the path-filtered workflow, leaving the required Test Summary check permanently at Expected. Pull requests #1438, #1444, and #1445 demonstrated the failure: other checks could finish successfully while Test Summary never appeared.

The detector uses read-only pull request metadata, scopes that permission to one job, and conservatively runs quick tests when changed-file metadata is incomplete or the detector itself changes.

Fixes #1473

## How Has This Been Tested?

    node --test .github/scripts/*.test.js
    actionlint .github/workflows/integration-tests.yml
    actionlint -shellcheck= .github/workflows/commit.yml
    go build ./...
    go test ./...
    go test -race ./...
    pre-commit run --all-files

All commands above pass locally. Coverage measurement is not applicable because the change contains no Go source files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (go fmt, go vet)
- [x] I have tested my changes (go test ./...)
- [x] I have updated the documentation accordingly (not needed for this CI-only change)
