### PR TITLE
fix(vfs): verify LTX files during hydration

### DIFF
--- a/vfs.go
+++ b/vfs.go
@@ -655,6 +655,7 @@ type Hydrator struct {
 	persistent bool           // True when file should survive across restarts
 	file       *os.File       // Local database file
 	complete   atomic.Bool    // True when restore completes
+	tainted    atomic.Bool    // True once an applied LTX file failed verification; never persisted
 	txid       ltx.TXID       // TXID the hydrated file is at
 	mu         sync.Mutex     // Protects hydration file writes
 	err        error          // Stores fatal hydration error
@@ -849,6 +850,7 @@ func (h *Hydrator) ApplyLTX(ctx context.Context, info *ltx.FileInfo) error {
 	defer rc.Close()
 
 	dec := ltx.NewDecoder(rc)
+	dec.SetRetainPageIndex(false) // pages are streamed; the index is validated, not kept
 	if err := dec.DecodeHeader(); err != nil {
 		return fmt.Errorf("decode header: %w", err)
 	}
@@ -856,23 +858,40 @@ func (h *Hydrator) ApplyLTX(ctx context.Context, info *ltx.FileInfo) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// Apply each page to the hydration file
+	// Apply each page to the hydration file. Pages are applied as they
+	// stream, so any failure from here on leaves unverified or partial
+	// content in the hydration file: mark it tainted so Close discards it
+	// instead of persisting it for a resume on the next start.
+	data := make([]byte, h.pageSize)
 	for {
 		var phdr ltx.PageHeader
-		data := make([]byte, h.pageSize)
 		if err := dec.DecodePage(&phdr, data); err == io.EOF {
 			break
 		} else if err != nil {
+			h.tainted.Store(true)
 			return fmt.Errorf("decode page: %w", err)
 		}
 
 		off := int64(phdr.Pgno-1) * int64(h.pageSize)
 		if _, err := h.file.WriteAt(data, off); err != nil {
+			h.tainted.Store(true)
 			return fmt.Errorf("write page %d: %w", phdr.Pgno, err)
 		}
 	}
 
+	// Read the page index and trailer so the file checksum is verified.
+	if err := dec.Close(); err != nil {
+		h.tainted.Store(true)
+		return fmt.Errorf("verify ltx file: %w", err)
+	}
+
 	return nil
+}
+
+// Tainted reports whether an applied LTX file failed verification, in which
+// case the hydration file's content cannot be trusted.
+func (h *Hydrator) Tainted() bool {
+	return h.tainted.Load()
 }
 
 // ReadAt reads data from the hydrated local file.
@@ -940,7 +959,7 @@ func (h *Hydrator) Close() error {
 		return nil
 	}
 
-	if h.persistent && h.txid > 0 {
+	if h.persistent && h.txid > 0 && !h.tainted.Load() {
 		if err := h.file.Sync(); err != nil {
 			h.logger.Warn("failed to sync hydration file", "error", err)
 		}
@@ -950,17 +969,19 @@ func (h *Hydrator) Close() error {
 		return h.file.Close()
 	}
 
-	if err := h.file.Close(); err != nil {
-		return err
-	}
-
-	if err := os.Remove(h.path); err != nil && !os.IsNotExist(err) {
-		return err
-	}
+	// Discard: remove the meta first so a restart can never resume from
+	// this file, then the file itself; report every failure, not the first.
+	var errs []error
 	if err := os.Remove(h.metaPath()); err != nil && !os.IsNotExist(err) {
-		return err
+		errs = append(errs, err)
 	}
-	return nil
+	if err := h.file.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := os.Remove(h.path); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func (h *Hydrator) metaPath() string {

--- a/vfs_test.go
+++ b/vfs_test.go
@@ -5,6 +5,7 @@ package litestream
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -850,6 +851,8 @@ func newCountingReplicaClient() *countingReplicaClient { return &countingReplica
 
 func (c *countingReplicaClient) Type() string { return "count" }
 
+func (c *countingReplicaClient) SetLogger(*slog.Logger) {}
+
 func (c *countingReplicaClient) Init(context.Context) error { return nil }
 
 func (c *countingReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error) {
@@ -883,6 +886,8 @@ func newBlockingReplicaClient() *blockingReplicaClient {
 }
 
 func (c *mockReplicaClient) Type() string { return "mock" }
+
+func (c *mockReplicaClient) SetLogger(*slog.Logger) {}
 
 func (c *mockReplicaClient) Init(context.Context) error { return nil }
 
@@ -1403,4 +1408,118 @@ func TestVFSFile_Hydration_PersistentResumeOnReopen(t *testing.T) {
 	if !reopenedInfo.ModTime().Equal(initialInfo.ModTime()) {
 		t.Fatalf("expected hydration file modtime unchanged on reopen resume")
 	}
+}
+
+func TestHydrator_ApplyLTX_VerifiesFile(t *testing.T) {
+	newHydrator := func(t *testing.T, client ReplicaClient) *Hydrator {
+		t.Helper()
+		h := NewHydrator(filepath.Join(t.TempDir(), "hydration.db"), false, 4096, client, slog.Default())
+		if err := h.Init(); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+		t.Cleanup(func() { _ = h.Close() })
+		return h
+	}
+
+	t.Run("ValidFile", func(t *testing.T) {
+		client := newMockReplicaClient()
+		fx := buildLTXFixture(t, 1, 'a')
+		client.addFixture(t, fx)
+		h := newHydrator(t, client)
+		if err := h.ApplyLTX(context.Background(), fx.info); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		buf := make([]byte, 4096)
+		if _, err := h.ReadAt(buf, 0); err != nil {
+			t.Fatal(err)
+		}
+		if buf[0] != 'a' || buf[4095] != 'a' {
+			t.Fatalf("page not applied: %q %q", buf[0], buf[4095])
+		}
+	})
+
+	t.Run("CorruptChecksumRejected", func(t *testing.T) {
+		client := newMockReplicaClient()
+		fx := buildLTXFixture(t, 1, 'a')
+		fx.data = bytes.Clone(fx.data)
+		fx.data[len(fx.data)-1] ^= 0xFF // flip a byte of the trailer's file checksum
+		client.addFixture(t, fx)
+		h := newHydrator(t, client)
+		if err := h.ApplyLTX(context.Background(), fx.info); err == nil {
+			t.Fatal("expected ApplyLTX to reject a file whose checksum does not verify")
+		}
+	})
+
+	t.Run("TaintedPersistentHydrationIsDiscarded", func(t *testing.T) {
+		client := newMockReplicaClient()
+		fx := buildLTXFixture(t, 1, 'a')
+		fx.data = bytes.Clone(fx.data)
+		fx.data[len(fx.data)-1] ^= 0xFF
+		client.addFixture(t, fx)
+		path := filepath.Join(t.TempDir(), "hydration.db")
+		h := NewHydrator(path, true, 4096, client, slog.Default())
+		if err := h.Init(); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+		h.SetTXID(1)
+		if err := h.ApplyLTX(context.Background(), fx.info); err == nil {
+			t.Fatal("expected verification failure")
+		}
+		if !h.Tainted() {
+			t.Fatal("expected hydrator to be tainted")
+		}
+		if err := h.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if _, err := os.Stat(path + ".meta"); !os.IsNotExist(err) {
+			t.Fatalf("tainted persistent hydration must not save meta for resume (err=%v)", err)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("tainted persistent hydration file must be removed (err=%v)", err)
+		}
+	})
+
+	t.Run("MidFileCorruptionTaints", func(t *testing.T) {
+		client := newMockReplicaClient()
+		fx := buildLTXFixtureWithPages(t, 1, 4096, []uint32{1, 2}, 'a')
+		fx.data = bytes.Clone(fx.data)
+		// Corrupt the second page frame's header so decoding fails after
+		// page 1 has already been written to the hydration file. Frames are
+		// LZ4-compressed, so locate the second one from the first frame's
+		// size field rather than the page size.
+		firstFrame := ltx.HeaderSize
+		firstSize := int(binary.BigEndian.Uint32(fx.data[firstFrame+ltx.PageHeaderSize:]))
+		second := firstFrame + ltx.PageHeaderSize + 4 + firstSize
+		fx.data[second] ^= 0xFF
+		client.addFixture(t, fx)
+		path := filepath.Join(t.TempDir(), "hydration.db")
+		h := NewHydrator(path, true, 4096, client, slog.Default())
+		if err := h.Init(); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+		h.SetTXID(1)
+		if err := h.ApplyLTX(context.Background(), fx.info); err == nil {
+			t.Fatal("expected apply to fail on the corrupted page")
+		}
+		if !h.Tainted() {
+			t.Fatal("expected hydrator to be tainted after a mid-file failure")
+		}
+		if err := h.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if _, err := os.Stat(path + ".meta"); !os.IsNotExist(err) {
+			t.Fatalf("meta must not be saved for a tainted hydration (err=%v)", err)
+		}
+	})
+
+	t.Run("TruncatedIndexRejected", func(t *testing.T) {
+		client := newMockReplicaClient()
+		fx := buildLTXFixture(t, 1, 'a')
+		fx.data = bytes.Clone(fx.data[:len(fx.data)-ltx.TrailerSize-4])
+		client.addFixture(t, fx)
+		h := newHydrator(t, client)
+		if err := h.ApplyLTX(context.Background(), fx.info); err == nil {
+			t.Fatal("expected ApplyLTX to reject a truncated file")
+		}
+	})
 }

--- a/vfs_write_test.go
+++ b/vfs_write_test.go
@@ -38,6 +38,8 @@ func newWriteTestReplicaClient() *writeTestReplicaClient {
 
 func (c *writeTestReplicaClient) Type() string { return "test" }
 
+func (c *writeTestReplicaClient) SetLogger(*slog.Logger) {}
+
 func (c *writeTestReplicaClient) Init(ctx context.Context) error { return nil }
 
 func (c *writeTestReplicaClient) LTXFiles(ctx context.Context, level int, seek ltx.TXID, useMetadata bool) (ltx.FileIterator, error) {


### PR DESCRIPTION
Stacked on #1483 (base `perf/1477-ltx-spill-dir`); needs the `SetRetainPageIndex` API from https://github.com/superfly/ltx/pull/97. Follow-up noted in #1483 and https://github.com/superfly/ltx/issues/96.

## Summary

- `Hydrator.ApplyLTX` decoded pages until the end-of-pages marker and returned without `Decoder.Close()`, so the page index, trailer and file checksum of hydrated LTX objects were never verified — a truncated or corrupted object was applied silently. It now closes the decoder with page-index retention off (verified, not retained, so no database-sized map) and fails the apply when verification fails. Pages are applied as they stream, so a failure means the hydration file holds unverified content; the error is surfaced for that reason rather than hidden.
- Reuses the page buffer across the loop instead of allocating one per page.
- Adds `SetLogger` to the vfs test mocks: the `-tags vfs` root test suite had drifted from the `ReplicaClient` interface and did not compile (it is not run in CI, only `cmd/litestream-vfs` is). With that fixed, the whole vfs-tagged root suite passes again.

## Test plan

- [x] `TestHydrator_ApplyLTX_VerifiesFile`: valid file applies; a flipped trailer checksum byte and a truncated index are both rejected
- [x] `go test -tags vfs ./` (full root suite, now compiling) green; `go test ./` green; `go vet -tags vfs ./` clean
