### PR TITLE
fix(s3): tune Tigris multipart upload defaults

### DIFF
--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -1630,6 +1630,10 @@ func NewS3ReplicaClientFromConfig(c *ReplicaConfig, _ *litestream.Replica) (_ *s
 	if isCloudflareR2 {
 		client.Concurrency = s3.DefaultR2Concurrency
 	}
+	if isTigris {
+		client.Concurrency = s3.DefaultTigrisConcurrency
+		client.PartSize = s3.DefaultTigrisPartSize
+	}
 
 	// Apply upload configuration from URL query, then config overrides.
 	if upartSizeSet {

--- a/cmd/litestream/main_test.go
+++ b/cmd/litestream/main_test.go
@@ -3149,6 +3149,12 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		if client.RequireContentMD5 {
 			t.Error("expected RequireContentMD5 to be false for Tigris")
 		}
+		if client.Concurrency != s3.DefaultTigrisConcurrency {
+			t.Errorf("expected Tigris concurrency %d, got %d", s3.DefaultTigrisConcurrency, client.Concurrency)
+		}
+		if client.PartSize != s3.DefaultTigrisPartSize {
+			t.Errorf("expected Tigris part size %d, got %d", s3.DefaultTigrisPartSize, client.PartSize)
+		}
 	})
 
 	t.Run("TigrisConfigEndpoint", func(t *testing.T) {
@@ -3170,6 +3176,12 @@ func TestNewS3ReplicaClientFromConfig(t *testing.T) {
 		}
 		if client.RequireContentMD5 {
 			t.Error("expected RequireContentMD5 to be false for config-based Tigris endpoint")
+		}
+		if client.Concurrency != s3.DefaultTigrisConcurrency {
+			t.Errorf("expected config-based Tigris concurrency %d, got %d", s3.DefaultTigrisConcurrency, client.Concurrency)
+		}
+		if client.PartSize != s3.DefaultTigrisPartSize {
+			t.Errorf("expected config-based Tigris part size %d, got %d", s3.DefaultTigrisPartSize, client.PartSize)
 		}
 	})
 

--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -341,8 +341,8 @@ Parameters with an alias accept both camelCase and hyphenated forms
 | `skipVerify` | `skip-verify` | Skip TLS verification | `false` |
 | `signPayload` | `sign-payload` | Sign request payloads | `true` |
 | `requireContentMD5` | `require-content-md5` | Require Content-MD5 header | `true` |
-| `concurrency` | | Multipart upload concurrency | `5` |
-| `partSize` | `part-size` | Multipart upload part size in bytes | `5242880` (5MB) |
+| `concurrency` | | Multipart upload concurrency | `5` (`2` for R2/Tigris) |
+| `partSize` | `part-size` | Multipart upload part size | `5242880` (5MB) (`16MiB` for Tigris) |
 | `storageClass` | `storage-class` | Storage class for uploaded objects | None |
 | `sseCustomerAlgorithm` | `sse-customer-algorithm` | SSE-C encryption algorithm | None |
 | `sseCustomerKey` | `sse-customer-key` | SSE-C encryption key | None |
@@ -361,7 +361,7 @@ Litestream automatically detects certain providers and applies appropriate defau
 | DigitalOcean | `*.digitaloceanspaces.com` | `sign-payload=true` |
 | Scaleway | `*.scw.cloud` | `sign-payload=true` |
 | Filebase | `s3.filebase.com` | `sign-payload=true`, `force-path-style=true` |
-| Tigris | `*.tigris.dev` | `sign-payload=true`, `require-content-md5=false` |
+| Tigris | `*.tigris.dev` | `sign-payload=true`, `require-content-md5=false`, `concurrency=2`, `part-size=16MiB` |
 | MinIO | host with port (not cloud provider) | `sign-payload=true`, `force-path-style=true` |
 | Supabase | `*.supabase.co` | `sign-payload=true`, `force-path-style=true` |
 | Google Cloud Storage | Exact `googleapis.com` suffix with a first-label `storage` segment | Excludes `Accept-Encoding` from SigV4 signatures |

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -68,6 +68,13 @@ const DefaultMetadataConcurrency = 50
 // parts for Cloudflare R2, which has strict concurrent upload limits.
 const DefaultR2Concurrency = 2
 
+// DefaultTigrisConcurrency is the default number of concurrent multipart
+// upload parts for Tigris, which has strict concurrent upload limits.
+const DefaultTigrisConcurrency = 2
+
+// DefaultTigrisPartSize is the default multipart upload part size for Tigris.
+const DefaultTigrisPartSize = 16 * 1024 * 1024
+
 // contentMD5StackKey is used to pass the precomputed Content-MD5 checksum
 // through the middleware stack from Serialize to Finalize phase.
 type contentMD5StackKey struct{}
@@ -251,6 +258,12 @@ func NewReplicaClientFromURL(scheme, host, urlPath string, query url.Values, use
 		}
 		if !requireMD5Set {
 			requireMD5, requireMD5Set = false, true
+		}
+		if !concurrencySet {
+			client.Concurrency = DefaultTigrisConcurrency
+		}
+		if partSize == 0 {
+			client.PartSize = DefaultTigrisPartSize
 		}
 	}
 	if isHetzner || isDigitalOcean || isBackblaze || isFilebase || isScaleway || isCloudflareR2 || isMinIO || isSupabase {

--- a/s3/replica_client_test.go
+++ b/s3/replica_client_test.go
@@ -1913,6 +1913,55 @@ func TestReplicaClient_TigrisConsistentHeader(t *testing.T) {
 	}
 }
 
+// TestReplicaClient_ProviderUploadDefaults verifies provider-specific upload
+// defaults for S3-compatible endpoints with known concurrency limits.
+func TestReplicaClient_ProviderUploadDefaults(t *testing.T) {
+	tests := []struct {
+		name            string
+		url             string
+		wantConcurrency int
+		wantPartSize    int64
+	}{
+		{
+			name:            "R2_DefaultConcurrency",
+			url:             "s3://mybucket/path?endpoint=https://account123.r2.cloudflarestorage.com",
+			wantConcurrency: 2,
+		},
+		{
+			name:            "Tigris_DefaultUploadShape",
+			url:             "s3://mybucket/path?endpoint=https://fly.storage.tigris.dev",
+			wantConcurrency: DefaultTigrisConcurrency,
+			wantPartSize:    DefaultTigrisPartSize,
+		},
+		{
+			name:            "Tigris_ExplicitUploadShape",
+			url:             "s3://mybucket/path?endpoint=https://fly.storage.tigris.dev&concurrency=4&part-size=33554432",
+			wantConcurrency: 4,
+			wantPartSize:    33554432,
+		},
+		{
+			name: "AWS_NoConcurrencyOverride",
+			url:  "s3://mybucket/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := litestream.NewReplicaClientFromURL(tt.url)
+			if err != nil {
+				t.Fatalf("NewReplicaClientFromURL() error: %v", err)
+			}
+			c := client.(*ReplicaClient)
+			if c.Concurrency != tt.wantConcurrency {
+				t.Errorf("Concurrency = %d, want %d", c.Concurrency, tt.wantConcurrency)
+			}
+			if c.PartSize != tt.wantPartSize {
+				t.Errorf("PartSize = %d, want %d", c.PartSize, tt.wantPartSize)
+			}
+		})
+	}
+}
+
 func TestReplicaClient_GCSAcceptEncodingNotSigned(t *testing.T) {
 	tests := []struct {
 		name                     string


### PR DESCRIPTION
## Summary

Apply conservative multipart upload defaults for Tigris S3-compatible storage: limit concurrent upload parts to 2 and use 16 MiB parts by default. Preserve explicit URL and config overrides, and document the provider-specific behavior.

## Problem

Issue #1278 identified Tigris multipart upload defaults as a contributor to S3-compatible storage flakiness during soak runs. The issue's retry half has already landed in #1433; this PR addresses the remaining Tigris upload-defaults scope.

## Solution

- Add `DefaultTigrisConcurrency` (2) and `DefaultTigrisPartSize` (16 MiB).
- Apply the defaults in both the URL factory and CLI/config factory.
- Keep explicit `concurrency`, `part-size`, and config values authoritative.
- Add URL-factory and config-factory regression coverage.
- Document Tigris defaults in the provider compatibility guide.

## Scope

**In scope:**
- Tigris multipart concurrency and part-size defaults.
- Configuration parity and regression tests.
- Provider compatibility documentation.

**Not in scope:**
- The request-cancellation retry behavior already addressed by #1433.
- Live Tigris credentials or integration-only behavior.
- Database sync/checkpoint changes.

## Test Plan

- `go test ./s3 -run 'TestReplicaClient_(ProviderUploadDefaults|NewS3Retryer|LTXFiles_RetriesRequestCanceledList)$' -count=1` — pass
- `go test ./cmd/litestream -run 'TestNewS3ReplicaClientFromConfig/(TigrisExample|TigrisConfigEndpoint)' -count=1` — pass
- `go test ./s3 -count=1` — pass
- `go test ./... -run 'TestReplicaClient_ProviderUploadDefaults|TestNewS3ReplicaClientFromConfig/(TigrisExample|TigrisConfigEndpoint)' -count=1` — pass
- `go vet ./s3 ./cmd/litestream` — pass
- `git diff --check` — pass

The full `go test ./cmd/litestream -count=1` run was also attempted. Existing Windows-specific failures occur in unrelated file-backed command tests (Windows `file://` URL parsing and temporary-directory/file-lock `Access is denied` cleanup paths); the changed focused tests and S3 package pass.

Fixes #1278
