### PR TITLE
test(integration): give load deadline headroom

### DIFF
--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -179,8 +179,26 @@ func (db *TestDB) PopulateWithOptions(targetSize string, pageSize int, rowSize i
 	return nil
 }
 
+const loadGenerationTimeoutMargin = 30 * time.Second
+
+func newLoadGenerationContext(ctx context.Context, duration time.Duration) (context.Context, func()) {
+	loadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), duration+loadGenerationTimeoutMargin)
+	stopCancel := context.AfterFunc(ctx, func() {
+		if ctx.Err() == context.Canceled {
+			cancel()
+		}
+	})
+	return loadCtx, func() {
+		stopCancel()
+		cancel()
+	}
+}
+
 func (db *TestDB) GenerateLoad(ctx context.Context, writeRate int, duration time.Duration, pattern string) error {
-	cmd := exec.CommandContext(ctx, getBinaryPath("litestream-test"), "load",
+	loadCtx, cancel := newLoadGenerationContext(ctx, duration)
+	defer cancel()
+
+	cmd := exec.CommandContext(loadCtx, getBinaryPath("litestream-test"), "load",
 		"-db", db.Path,
 		"-write-rate", fmt.Sprintf("%d", writeRate),
 		"-duration", duration.String(),
@@ -215,7 +233,10 @@ func (db *TestDB) GenerateLoadWithOptions(ctx context.Context, writeRate int, du
 		args = append(args, "-payload-size", fmt.Sprintf("%d", payloadSize))
 	}
 
-	cmd := exec.CommandContext(ctx, getBinaryPath("litestream-test"), args...)
+	loadCtx, cancel := newLoadGenerationContext(ctx, duration)
+	defer cancel()
+
+	cmd := exec.CommandContext(loadCtx, getBinaryPath("litestream-test"), args...)
 	_, stdoutBuf, stderrBuf := configureCmdIO(cmd)
 
 	db.t.Logf("Starting load generation: %d writes/sec for %v (%s pattern, %d workers, %d byte payload)",

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -179,14 +179,28 @@ func (db *TestDB) PopulateWithOptions(targetSize string, pageSize int, rowSize i
 	return nil
 }
 
-const loadGenerationTimeoutMargin = 30 * time.Second
+const (
+	loadGenerationTimeoutMargin     = 30 * time.Second
+	loadGenerationDeadlineTolerance = time.Second
+)
 
-func newLoadGenerationContext(ctx context.Context, duration time.Duration) (context.Context, func()) {
+func deadlineMatchesLoadDuration(ctx context.Context, duration time.Duration) bool {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return false
+	}
+	delta := time.Until(deadline) - duration
+	return delta >= -loadGenerationDeadlineTolerance && delta <= loadGenerationDeadlineTolerance
+}
+
+func newLoadGenerationContext(ctx context.Context, duration time.Duration) (context.Context, context.CancelFunc) {
 	loadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), duration+loadGenerationTimeoutMargin)
+	completionDeadline := deadlineMatchesLoadDuration(ctx, duration)
 	stopCancel := context.AfterFunc(ctx, func() {
-		if ctx.Err() == context.Canceled {
-			cancel()
+		if ctx.Err() == context.DeadlineExceeded && completionDeadline {
+			return
 		}
+		cancel()
 	})
 	return loadCtx, func() {
 		stopCancel()

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestTestDB_GenerateLoadCompletesAtDeadline(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *TestDB, time.Duration) error
+	}{
+		{
+			name: "default options",
+			run: func(ctx context.Context, db *TestDB, duration time.Duration) error {
+				return db.GenerateLoad(ctx, 10, duration, "constant")
+			},
+		},
+		{
+			name: "custom options",
+			run: func(ctx context.Context, db *TestDB, duration time.Duration) error {
+				return db.GenerateLoadWithOptions(ctx, 10, duration, "constant", 2, 128)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := SetupTestDB(t, "generate-load")
+			if err := db.Create(); err != nil {
+				t.Fatalf("create database: %v", err)
+			}
+
+			const duration = 100 * time.Millisecond
+			ctx, cancel := context.WithTimeout(t.Context(), duration)
+			defer cancel()
+
+			if err := tt.run(ctx, db, duration); err != nil {
+				t.Fatalf("generate load: %v", err)
+			}
+		})
+	}
+}
+
+func TestTestDB_GenerateLoadStopsOnCancel(t *testing.T) {
+	db := SetupTestDB(t, "cancel-load")
+	if err := db.Create(); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	timer := time.AfterFunc(100*time.Millisecond, cancel)
+	defer timer.Stop()
+
+	start := time.Now()
+	if err := db.GenerateLoad(ctx, 10, 5*time.Second, "constant"); err == nil {
+		t.Fatal("expected canceled load generation to fail")
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("canceled load generation took %v", elapsed)
+	}
+}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestTestDB_GenerateLoadCompletesAtDeadline(t *testing.T) {
+	RequireBinaries(t)
+
 	tests := []struct {
 		name string
 		run  func(context.Context, *TestDB, time.Duration) error
@@ -46,20 +48,41 @@ func TestTestDB_GenerateLoadCompletesAtDeadline(t *testing.T) {
 }
 
 func TestTestDB_GenerateLoadStopsOnCancel(t *testing.T) {
+	RequireBinaries(t)
+
 	db := SetupTestDB(t, "cancel-load")
 	if err := db.Create(); err != nil {
 		t.Fatalf("create database: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	timer := time.AfterFunc(100*time.Millisecond, cancel)
 	defer timer.Stop()
 
-	start := time.Now()
 	if err := db.GenerateLoad(ctx, 10, 5*time.Second, "constant"); err == nil {
 		t.Fatal("expected canceled load generation to fail")
 	}
-	if elapsed := time.Since(start); elapsed >= time.Second {
-		t.Fatalf("canceled load generation took %v", elapsed)
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("context error=%v, want %v", ctx.Err(), context.Canceled)
+	}
+}
+
+func TestTestDB_GenerateLoadStopsAtEarlierDeadline(t *testing.T) {
+	RequireBinaries(t)
+
+	db := SetupTestDB(t, "deadline-load")
+	if err := db.Create(); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := db.GenerateLoad(ctx, 10, 5*time.Second, "constant"); err == nil {
+		t.Fatal("expected expired load generation to fail")
+	}
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("context error=%v, want %v", ctx.Err(), context.DeadlineExceeded)
 	}
 }


### PR DESCRIPTION
## Description

Give integration load-generator subprocesses 30 seconds of completion headroom while preserving explicit early cancellation. Add regressions for both load helper variants and for early cancellation.

The change is confined to tests/integration and does not alter load rates, patterns, durations, monitor timing, or soak assertions.

## Root cause

The soak monitor context and the litestream-test load duration expired at the same instant. Because GenerateLoad passed that context directly to exec.CommandContext, the parent sent SIGKILL before the child could complete normally and emit final statistics.

The subprocess now receives a detached deadline with completion headroom. Explicit caller cancellation is still forwarded, while MonitorSoakTest keeps the original context and still ends at the configured duration.

Fixes #1503

## Test plan

Before the fix, both regression cases failed with:

```text
load generation failed: signal: killed
```

Validation after the fix:

```text
$ go build ./... && go vet ./...
(exit 0)

$ go test -race -tags integration -run TestTestDB_GenerateLoad -count=5 ./tests/integration/
ok github.com/benbjohnson/litestream/tests/integration 3.180s

$ SOAK_KEEP_TEMP=1 SOAK_DURATION=2m SOAK_DEBUG=1 go test -tags 'integration,soak' -run TestComprehensiveSoak -v -count=1 -timeout 10m ./tests/integration/
level=INFO msg="Load generation complete" duration=2m0s total_errors=0
Monitoring stopped: test duration completed
--- PASS: TestComprehensiveSoak (124.61s)
PASS

$ GOTOOLCHAIN=go1.25.14 pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for added large files..............................................Passed
go-imports-repo..........................................................Passed
go-vet-repo-mod..........................................................Passed
go-staticcheck-repo-mod..................................................Passed
```

The soak output contained no signal: killed line, and its restore and integrity checks passed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (go fmt, go vet)
- [x] I have tested my changes (go test ./...)
- [x] I have updated the documentation accordingly (if needed)