### PR TITLE
chore(deps): bump x/crypto to v0.56.0 for govulncheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 # Install build dependencies for VFS extension
 RUN apt-get update && apt-get install -y gcc libc6-dev && rm -rf /var/lib/apt/lists/*

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/benbjohnson/litestream
 
-go 1.25.0
-
-toolchain go1.25.14
+go 1.26.0
 
 require (
 	cloud.google.com/go/storage v1.36.0
@@ -28,7 +26,7 @@ require (
 	github.com/psanford/sqlite3vfs v0.0.0-20260519004904-f9180fa2acc9 // direct
 	github.com/studio-b12/gowebdav v0.11.0
 	github.com/superfly/ltx v0.5.2
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/sys v0.47.0
 	google.golang.org/api v0.155.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/benbjohnson/litestream
 
 go 1.26.0
 
+toolchain go1.26.8
+
 require (
 	cloud.google.com/go/storage v1.36.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/crypto/x509roots/fallback v0.0.0-20260209214922-2f26647a795e h1:G2pNJMnWEb60ip90TMo++m9fpt+d3YIZa0er3buPKRo=
 golang.org/x/crypto/x509roots/fallback v0.0.0-20260209214922-2f26647a795e/go.mod h1:MEIPiCnxvQEjA4astfaKItNwEVZA5Ki+3+nyGbJ5N18=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
## Summary

govulncheck flags two vulnerabilities in `golang.org/x/crypto` v0.55.0 that our code actually calls. This bumps to v0.56.0, where both are fixed, and pins a patched Go toolchain to go with it.

Reported on PR #1504's build-metrics comment (govulncheck runs there and applies the `metrics: vulns-found` label; it does not fail the job), but the vulnerable version is on `main`, so the fix belongs here rather than on that branch.

## Vulnerabilities addressed

| ID | Description | Found in | Fixed in |
|---|---|---|---|
| GO-2026-6355 | DoS on deadlocked established channel in `x/crypto/ssh` | x/crypto@v0.55.0 | x/crypto@v0.56.0 |
| GO-2026-6354 | DoS on deadlocked undecided channel in `x/crypto/ssh` | x/crypto@v0.55.0 | x/crypto@v0.56.0 |

Both are reachable from our code:

- `sftp/replica_client.go:163` — `sftp.ReplicaClient.init` calls `ssh.Dial`
- `internal/testingutil/testingutil.go:485` — `testingutil.MockSFTPServer` calls `ssh.NewServerConn`

https://pkg.go.dev/vuln/GO-2026-6355
https://pkg.go.dev/vuln/GO-2026-6354

## Changes

- `go.mod` / `go.sum`: `golang.org/x/crypto` v0.55.0 → v0.56.0
- `go.mod`: `go` directive 1.25.0 → 1.26.0. x/crypto v0.56.0 declares `go 1.26.0`, so this is required, not optional.
- `go.mod`: `toolchain` re-pinned to `go1.26.8` (was `go1.25.14`). See below — this part matters.
- `Dockerfile`: builder image `golang:1.25` → `golang:1.26`, to match the new minimum. Without this the Docker build would have to download a toolchain at build time.

No source changes.

## Why the toolchain pin is part of this

The first push here bumped the `go` directive without re-pinning `toolchain`, and `go mod tidy` dropped the old `go1.25.14` line as stale. CI resolves its Go version from `go.mod`, so it installed the bare `go1.26.0` release — which predates every 1.26.x security patch. govulncheck on that commit went from 2 x/crypto findings to **16 reachable standard library findings** across `crypto/tls`, `crypto/x509`, `net/http`, `html/template`, `encoding/xml`, `encoding/asn1`, `net`, and `net/textproto`, most of them fixed in go1.26.6.

Pinning `toolchain go1.26.8` (latest 1.26 patch) keeps the minimum language version at 1.26.0 for x/crypto while building against a patched toolchain. The previous `go1.25.14` pin was doing this same job, which is why `main` shows no stdlib findings.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass (compiles test files, including both ssh call sites)
- `golang:1.26` image confirmed to exist on Docker Hub
- govulncheck on the first commit confirmed GO-2026-6354/6355 are gone; the stdlib findings it surfaced are what the toolchain pin addresses. Watching the re-run on this push to confirm a clean report.

Local `govulncheck` and the full `go test ./...` run could not be completed on this machine — load average was 85–310 from unrelated concurrent work, and every package hit its test timeout at once. Those timeouts are contention, not this change; CI is the authoritative check here.

https://claude.ai/code/session_01X7j7tBBazajTUyVAP6jVt2