### PR TITLE
fix(store): serialize snapshots and compactions per database

### DIFF
--- a/db.go
+++ b/db.go
@@ -65,19 +65,23 @@ const (
 // with indefinite write blocking (issue #724). All checkpoints now use either
 // PASSIVE (non-blocking) or TRUNCATE (emergency only) modes.
 type DB struct {
-	mu        sync.RWMutex
-	execSem   *semaphore.Weighted
-	path      string        // part to database
-	metaPath  string        // Path to the database metadata.
-	db        *sql.DB       // target database
-	f         *os.File      // long-running db file descriptor
-	rtx       *sql.Tx       // long running read transaction
-	pageSize  int           // page size, in bytes
-	notify    chan struct{} // closes on WAL change
-	chkMu     sync.RWMutex  // checkpoint lock
-	opened    bool          // true if Open() was called and Close() not yet called
-	syncState syncState
-	syncDiag  diagState
+	mu       sync.RWMutex
+	execSem  *semaphore.Weighted
+	path     string        // part to database
+	metaPath string        // Path to the database metadata.
+	db       *sql.DB       // target database
+	f        *os.File      // long-running db file descriptor
+	rtx      *sql.Tx       // long running read transaction
+	pageSize int           // page size, in bytes
+	notify   chan struct{} // closes on WAL change
+	chkMu    sync.RWMutex  // checkpoint lock
+	// maintenanceMu serializes snapshots & compactions per database; held via
+	// TryLock by Store.CompactDB so overlapping maintenance is refused with
+	// ErrMaintenanceBusy rather than queued (issue #1477).
+	maintenanceMu sync.Mutex
+	opened        bool // true if Open() was called and Close() not yet called
+	syncState     syncState
+	syncDiag      diagState
 
 	// last file info for each level
 	maxLTXFileInfos struct {
@@ -2693,12 +2697,23 @@ func (p *snapshotReadPosition) close() {
 
 type snapshotReadCloser struct {
 	*io.PipeReader
-	pos *snapshotReadPosition
+	pos    *snapshotReadPosition
+	cancel context.CancelFunc // stops the producing goroutine
+	done   <-chan struct{}    // closed when the producing goroutine has exited
 }
 
+// Close stops the producing goroutine and waits for it to exit, so that no
+// snapshot state (WAL page map, LTX encoder page index) outlives the reader.
+// Cancelling the producer's context interrupts the WAL scan that runs before
+// the first pipe write; closing the pipe interrupts any write in progress.
+// Store.CompactDB relies on this to keep a failed snapshot's memory from
+// overlapping the next maintenance operation.
 func (r *snapshotReadCloser) Close() error {
-	defer r.pos.close()
-	return r.PipeReader.Close()
+	r.cancel()
+	err := r.PipeReader.Close()
+	<-r.done
+	r.pos.close()
+	return err
 }
 
 // SnapshotReader returns the current position of the database & a reader that contains a full database snapshot.
@@ -2812,8 +2827,12 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 
 	// Execute encoding in a separate goroutine so the caller can initialize before reading.
 	pr, pw := io.Pipe()
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer pos.close()
+		defer cancel() // release the derived context even if the reader is never closed
 
 		walFile, err := os.Open(db.WALPath())
 		if err != nil {
@@ -2893,7 +2912,7 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 		_ = pw.Close()
 	}()
 
-	return &snapshotReadCloser{PipeReader: pr, pos: pos}, nil
+	return &snapshotReadCloser{PipeReader: pr, pos: pos, cancel: cancel, done: done}, nil
 }
 
 func snapshotHeaderWALRange(maxOffset, frameSize int64) (offset, size int64) {

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/psanford/sqlite3vfs v0.0.0-20260519004904-f9180fa2acc9 // direct
 	github.com/studio-b12/gowebdav v0.11.0
-	github.com/superfly/ltx v0.5.3-0.20260910220417-f299ac5b951c
+	github.com/superfly/ltx v0.5.3
 	golang.org/x/crypto v0.56.0
 	golang.org/x/sys v0.47.0
 	google.golang.org/api v0.155.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/psanford/sqlite3vfs v0.0.0-20260519004904-f9180fa2acc9 // direct
 	github.com/studio-b12/gowebdav v0.11.0
-	github.com/superfly/ltx v0.5.2
+	github.com/superfly/ltx v0.5.3-0.20260910220417-f299ac5b951c
 	golang.org/x/crypto v0.56.0
 	golang.org/x/sys v0.47.0
 	google.golang.org/api v0.155.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/studio-b12/gowebdav v0.11.0 h1:qbQzq4USxY28ZYsGJUfO5jR+xkFtcnwWgitp4Zp1irU=
 github.com/studio-b12/gowebdav v0.11.0/go.mod h1:bHA7t77X/QFExdeAnDzK6vKM34kEZAcE1OX4MfiwjkE=
-github.com/superfly/ltx v0.5.3-0.20260910220417-f299ac5b951c h1:rjWRdrADYsbQPjldkmSqmpACV5vv0j2ZkiOD1iBLSCE=
-github.com/superfly/ltx v0.5.3-0.20260910220417-f299ac5b951c/go.mod h1:0OtLSLHHHPa3qDrAmwkLW5pUBfj365JS+bR9FEJDrM4=
+github.com/superfly/ltx v0.5.3 h1:fl2YH4xlLcOaS+On4yzex9V05ZGeOmcm3iFcLALqkQY=
+github.com/superfly/ltx v0.5.3/go.mod h1:0OtLSLHHHPa3qDrAmwkLW5pUBfj365JS+bR9FEJDrM4=
 github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
 github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/wasilibs/go-re2 v1.3.0 h1:LFhBNzoStM3wMie6rN2slD1cuYH2CGiHpvNL3UtcsMw=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/studio-b12/gowebdav v0.11.0 h1:qbQzq4USxY28ZYsGJUfO5jR+xkFtcnwWgitp4Zp1irU=
 github.com/studio-b12/gowebdav v0.11.0/go.mod h1:bHA7t77X/QFExdeAnDzK6vKM34kEZAcE1OX4MfiwjkE=
-github.com/superfly/ltx v0.5.2 h1:XVzytSsIlpUaOd2I7M40lDhUQIzGIdqkLBNg5M5Ax48=
-github.com/superfly/ltx v0.5.2/go.mod h1:0OtLSLHHHPa3qDrAmwkLW5pUBfj365JS+bR9FEJDrM4=
+github.com/superfly/ltx v0.5.3-0.20260910220417-f299ac5b951c h1:rjWRdrADYsbQPjldkmSqmpACV5vv0j2ZkiOD1iBLSCE=
+github.com/superfly/ltx v0.5.3-0.20260910220417-f299ac5b951c/go.mod h1:0OtLSLHHHPa3qDrAmwkLW5pUBfj365JS+bR9FEJDrM4=
 github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
 github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/wasilibs/go-re2 v1.3.0 h1:LFhBNzoStM3wMie6rN2slD1cuYH2CGiHpvNL3UtcsMw=

--- a/store.go
+++ b/store.go
@@ -23,6 +23,13 @@ var (
 	// re-compaction when restarting the process.
 	ErrCompactionTooEarly = errors.New("compaction too early")
 
+	// ErrMaintenanceBusy is returned when a snapshot or compaction is refused
+	// because another maintenance operation for the same database is still in
+	// flight. Maintenance is serialized per database so that concurrent
+	// operations cannot each hold a database-sized page index in memory at the
+	// same time (issue #1477); callers retry on the next monitor interval.
+	ErrMaintenanceBusy = errors.New("maintenance busy")
+
 	// ErrTxNotAvailable is returned when a transaction does not exist.
 	ErrTxNotAvailable = errors.New("transaction not available")
 
@@ -57,8 +64,17 @@ func (e *DBNotReadyError) Is(target error) bool {
 
 // Store defaults
 const (
-	DefaultSnapshotInterval  = 24 * time.Hour
-	DefaultSnapshotRetention = 24 * time.Hour
+	DefaultSnapshotInterval = 24 * time.Hour
+
+	// DefaultMaintenanceBusyRetryInterval caps how long a level monitor waits
+	// before retrying a database whose snapshot or compaction was refused with
+	// ErrMaintenanceBusy. Retries start at maintenanceBusyRetryBase and double
+	// on each consecutive busy pass up to this cap, so a momentary collision
+	// between levels resolves within a second while a long-running snapshot
+	// is not polled more than every few seconds.
+	DefaultMaintenanceBusyRetryInterval = 10 * time.Second
+	maintenanceBusyRetryBase            = time.Second
+	DefaultSnapshotRetention            = 24 * time.Hour
 
 	DefaultRetention              = 24 * time.Hour
 	DefaultRetentionCheckInterval = 1 * time.Hour
@@ -96,6 +112,10 @@ type Store struct {
 
 	// The frequency of snapshots.
 	SnapshotInterval time.Duration
+
+	// MaintenanceBusyRetryInterval bounds the delay before a level monitor
+	// retries databases that reported ErrMaintenanceBusy.
+	MaintenanceBusyRetryInterval time.Duration
 	// The duration of time that snapshots are kept before being deleted.
 	SnapshotRetention time.Duration
 
@@ -140,16 +160,17 @@ func NewStore(dbs []*DB, levels CompactionLevels) *Store {
 		dbs:    dbs,
 		levels: levels,
 
-		SnapshotInterval:         DefaultSnapshotInterval,
-		SnapshotRetention:        DefaultSnapshotRetention,
-		L0Retention:              DefaultL0Retention,
-		L0RetentionCheckInterval: DefaultL0RetentionCheckInterval,
-		CompactionMonitorEnabled: true,
-		RetentionEnabled:         true,
-		ShutdownSyncTimeout:      DefaultShutdownSyncTimeout,
-		ShutdownSyncInterval:     DefaultShutdownSyncInterval,
-		HeartbeatCheckInterval:   DefaultHeartbeatCheckInterval,
-		Logger:                   slog.Default().With(LogKeySystem, LogSystemStore),
+		SnapshotInterval:             DefaultSnapshotInterval,
+		MaintenanceBusyRetryInterval: DefaultMaintenanceBusyRetryInterval,
+		SnapshotRetention:            DefaultSnapshotRetention,
+		L0Retention:                  DefaultL0Retention,
+		L0RetentionCheckInterval:     DefaultL0RetentionCheckInterval,
+		CompactionMonitorEnabled:     true,
+		RetentionEnabled:             true,
+		ShutdownSyncTimeout:          DefaultShutdownSyncTimeout,
+		ShutdownSyncInterval:         DefaultShutdownSyncInterval,
+		HeartbeatCheckInterval:       DefaultHeartbeatCheckInterval,
+		Logger:                       slog.Default().With(LogKeySystem, LogSystemStore),
 	}
 
 	for _, db := range dbs {
@@ -566,6 +587,15 @@ func (s *Store) monitorCompactionLevel(ctx context.Context, lvl *CompactionLevel
 	timer := time.NewTimer(time.Nanosecond)
 	defer timer.Stop()
 
+	// Databases to revisit before the next regular pass: those refused with
+	// ErrMaintenanceBusy and those not yet ready. While any exist the monitor
+	// wakes early and only revisits them, leaving snapshot retention and the
+	// other databases to the regular schedule anchored at nextRegular.
+	var nextRegular time.Time
+	pending := make(map[*DB]struct{})
+	known := make(map[*DB]struct{}) // databases seen on the last regular pass
+	busyStreak := 0                 // consecutive passes that saw a busy database
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -575,32 +605,57 @@ func (s *Store) monitorCompactionLevel(ctx context.Context, lvl *CompactionLevel
 		}
 
 		now := time.Now()
-		nextDelay := time.Until(lvl.NextCompactionAt(now))
+		earlyPass := len(pending) > 0 && now.Before(nextRegular)
+		if !earlyPass {
+			nextRegular = lvl.NextCompactionAt(now)
+			known = make(map[*DB]struct{}) // rebuilt from this regular pass
+		}
 
 		var notReadyDBs []string
+		busySet := make(map[*DB]struct{})
+		notReadySet := make(map[*DB]struct{})
 
 		for _, db := range s.DBs() {
 			if !db.IsOpen() {
 				continue // skip disabled DBs
 			}
+			if earlyPass {
+				// Early pass: only revisit busy or not-ready databases, plus
+				// any registered since the last regular pass so a new database
+				// still gets its initialization retries.
+				_, revisit := pending[db]
+				_, seen := known[db]
+				if !revisit && seen {
+					continue
+				}
+			}
+			known[db] = struct{}{}
 			_, err := s.CompactDB(ctx, db, lvl)
 			switch {
 			case errors.Is(err, ErrNoCompaction), errors.Is(err, ErrCompactionTooEarly):
 				db.Logger.Debug("no compaction", "level", lvl.Level, "path", db.Path())
+			case errors.Is(err, ErrMaintenanceBusy):
+				db.Logger.Debug("maintenance busy, will retry", "level", lvl.Level, "path", db.Path(), "retry", s.MaintenanceBusyRetryInterval)
+				busySet[db] = struct{}{}
 			case errors.Is(err, ErrDBNotReady):
 				db.Logger.Debug("db not ready, skipping", "level", lvl.Level, "path", db.Path(), "error", err)
 				notReadyDBs = append(notReadyDBs, db.Path())
+				notReadySet[db] = struct{}{}
 			case err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded):
 				db.Logger.Error("compaction failed", "level", lvl.Level, "error", err)
 			}
 
-			if lvl.Level == SnapshotLevel {
+			if lvl.Level == SnapshotLevel && !earlyPass {
 				if err := s.EnforceSnapshotRetention(ctx, db); err != nil &&
 					!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					db.Logger.Error("retention enforcement failed", "error", err)
 				}
 			}
 		}
+
+		// Computed after the work so a long pass cannot push the regular
+		// schedule out by its own runtime.
+		nextDelay := time.Until(nextRegular)
 
 		timedOut := !retryDeadline.IsZero() && now.After(retryDeadline)
 		if len(notReadyDBs) > 0 && !timedOut {
@@ -618,13 +673,50 @@ func (s *Store) monitorCompactionLevel(ctx context.Context, lvl *CompactionLevel
 					"hint", "database may have corrupted local state or blocked transactions; try removing -litestream directory and restarting")
 			}
 			retryDeadline = time.Time{}
+			notReadySet = nil // give up early retries; regular passes still cover them
 		}
 
-		if nextDelay < 0 {
-			nextDelay = 0
+		pending = make(map[*DB]struct{}, len(busySet)+len(notReadySet))
+		for db := range busySet {
+			pending[db] = struct{}{}
 		}
-		timer.Reset(nextDelay)
+		for db := range notReadySet {
+			pending[db] = struct{}{}
+		}
+
+		if len(busySet) > 0 {
+			busyStreak++
+		} else {
+			busyStreak = 0
+		}
+		timer.Reset(busyRetryDelay(nextDelay, busyStreak, s.MaintenanceBusyRetryInterval))
 	}
+}
+
+// busyRetryDelay returns the delay before the next monitor pass. While a
+// database keeps reporting ErrMaintenanceBusy (busyStreak > 0) the delay is
+// capped at an exponential backoff from maintenanceBusyRetryBase up to
+// maxRetry, so the refused operation is reattempted soon after the in-flight
+// one finishes rather than after the level's full interval (a snapshot losing
+// startup contention to L1 would otherwise wait until the next snapshot
+// boundary), and a momentary collision between levels costs about a second.
+func busyRetryDelay(nextDelay time.Duration, busyStreak int, maxRetry time.Duration) time.Duration {
+	if busyStreak > 0 && maxRetry > 0 {
+		retry := maintenanceBusyRetryBase
+		for i := 1; i < busyStreak && retry < maxRetry; i++ {
+			retry *= 2
+		}
+		if retry > maxRetry {
+			retry = maxRetry
+		}
+		if nextDelay > retry {
+			nextDelay = retry
+		}
+	}
+	if nextDelay < 0 {
+		nextDelay = 0
+	}
+	return nextDelay
 }
 
 func (s *Store) monitorL0Retention(ctx context.Context) {
@@ -771,6 +863,17 @@ func (s *Store) CompactDB(ctx context.Context, db *DB, lvl *CompactionLevel) (*l
 	if db.PageSize() == 0 {
 		return nil, &DBNotReadyError{Reason: "page size not initialized"}
 	}
+
+	// Serialize maintenance per database: a snapshot and a compaction (or two
+	// compaction levels) each retain a database-sized page index, so letting
+	// them overlap multiplies peak memory with database size (issue #1477).
+	// Refuse instead of waiting so one database's long snapshot cannot stall
+	// the level monitor for every other database; the caller's next interval
+	// retries.
+	if !db.maintenanceMu.TryLock() {
+		return nil, ErrMaintenanceBusy
+	}
+	defer db.maintenanceMu.Unlock()
 
 	dstLevel := lvl.Level
 

--- a/store_internal_test.go
+++ b/store_internal_test.go
@@ -1,0 +1,31 @@
+package litestream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBusyRetryDelay(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		nextDelay time.Duration
+		streak    int
+		maxRetry  time.Duration
+		want      time.Duration
+	}{
+		{"not busy keeps interval", time.Hour, 0, 10 * time.Second, time.Hour},
+		{"first busy pass retries after base", time.Hour, 1, 10 * time.Second, time.Second},
+		{"second busy pass doubles", time.Hour, 2, 10 * time.Second, 2 * time.Second},
+		{"fourth busy pass doubles again", time.Hour, 4, 10 * time.Second, 8 * time.Second},
+		{"backoff is capped", time.Hour, 20, 10 * time.Second, 10 * time.Second},
+		{"busy keeps shorter interval", 500 * time.Millisecond, 3, 10 * time.Second, 500 * time.Millisecond},
+		{"busy with retry disabled", time.Hour, 1, 0, time.Hour},
+		{"negative clamps to zero", -time.Second, 0, 10 * time.Second, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := busyRetryDelay(tt.nextDelay, tt.streak, tt.maxRetry); got != tt.want {
+				t.Fatalf("busyRetryDelay()=%s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/store_test.go
+++ b/store_test.go
@@ -2,14 +2,17 @@ package litestream_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/superfly/ltx"
 
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
@@ -577,4 +580,124 @@ func TestStore_SetRetentionEnabled(t *testing.T) {
 			t.Fatalf("expected db.RetentionEnabled=true for %s after reset", db.Path())
 		}
 	}
+}
+
+func TestStore_CompactDB_SerializesPerDBMaintenance(t *testing.T) {
+	// Teardown is registered with t.Cleanup (LIFO) so that on failure the
+	// held snapshot is released and joined before the store and databases
+	// close underneath it.
+	db0, sqldb0 := testingutil.MustOpenDBs(t)
+	t.Cleanup(func() { testingutil.MustCloseDBs(t, db0, sqldb0) })
+
+	db1, sqldb1 := testingutil.MustOpenDBs(t)
+	t.Cleanup(func() { testingutil.MustCloseDBs(t, db1, sqldb1) })
+
+	levels := litestream.CompactionLevels{
+		{Level: 0},
+		{Level: 1, Interval: 1 * time.Second},
+	}
+	s := litestream.NewStore([]*litestream.DB{db0, db1}, levels)
+	s.CompactionMonitorEnabled = false
+	if err := s.Open(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close(context.Background()) })
+
+	for _, tt := range []struct {
+		sqldb *sql.DB
+		db    *litestream.DB
+	}{{sqldb0, db0}, {sqldb1, db1}} {
+		if _, err := tt.sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tt.sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := tt.db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := tt.db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wrap db0's replica client so its snapshot write blocks until released,
+	// holding db0's maintenance slot the way a long-running snapshot upload does.
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseSnapshot := func() { releaseOnce.Do(func() { close(release) }) }
+	db0.Replica.Client = &blockingSnapshotClient{
+		ReplicaClient: db0.Replica.Client,
+		started:       started,
+		release:       release,
+	}
+
+	snapshotDone := make(chan error, 1)
+	go func() {
+		_, err := s.CompactDB(context.Background(), db0, s.SnapshotLevel())
+		snapshotDone <- err
+	}()
+	t.Cleanup(func() {
+		releaseSnapshot()
+		select {
+		case <-snapshotDone:
+		case <-time.After(10 * time.Second):
+			t.Error("snapshot goroutine did not exit after release")
+		}
+	})
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for snapshot to start")
+	}
+
+	// A concurrent compaction for the same database must be refused while the
+	// snapshot is in flight — refused, not queued, so run it with a deadline.
+	compactDone := make(chan error, 1)
+	go func() {
+		_, err := s.CompactDB(t.Context(), db0, levels[1])
+		compactDone <- err
+	}()
+	select {
+	case err := <-compactDone:
+		require.ErrorIs(t, err, litestream.ErrMaintenanceBusy)
+	case <-time.After(5 * time.Second):
+		t.Fatal("same-database compaction blocked behind the snapshot instead of returning ErrMaintenanceBusy")
+	}
+
+	// A different database must not be blocked by db0's snapshot.
+	_, err := s.CompactDB(t.Context(), db1, levels[1])
+	require.NoError(t, err)
+
+	releaseSnapshot()
+	select {
+	case err := <-snapshotDone:
+		snapshotDone <- err // requeue first so cleanup's join sees completion even on failure
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for snapshot to finish")
+	}
+
+	// Once the snapshot finishes, db0 maintenance is available again.
+	_, err = s.CompactDB(t.Context(), db0, levels[1])
+	require.NotErrorIs(t, err, litestream.ErrMaintenanceBusy)
+}
+
+type blockingSnapshotClient struct {
+	litestream.ReplicaClient
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingSnapshotClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if level == litestream.SnapshotLevel {
+		c.once.Do(func() { close(c.started) })
+		select {
+		case <-c.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
 }


### PR DESCRIPTION
## Summary

`Store.Open` runs one goroutine per compaction level plus one for the snapshot level, and `CompactDB` did nothing to serialize work per database, so an L9 snapshot and an L1 compaction can run at the same time on the same database. Each holds a database-sized LTX page index, so peak memory multiplies with database size; a 130 GiB database was OOM-killed in a 12 GiB container this way (#1477).

- `Store.CompactDB` now takes a per-database `TryLock`. A refused operation returns the new `ErrMaintenanceBusy` instead of queueing, so one database's long snapshot cannot stall the level monitor for every other database.
- The level monitor treats busy like "no compaction" but wakes early to retry: 1s after the first refusal, doubling up to `MaintenanceBusyRetryInterval` (10s) while the database stays busy. An early pass only re-attempts the databases that were refused (plus any registered since the last regular pass) and skips snapshot retention; regular passes stay anchored to the level's schedule. Without the early retry a snapshot that lost startup contention to L1 would wait for the next snapshot boundary (up to 24h); without the 1s start, levels whose boundaries coincide (e.g. L1 15s / L2 30s in the LTX behavioral gate) would drift by a full 10s on every collision.
- The snapshot reader's `Close` now cancels and joins the producer goroutine, so a snapshot whose replica write fails early cannot leave its WAL page map and encoder alive after the lock is released.
- Compaction across different databases is unaffected (covered by the new test).

This bounds concurrent maintenance memory to one operation per database. The page indexes themselves still scale with database size; shrinking the encoder's index is https://github.com/superfly/ltx/pull/95, and this PR pins `go.mod` to that branch's head so it builds and soaks as the intended final combination. **The pin must be replaced with the tagged ltx release before merge.**

Fixes #1477

## Evidence

Measured with the litestream-soak `snapshot-compaction-overlap` rig (https://github.com/corylanou/litestream-soak/pull/196, https://github.com/corylanou/litestream-soak/pull/197): it runs snapshot and L1 compaction sequentially as a baseline, then holds the snapshot's replica stream at 95% so the encoder's page index stays resident while the L1 compaction runs, sampling `runtime.MemStats` (GOGC=25) and writing a heap profile at each phase's peak. "Overlap" is the peak heap growth during that phase; the pass limit is 1.10× the larger sequential phase plus one multipart upload's fixed buffers. The "this PR" rows were built by the rig straight from this PR's head (`go.mod` as committed, ltx pinned to superfly/ltx#95), not via a local replace.

| build | DB | seq snapshot | seq compact-l1 | overlap | limit | result |
|---|---|---|---|---|---|---|
| main 3b468c9 + ltx v0.5.2 | 1 GiB / 262,803 pages | 69.0 MB | 101.3 MB | **170.0 MB** | 145.0 MB | fail (overlap/sum = 1.00) |
| serialization only (ltx v0.5.2) | 1 GiB | 68.6 MB | 99.3 MB | **99.1 MB** | 142.8 MB | pass (ratio 1.00) |
| this PR (serialization + ltx#95) | 1 GiB | 48.7 MB | 79.2 MB | **81.3 MB** | 120.7 MB | pass (ratio 1.03) |
| main 3b468c9 + ltx v0.5.2 | 4 GiB / 1,051,216 pages | 168.6 MB | 306.3 MB | **470.6 MB** | 370.5 MB | fail (overlap/sum = 0.99) |
| serialization only (ltx v0.5.2) | 4 GiB | 173.1 MB | 300.7 MB | **286.5 MB** | 364.3 MB | pass (ratio 0.95) |
| this PR (serialization + ltx#95) | 4 GiB | 68.8 MB | 203.4 MB | **199.6 MB** | 257.3 MB | pass (ratio 0.98, `gate_release_reason=timeout`, 364 busy retries) |

On main the overlap's memory is the sum of the two operations; with serialization it is the larger of the two; with ltx#95 the encoder index itself shrinks from ~95 B/page to ~18 B/page. Peak heap profiles (`inuse_space`, 4 GiB run):

```
main, overlap phase:        233.81MB ltx.(*Encoder).EncodePage   (two live encoders)
                             64.00MB s3/manager.(*maxSlicePool).newSlice (two in-flight uploads)
                             48.03MB ltx.DecodePageIndex
serialization only:         114.54MB ltx.(*Encoder).EncodePage   (one encoder)
                             32.00MB s3/manager.(*maxSlicePool).newSlice
                             13.20MB ltx.DecodePageIndex
this PR, snapshot phase:     32.00MB s3/manager.(*maxSlicePool).newSlice
                             15.70MB ltx.(*pageIndex).append
this PR, overlap phase:      84.45MB ltx.DecodePageIndex        (now the largest term; follow-up in ltx)
                             32.00MB s3/manager.(*maxSlicePool).newSlice
```

Overlap cost: ~450 B/page on main, ~270 B/page with serialization alone, ~190 B/page for this PR as pinned — at the reporter's 34.2M pages that is ≈15 GB → ≈9.3 GB → ≈6.5 GB. The decoder-side `DecodePageIndex` map is now the biggest remaining per-page term (~80 B/page) and is called out as follow-up work in superfly/ltx#95.

The same head is also deployed as the `pr-1479` litestream-soak fleet (15 workers incl. two 100-database workers that upload hourly heap/alloc/goroutine/CPU pprof captures) for a longer-running comparison against `main`.

## Known limits

- `TryLock` is not fair; under continuous contention on one database a level could repeatedly lose to another. Defaults make that unlikely (snapshots are daily, compactions minutes apart).
- Only `Store.CompactDB` takes the lock. Direct `DB.Snapshot`/`DB.Compact` callers (e.g. `replicate -force-snapshot`, which runs with monitors disabled) are not serialized.
- The pre-existing race between the monitor's `IsOpen` check and `DisableDB`/`UnregisterDB` is unchanged; a re-registered path gets a fresh `DB` and therefore a fresh lock.

## Test plan

- [x] `tests/integration` LTX behavioral gate (`-short`) passes locally with the 1s→10s backoff (it failed on the first push, where a 10s retry after every L1/L2 boundary collision fell outside the ±50% timing window)
- [x] `TestStore_CompactDB_SerializesPerDBMaintenance`: same-DB compaction refused with `ErrMaintenanceBusy` while a snapshot is held, other DB unaffected, lock available after release
- [x] `TestBusyRetryDelay` for the monitor delay cap
- [x] `go test ./` root package, `go vet ./...`, pre-commit (goimports, vet, staticcheck)
- [x] Rig A/B above, 1 GiB and 4 GiB, including a build from this PR's exact head
- [x] Five adversarial Codex review passes; all confirmed findings addressed (producer join + cancellation, busy retry cap, early passes scoped to refused/not-ready/newly registered DBs, schedule anchored at the regular boundary, test cleanup ordering); final pass approved with no confirmed regressions
