### PR TITLE
fix(s3lease): support Hetzner lease semantics

### DIFF
--- a/docs/PROVIDER_COMPATIBILITY.md
+++ b/docs/PROVIDER_COMPATIBILITY.md
@@ -154,6 +154,8 @@ Related issues: #912
 - `InvalidArgument` errors with default AWS SDK settings
 - Does not support `aws-chunked` content encoding
 - Requires signed payloads for all requests
+- Conditional PUT requests require unquoted ETags
+- Conditional DELETE requests ignore `If-Match`; lease release uses a conditional PUT
 
 **Configuration**:
 

--- a/s3/leaser.go
+++ b/s3/leaser.go
@@ -43,10 +43,11 @@ type Leaser struct {
 	s3     S3API
 	logger *slog.Logger
 
-	Bucket string
-	Path   string
-	TTL    time.Duration
-	Owner  string
+	Bucket   string
+	Path     string
+	Endpoint string
+	TTL      time.Duration
+	Owner    string
 }
 
 func NewLeaser() *Leaser {
@@ -176,26 +177,54 @@ func (l *Leaser) ReleaseLease(ctx context.Context, lease *litestream.Lease) erro
 		return ErrLeaseETagRequired
 	}
 
-	key := l.lockKey()
-	_, err := l.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket:  aws.String(l.Bucket),
-		Key:     aws.String(key),
-		IfMatch: aws.String(lease.ETag),
-	})
-	if err != nil {
-		if isNotExists(err) || isNotFoundError(err) {
-			return ErrLeaseAlreadyReleased
+	if litestream.IsHetznerEndpoint(l.Endpoint) {
+		// Hetzner ignores If-Match on DELETE requests. Replace the lock with an
+		// expired lease instead so a stale owner cannot delete a newer lease.
+		if err := l.releaseLeaseByWrite(ctx, lease); err != nil {
+			return err
 		}
-		if isPreconditionFailed(err) {
-			return litestream.ErrLeaseNotHeld
+	} else {
+		key := l.lockKey()
+		_, err := l.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket:  aws.String(l.Bucket),
+			Key:     aws.String(key),
+			IfMatch: aws.String(lease.ETag),
+		})
+		if err != nil {
+			if isNotExists(err) || isNotFoundError(err) {
+				return ErrLeaseAlreadyReleased
+			}
+			if isPreconditionFailed(err) {
+				return litestream.ErrLeaseNotHeld
+			}
+			return fmt.Errorf("delete lease: %w", err)
 		}
-		return fmt.Errorf("delete lease: %w", err)
 	}
 
 	l.logger.Debug("lease released",
 		"generation", lease.Generation,
 		"owner", lease.Owner)
 
+	return nil
+}
+
+func (l *Leaser) releaseLeaseByWrite(ctx context.Context, lease *litestream.Lease) error {
+	releasedLease := *lease
+	releasedLease.ExpiresAt = time.Time{}
+	if _, err := l.writeLease(ctx, &releasedLease, lease.ETag); err != nil {
+		var leaseErr *litestream.LeaseExistsError
+		if !errors.As(err, &leaseErr) {
+			return fmt.Errorf("expire lease: %w", err)
+		}
+
+		if _, _, readErr := l.readLease(ctx); readErr != nil {
+			if errors.Is(readErr, os.ErrNotExist) {
+				return ErrLeaseAlreadyReleased
+			}
+			return fmt.Errorf("read lease after failed release: %w", readErr)
+		}
+		return litestream.ErrLeaseNotHeld
+	}
 	return nil
 }
 
@@ -246,7 +275,7 @@ func (l *Leaser) writeLease(ctx context.Context, lease *litestream.Lease, etag s
 	if etag == "" {
 		input.IfNoneMatch = aws.String("*")
 	} else {
-		input.IfMatch = aws.String(etag)
+		input.IfMatch = aws.String(l.ifMatchETag(etag))
 	}
 
 	out, err := l.s3.PutObject(ctx, input)
@@ -263,6 +292,15 @@ func (l *Leaser) writeLease(ctx context.Context, lease *litestream.Lease, etag s
 	}
 
 	return newETag, nil
+}
+
+func (l *Leaser) ifMatchETag(etag string) string {
+	// Hetzner returns quoted ETags but only accepts the unquoted value in
+	// If-Match headers on PUT requests.
+	if litestream.IsHetznerEndpoint(l.Endpoint) && len(etag) >= 2 && etag[0] == '"' && etag[len(etag)-1] == '"' {
+		return etag[1 : len(etag)-1]
+	}
+	return etag
 }
 
 func isPreconditionFailed(err error) bool {

--- a/s3/leaser_test.go
+++ b/s3/leaser_test.go
@@ -267,6 +267,41 @@ func TestLeaser_RenewLease(t *testing.T) {
 	}
 }
 
+func TestLeaser_RenewLease_Hetzner(t *testing.T) {
+	oldETag := `"old-etag"`
+	newETag := `"new-etag"`
+	var receivedIfMatch string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			receivedIfMatch = r.Header.Get("If-Match")
+			w.Header().Set("ETag", newETag)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	leaser := newTestLeaser(t, server.URL)
+	leaser.Endpoint = "https://fsn1.your-objectstorage.com"
+
+	lease, err := leaser.RenewLease(context.Background(), &litestream.Lease{
+		Generation: 5,
+		ExpiresAt:  time.Now().Add(5 * time.Second),
+		Owner:      "me",
+		ETag:       oldETag,
+	})
+	if err != nil {
+		t.Fatalf("RenewLease() error: %v", err)
+	}
+
+	if receivedIfMatch != "old-etag" {
+		t.Errorf("expected unquoted If-Match=%q, got %q", "old-etag", receivedIfMatch)
+	}
+	if lease.ETag != newETag {
+		t.Errorf("expected ETag=%q, got %q", newETag, lease.ETag)
+	}
+}
+
 func TestLeaser_RenewLease_LostLease(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
@@ -360,6 +395,118 @@ func TestLeaser_ReleaseLease(t *testing.T) {
 	}
 	if receivedIfMatch != `"my-etag"` {
 		t.Errorf("expected If-Match=%q, got %q", `"my-etag"`, receivedIfMatch)
+	}
+}
+
+func TestLeaser_ReleaseLease_Hetzner(t *testing.T) {
+	var putCalled atomic.Bool
+	var receivedIfMatch string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		putCalled.Store(true)
+		receivedIfMatch = r.Header.Get("If-Match")
+
+		var releasedLease litestream.Lease
+		if err := json.NewDecoder(r.Body).Decode(&releasedLease); err != nil {
+			t.Errorf("decode lease: %v", err)
+		}
+		if !releasedLease.IsExpired() {
+			t.Errorf("expected expired lease, got expires_at=%s", releasedLease.ExpiresAt)
+		}
+		if releasedLease.Generation != 5 {
+			t.Errorf("expected generation=5, got %d", releasedLease.Generation)
+		}
+		if releasedLease.Owner != "me" {
+			t.Errorf("expected owner=%q, got %q", "me", releasedLease.Owner)
+		}
+
+		w.Header().Set("ETag", `"released-etag"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	leaser := newTestLeaser(t, server.URL)
+	leaser.Endpoint = "https://fsn1.your-objectstorage.com"
+	lease := &litestream.Lease{
+		Generation: 5,
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+		Owner:      "me",
+		ETag:       `"my-etag"`,
+	}
+
+	if err := leaser.ReleaseLease(context.Background(), lease); err != nil {
+		t.Fatalf("ReleaseLease() error: %v", err)
+	}
+	if !putCalled.Load() {
+		t.Error("expected PUT to be called")
+	}
+	if receivedIfMatch != "my-etag" {
+		t.Errorf("expected unquoted If-Match=%q, got %q", "my-etag", receivedIfMatch)
+	}
+}
+
+func TestLeaser_ReleaseLease_HetznerStaleETag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			w.Header().Set("ETag", `"current-etag"`)
+			_ = json.NewEncoder(w).Encode(&litestream.Lease{
+				Generation: 6,
+				ExpiresAt:  time.Now().Add(time.Minute),
+				Owner:      "new-owner",
+			})
+		default:
+			t.Errorf("expected PUT or GET, got %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	leaser := newTestLeaser(t, server.URL)
+	leaser.Endpoint = "https://fsn1.your-objectstorage.com"
+	lease := &litestream.Lease{
+		Generation: 5,
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+		Owner:      "me",
+		ETag:       `"stale-etag"`,
+	}
+
+	if err := leaser.ReleaseLease(context.Background(), lease); err != litestream.ErrLeaseNotHeld {
+		t.Errorf("expected ErrLeaseNotHeld for stale ETag, got %v", err)
+	}
+}
+
+func TestLeaser_ReleaseLease_HetznerAlreadyReleased(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("expected PUT or GET, got %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	leaser := newTestLeaser(t, server.URL)
+	leaser.Endpoint = "https://fsn1.your-objectstorage.com"
+	lease := &litestream.Lease{
+		Generation: 5,
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+		Owner:      "me",
+		ETag:       `"released-etag"`,
+	}
+
+	if err := leaser.ReleaseLease(context.Background(), lease); !errors.Is(err, ErrLeaseAlreadyReleased) {
+		t.Errorf("expected ErrLeaseAlreadyReleased, got %v", err)
 	}
 }
 
@@ -595,6 +742,9 @@ func TestReplicaClient_NewLeaser(t *testing.T) {
 	}
 	if leaser.Path != client.Path {
 		t.Fatalf("leaser.Path=%q, want %q", leaser.Path, client.Path)
+	}
+	if leaser.Endpoint != client.Endpoint {
+		t.Fatalf("leaser.Endpoint=%q, want %q", leaser.Endpoint, client.Endpoint)
 	}
 	if leaser.Client() == nil {
 		t.Fatal("expected leaser client")

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -140,6 +140,7 @@ func (c *ReplicaClient) NewLeaser(ctx context.Context) (*Leaser, error) {
 	leaser := NewLeaser()
 	leaser.Bucket = c.Bucket
 	leaser.Path = c.Path
+	leaser.Endpoint = c.Endpoint
 	leaser.SetClient(c.s3)
 	if c.logger != nil {
 		leaser.SetLogger(c.logger)


### PR DESCRIPTION
## Summary

Make the S3 lease implementation in #1317 compatible with Hetzner Object Storage while preserving the existing AWS S3 behavior.

This PR is intentionally stacked on #1317 so it can be reviewed or absorbed into that feature branch as one small follow-up commit.

## Problem

A live compatibility test against a disposable prefix in a Hetzner test bucket showed two differences from AWS S3:

| Request | Hetzner response |
| --- | --- |
| `PUT If-None-Match: *` against an existing lock | `412 PreconditionFailed`; object preserved |
| `PUT If-Match` with the quoted ETag returned by S3 | `412 PreconditionFailed` |
| `PUT If-Match` with the same ETag unquoted | `200`; stale unquoted ETags still return `412` |
| `DELETE If-Match` with a deliberately wrong ETag | `204`; object was deleted |

On the unmodified #1317 head (`07202a4`), the exact `s3lease` binary acquired its lock but failed on the first renewal:

```text
Error: renew lease: lease not held
```

The unconditional delete behavior is also unsafe for fencing: a stale owner could delete a newer owner's lock.

## Solution

- Propagate the configured S3 endpoint to the leaser.
- For Hetzner endpoints, remove the surrounding quotes from ETags used by conditional PUTs.
- Release a Hetzner lease by conditionally replacing it with an expired lease instead of using conditional DELETE.
- Re-read after a failed release write to preserve the distinction between an already released lease and a lease held by another owner.
- Document the provider-specific behavior.

AWS S3 and other providers continue using their existing quoted ETags and conditional DELETE release path.

## Scope

**In scope:**
- Hetzner-specific S3 lease renewal, takeover, and release behavior.
- Unit coverage for renewal, safe release, stale owners, and already-released leases.
- Provider compatibility documentation.

**Not in scope:**
- General Litestream replication behavior.
- Changes to lease timing or the `s3lease` process lifecycle.
- Compatibility changes for other S3 providers.

## Test Plan

```bash
go test ./...
go test -race ./...
pre-commit run --all-files
```

All commands pass locally, including `go vet`, `goimports`, and `staticcheck` through pre-commit.

The patched `s3lease` binary was also tested end-to-end against a unique disposable Hetzner object prefix with a 4-second TTL and 1-second heartbeat:

- the first owner remained alive across multiple renewals;
- a second owner timed out while the lease was held;
- the second owner acquired immediately after the first owner's PUT-based release;
- the disposable lock object was removed after the test.

## Related

- Stacked on #1317
- Related to #1301
