### PR TITLE
fix(vfs): return SQLITE_OK from the auto-extension for non-VFS connections

### DIFF
--- a/cmd/litestream-vfs/auto_extension_e2e_test.go
+++ b/cmd/litestream-vfs/auto_extension_e2e_test.go
@@ -1,0 +1,64 @@
+//go:build vfs
+// +build vfs
+
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/benbjohnson/litestream/file"
+)
+
+// TestAutoExtension_E2E_OrdinaryConnectionStillOpens loads the extension, reads
+// the replica through the VFS, then opens an ordinary database in the same
+// process. Loading registers an auto-extension that SQLite runs on every later
+// sqlite3_open(), and its return value is that open's status: it must report
+// SQLITE_OK for a connection that is not on the litestream VFS, or every other
+// database the process opens fails with "automatic extension loading failed".
+func TestAutoExtension_E2E_OrdinaryConnectionStillOpens(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("skipping: test only runs on darwin or linux")
+	}
+
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("skipping: sqlite3 CLI not found in PATH")
+	}
+
+	extPath := buildVFSExtension(t)
+
+	replicaDir := t.TempDir()
+	setupTestReplica(t, file.NewReplicaClient(replicaDir))
+
+	// The entry point is named explicitly because SQLite otherwise derives it
+	// from the file name, and the build outputs are arch-suffixed. Each .open is
+	// a fresh sqlite3_open(), which is what runs the auto-extension.
+	cmd := exec.Command("sqlite3", ":memory:",
+		"-cmd", ".load "+extPath+" sqlite3_litestreamvfs_init",
+		"-cmd", ".open file:replica.db?vfs=litestream",
+		"-cmd", "SELECT 'vfs ok ' || litestream_txid() || ' ' || name FROM users;",
+		"-cmd", ".open :memory:",
+		"SELECT 'second connection ok';",
+	)
+	cmd.Env = append(os.Environ(), "LITESTREAM_REPLICA_URL=file://"+replicaDir)
+
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+	// A shell that cannot load extensions says so on the .load and, without
+	// -bail, carries on, so this cannot be gated on err.
+	if strings.Contains(outputStr, "Error: unknown command") ||
+		strings.Contains(outputStr, "not authorized") ||
+		strings.Contains(outputStr, "symbol not found") ||
+		strings.Contains(outputStr, "dlsym") {
+		t.Skipf("skipping: sqlite3 cannot load extensions (common on macOS): %s", outputStr)
+	}
+	require.NoError(t, err, "sqlite3 output: %s", outputStr)
+	require.Contains(t, outputStr, "vfs ok ", "the VFS connection should get the litestream functions and read the replica")
+	require.Contains(t, outputStr, "Alice", "the VFS connection should read the replica")
+	require.Contains(t, outputStr, "second connection ok", "an ordinary connection opened after the load should work")
+}

--- a/src/litestream-vfs.c
+++ b/src/litestream-vfs.c
@@ -27,7 +27,7 @@ static void litestream_time_impl(sqlite3_context* ctx, int argc, sqlite3_value**
 static void litestream_txid_impl(sqlite3_context* ctx, int argc, sqlite3_value** argv);
 static void litestream_lag_impl(sqlite3_context* ctx, int argc, sqlite3_value** argv);
 static void litestream_function_destroy(void* db);
-static void litestream_auto_extension(sqlite3* db, const char** pzErrMsg, const struct sqlite3_api_routines* pApi);
+static int litestream_auto_extension(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi);
 
 /* This routine is called when the extension is loaded. */
 int sqlite3_litestreamvfs_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
@@ -56,12 +56,13 @@ int sqlite3_litestreamvfs_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_r
   return rc;
 }
 
-static void litestream_auto_extension(sqlite3* db, const char** pzErrMsg, const struct sqlite3_api_routines* pApi) {
+/* SQLite fails an open whose auto-extension returns non-zero, so a connection that is not ours must report success. */
+static int litestream_auto_extension(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi) {
   (void)pzErrMsg;
   (void)pApi;
 
   if (litestream_register_connection(db) != SQLITE_OK) {
-    return;
+    return SQLITE_OK;
   }
 
   /* litestream_set_time(timestamp) - for time travel */
@@ -71,6 +72,8 @@ static void litestream_auto_extension(sqlite3* db, const char** pzErrMsg, const 
   sqlite3_create_function_v2(db, "litestream_time", 0, SQLITE_UTF8, db, litestream_time_impl, 0, 0, 0);
   sqlite3_create_function_v2(db, "litestream_txid", 0, SQLITE_UTF8, db, litestream_txid_impl, 0, 0, 0);
   sqlite3_create_function_v2(db, "litestream_lag", 0, SQLITE_UTF8, db, litestream_lag_impl, 0, 0, 0);
+
+  return SQLITE_OK;
 }
 
 static int litestream_register_connection(sqlite3* db) {


### PR DESCRIPTION
Hey Ben & co! 

I was excited to play around with sqlite and vfs, but ran into vfs corrupting non-syncing sqlite connections.
I had claude take a stab at finding the fix, and I've thrown a lot of tokens at verifying this and making the fix as small as possible.

I hope it makes sense to you, code is working on my machine after the signature change.

## Summary

Loading the VFS extension makes **every later `sqlite3_open()` in the process fail** — `:memory:` and plain files included — with `automatic extension loading failed:` (rc 101, empty message). The auto-extension callback in `src/litestream-vfs.c` is declared `void` where SQLite reads an `int` status, so SQLite reads whatever the last call left in the return register.

Any application that opens its own SQLite databases in the same process cannot use the VFS at all, and the failure surfaces at the *next* unrelated `open()`, far from the `load_extension()` that caused it.

## Reproduction

Four lines, python3 stdlib, against the v0.5.17 `linux-arm64` extension. No replica needed:

```python
import sqlite3
conn = sqlite3.connect(":memory:")
conn.enable_load_extension(True)
conn.load_extension("./litestream")   # ok
sqlite3.connect(":memory:")           # OperationalError: automatic extension loading failed:
```

Same from the `sqlite3` CLI (`.load` then `.open :memory:`) and from `bun:sqlite`, on linux/arm64 and darwin/arm64, with or without `LITESTREAM_REPLICA_URL`. Opening the **VFS** database still works; only ordinary connections break.

<details>
<summary><b>Root cause</b> — why the VFS database opens and every other one does not</summary>

`sqlite3_litestreamvfs_init` registers an auto-extension (#856) so new connections get the `litestream_time`/`litestream_txid`/`litestream_lag` functions:

```c
rc = sqlite3_auto_extension((void (*)(void))litestream_auto_extension);
```

SQLite invokes an auto-extension as `int (*)(sqlite3*, char**, const sqlite3_api_routines*)` and fails the open on any non-zero result (`sqlite3AutoLoadExtensions` in `loadext.c`):

```c
if( xInit && (rc = xInit(db, &zErrmsg, pThunk))!=0 ){
  sqlite3ErrorWithMsg(db, rc, "automatic extension loading failed: %s", zErrmsg);
```

But the callback returns `void`, so SQLite reads whatever the last call left behind:

| connection | last call before returning | SQLite reads | result |
|---|---|---|---|
| not on the litestream VFS | `litestream_register_connection` → `SQLITE_DONE` (101), its internal "not mine" | 101 | open fails, `*pzErrMsg` never set → empty message |
| on the litestream VFS | fourth `sqlite3_create_function_v2` → `SQLITE_OK` | 0 | open succeeds |

That is exactly why the VFS database opens and every other database does not, and why the error text is blank.

</details>

## The fix

Four lines. `litestream_register_connection` is untouched — its `SQLITE_DONE` still means "not our VFS", it just no longer reaches SQLite as a status.

```diff
-static void litestream_auto_extension(sqlite3* db, const char** pzErrMsg, const struct sqlite3_api_routines* pApi) {
+/* SQLite fails an open whose auto-extension returns non-zero, so a connection that is not ours must report success. */
+static int litestream_auto_extension(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi) {
   (void)pzErrMsg;
   (void)pApi;
 
   if (litestream_register_connection(db) != SQLITE_OK) {
-    return;
+    return SQLITE_OK;
   }
 
   /* ... the four sqlite3_create_function_v2 calls, unchanged ... */
+
+  return SQLITE_OK;
 }
```

Plus `cmd/litestream-vfs/auto_extension_e2e_test.go`: load the built extension into the sqlite3 CLI, read the replica through `?vfs=litestream` and call `litestream_txid()` there, then `.open :memory:` and query it.

<details>
<summary><b>Test plan</b> — build commands and A/B results</summary>

`buildVFSExtension` looks for `dist/litestream-vfs.so`, and on a native arm64 host the `vfs-linux-arm64` target wants `aarch64-linux-gnu-gcc`, so its three commands with the native compiler:

```bash
go build -tags vfs,SQLITE3VFS_LOADABLE_EXT -o dist/litestream-vfs-linux-arm64.a -buildmode=c-archive ./cmd/litestream-vfs
cp dist/litestream-vfs-linux-arm64.h src/litestream-vfs.h
gcc -DSQLITE3VFS_LOADABLE_EXT -g -fPIC -shared -o dist/litestream-vfs.so src/litestream-vfs.c dist/litestream-vfs-linux-arm64.a -lpthread -ldl -lm

go test -tags vfs -count=1 -run TestAutoExtension ./cmd/litestream-vfs
```

`golang:1.25-bookworm` on linux/arm64, Debian's sqlite3 CLI 3.40.1:

```
# dist/litestream-vfs.so built from this branch
ok  github.com/benbjohnson/litestream/cmd/litestream-vfs

# the same, with the v0.5.17 release's litestream.so in its place
    sqlite3 output: Error: unable to open database ":memory:": automatic extension loading failed:
        Error: in prepare, automatic extension loading failed:  (21)
--- FAIL: TestAutoExtension_E2E_OrdinaryConnectionStillOpens (0.34s)
```

Also checked on darwin/arm64 (built with the `vfs-darwin-arm64` commands, bun pointed at a SQLite that permits extension loading, since Apple's omits it): the four-line repro above fails on v0.5.17 and passes with the fix, and one process holding a `file:…?vfs=litestream` handle while it opens, writes to and reads ordinary WAL and `:memory:` databases passes every step. `litestream_txid()` resolves on the VFS connection and is absent on the ordinary ones; the held VFS handle still advances on new commits.

**No regressions in the existing suite.** `go test -tags vfs ./cmd/litestream-vfs` on `main` and on this branch fails the same four hydration e2e tests (#1449). The other differences between runs are that suite's known nondeterminism, on both trees: `src/litestream-vfs.c` is outside the Go package, so cgo never compiles it into the test binary (`nm` finds zero shim symbols in either), and only the two `.so`-loading test files can execute the shim at all. Interleaving the worst-looking test on both trees under identical load had `main` fail 2 of 6 and this branch 0 of 6.

Lint, as pre-commit runs it: `gofmt`, `goimports -local github.com/benbjohnson/litestream`, `go vet ./...` and `go vet -tags vfs,SQLITE3VFS_LOADABLE_EXT ./cmd/litestream-vfs`, and `staticcheck` on the same — all clean. The shim compiles under `-Wall -Wextra -Werror`.

</details>

<details>
<summary><b>Scope</b> — what this deliberately leaves alone</summary>

Happy to follow up on any of these separately; none of them is this bug, and I would rather not mix them in.

- **Anything in the shim beyond the return value.** `litestream_register_connection` still signals "not our VFS" with an out-of-band `SQLITE_DONE`, the failure message still does not name the database, and the `sqlite3_create_function_v2` return codes are still unchecked. The last would fail opens that succeed today.
- **`runSQLiteCLI` in `hydration_e2e_test.go`.** Extending it would suit the new test, but four existing tests share it, so the new test builds its own command instead and repeats four lines of skip heuristic.
- **The rest of the `-tags vfs` suite.** `TestHydration_E2E_SQLiteCLI` fails identically with and without this change: the shell opens `:memory:` *before* `.load`, so `SELECT … FROM users` on that connection cannot see the replica.
- **Whether the SQL-function surface should exist at all.** `VFSFile.FileControl` already answers `PRAGMA litestream_txid`/`litestream_lag`/`litestream_time` per file. `sqlite3_auto_extension` is the only hook that reaches a `sqlite3*` for every open, so this makes it harmless rather than deciding that.
- **A CI check.** `release.yml` already loads the built `.so` into `sqlite3 ':memory:'` on amd64; adding `".open :memory:" "select 1"` to that line would catch this bug where the artifact is actually run. Say the word and I will add it here or separately.

</details>

## Related

- #856 — the PR that added the auto-extension registration, for #849 (time-travel functions).
- No issue was filed for this bug; searches for `automatic extension loading`, `auto_extension` and `sqlite3_auto_extension` across issues, PRs and discussions return nothing relevant.

---

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (commands above)
- [ ] I have updated the documentation accordingly (not needed: no documented behaviour changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
