### PR TITLE
perf: spill large page indexes into the db meta directory

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -31,6 +31,12 @@ type Compactor struct {
 	// policies handle retention instead. Local file cleanup still occurs.
 	RetentionEnabled bool
 
+	// SpillDir, when set, lets the ltx encoder spill the output page index of
+	// a very large compaction to a temp file in that directory instead of
+	// holding it in memory (ltx#96). DB sets it to the database meta
+	// directory, which is writable even in the hardened image.
+	SpillDir string
+
 	// CompactionVerifyErrorCounter is incremented when post-compaction
 	// verification fails. Optional; if nil, no metric is recorded.
 	CompactionVerifyErrorCounter prometheus.Counter
@@ -162,7 +168,9 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 			_ = pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
 			return
 		}
+		defer func() { _ = comp.Cleanup() }()
 		comp.HeaderFlags = ltx.HeaderFlagNoChecksum
+		comp.SetSpillDir(c.SpillDir)
 		_ = pw.CloseWithError(comp.Compact(ctx))
 	}()
 

--- a/db.go
+++ b/db.go
@@ -1113,6 +1113,7 @@ func (db *DB) init(ctx context.Context) (err error) {
 	if err := internal.MkdirAll(db.metaPath, db.dirInfo); err != nil {
 		return err
 	}
+	db.compactor.SpillDir = db.metaPath
 
 	// Ensure WAL has at least one frame in it.
 	if err := db.ensureWALExists(ctx); err != nil {
@@ -2883,6 +2884,11 @@ func (db *DB) snapshotReader(ctx context.Context, pos *snapshotReadPosition) (io
 			pw.CloseWithError(fmt.Errorf("new ltx encoder: %w", err))
 			return
 		}
+		// Very large snapshots spill their page index into the meta
+		// directory rather than holding it in memory; Cleanup covers the
+		// cancellation paths that never reach enc.Close.
+		enc.SetSpillDir(db.MetaPath())
+		defer enc.Cleanup()
 		if err := enc.EncodeHeader(ltx.Header{
 			Version:   ltx.Version,
 			Flags:     ltx.HeaderFlagNoChecksum,

--- a/replica.go
+++ b/replica.go
@@ -743,6 +743,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 			pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
 			return
 		}
+		defer func() { _ = c.Cleanup() }()
 		c.HeaderFlags = ltx.HeaderFlagNoChecksum
 		_ = pw.CloseWithError(c.Compact(ctx))
 	}()

--- a/vfs.go
+++ b/vfs.go
@@ -788,6 +788,7 @@ func (h *Hydrator) Restore(ctx context.Context, infos []*ltx.FileInfo) error {
 	if err != nil {
 		return fmt.Errorf("new ltx compactor: %w", err)
 	}
+	defer func() { _ = c.Cleanup() }()
 	c.HeaderFlags = ltx.HeaderFlagNoChecksum
 	h.compactor = c
 


### PR DESCRIPTION
Stacked on #1479 (base branch `fix/1477-serialize-db-maintenance`); pairs with https://github.com/superfly/ltx/pull/97 (tracked in https://github.com/superfly/ltx/issues/96). Part of #1477.

## Summary

- Enables the ltx encoder's page-index spill for snapshots and compactions, with `DB.MetaPath()` as the spill directory — it exists in every deployment, including the hardened `FROM scratch` image, which has no `/tmp`.
- Every `ltx.NewCompactor` site (compaction, restore, VFS hydration) and the snapshot encoder now `defer Cleanup()`, so a cancelled or failed operation cannot leave a spill file behind, and an abandoned encoder cannot later be closed into a checksum-valid file with an empty index (ltx#97 makes `Cleanup` terminal for that reason).
- With ltx#97's streaming decoder, compaction inputs no longer materialize a page-index map at all.
- `go.mod` pins ltx to the head of superfly/ltx#97 for evaluation. **Replace with the tagged ltx release before merge** (same as #1479's pin).

## Evidence

litestream-soak `snapshot-compaction-overlap` rig (https://github.com/corylanou/litestream-soak/pull/196): the snapshot's replica stream is held at 95% so its page index stays resident while the L1 compaction runs; heap growth = peak `HeapInuse` − post-GC baseline, GOGC=25, peak heap profile per phase. All rows below include per-database serialization (#1479); the ltx column is what changes.

| build | fixture | snapshot | L1 compaction | overlap |
|---|---|---|---|---|
| #1479 + ltx v0.5.2 | 4 GiB / 1,051,216 pages | 173.1 MB | 300.7 MB | 286.5 MB |
| #1479 + ltx#95 (as pinned there) | 4 GiB | 68.8 MB | 203.4 MB | 199.6 MB |
| **this PR + ltx#97** | 4 GiB | **70.4 MB** | **73.7 MB** | **73.1 MB** |
| **this PR + ltx#97** | 8 GiB / 2,102,433 pages | **73.1 MB** | **72.9 MB** | **73.9 MB** |

Going from 4 to 8 GiB no longer moves any phase: ~32 MB is the fixed S3 multipart upload buffers, the rest is the ≤24 MiB of in-memory index chunks before the spill engages. Peak profile of the 8 GiB compaction phase is `s3/manager.(*maxSlicePool).newSlice` 32 MB + `ltx.(*pageIndex).append` 22.8 MB; `DecodePageIndex` (84 MB at 4 GiB before) is gone. For comparison, litestream main with ltx v0.5.2 measured 470.6 MB for the 4 GiB overlap.

At the reporter's 34.2M pages this leaves maintenance memory at roughly the S3 buffer allowance plus a few tens of MB, versus ≈15 GB on main and ≈6.5 GB with #1479 + ltx#95.

## Follow-up

- `Hydrator.ApplyLTX` (vfs.go) reads pages and returns without `dec.Close()`, so it never verifies the index/trailer/file checksum. Pre-existing; it should close the decoder with retention off. Separate PR.

## Test plan

- [x] `go test ./` root suite green against ltx#97; `go vet`, pre-commit (goimports, vet, staticcheck)
- [x] Rig evidence above at 4 GiB and 8 GiB, profiles saved
- [x] ltx side reviewed in four adversarial Codex passes (see ltx#97)
