### PR TITLE
fix(replica): stop resumable readers reopening streams after close

### DIFF
--- a/compactor_test.go
+++ b/compactor_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -116,6 +118,50 @@ func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
 			t.Fatalf("compactor goroutine leaked: got %d, want <= %d", countCompactorPipeWriters(), before)
 		case <-ticker.C:
 		}
+	}
+}
+
+// TestCompactor_CompactDoesNotReopenSourcesAfterClose verifies that no source
+// stream is left open once Compact and its compaction goroutine have finished,
+// even when the destination write fails while the goroutine is still reading.
+//
+// Compact does not wait for the compaction goroutine before returning. When
+// WriteLTXFile fails first, Compact returns and closes every source stream
+// while the goroutine may still be reading them. Each subsequent read then
+// fails, which the resumable reader treats as a transient connection failure:
+// it reopens the source from the current offset and keeps going until the
+// goroutine finally hits the closed pipe. Nothing ever closes those reopened
+// streams. Against an S3 replica each one pins an HTTP response body, so a
+// wedged compaction leaks one connection per source file on every attempt.
+func TestCompactor_CompactDoesNotReopenSourcesAfterClose(t *testing.T) {
+	client := newLeakCheckCompactionClient(t.TempDir())
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
+	createTestLTXFile(t, client, 0, 3, 3)
+	client.failWrites = true
+
+	if _, err := compactor.Compact(context.Background(), 1); err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Compact has returned and closed the streams it opened. Wait for the
+	// detached compaction goroutine to finish before checking for leaks.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for countCompactorPipeWriters() > 0 {
+		select {
+		case <-deadline.C:
+			t.Fatal("compactor goroutine did not exit")
+		case <-ticker.C:
+		}
+	}
+
+	if total, open, labels := client.streamStats(); open > 0 {
+		t.Fatalf("%d of %d source streams still open after Compact: %v", open, total, labels)
 	}
 }
 
@@ -730,6 +776,122 @@ func (r *disconnectingReadCloser) Read(p []byte) (int, error) {
 		return n, io.EOF
 	}
 	return n, nil
+}
+
+// leakCheckCompactionClient tracks every stream opened via OpenLTXFile and
+// whether it was closed. The first read of the first source stream parks until
+// that stream is closed, holding the compaction goroutine inside a source read
+// while WriteLTXFile fails. This pins down the ordering seen in production
+// when an upload to a remote replica fails mid-compaction.
+type leakCheckCompactionClient struct {
+	litestream.ReplicaClient
+	failWrites bool
+	parked     chan struct{} // closed once a source read is parked
+
+	mu      sync.Mutex
+	gated   bool // whether the parking stream has been handed out
+	streams []*leakCheckStream
+}
+
+func newLeakCheckCompactionClient(path string) *leakCheckCompactionClient {
+	return &leakCheckCompactionClient{
+		ReplicaClient: file.NewReplicaClient(path),
+		parked:        make(chan struct{}),
+	}
+}
+
+func (c *leakCheckCompactionClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	rc, err := c.ReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := &leakCheckStream{
+		rc:    rc,
+		label: fmt.Sprintf("level=%d txid=%s-%s offset=%d", level, minTXID, maxTXID, offset),
+		done:  make(chan struct{}),
+	}
+	if !c.gated {
+		c.gated = true
+		s.parked = c.parked
+	}
+	c.streams = append(c.streams, s)
+	return s, nil
+}
+
+func (c *leakCheckCompactionClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if !c.failWrites {
+		return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+	}
+
+	// Fail the upload only once the compaction goroutine is inside a read of
+	// its first source stream.
+	select {
+	case <-c.parked:
+	case <-time.After(5 * time.Second):
+		return nil, fmt.Errorf("timeout waiting for compaction goroutine to park")
+	}
+	return nil, fmt.Errorf("simulated upload failure")
+}
+
+func (c *leakCheckCompactionClient) streamStats() (total, open int, labels []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.streams {
+		total++
+		if !s.isClosed() {
+			open++
+			labels = append(labels, s.label)
+		}
+	}
+	return total, open, labels
+}
+
+type leakCheckStream struct {
+	rc     io.ReadCloser
+	label  string
+	parked chan struct{} // if non-nil, the first read parks until close
+	once   sync.Once
+	done   chan struct{} // closed when the stream is closed
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func (s *leakCheckStream) Read(p []byte) (int, error) {
+	if s.parked != nil {
+		s.once.Do(func() { close(s.parked) })
+		<-s.done
+	}
+
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return 0, os.ErrClosed
+	}
+	return s.rc.Read(p)
+}
+
+func (s *leakCheckStream) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	close(s.done)
+	return s.rc.Close()
+}
+
+func (s *leakCheckStream) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
 }
 
 func countCompactorPipeWriters() int {

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/superfly/ltx"
@@ -44,10 +45,17 @@ type ResumableReader struct {
 	maxTXID ltx.TXID
 	size    int64 // expected total file size from FileInfo; 0 means unknown
 	offset  int64
-	rc      io.ReadCloser
 	retryN  int
 	err     error
 	logger  *slog.Logger
+
+	// mu guards rc and closed. Close may be called from a different goroutine
+	// than Read: Compactor.Compact closes its source readers when it returns
+	// while its compaction goroutine may still be reading them. Once closed is
+	// set, Read must not reopen the stream or it would leak the new connection.
+	mu     sync.Mutex
+	rc     io.ReadCloser
+	closed bool
 }
 
 // NewResumableReader creates a ResumableReader. Primarily exposed for testing.
@@ -77,10 +85,15 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 	}
 
 	for {
+		rc, err := r.stream()
+		if err != nil {
+			return 0, err
+		}
+
 		// Reopen the stream from the current offset if the previous
-		// connection was closed (rc is nil after a retry).
-		if r.rc == nil {
-			rc, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
+		// connection was closed (the stream is nil after a retry).
+		if rc == nil {
+			newRC, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || r.ctx.Err() != nil {
 					return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
@@ -93,10 +106,15 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 					"offset", r.offset, "error", err, "attempt", r.retryN)
 				continue
 			}
-			r.rc = rc
+			if !r.setStream(newRC) {
+				// Closed while the stream was being reopened.
+				_ = newRC.Close()
+				return 0, os.ErrClosed
+			}
+			rc = newRC
 		}
 
-		n, err := r.rc.Read(p)
+		n, err := rc.Read(p)
 		r.offset += int64(n)
 
 		if err == nil {
@@ -111,8 +129,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 				r.logger.Debug("premature EOF on ltx file, reconnecting",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 					"offset", r.offset, "size", r.size, "attempt", r.retryN+1)
-				r.close()
-				r.rc = nil
+				r.dropStream()
 				if retryErr := r.retry(io.ErrUnexpectedEOF); retryErr != nil {
 					return n, retryErr
 				}
@@ -131,8 +148,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		r.logger.Debug("read error on ltx file, reconnecting",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"error", err, "offset", r.offset, "attempt", r.retryN+1)
-		r.close()
-		r.rc = nil
+		r.dropStream()
 		if retryErr := r.retry(err); retryErr != nil {
 			return n, retryErr
 		}
@@ -142,17 +158,64 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 	}
 }
 
+// Close closes the current underlying stream, if any, and marks the reader as
+// closed. Closing is permanent: subsequent reads fail with os.ErrClosed rather
+// than reopening the remote stream, which would leak the new connection.
 func (r *ResumableReader) Close() error {
-	if r.rc != nil {
-		return r.rc.Close()
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	rc := r.rc
+	r.rc = nil
+	r.mu.Unlock()
+
+	if rc != nil {
+		return rc.Close()
 	}
 	return nil
 }
 
-func (r *ResumableReader) close() {
-	// The stream is already being discarded after a read failure, so a close
-	// error should not stop recovery. Log it only to aid debugging.
-	if err := r.rc.Close(); err != nil {
+// stream returns the current underlying stream, or nil if the next read should
+// reopen it. Returns os.ErrClosed if the reader has been closed.
+func (r *ResumableReader) stream() (io.ReadCloser, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil, os.ErrClosed
+	}
+	return r.rc, nil
+}
+
+// setStream installs a newly reopened stream. It reports false if the reader
+// was closed while the stream was being opened, in which case the caller must
+// close the new stream itself.
+func (r *ResumableReader) setStream(rc io.ReadCloser) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	r.rc = rc
+	return true
+}
+
+// dropStream closes and clears the current stream after a read failure so the
+// next read reopens from the current offset. The stream is already being
+// discarded, so a close error should not stop recovery. Log it only to aid
+// debugging.
+func (r *ResumableReader) dropStream() {
+	r.mu.Lock()
+	rc := r.rc
+	r.rc = nil
+	r.mu.Unlock()
+
+	if rc == nil {
+		return
+	}
+	if err := rc.Close(); err != nil {
 		r.logger.Debug("close ltx file",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"offset", r.offset, "error", err)

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -80,14 +80,13 @@ const resumableReaderMaxRetries = 3
 const resumableReaderBackoff = 250 * time.Millisecond
 
 func (r *ResumableReader) Read(p []byte) (int, error) {
-	if r.err != nil {
-		return 0, r.err
-	}
-
 	for {
 		rc, err := r.stream()
 		if err != nil {
 			return 0, err
+		}
+		if r.err != nil {
+			return 0, r.err
 		}
 
 		// Reopen the stream from the current offset if the previous

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -179,6 +180,12 @@ func TestResumableReader(t *testing.T) {
 		if !strings.Contains(err.Error(), "max retries exceeded") {
 			t.Fatalf("expected 'max retries exceeded' error, got: %v", err)
 		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := r.Read(buf); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("read after close returned %v, want os.ErrClosed", err)
+		}
 	})
 
 	t.Run("ReopenFailure", func(t *testing.T) {
@@ -271,6 +278,64 @@ func TestResumableReader(t *testing.T) {
 	})
 }
 
+func TestResumableReader_CloseWhileReopening(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	openStarted := make(chan struct{})
+	continueOpen := make(chan struct{})
+	stream := &closeTrackingReadCloser{Reader: bytes.NewReader(nil)}
+	var openN atomic.Int64
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			if openN.Add(1) == 1 {
+				close(openStarted)
+			}
+			select {
+			case <-continueOpen:
+				return stream, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+	r := NewResumableReader(ctx, client, 0, 1, 1, 1, nil, slog.Default())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		errCh <- err
+	}()
+
+	select {
+	case <-openStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reopen")
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	close(continueOpen)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("read returned %v, want os.ErrClosed", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for read")
+	}
+	if !stream.closed.Load() {
+		t.Fatal("reopened stream was not closed")
+	}
+	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("read after close returned %v, want os.ErrClosed", err)
+	}
+	if got := openN.Load(); got != 1 {
+		t.Fatalf("OpenLTXFile() count=%d, want 1", got)
+	}
+}
+
 func TestResumableReader_BoundsConnectionsAcrossPartialReads(t *testing.T) {
 	data := []byte("0123456789abcdef")
 	var connectionN atomic.Int64
@@ -339,6 +404,16 @@ type testLTXFileOpener struct {
 
 func (t *testLTXFileOpener) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
 	return t.OpenLTXFileFunc(ctx, level, minTXID, maxTXID, offset, size)
+}
+
+type closeTrackingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (r *closeTrackingReadCloser) Close() error {
+	r.closed.Store(true)
+	return nil
 }
 
 // errorAfterN is a reader that returns data normally for the first n bytes,


### PR DESCRIPTION
## Summary

Makes `internal.ResumableReader.Close` sticky so source streams can no longer be reopened, and therefore leaked, by the detached compaction goroutine after `Compactor.Compact` has returned and closed them. Adds a regression test that fails on the previous code.

Fixes #1492

## Problem

`Compactor.Compact` (compactor.go:158-172) does not wait for its compaction goroutine before returning. When `WriteLTXFile` fails while that goroutine is still reading source files, `Compact` returns and its defer (compactor.go:120-126) closes every source stream, but the goroutine keeps reading. Each read on a closed stream fails, which `ResumableReader` treated as a transient connection failure: it reopened the stream from the current offset (internal/resumable_reader.go, reopen path in `Read`) and kept going until it finally hit the closed pipe. Nothing ever closed those reopened streams. `Close` only closed the current body and did not mark the reader closed, so nothing stopped the reopen.

Evidence, detailed in #1492:

- The new test on the previous code fails with `3 of 6 source streams still open after Compact`: three streams opened, closed by the defer, then all three reopened by the detached goroutine and leaked.
- Reproduced identically on v0.5.15, v0.5.16, and main (25ac743).
- Production observation on a host replicating a low write SQLite database to Cloudflare R2 with a wedged L1 compaction: sustained fd growth (~460 fds per minute), CLOSE_WAIT accumulation, ~28,000 fds and 2.5 GB RSS at peak, repeated OOM kills.
- Verified the other ordering is already correct: when the compaction goroutine fails first (for example a corrupt source file), the existing defer closes everything and nothing leaks, so this PR does not touch `Compact` itself.

## Solution

- Guard `ResumableReader`'s underlying stream with a mutex and add a `closed` flag. `Close` may be called from a different goroutine than `Read` (Compact's cleanup vs its compaction goroutine), and previously those accesses to `rc` were unsynchronized.
- After `Close`, reads fail with `os.ErrClosed` and the reader never reopens the remote stream. If a reopen is in flight when `Close` lands, the freshly opened stream is closed immediately.
- Side benefit: the detached compaction goroutine now exits on its next source read instead of resurrecting and reading every remaining input against a dead pipe.
- Behavior while the reader is live (resume on disconnect, premature EOF handling, bounded retries from #1360) is unchanged; the existing `internal` tests still pass.

## Scope

**In scope:**

- `internal/resumable_reader.go`: sticky, concurrency safe `Close`; no reopen after close.
- `compactor_test.go`: regression test `TestCompactor_CompactDoesNotReopenSourcesAfterClose` plus its close tracking fake replica client.

**Not in scope:**

- Making `Compact` join its compaction goroutine before returning.
- The wedged compaction scenario itself (a corrupt L0 file failing every attempt while the L0 backlog grows); that trigger is what made this leak fatal in production but is a separate issue.

## Test Plan

```bash
# Regression test (fails before this change, passes after)
go test -race -run TestCompactor_CompactDoesNotReopenSourcesAfterClose -v .

# Resumable reader behavior unchanged
go test -race ./internal/

# Full suite
go test -race ./...

# Soak gate per CONTRIBUTING.md (compaction is core replication)
go build -o bin/litestream ./cmd/litestream
go build -o bin/litestream-test ./cmd/litestream-test
go test -tags 'integration,soak' -run 'TestLTXBehavior$' -short -timeout 25m -v ./tests/integration/
```

All of the above pass on this branch (macOS, Go 1.27). The soak gate passes with all profiles green (`TestLTXBehavior` 506s: low-volume, high-volume, burst-volume, including restoration and integrity checks). Note the explicit `-timeout 25m`: the short mode suite needs a bit over 10 minutes, so go test's default 10m timeout kills it before the last profile otherwise. Before the fix, the regression test fails with:

```text
3 of 6 source streams still open after Compact: [level=0 txid=0000000000000001-0000000000000001 offset=0 ...]
```

`go vet ./...`, `gofmt`, and `goimports -local github.com/benbjohnson/litestream` are clean on the changed files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)

## Related

- Fixes #1492
- Distinct from #1354 / #1360 (bounded retries inside a live reader); verified on v0.5.16 that the fix there does not cover this leak
- Background: #1308 / #1326 introduced resumable source reads in compaction; #1467 describes the large backlog conditions that make the failure ordering here likely

## AI assistance disclosure

Investigated and drafted with AI assistance (Claude, per AI_PR_GUIDE.md), including the production investigation, the repro test, and the fix. Reviewed and submitted by a human account owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
