### PR TITLE
fix(replica): reconcile resumable reader recovery

### DIFF
--- a/compactor_test.go
+++ b/compactor_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -116,6 +118,50 @@ func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
 			t.Fatalf("compactor goroutine leaked: got %d, want <= %d", countCompactorPipeWriters(), before)
 		case <-ticker.C:
 		}
+	}
+}
+
+// TestCompactor_CompactDoesNotReopenSourcesAfterClose verifies that no source
+// stream is left open once Compact and its compaction goroutine have finished,
+// even when the destination write fails while the goroutine is still reading.
+//
+// Compact does not wait for the compaction goroutine before returning. When
+// WriteLTXFile fails first, Compact returns and closes every source stream
+// while the goroutine may still be reading them. Each subsequent read then
+// fails, which the resumable reader treats as a transient connection failure:
+// it reopens the source from the current offset and keeps going until the
+// goroutine finally hits the closed pipe. Nothing ever closes those reopened
+// streams. Against an S3 replica each one pins an HTTP response body, so a
+// wedged compaction leaks one connection per source file on every attempt.
+func TestCompactor_CompactDoesNotReopenSourcesAfterClose(t *testing.T) {
+	client := newLeakCheckCompactionClient(t.TempDir())
+	compactor := litestream.NewCompactor(client, slog.Default())
+
+	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
+	createTestLTXFile(t, client, 0, 3, 3)
+	client.failWrites = true
+
+	if _, err := compactor.Compact(context.Background(), 1); err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Compact has returned and closed the streams it opened. Wait for the
+	// detached compaction goroutine to finish before checking for leaks.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for countCompactorPipeWriters() > 0 {
+		select {
+		case <-deadline.C:
+			t.Fatal("compactor goroutine did not exit")
+		case <-ticker.C:
+		}
+	}
+
+	if total, open, labels := client.streamStats(); open > 0 {
+		t.Fatalf("%d of %d source streams still open after Compact: %v", open, total, labels)
 	}
 }
 
@@ -730,6 +776,122 @@ func (r *disconnectingReadCloser) Read(p []byte) (int, error) {
 		return n, io.EOF
 	}
 	return n, nil
+}
+
+// leakCheckCompactionClient tracks every stream opened via OpenLTXFile and
+// whether it was closed. The first read of the first source stream parks until
+// that stream is closed, holding the compaction goroutine inside a source read
+// while WriteLTXFile fails. This pins down the ordering seen in production
+// when an upload to a remote replica fails mid-compaction.
+type leakCheckCompactionClient struct {
+	litestream.ReplicaClient
+	failWrites bool
+	parked     chan struct{} // closed once a source read is parked
+
+	mu      sync.Mutex
+	gated   bool // whether the parking stream has been handed out
+	streams []*leakCheckStream
+}
+
+func newLeakCheckCompactionClient(path string) *leakCheckCompactionClient {
+	return &leakCheckCompactionClient{
+		ReplicaClient: file.NewReplicaClient(path),
+		parked:        make(chan struct{}),
+	}
+}
+
+func (c *leakCheckCompactionClient) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+	rc, err := c.ReplicaClient.OpenLTXFile(ctx, level, minTXID, maxTXID, offset, size)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := &leakCheckStream{
+		rc:    rc,
+		label: fmt.Sprintf("level=%d txid=%s-%s offset=%d", level, minTXID, maxTXID, offset),
+		done:  make(chan struct{}),
+	}
+	if !c.gated {
+		c.gated = true
+		s.parked = c.parked
+	}
+	c.streams = append(c.streams, s)
+	return s, nil
+}
+
+func (c *leakCheckCompactionClient) WriteLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, r io.Reader) (*ltx.FileInfo, error) {
+	if !c.failWrites {
+		return c.ReplicaClient.WriteLTXFile(ctx, level, minTXID, maxTXID, r)
+	}
+
+	// Fail the upload only once the compaction goroutine is inside a read of
+	// its first source stream.
+	select {
+	case <-c.parked:
+	case <-time.After(5 * time.Second):
+		return nil, fmt.Errorf("timeout waiting for compaction goroutine to park")
+	}
+	return nil, fmt.Errorf("simulated upload failure")
+}
+
+func (c *leakCheckCompactionClient) streamStats() (total, open int, labels []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.streams {
+		total++
+		if !s.isClosed() {
+			open++
+			labels = append(labels, s.label)
+		}
+	}
+	return total, open, labels
+}
+
+type leakCheckStream struct {
+	rc     io.ReadCloser
+	label  string
+	parked chan struct{} // if non-nil, the first read parks until close
+	once   sync.Once
+	done   chan struct{} // closed when the stream is closed
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func (s *leakCheckStream) Read(p []byte) (int, error) {
+	if s.parked != nil {
+		s.once.Do(func() { close(s.parked) })
+		<-s.done
+	}
+
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return 0, os.ErrClosed
+	}
+	return s.rc.Read(p)
+}
+
+func (s *leakCheckStream) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	close(s.done)
+	return s.rc.Close()
+}
+
+func (s *leakCheckStream) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
 }
 
 func countCompactorPipeWriters() int {

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/superfly/ltx"
@@ -44,10 +45,17 @@ type ResumableReader struct {
 	maxTXID ltx.TXID
 	size    int64 // expected total file size from FileInfo; 0 means unknown
 	offset  int64
-	rc      io.ReadCloser
 	retryN  int
 	err     error
 	logger  *slog.Logger
+
+	// mu guards rc and closed. Close may be called from a different goroutine
+	// than Read: Compactor.Compact closes its source readers when it returns
+	// while its compaction goroutine may still be reading them. Once closed is
+	// set, Read must not reopen the stream or it would leak the new connection.
+	mu     sync.Mutex
+	rc     io.ReadCloser
+	closed bool
 }
 
 // NewResumableReader creates a ResumableReader. Primarily exposed for testing.
@@ -77,10 +85,15 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 	}
 
 	for {
+		rc, err := r.stream()
+		if err != nil {
+			return 0, err
+		}
+
 		// Reopen the stream from the current offset if the previous
-		// connection was closed (rc is nil after a retry).
-		if r.rc == nil {
-			rc, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
+		// connection was closed (the stream is nil after a retry).
+		if rc == nil {
+			newRC, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || r.ctx.Err() != nil {
 					return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
@@ -93,10 +106,15 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 					"offset", r.offset, "error", err, "attempt", r.retryN)
 				continue
 			}
-			r.rc = rc
+			if !r.setStream(newRC) {
+				// Closed while the stream was being reopened.
+				_ = newRC.Close()
+				return 0, os.ErrClosed
+			}
+			rc = newRC
 		}
 
-		n, err := r.rc.Read(p)
+		n, err := rc.Read(p)
 		r.offset += int64(n)
 
 		if err == nil {
@@ -111,8 +129,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 				r.logger.Debug("premature EOF on ltx file, reconnecting",
 					"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 					"offset", r.offset, "size", r.size, "attempt", r.retryN+1)
-				r.close()
-				r.rc = nil
+				r.dropStream()
 				if retryErr := r.retry(io.ErrUnexpectedEOF); retryErr != nil {
 					return n, retryErr
 				}
@@ -131,8 +148,7 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		r.logger.Debug("read error on ltx file, reconnecting",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"error", err, "offset", r.offset, "attempt", r.retryN+1)
-		r.close()
-		r.rc = nil
+		r.dropStream()
 		if retryErr := r.retry(err); retryErr != nil {
 			return n, retryErr
 		}
@@ -142,17 +158,64 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 	}
 }
 
+// Close closes the current underlying stream, if any, and marks the reader as
+// closed. Closing is permanent: subsequent reads fail with os.ErrClosed rather
+// than reopening the remote stream, which would leak the new connection.
 func (r *ResumableReader) Close() error {
-	if r.rc != nil {
-		return r.rc.Close()
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	rc := r.rc
+	r.rc = nil
+	r.mu.Unlock()
+
+	if rc != nil {
+		return rc.Close()
 	}
 	return nil
 }
 
-func (r *ResumableReader) close() {
-	// The stream is already being discarded after a read failure, so a close
-	// error should not stop recovery. Log it only to aid debugging.
-	if err := r.rc.Close(); err != nil {
+// stream returns the current underlying stream, or nil if the next read should
+// reopen it. Returns os.ErrClosed if the reader has been closed.
+func (r *ResumableReader) stream() (io.ReadCloser, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil, os.ErrClosed
+	}
+	return r.rc, nil
+}
+
+// setStream installs a newly reopened stream. It reports false if the reader
+// was closed while the stream was being opened, in which case the caller must
+// close the new stream itself.
+func (r *ResumableReader) setStream(rc io.ReadCloser) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	r.rc = rc
+	return true
+}
+
+// dropStream closes and clears the current stream after a read failure so the
+// next read reopens from the current offset. The stream is already being
+// discarded, so a close error should not stop recovery. Log it only to aid
+// debugging.
+func (r *ResumableReader) dropStream() {
+	r.mu.Lock()
+	rc := r.rc
+	r.rc = nil
+	r.mu.Unlock()
+
+	if rc == nil {
+		return
+	}
+	if err := rc.Close(); err != nil {
 		r.logger.Debug("close ltx file",
 			"level", r.level, "min", r.minTXID, "max", r.maxTXID,
 			"offset", r.offset, "error", err)

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -80,14 +80,13 @@ const resumableReaderMaxRetries = 3
 const resumableReaderBackoff = 250 * time.Millisecond
 
 func (r *ResumableReader) Read(p []byte) (int, error) {
-	if r.err != nil {
-		return 0, r.err
-	}
-
 	for {
 		rc, err := r.stream()
 		if err != nil {
 			return 0, err
+		}
+		if r.err != nil {
+			return 0, r.err
 		}
 
 		// Reopen the stream from the current offset if the previous

--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -117,6 +117,9 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		r.offset += int64(n)
 
 		if err == nil {
+			if n > 0 && n == len(p) {
+				r.retryN = 0
+			}
 			return n, nil
 		}
 

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -376,9 +376,48 @@ func TestResumableReader_BoundsConnectionsAcrossPartialReads(t *testing.T) {
 	_, err := io.ReadAll(r)
 	if err == nil {
 		t.Error("ReadAll() error=nil, want retry limit error")
+	} else if !strings.Contains(err.Error(), "max retries exceeded") {
+		t.Errorf("ReadAll() error=%v, want retry limit error", err)
 	}
 	if got, max := connectionN.Load(), int64(resumableReaderMaxRetries+1); got > max {
 		t.Errorf("connections=%d, want at most %d", got, max)
+	}
+}
+
+func TestResumableReader_ResetsRetriesAfterCompleteRead(t *testing.T) {
+	const (
+		readSize     = 4 * 1024
+		progressSize = 64 * 1024
+		disconnectN  = resumableReaderMaxRetries + 2
+	)
+	data := bytes.Repeat([]byte("0123456789abcdef"), ((disconnectN+1)*progressSize)/16)
+	openN := 0
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			openN++
+			if openN <= disconnectN {
+				return io.NopCloser(&errorAfterN{
+					data: data[offset:],
+					n:    progressSize,
+					err:  fmt.Errorf("connection reset"),
+				}), nil
+			}
+			return io.NopCloser(bytes.NewReader(data[offset:])), nil
+		},
+	}
+
+	r := newTestResumableReader(client, int64(len(data)), data)
+	got := make([]byte, len(data))
+	for offset := 0; offset < len(got); offset += readSize {
+		if _, err := io.ReadFull(r, got[offset:offset+readSize]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("read %d bytes, want %d", len(got), len(data))
+	}
+	if got, want := openN, disconnectN+1; got != want {
+		t.Fatalf("OpenLTXFile() count=%d, want %d", got, want)
 	}
 }
 

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -179,6 +180,12 @@ func TestResumableReader(t *testing.T) {
 		if !strings.Contains(err.Error(), "max retries exceeded") {
 			t.Fatalf("expected 'max retries exceeded' error, got: %v", err)
 		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := r.Read(buf); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("read after close returned %v, want os.ErrClosed", err)
+		}
 	})
 
 	t.Run("ReopenFailure", func(t *testing.T) {
@@ -271,6 +278,64 @@ func TestResumableReader(t *testing.T) {
 	})
 }
 
+func TestResumableReader_CloseWhileReopening(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	openStarted := make(chan struct{})
+	continueOpen := make(chan struct{})
+	stream := &closeTrackingReadCloser{Reader: bytes.NewReader(nil)}
+	var openN atomic.Int64
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			if openN.Add(1) == 1 {
+				close(openStarted)
+			}
+			select {
+			case <-continueOpen:
+				return stream, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+	r := NewResumableReader(ctx, client, 0, 1, 1, 1, nil, slog.Default())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := r.Read(make([]byte, 1))
+		errCh <- err
+	}()
+
+	select {
+	case <-openStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reopen")
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	close(continueOpen)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("read returned %v, want os.ErrClosed", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for read")
+	}
+	if !stream.closed.Load() {
+		t.Fatal("reopened stream was not closed")
+	}
+	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("read after close returned %v, want os.ErrClosed", err)
+	}
+	if got := openN.Load(); got != 1 {
+		t.Fatalf("OpenLTXFile() count=%d, want 1", got)
+	}
+}
+
 func TestResumableReader_BoundsConnectionsAcrossPartialReads(t *testing.T) {
 	data := []byte("0123456789abcdef")
 	var connectionN atomic.Int64
@@ -339,6 +404,16 @@ type testLTXFileOpener struct {
 
 func (t *testLTXFileOpener) OpenLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
 	return t.OpenLTXFileFunc(ctx, level, minTXID, maxTXID, offset, size)
+}
+
+type closeTrackingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (r *closeTrackingReadCloser) Close() error {
+	r.closed.Store(true)
+	return nil
 }
 
 // errorAfterN is a reader that returns data normally for the first n bytes,


### PR DESCRIPTION
## Description

Reconciles the resumable reader's retry and lifecycle policies so large transfers can recover from repeated transient disconnects without restoring the unbounded connection churn fixed by #1360. It also makes `Close` terminal and concurrency-safe: later reads return `os.ErrClosed`, no stream is reopened after close, and a stream returned by an in-flight reopen is closed immediately.

This PR incorporates the complete lifecycle work from #1493 by @akeemjenkins, including its deterministic compactor leak regression, and the close-priority follow-up by @corylanou. It addresses the restore-liveness failure reported and initially fixed in #1472 by @darkgnotic while preserving #1360's protection for #1354. The carried commits retain their original authors and source-SHA trailers.

The retry budget is renewed only after a positive underlying read completely satisfies the caller's request. Bytes returned with an error or as a short read still advance the resume offset, but do not clear the connection-churn protection.

## Motivation and Context

The existing lifetime retry limit protects replication from a pathological backend that declares the remaining object length but returns only one byte per connection. Resetting the complete budget on any `n > 0`, as proposed in #1472, lets that case open one connection per byte and prevents replication backoff from engaging.

A pure lifetime limit causes a different failure: #1472 observed disconnects around offsets 1.2 MB and 25 MB in the same file. Despite roughly 24 MB of healthy progress, the fourth lifetime disconnect aborted the restore, causing it to restart without converging.

Completing a caller read is the meaningful-progress invariant. The LTX decoder uses `io.ReadFull` for file headers, page headers, size prefixes, and payloads, so a healthy resumed stream completes these requests. A tiny truncated response does not. This avoids adding an arbitrary byte or time threshold.

| Scenario | Previous behavior | Reconciled behavior |
|---|---|---|
| Five disconnects with 64 KiB progress between each | Retry limit at the fourth disconnect | Completes all 393,216 bytes |
| One-byte truncated responses | `n > 0` reset opens one connection per byte | Retry-limit error within four connections |
| Close during an in-flight reopen | Raced stream could be installed or leaked | Raced stream is closed; read returns `os.ErrClosed` |
| Failed compaction closes source readers | Detached reader could reopen and leak streams | Close remains terminal; no reopen or leak |

Fixes #1492

Supersedes #1472 and incorporates #1493. Related to #1354 and #1360.

## How Has This Been Tested?

Tested on macOS arm64 with the repository-declared Go 1.25.14 toolchain.

```bash
GOTOOLCHAIN=go1.25.14 go test -race -count=1 \
  -run '^(TestResumableReader.*|TestCompactor_Compact(DoesNotReopenSourcesAfterClose|ClosesPipeOnWriteError|ResumesRemoteSourceAfterDisconnect))$' \
  ./internal .

GOTOOLCHAIN=go1.25.14 go test -race -count=1 ./...
GOTOOLCHAIN=go1.25.14 go vet ./...
GOTOOLCHAIN=go1.25.14 staticcheck ./...
GOTOOLCHAIN=go1.25.14 pre-commit run --all-files

golang_toolchain=go1.25.14
env GOTOOLCHAIN="$golang_toolchain" go build -o bin/litestream ./cmd/litestream
env GOTOOLCHAIN="$golang_toolchain" go build -o bin/litestream-test ./cmd/litestream-test
LOG_LEVEL=DEBUG GOTOOLCHAIN="$golang_toolchain" \
  go test -tags 'integration,soak' \
  -run '^TestLTXBehavior$' \
  -short -v -timeout 15m \
  ./tests/integration/
```

All commands pass. The LTX behavioral gate completed in 504.95 seconds; low-volume, high-volume, and burst-volume all passed their behavioral assertions, restoration, and integrity checks.

The progress regression first failed on the #1493 baseline at the fourth disconnect and offset 262,144, then passed with the reconciled policy. The preserved one-byte truncation regression still returns `max retries exceeded` with no more than the initial connection plus three retries.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (no documentation change is needed for this internal retry/lifecycle policy)
