### PR TITLE
perf(restore): drop unused page index map on restore decode paths

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -594,6 +594,16 @@ func (r *Replica) CalcRestoreTarget(ctx context.Context, opt RestoreOptions) (up
 	return updatedAt, nil
 }
 
+// newRestoreDecoder returns an LTX decoder for paths that materialize a
+// database file and never read the decoder's page index. Retaining the index
+// would build a map with one entry per page, which dominates peak memory when
+// restoring large databases (#1486). Close still validates the index either way.
+func newRestoreDecoder(r io.Reader) *ltx.Decoder {
+	dec := ltx.NewDecoder(r)
+	dec.SetRetainPageIndex(false)
+	return dec
+}
+
 // Replica restores the database from a replica based on the options given.
 // This method will restore into opt.OutputPath, if specified, or into the
 // DB's original database path. It can optionally restore from a specific
@@ -748,7 +758,7 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 		_ = pw.CloseWithError(c.Compact(ctx))
 	}()
 
-	dec := ltx.NewDecoder(pr)
+	dec := newRestoreDecoder(pr)
 	if err := dec.DecodeDatabaseTo(f); err != nil {
 		return fmt.Errorf("decode database: %w", err)
 	}
@@ -951,7 +961,7 @@ func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileIn
 	}
 	defer rc.Close()
 
-	dec := ltx.NewDecoder(rc)
+	dec := newRestoreDecoder(rc)
 	if err := dec.DecodeHeader(); err != nil {
 		return fmt.Errorf("decode header: %w", err)
 	}

--- a/replica.go
+++ b/replica.go
@@ -604,6 +604,19 @@ func newRestoreDecoder(r io.Reader) *ltx.Decoder {
 	return dec
 }
 
+// newRestoreCompactor returns an LTX compactor for restore paths. Its output
+// page index spills into spillDir past the encoder's threshold, so compacting
+// a large database does not hold a per-page index in memory either (#1486).
+func newRestoreCompactor(w io.Writer, rdrs []io.Reader, spillDir string) (*ltx.Compactor, error) {
+	c, err := ltx.NewCompactor(w, rdrs)
+	if err != nil {
+		return nil, err
+	}
+	c.HeaderFlags = ltx.HeaderFlagNoChecksum
+	c.SetSpillDir(spillDir)
+	return c, nil
+}
+
 // Replica restores the database from a replica based on the options given.
 // This method will restore into opt.OutputPath, if specified, or into the
 // DB's original database path. It can optionally restore from a specific
@@ -748,13 +761,12 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	pr, pw := io.Pipe()
 
 	go func() {
-		c, err := ltx.NewCompactor(pw, rdrs)
+		c, err := newRestoreCompactor(pw, rdrs, filepath.Dir(tmpOutputPath))
 		if err != nil {
 			pw.CloseWithError(fmt.Errorf("new ltx compactor: %w", err))
 			return
 		}
 		defer func() { _ = c.Cleanup() }()
-		c.HeaderFlags = ltx.HeaderFlagNoChecksum
 		_ = pw.CloseWithError(c.Compact(ctx))
 	}()
 

--- a/replica.go
+++ b/replica.go
@@ -771,7 +771,9 @@ func (r *Replica) Restore(ctx context.Context, opt RestoreOptions) (err error) {
 	}()
 
 	dec := newRestoreDecoder(pr)
-	if err := dec.DecodeDatabaseTo(f); err != nil {
+	err = dec.DecodeDatabaseTo(f)
+	_ = pr.CloseWithError(err)
+	if err != nil {
 		return fmt.Errorf("decode database: %w", err)
 	}
 

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -689,3 +689,48 @@ func mustBuildChecksummedSnapshotLTX(tb testing.TB, pageSize uint32, pages [][]b
 
 	return buf.Bytes()
 }
+
+func TestNewRestoreCompactor(t *testing.T) {
+	const pageSize = 4096
+	pages := [][]byte{
+		newSQLiteHeaderPage(pageSize),
+		bytes.Repeat([]byte{0xE5}, pageSize),
+	}
+	snapshot := mustBuildSnapshotLTX(t, 1, 1, pageSize, pages)
+	update := mustBuildIncrementalLTX(t, 2, 2, pageSize, 2, 0xF6)
+
+	spillDir := t.TempDir()
+	pr, pw := io.Pipe()
+	c, err := newRestoreCompactor(pw, []io.Reader{bytes.NewReader(snapshot), bytes.NewReader(update)}, spillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Cleanup() }()
+
+	go func() {
+		_ = pw.CloseWithError(c.Compact(context.Background()))
+	}()
+
+	dec := newRestoreDecoder(pr)
+	var db bytes.Buffer
+	if err := dec.DecodeDatabaseTo(&db); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := db.Len(), len(pages)*pageSize; got != want {
+		t.Fatalf("decoded database size=%d, want %d", got, want)
+	}
+	if !bytes.Equal(db.Bytes()[pageSize:], bytes.Repeat([]byte{0xF6}, pageSize)) {
+		t.Fatal("page 2 does not contain compacted update")
+	}
+
+	if err := c.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	ents, err := os.ReadDir(spillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("spill dir not empty after cleanup: %d entries", len(ents))
+	}
+}

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -543,3 +543,52 @@ func TestApplyLTXFile_MultiplePages(t *testing.T) {
 		}
 	}
 }
+
+func TestNewRestoreDecoder(t *testing.T) {
+	const pageSize = 4096
+	pages := [][]byte{
+		newSQLiteHeaderPage(pageSize),
+		bytes.Repeat([]byte{0xC3}, pageSize),
+		bytes.Repeat([]byte{0xD4}, pageSize),
+	}
+	data := mustBuildSnapshotLTX(t, 1, 5, pageSize, pages)
+
+	t.Run("DoesNotRetainPageIndex", func(t *testing.T) {
+		dec := newRestoreDecoder(bytes.NewReader(data))
+		var db bytes.Buffer
+		if err := dec.DecodeDatabaseTo(&db); err != nil {
+			t.Fatal(err)
+		}
+		if dec.PageIndex() != nil {
+			t.Fatalf("expected nil page index, got %d entries", len(dec.PageIndex()))
+		}
+		if got, want := db.Len(), len(pages)*pageSize; got != want {
+			t.Fatalf("decoded database size=%d, want %d", got, want)
+		}
+		for i, page := range pages {
+			if got := db.Bytes()[i*pageSize : (i+1)*pageSize]; !bytes.Equal(got, page) {
+				t.Fatalf("page %d data mismatch", i+1)
+			}
+		}
+	})
+
+	t.Run("DefaultDecoderRetainsPageIndex", func(t *testing.T) {
+		dec := ltx.NewDecoder(bytes.NewReader(data))
+		var db bytes.Buffer
+		if err := dec.DecodeDatabaseTo(&db); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(dec.PageIndex()), len(pages); got != want {
+			t.Fatalf("page index entries=%d, want %d", got, want)
+		}
+	})
+
+	t.Run("StillValidatesCorruptPageIndex", func(t *testing.T) {
+		corrupt := bytes.Clone(data)
+		corrupt[len(corrupt)-ltx.TrailerSize-1] ^= 0xFF
+		dec := newRestoreDecoder(bytes.NewReader(corrupt))
+		if err := dec.DecodeDatabaseTo(io.Discard); err == nil {
+			t.Fatal("expected error decoding LTX file with corrupt page index")
+		}
+	})
+}

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -734,3 +734,52 @@ func TestNewRestoreCompactor(t *testing.T) {
 		t.Fatalf("spill dir not empty after cleanup: %d entries", len(ents))
 	}
 }
+
+func TestNewRestoreCompactor_ConsumerAbort(t *testing.T) {
+	const pageSize = 4096
+	pages := [][]byte{
+		newSQLiteHeaderPage(pageSize),
+		bytes.Repeat([]byte{0xA7}, pageSize),
+	}
+	snapshot := mustBuildSnapshotLTX(t, 1, 1, pageSize, pages)
+
+	spillDir := t.TempDir()
+	pr, pw := io.Pipe()
+	c, err := newRestoreCompactor(pw, []io.Reader{bytes.NewReader(snapshot)}, spillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		err := c.Compact(context.Background())
+		_ = pw.CloseWithError(err)
+		done <- err
+	}()
+
+	hdr := make([]byte, ltx.HeaderSize)
+	if _, err := io.ReadFull(pr, hdr); err != nil {
+		t.Fatal(err)
+	}
+	_ = pr.CloseWithError(errors.New("consumer aborted"))
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected compact error after consumer abort")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("compactor still blocked after pipe reader closed")
+	}
+
+	if err := c.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	ents, err := os.ReadDir(spillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("spill dir not empty after cleanup: %d entries", len(ents))
+	}
+}

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -591,4 +592,100 @@ func TestNewRestoreDecoder(t *testing.T) {
 			t.Fatal("expected error decoding LTX file with corrupt page index")
 		}
 	})
+
+	// Overwrite the first index entry's page number so the index no longer
+	// matches the decoded pages. This is rejected by the structural index
+	// validation in Close, which runs before any checksum comparison, so a
+	// pass here proves validation is not skipped when retention is off.
+	t.Run("StillValidatesIndexStructure", func(t *testing.T) {
+		sizeField := binary.BigEndian.Uint64(data[len(data)-ltx.TrailerSize-8:])
+		indexStart := len(data) - ltx.TrailerSize - 8 - int(sizeField)
+		if got := data[indexStart]; got != 0x01 {
+			t.Fatalf("expected first index entry pgno varint 0x01 at offset %d, got %#x", indexStart, got)
+		}
+
+		corrupt := bytes.Clone(data)
+		corrupt[indexStart] = 0x03
+
+		dec := newRestoreDecoder(bytes.NewReader(corrupt))
+		err := dec.DecodeDatabaseTo(io.Discard)
+		if err == nil {
+			t.Fatal("expected error decoding LTX file with out-of-order page index")
+		}
+		if !strings.Contains(err.Error(), "page index") {
+			t.Fatalf("expected structural page index error, got: %v", err)
+		}
+
+		retainDec := ltx.NewDecoder(bytes.NewReader(corrupt))
+		retainErr := retainDec.DecodeDatabaseTo(io.Discard)
+		if retainErr == nil {
+			t.Fatal("expected error from retaining decoder on same corrupt input")
+		}
+		if err.Error() != retainErr.Error() {
+			t.Fatalf("validation parity broken: retain=false err %q, retain=true err %q", err, retainErr)
+		}
+	})
+
+	t.Run("StillValidatesPostApplyChecksum", func(t *testing.T) {
+		valid := mustBuildChecksummedSnapshotLTX(t, pageSize, pages, 0)
+		dec := newRestoreDecoder(bytes.NewReader(valid))
+		var db bytes.Buffer
+		if err := dec.DecodeDatabaseTo(&db); err != nil {
+			t.Fatal(err)
+		}
+		if dec.PageIndex() != nil {
+			t.Fatal("expected nil page index for checksummed snapshot")
+		}
+
+		invalid := mustBuildChecksummedSnapshotLTX(t, pageSize, pages, 1<<1)
+		dec = newRestoreDecoder(bytes.NewReader(invalid))
+		err := dec.DecodeDatabaseTo(io.Discard)
+		if err == nil {
+			t.Fatal("expected error decoding snapshot with wrong post-apply checksum")
+		}
+		if !strings.Contains(err.Error(), "post-apply checksum") {
+			t.Fatalf("expected post-apply checksum error, got: %v", err)
+		}
+	})
+}
+
+// mustBuildChecksummedSnapshotLTX encodes a snapshot LTX file with checksum
+// tracking enabled, XORing xor into the post-apply checksum so callers can
+// produce an otherwise-valid file whose post-apply checksum is wrong.
+func mustBuildChecksummedSnapshotLTX(tb testing.TB, pageSize uint32, pages [][]byte, xor uint64) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	hdr := ltx.Header{
+		Version:   ltx.Version,
+		PageSize:  pageSize,
+		Commit:    uint32(len(pages)),
+		MinTXID:   1,
+		MaxTXID:   1,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	if err := enc.EncodeHeader(hdr); err != nil {
+		tb.Fatal(err)
+	}
+
+	chksum := ltx.ChecksumFlag
+	for i, page := range pages {
+		pgno := uint32(i + 1)
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, page); err != nil {
+			tb.Fatal(err)
+		}
+		chksum = ltx.ChecksumFlag | (chksum ^ ltx.ChecksumPage(pgno, page))
+	}
+
+	enc.SetPostApplyChecksum(ltx.ChecksumFlag | (chksum ^ ltx.Checksum(xor)))
+	if err := enc.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	return buf.Bytes()
 }

--- a/vfs.go
+++ b/vfs.go
@@ -799,7 +799,7 @@ func (h *Hydrator) Restore(ctx context.Context, infos []*ltx.FileInfo) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	dec := ltx.NewDecoder(pr)
+	dec := newRestoreDecoder(pr)
 	if err := dec.DecodeDatabaseTo(h.file); err != nil {
 		return fmt.Errorf("decode database: %w", err)
 	}

--- a/vfs.go
+++ b/vfs.go
@@ -791,16 +791,24 @@ func (h *Hydrator) Restore(ctx context.Context, infos []*ltx.FileInfo) error {
 	defer func() { _ = c.Cleanup() }()
 	h.compactor = c
 
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		_ = pw.CloseWithError(c.Compact(ctx))
 	}()
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	// Close the pipe reader on failure so the compactor goroutine cannot stay
+	// blocked in a pipe write, then wait for it to finish so the deferred
+	// Cleanup never runs concurrently with Compact.
 	dec := newRestoreDecoder(pr)
-	if err := dec.DecodeDatabaseTo(h.file); err != nil {
-		return fmt.Errorf("decode database: %w", err)
+	decodeErr := dec.DecodeDatabaseTo(h.file)
+	_ = pr.CloseWithError(decodeErr)
+	<-done
+	if decodeErr != nil {
+		return fmt.Errorf("decode database: %w", decodeErr)
 	}
 
 	h.txid = infos[len(infos)-1].MaxTXID

--- a/vfs.go
+++ b/vfs.go
@@ -784,12 +784,11 @@ func (h *Hydrator) Restore(ctx context.Context, infos []*ltx.FileInfo) error {
 
 	// Compact and decode using io.Pipe pattern
 	pr, pw := io.Pipe()
-	c, err := ltx.NewCompactor(pw, rdrs)
+	c, err := newRestoreCompactor(pw, rdrs, filepath.Dir(h.path))
 	if err != nil {
 		return fmt.Errorf("new ltx compactor: %w", err)
 	}
 	defer func() { _ = c.Cleanup() }()
-	c.HeaderFlags = ltx.HeaderFlagNoChecksum
 	h.compactor = c
 
 	go func() {


### PR DESCRIPTION
## Description

Adds two unexported helpers and wires them into the restore paths:

- `newRestoreDecoder` calls `ltx.Decoder.SetRetainPageIndex(false)` so `Close()` validates but does not materialize the per-page index map.
- `newRestoreCompactor` sets the restore header flags and enables output page-index spilling via `ltx.Compactor.SetSpillDir`, used by `Replica.Restore` (spills to the restore output directory) and the VFS `Hydrator` (spills to the hydration file's directory).

`newRestoreDecoder` is used on the three decode paths that materialize a database file and never read the decoder's page index:

- `Replica.Restore` (`replica.go`) — the restore path from #1486
- `Replica.applyLTXFile` (`replica.go`) — follow-mode LTX application, which also calls `Close()`
- `Hydrator` hydration (`vfs.go`) — same compactor-into-`DecodeDatabaseTo` pattern

The other six `ltx.NewDecoder` call sites were audited and left unchanged: `db.go:1704`, `db.go:2795`, `vfs.go` `readPageSizeFromInfo`, and `Hydrator.ApplyLTX` decode only the header (or never call `Close()`), so no index is ever built there; `db.go` `Pos()` uses `Verify()` on a single small L0 file and is out of scope for this change.

## Motivation and Context

Fixes #1486 — with #1483, which this PR is based on and depends on.

Full credit to @darkgnotic for the diagnosis: the issue includes the exact call path, both allocations, and an RSS graph showing a ~124 GB restore flat at ~8 GB until the final instant, then OOM-killed past 20 GB.

`Decoder.Close()` in ltx had two per-database costs on the restore path, both wasted because `DecodeDatabaseTo` never reads `dec.PageIndex()`:

1. `io.ReadAll(dec.r)` slurping the whole trailing page-index block into one `[]byte`.
2. `DecodePageIndex(...)` building a `map[uint32]PageIndexElem` with one entry per page (~2.5 GB at ~30M pages).

The split between the two PRs: the ltx bump in #1483 (`v0.5.3-0.20260828134549`) removes cost 1 by streaming the index instead of slurping it, and adds the `SetRetainPageIndex` opt-out — but nothing in litestream called it, so the map (cost 2) was still built. This PR wires up the opt-out. **Neither PR alone fully closes #1486**; this one completes it.

Correctness note: with retention off, `Decoder.Close()` in the pinned ltx version still streams, checksums, and validates the page index (entry ordering, overlap, entry count vs. decoded pages, page-sequence hash, file checksum, post-apply checksum) — it only skips materializing the map, and `PageIndex()` returns nil.

Adversarial review also flagged the last per-database allocation on the restore pipe: the `ltx.Compactor`'s encoder kept its own output page index in memory (compact 24-byte entries, ~687 MiB at 30M pages) because the restore paths never called `SetSpillDir`, unlike store compaction (`compactor.go:173`) and snapshots (`db.go:2890`). This PR fixes that too via a `newRestoreCompactor` helper: `Replica.Restore` spills into the restore output directory and the VFS `Hydrator` into the hydration file's directory — both writable by construction, consistent with the spill-dir rationale from #1477 (hardened images may lack `/tmp`). The compactor's input decoders already disable retention upstream, so restore memory no longer scales with database page count anywhere in the pipe.

## How Has This Been Tested?

- New `TestNewRestoreDecoder` (written first, watched fail): asserts `PageIndex()` is nil after `DecodeDatabaseTo` with the helper while decoded bytes are intact, that the stock decoder still retains the index (guards against silently relying on an upstream default change), and that a corrupted page index still fails the decode with retention off (validation is not skipped).
- Hardened after adversarial review: an out-of-order index entry is rejected by structural validation (which runs before any checksum comparison) with identical errors in both retention modes, and a checksum-tracked snapshot with a wrong post-apply checksum fails with a post-apply checksum error — the `NoChecksum` fixture alone could not exercise that path.
- New `TestNewRestoreCompactor`: compacts a snapshot plus an incremental through the spill-configured helper into `DecodeDatabaseTo`, verifying the merged output and that the spill directory is left empty after cleanup. (Honest limitation: the fixture is far below the 1M-entry spill threshold, so actual spill mechanics are covered by ltx's own `encoder_spill_test.go`, not here — the compactor API does not expose the threshold.)
- New `TestNewRestoreCompactor_ConsumerAbort`: closes the pipe reader mid-stream and asserts `Compact` unblocks with an error and cleanup leaves the spill directory empty — the contract the error paths below rely on.

A second adversarial review pass on the spill commit found that neither restore path closed the pipe reader when `DecodeDatabaseTo` failed, leaving the compactor goroutine blocked in a pipe write with its deferred cleanup (and any active spill file) stranded. Fixed by closing the reader with the decode error, mirroring store compaction's `Compactor.compact`; the hydrator additionally waits for the compactor goroutine to exit so its caller-side `Cleanup` cannot run concurrently with `Compact`. That pass also confirmed the spill temp file (`.ltx-page-index-*.tmp` via `os.CreateTemp`) cannot collide with the restore temp output and is rejected by litestream's directory discovery, and flagged one pre-existing, unrelated data race (`h.compactor` written in `Restore` vs. read in `Status`) that predates this PR and is left untouched.
- `go build ./...` and `go build -tags vfs ./...`
- `go test -race -count=1 ./...` — green
- `go test -tags vfs -race -count=1 ./cmd/litestream-vfs/...` — compared against a baseline run at this PR's base commit (#1483 tip); failures match the pre-existing nondeterministic set (#1449) — see comparison in the PR discussion if needed
- `pre-commit run --all-files` — clean

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [ ] I have updated the documentation accordingly (if needed)

https://claude.ai/code/session_01JAbGJy6uwUcj87ZRJkVXnF
