### PR TITLE
fix(gs): abort uploads when source reader fails

### DIFF
--- a/gs/replica_client.go
+++ b/gs/replica_client.go
@@ -159,8 +159,9 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 	// Combine buffered data with rest of reader
 	fullReader := io.MultiReader(&buf, rd)
 
-	w := c.bkt.Object(key).NewWriter(ctx)
-	defer w.Close()
+	writeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	w := c.bkt.Object(key).NewWriter(writeCtx)
 
 	// Store timestamp in GCS metadata for accurate timestamp retrieval
 	w.Metadata = map[string]string{
@@ -169,6 +170,7 @@ func (c *ReplicaClient) WriteLTXFile(ctx context.Context, level int, minTXID, ma
 
 	n, err := io.Copy(w, fullReader)
 	if err != nil {
+		cancel()
 		return info, err
 	} else if err := w.Close(); err != nil {
 		return info, err

--- a/gs/replica_client_test.go
+++ b/gs/replica_client_test.go
@@ -3,10 +3,13 @@ package gs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
+	"github.com/benbjohnson/litestream"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/superfly/ltx"
 )
@@ -77,5 +80,47 @@ func TestReplicaClient_OpenLTXFileReadsFullObject(t *testing.T) {
 
 	if !bytes.Equal(out, data) {
 		t.Fatalf("unexpected replica content: got %q, want %q", out, data)
+	}
+}
+
+var errTestSource = errors.New("injected source failure")
+
+type failAfterReader struct {
+	r         *bytes.Reader
+	remaining int
+}
+
+func (r *failAfterReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, errTestSource
+	}
+
+	if len(p) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= n
+	if err != nil {
+		return n, errTestSource
+	}
+	return n, nil
+}
+
+func TestReplicaClient_WriteLTXFileAbortsOnSourceError(t *testing.T) {
+	rc, server := setupTestClient(t)
+	defer server.Stop()
+
+	ctx := context.Background()
+	minTXID, maxTXID := ltx.TXID(1), ltx.TXID(1)
+	data := ltxTestData(t, minTXID, maxTXID, bytes.Repeat([]byte("payload"), 1024))
+	rd := &failAfterReader{r: bytes.NewReader(data), remaining: len(data) - 1}
+
+	if _, err := rc.WriteLTXFile(ctx, 0, minTXID, maxTXID, rd); !errors.Is(err, errTestSource) {
+		t.Fatalf("WriteLTXFile error = %v, want %v", err, errTestSource)
+	}
+
+	key := litestream.LTXFilePath(rc.Path, 0, minTXID, maxTXID)
+	if _, err := rc.bkt.Object(key).Attrs(ctx); !errors.Is(err, storage.ErrObjectNotExist) {
+		t.Fatalf("object attrs error = %v, want %v", err, storage.ErrObjectNotExist)
 	}
 }

--- a/gs/replica_client_test.go
+++ b/gs/replica_client_test.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/benbjohnson/litestream"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream"
 )
 
 func ltxTestData(tb testing.TB, minTXID, maxTXID ltx.TXID, payload []byte) []byte {


### PR DESCRIPTION
## Summary

Abort a GCS upload when the source reader returns an error instead of allowing a deferred `Writer.Close()` to finalize the partial object under its final LTX key.

## Problem

`gs.ReplicaClient.WriteLTXFile()` previously deferred `w.Close()` immediately after creating the GCS writer. If `io.Copy()` read a partial LTX stream and then returned a source error, the deferred close still completed the GCS write. That could leave a partial object visible at the final LTX path even though `WriteLTXFile()` returned an error.

Issue #1263 identifies this path, including the compaction case where an `io.Pipe` forwards a source or compaction error after partial output. The issue discussion also confirms that the earlier PR covering this behavior is no longer present and that the issue remains uncovered.

## Solution

- Create a writer-scoped context with `context.WithCancel`.
- Pass that context to `NewWriter`.
- Cancel the writer context on `io.Copy()` failure and return without calling normal `Close()`.
- Keep normal `Close()` only on the successful copy path.
- Add a fake-GCS regression test with a reader that fails after returning partial data, asserting that the final object does not exist.

## Scope

**In scope:**
- GCS `WriteLTXFile()` failure cleanup.
- A focused regression test for partial source reads.

**Not in scope:**
- Other replica backends.
- LTX format, object naming, or compaction behavior.

## Test Plan

- `go test ./gs -run 'TestReplicaClient_(OpenLTXFileReadsFullObject|WriteLTXFileAbortsOnSourceError)$' -count=1`
- `go test ./gs -count=1`
- `go test ./... -count=1` (the GCS package passes; unrelated Windows filesystem/path assumptions cause failures in `file`, `cmd/litestream`, and `tests/integration` on this host)

The focused regression test passes against the fake GCS server. The full test command reaches the changed package successfully but has environment-specific failures involving Windows path semantics, directory syncing, and file locks outside this change.

Fixes #1263
