### PR TITLE
fix(replica): wrap ctx error on cancelled reopen

### DIFF
--- a/internal/resumable_reader.go
+++ b/internal/resumable_reader.go
@@ -82,8 +82,12 @@ func (r *ResumableReader) Read(p []byte) (int, error) {
 		if r.rc == nil {
 			rc, err := r.client.OpenLTXFile(r.ctx, r.level, r.minTXID, r.maxTXID, r.offset, 0)
 			if err != nil {
-				if errors.Is(err, os.ErrNotExist) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || r.ctx.Err() != nil {
+				if errors.Is(err, os.ErrNotExist) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return 0, fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)
+				}
+				if ctxErr := r.ctx.Err(); ctxErr != nil {
+					r.err = fmt.Errorf("reopen ltx file at offset %d: %v: %w", r.offset, err, ctxErr)
+					return 0, r.err
 				}
 				if retryErr := r.retry(fmt.Errorf("reopen ltx file at offset %d: %w", r.offset, err)); retryErr != nil {
 					return 0, retryErr

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -446,3 +446,37 @@ func TestResumableReader_ContextCancelAbortsBackoff(t *testing.T) {
 		t.Fatal("read after cancellation reopened the file; cancellation must be sticky")
 	}
 }
+
+func TestResumableReader_ContextCancelDuringReopen(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opened := make(chan struct{})
+	openN := 0
+	client := &testLTXFileOpener{
+		OpenLTXFileFunc: func(ctx context.Context, level int, minTXID, maxTXID ltx.TXID, offset, size int64) (io.ReadCloser, error) {
+			openN++
+			if openN == 1 {
+				close(opened)
+			}
+			<-ctx.Done()
+			return nil, fmt.Errorf("connection reset")
+		},
+	}
+
+	go func() {
+		<-opened
+		cancel()
+	}()
+
+	r := NewResumableReader(ctx, client, 2, 1, 2, 11, nil, slog.Default())
+	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
+		t.Errorf("Read() error=%v, want an error wrapping context.Canceled", err)
+	}
+	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
+		t.Errorf("second Read() error=%v, want an error wrapping context.Canceled", err)
+	}
+	if got, want := openN, 1; got != want {
+		t.Errorf("OpenLTXFile() count=%d, want %d", got, want)
+	}
+}

--- a/internal/resumable_reader_test.go
+++ b/internal/resumable_reader_test.go
@@ -470,8 +470,12 @@ func TestResumableReader_ContextCancelDuringReopen(t *testing.T) {
 	}()
 
 	r := NewResumableReader(ctx, client, 2, 1, 2, 11, nil, slog.Default())
-	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
+	_, err := r.Read(make([]byte, 1))
+	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Read() error=%v, want an error wrapping context.Canceled", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "connection reset") {
+		t.Errorf("Read() error=%v, want connection reset context", err)
 	}
 	if _, err := r.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
 		t.Errorf("second Read() error=%v, want an error wrapping context.Canceled", err)


### PR DESCRIPTION
## Description

Return the reader context error when cancellation or deadline expiry lands while `OpenLTXFile` is reopening a stream. The returned error retains the transport error text, wraps the context error for `errors.Is`, and is cached so later reads cannot reopen the file.

A deterministic regression test blocks the reopen until cancellation is observable, then verifies the context error and sticky terminal state.

## Root cause

The terminal reopen-error condition included `r.ctx.Err() != nil`, but its return value wrapped the `OpenLTXFile` error. When the opener returned a transport error after cancellation, callers received `connection reset` instead of `context.Canceled`, and `r.err` remained unset.

This change leaves the existing handling of `os.ErrNotExist` and opener errors that already wrap a context error unchanged. It does not alter retry policy, backoff, or close behavior.

## Motivation and Context

Fixes #1502

## How Has This Been Tested?

The new regression test fails on the old production code:

```text
$ go test -race -count=1 -run '^TestResumableReader_ContextCancelDuringReopen$' ./internal/
--- FAIL: TestResumableReader_ContextCancelDuringReopen (0.00s)
    resumable_reader_test.go:474: Read() error=reopen ltx file at offset 0: connection reset, want an error wrapping context.Canceled
    resumable_reader_test.go:477: second Read() error=reopen ltx file at offset 0: connection reset, want an error wrapping context.Canceled
    resumable_reader_test.go:480: OpenLTXFile() count=2, want 1
FAIL
FAIL    github.com/benbjohnson/litestream/internal    0.265s
FAIL
```

Validation with the fix applied:

```text
$ go test -race -count=20 -run 'TestResumableReader' ./internal/
ok      github.com/benbjohnson/litestream/internal    156.863s

$ go test -race ./internal/ ./
ok      github.com/benbjohnson/litestream/internal    9.014s
ok      github.com/benbjohnson/litestream             37.168s

$ go vet ./...

$ GOTOOLCHAIN=go1.25.14 pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for added large files..............................................Passed
go-imports-repo..........................................................Passed
go-vet-repo-mod..........................................................Passed
go-staticcheck-repo-mod..................................................Passed
```

The module-pinned Go 1.25.14 toolchain was used for pre-commit because the shell's Go 1.27.1 export data is newer than the installed staticcheck binary supports.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (no documentation change is needed for this internal error-handling fix)
