### PR TITLE
test(db): stabilize delayed checkpoint

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1483,37 +1483,27 @@ func TestDB_DelayedCheckpointAfterWrite(t *testing.T) {
 	db, sqldb := testingutil.MustOpenDBs(t)
 	defer testingutil.MustCloseDBs(t, db, sqldb)
 
-	// Use a longer checkpoint interval so we can control when it triggers
-	db.CheckpointInterval = 100 * time.Millisecond
+	db.CheckpointInterval = time.Hour
 
-	// Create table and initial sync
 	if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)`); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Sync(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-
-	// Wait for interval to pass and sync to trigger initial checkpoint
-	time.Sleep(150 * time.Millisecond)
-	if err := db.Sync(t.Context()); err != nil {
+	if err := db.Checkpoint(t.Context(), litestream.CheckpointModePassive); err != nil {
 		t.Fatal(err)
 	}
 
-	// Record TXID after first checkpoint
 	posAfterFirstCheckpoint, err := db.Pos()
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("TXID after first checkpoint: %d", posAfterFirstCheckpoint.TXID)
 
-	// Insert data immediately (before interval elapses)
 	if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (data) VALUES ('delayed checkpoint test')`); err != nil {
 		t.Fatal(err)
 	}
-
-	// Sync immediately - this should NOT trigger a checkpoint (interval hasn't elapsed)
-	// but should set syncedSinceCheckpoint = true
 	if err := db.Sync(t.Context()); err != nil {
 		t.Fatal(err)
 	}
@@ -1523,26 +1513,32 @@ func TestDB_DelayedCheckpointAfterWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("TXID after insert+sync: %d", posAfterInsert.TXID)
-
-	// Now wait for the interval to pass and sync again (no new data)
-	time.Sleep(150 * time.Millisecond)
-	if err := db.Sync(t.Context()); err != nil {
-		t.Fatal(err)
+	if posAfterInsert.TXID <= posAfterFirstCheckpoint.TXID {
+		t.Fatalf("expected insert sync to advance TXID: checkpoint=%d insert=%d",
+			posAfterFirstCheckpoint.TXID, posAfterInsert.TXID)
 	}
 
-	// A checkpoint should have been triggered because syncedSinceCheckpoint was true
-	// The TXID should have advanced due to the checkpoint
-	posAfterDelayedCheckpoint, err := db.Pos()
-	if err != nil {
-		t.Fatal(err)
+	db.CheckpointInterval = time.Nanosecond
+	deadline := time.Now().Add(5 * time.Second)
+	posAfterDelayedCheckpoint := posAfterInsert
+	for {
+		if err := db.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		posAfterDelayedCheckpoint, err = db.Pos()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if posAfterDelayedCheckpoint.TXID > posAfterInsert.TXID {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for delayed checkpoint: insert=%d current=%d",
+				posAfterInsert.TXID, posAfterDelayedCheckpoint.TXID)
+		}
+		time.Sleep(time.Millisecond)
 	}
 	t.Logf("TXID after delayed checkpoint: %d", posAfterDelayedCheckpoint.TXID)
-
-	// The TXID should have advanced from the insert position, indicating the checkpoint ran
-	if posAfterDelayedCheckpoint.TXID <= posAfterInsert.TXID {
-		t.Fatalf("expected TXID to advance after delayed checkpoint (syncedSinceCheckpoint should persist), got insert=%d delayed=%d",
-			posAfterInsert.TXID, posAfterDelayedCheckpoint.TXID)
-	}
 }
 
 func TestDB_SyncStatus(t *testing.T) {


### PR DESCRIPTION
## Description
Rework the delayed-checkpoint regression test so it controls checkpoint eligibility explicitly and waits for TXID advancement with a bounded condition poll.

The test now verifies the write sync advances replication before enabling a later time-based checkpoint. Production checkpoint behavior is unchanged.

## Motivation and Context
The failed CI attempt showed the initial checkpoint's post-processing outliving the test's 100 ms interval. The supposedly immediate write sync therefore performed the checkpoint early (`insert=4`), leaving the later sync at the same TXID (`delayed=4`). The retry passed, confirming the runner-speed dependency.

**In scope:** deterministic checkpoint setup, eligibility control, bounded polling, and diagnostic timeout output.

**Out of scope:** production checkpoint logic and unrelated concurrent-write test logging.

Fixes #1495

## How Has This Been Tested?
```bash
go build ./...
go test ./...
go test -race ./...
go test -race . -run '^TestDB_DelayedCheckpointAfterWrite$' -count=30
pre-commit run --all-files
golangci-lint run --new-from-rev=origin/main
```

The original failure was also reproduced deterministically before the rewrite, yielding `insert=4 delayed=4`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
