### PR TITLE
fix: prevent metric counter panics on clock regressions

### DIFF
--- a/db.go
+++ b/db.go
@@ -1257,6 +1257,14 @@ func (db *DB) lockExec(ctx context.Context) error {
 	return nil
 }
 
+// addDurationToCounter records positive durations without allowing a clock
+// adjustment to panic a Prometheus counter.
+func addDurationToCounter(counter prometheus.Counter, d time.Duration) {
+	if d > 0 {
+		counter.Add(d.Seconds())
+	}
+}
+
 func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syncResult, err error) {
 	db.beginSyncDiag(diagOpSync)
 	defer func() { db.finishSyncDiag(err) }()
@@ -1273,7 +1281,7 @@ func (db *DB) syncLocked(ctx context.Context, maxSyncWALBytes int64) (result syn
 		} else {
 			db.diskFullGauge.Set(0)
 		}
-		db.syncSecondsCounter.Add(float64(time.Since(t).Seconds()))
+		addDurationToCounter(db.syncSecondsCounter, time.Since(t))
 	}()
 
 	exec, err := db.newSyncExecutor(ctx)
@@ -2647,7 +2655,7 @@ func (db *DB) execCheckpoint(ctx context.Context, mode string) (walFrameN int, e
 		if err != nil {
 			db.checkpointErrorNCounterVec.With(labels).Inc()
 		}
-		db.checkpointSecondsCounterVec.With(labels).Add(float64(time.Since(t).Seconds()))
+		addDurationToCounter(db.checkpointSecondsCounterVec.With(labels), time.Since(t))
 	}()
 
 	// Ensure the read lock has been removed before issuing a checkpoint.

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/semaphore"
@@ -1110,6 +1111,35 @@ func TestCalcWALSize(t *testing.T) {
 					t.Errorf("calcWALSize(%d, %d) = %d (%.2f GB), suspiciously small, possible overflow",
 						tt.pageSize, tt.pageN, got, float64(got)/(1024*1024*1024))
 				}
+			}
+		})
+	}
+}
+
+// TestAddDurationToCounter ignores negative durations because Prometheus
+// counters cannot decrease. Negative durations can occur when the system clock
+// moves backwards between the start and end of an operation.
+func TestAddDurationToCounter(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     float64
+	}{
+		{name: "positive", duration: 1500 * time.Millisecond, want: 1.5},
+		{name: "zero", duration: 0, want: 0},
+		{name: "negative", duration: -500 * time.Millisecond, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := prometheus.NewCounter(prometheus.CounterOpts{
+				Name: "test_duration_seconds",
+				Help: "Test duration counter.",
+			})
+			addDurationToCounter(counter, tt.duration)
+
+			if got := testutil.ToFloat64(counter); got != tt.want {
+				t.Fatalf("counter value=%v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Prevent clock regressions from crashing Litestream when elapsed-time metrics are recorded in Prometheus counters.

## Problem
Issue #1488 reports that `DB.syncLocked` passes `time.Since(t).Seconds()` directly to `prometheus.Counter.Add`. If the monotonic clock regresses, the duration is negative and the Prometheus client panics with `counter cannot decrease in value`, terminating replication.

The same duration-to-counter pattern is also present in `DB.execCheckpoint`, so it is covered by the same guard.

## Solution
- Add `addDurationToCounter`, which records only positive durations and ignores zero or negative durations.
- Use the helper for both sync and checkpoint elapsed-time counters.
- Add a table-driven regression test covering positive, zero, and negative durations. The negative case verifies that no panic occurs and the counter remains unchanged.

## Scope
**In scope:**
- Hardening sync and checkpoint duration metrics against clock regressions.
- Regression coverage for the counter update behavior.

**Not in scope:**
- Changing the system clock or Litestream's timing behavior.
- Changing non-counter duration reporting or unrelated metrics.

## Test Plan
Passed:

```bash
go test -run '^TestAddDurationToCounter$' .
go test -run '^TestAddDurationToCounter$' ./...
go vet ./...
git diff --check
```

The full `go test ./... -count=1` run was attempted. On this Windows environment, existing database/integration tests fail while syncing a directory with `Access is denied` (for example, `tests/integration/TestCompaction_Compatibility`); the focused regression test passes. `go test -race` could not start because the environment has no C compiler (`gcc`).

## Related
- Fixes #1488
