### PR TITLE
chore(deps): bump Go toolchain to 1.25.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/benbjohnson/litestream
 
 go 1.25.0
 
-toolchain go1.25.13
+toolchain go1.25.14
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
## Description

Update the module toolchain directive from Go 1.25.13 to Go 1.25.14. Build and CI automation already resolves the toolchain from the module, so the patch update propagates without changing dependencies, source behavior, the Go language version, or the Docker image's Go 1.25 series.

The scope is limited to the patch-level toolchain selection. Moving to Go 1.26 or Go 1.27 is out of scope.

## Motivation and Context

PR Build Metrics reports that Go 1.25.14 is available while the repository remains pinned to 1.25.13. Go 1.25.14 includes net/http fixes, including a repair for the unencrypted HTTP/2 regression introduced by the preceding patch. Litestream's direct exposure is low, but selecting the corrected patch avoids carrying the regression through every build.

Fixes #1475

## How Has This Been Tested?

All applicable commands ran with GOTOOLCHAIN=go1.25.14:

- go mod tidy -diff
- go build ./...
- go test ./...
- go test -race ./...
- pre-commit run --all-files
- golangci-lint run --new-from-rev origin/main
- govulncheck ./... — zero called vulnerabilities

Coverage measurement is not applicable because the change contains no source files.

The requested go test -tags vfs -race ./... check is already red before this bump: root tagged test doubles do not satisfy the current replica-client logger contract. Repeating the check with Go 1.25.13 reproduces the same compile failure. The dedicated VFS race tests also expose pre-existing races under both patch versions, so the toolchain update does not introduce that baseline condition.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (go fmt, go vet)
- [x] I have tested my changes (go test ./...)
- [x] I have updated the documentation accordingly (not needed for this toolchain-only change)
