### PR TITLE
feat(replicate): upload snapshots directly to L9, reduce compaction overhead

### DIFF
--- a/_examples/library/library_example_test.go
+++ b/_examples/library/library_example_test.go
@@ -87,6 +87,23 @@ func TestLibraryExampleFileBackend(t *testing.T) {
 	if err := restoreReplica.Restore(ctx, opt); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
+
+	// Verify the restored database contains the replicated row. The write lived
+	// only in the base snapshot (ltx/9), so this exercises the snapshot-level
+	// restore path end to end.
+	restoredDB, err := sql.Open("sqlite", restorePath)
+	if err != nil {
+		t.Fatalf("open restored db: %v", err)
+	}
+	defer restoredDB.Close()
+
+	var message string
+	if err := restoredDB.QueryRowContext(ctx, `SELECT message FROM events WHERE id = 1`).Scan(&message); err != nil {
+		t.Fatalf("query restored row: %v", err)
+	}
+	if message != "hello" {
+		t.Fatalf("restored message = %q, want %q", message, "hello")
+	}
 }
 
 func openAppDB(ctx context.Context, path string) (*sql.DB, error) {
@@ -108,7 +125,10 @@ func openAppDB(ctx context.Context, path string) (*sql.DB, error) {
 func waitForLTXFiles(replicaPath string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		matches, err := filepath.Glob(filepath.Join(replicaPath, "ltx", "0", "*.ltx"))
+		// Match any level: the initial database state is captured as a base
+		// snapshot uploaded directly to the snapshot level (ltx/9), while later
+		// increments land at ltx/0. Either one means replication has occurred.
+		matches, err := filepath.Glob(filepath.Join(replicaPath, "ltx", "*", "*.ltx"))
 		if err != nil {
 			return fmt.Errorf("glob ltx files: %w", err)
 		}

--- a/compactor.go
+++ b/compactor.go
@@ -108,7 +108,20 @@ func (c *Compactor) Compact(ctx context.Context, dstLevel int) (*ltx.FileInfo, e
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine max ltx file for destination level: %w", err)
 	}
-	seekTXID := prevMaxInfo.MaxTXID + 1
+
+	snapInfo, err := c.MaxLTXFileInfo(ctx, SnapshotLevel)
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine snapshot max ltx file: %w", err)
+	}
+
+	// An initial snapshot is required before compaction can begin.
+	if snapInfo.MaxTXID == 0 {
+		return nil, ErrNoCompaction
+	}
+
+	// Snapshots are uploaded directly to the L9 SnapshotLevel, creating a "hole"
+	// in lower levels. Always seek past the newest snapshot.
+	seekTXID := max(prevMaxInfo.MaxTXID, snapInfo.MaxTXID) + 1
 
 	itr, err := c.client.LTXFiles(ctx, srcLevel, seekTXID, false)
 	if err != nil {
@@ -201,6 +214,35 @@ func (c *Compactor) VerifyLevelConsistency(ctx context.Context, level int) error
 	}
 	defer itr.Close()
 
+	// A ladder level skips TXIDs covered by a snapshot (Compact seeks past the
+	// latest snapshot), so a gap is valid when a SnapshotLevel file spans the
+	// missing range. Loaded lazily on the first gap so the common (gapless)
+	// path makes no extra request.
+	var snapshots []*ltx.FileInfo
+	snapshotsLoaded := false
+	gapCoveredBySnapshot := func(g0, g1 ltx.TXID) (bool, error) {
+		if !snapshotsLoaded {
+			sitr, err := c.client.LTXFiles(ctx, SnapshotLevel, 0, false)
+			if err != nil {
+				return false, fmt.Errorf("fetch snapshot ltx files: %w", err)
+			}
+			for sitr.Next() {
+				s := *sitr.Item()
+				snapshots = append(snapshots, &s)
+			}
+			if err := sitr.Close(); err != nil {
+				return false, fmt.Errorf("close snapshot iterator: %w", err)
+			}
+			snapshotsLoaded = true
+		}
+		for _, s := range snapshots {
+			if s.MinTXID <= g0 && s.MaxTXID >= g1 {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
 	var prevInfo *ltx.FileInfo
 	for itr.Next() {
 		info := itr.Item()
@@ -215,11 +257,20 @@ func (c *Compactor) VerifyLevelConsistency(ctx context.Context, level int) error
 		expectedMinTXID := prevInfo.MaxTXID + 1
 		if info.MinTXID != expectedMinTXID {
 			if info.MinTXID > expectedMinTXID {
-				return fmt.Errorf("TXID gap detected: prev.MaxTXID=%s, next.MinTXID=%s (expected %s)",
-					prevInfo.MaxTXID, info.MinTXID, expectedMinTXID)
+				covered, err := gapCoveredBySnapshot(expectedMinTXID, info.MinTXID-1)
+				if err != nil {
+					return err
+				}
+				if !covered {
+					return fmt.Errorf("TXID gap detected: prev.MaxTXID=%s, next.MinTXID=%s (expected %s)",
+						prevInfo.MaxTXID, info.MinTXID, expectedMinTXID)
+				}
+				// Gap is spanned by a snapshot; restore seeds from it and
+				// extends contiguously. Accept and continue.
+			} else {
+				return fmt.Errorf("TXID overlap detected: prev.MaxTXID=%s, next.MinTXID=%s",
+					prevInfo.MaxTXID, info.MinTXID)
 			}
-			return fmt.Errorf("TXID overlap detected: prev.MaxTXID=%s, next.MinTXID=%s",
-				prevInfo.MaxTXID, info.MinTXID)
 		}
 
 		prevInfo = info

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -22,9 +22,11 @@ func TestCompactor_Compact(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
 		compactor := litestream.NewCompactor(client, slog.Default())
 
-		// Create test L0 files
-		createTestLTXFile(t, client, 0, 1, 1)
+		// The base is captured in the snapshot at TXID 1; L0 holds increments
+		// from TXID 2 onward. Compaction into the empty L1 seeks from snapMax+1.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
 		createTestLTXFile(t, client, 0, 2, 2)
+		createTestLTXFile(t, client, 0, 3, 3)
 
 		info, err := compactor.Compact(context.Background(), 1)
 		if err != nil {
@@ -33,8 +35,8 @@ func TestCompactor_Compact(t *testing.T) {
 		if info.Level != 1 {
 			t.Errorf("Level=%d, want 1", info.Level)
 		}
-		if info.MinTXID != 1 || info.MaxTXID != 2 {
-			t.Errorf("TXID range=%d-%d, want 1-2", info.MinTXID, info.MaxTXID)
+		if info.MinTXID != 2 || info.MaxTXID != 3 {
+			t.Errorf("TXID range=%d-%d, want 2-3", info.MinTXID, info.MaxTXID)
 		}
 	})
 
@@ -52,29 +54,30 @@ func TestCompactor_Compact(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
 		compactor := litestream.NewCompactor(client, slog.Default())
 
-		// Create L0 files
-		createTestLTXFile(t, client, 0, 1, 1)
+		// Base in the snapshot at TXID 1; L0 increments from TXID 2.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
 		createTestLTXFile(t, client, 0, 2, 2)
+		createTestLTXFile(t, client, 0, 3, 3)
 
-		// Compact to L1
+		// Compact to L1 (seeks from snapMax+1 = 2)
 		_, err := compactor.Compact(context.Background(), 1)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Create more L0 files
-		createTestLTXFile(t, client, 0, 3, 3)
+		createTestLTXFile(t, client, 0, 4, 4)
 
-		// Compact to L1 again (should only include TXID 3)
+		// Compact to L1 again (should only include TXID 4)
 		info, err := compactor.Compact(context.Background(), 1)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if info.MinTXID != 3 || info.MaxTXID != 3 {
-			t.Errorf("TXID range=%d-%d, want 3-3", info.MinTXID, info.MaxTXID)
+		if info.MinTXID != 4 || info.MaxTXID != 4 {
+			t.Errorf("TXID range=%d-%d, want 4-4", info.MinTXID, info.MaxTXID)
 		}
 
-		// Now compact L1 to L2 (should include all from 1-3)
+		// Now compact L1 to L2 (empty L2 seeks from snapMax+1 = 2, pulling all L1)
 		info, err = compactor.Compact(context.Background(), 2)
 		if err != nil {
 			t.Fatal(err)
@@ -82,8 +85,163 @@ func TestCompactor_Compact(t *testing.T) {
 		if info.Level != 2 {
 			t.Errorf("Level=%d, want 2", info.Level)
 		}
-		if info.MinTXID != 1 || info.MaxTXID != 3 {
-			t.Errorf("TXID range=%d-%d, want 1-3", info.MinTXID, info.MaxTXID)
+		if info.MinTXID != 2 || info.MaxTXID != 4 {
+			t.Errorf("TXID range=%d-%d, want 2-4", info.MinTXID, info.MaxTXID)
+		}
+	})
+}
+
+func TestCompactor_Compact_SeeksFromSnapshot(t *testing.T) {
+	t.Run("EmptyDestinationSkipsSnapshottedRange", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		// A snapshot already covers TXID 1-5.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 5)
+
+		// L0 has the snapshotted range plus new increments.
+		createTestLTXFile(t, client, 0, 1, 5)
+		createTestLTXFile(t, client, 0, 6, 6)
+		createTestLTXFile(t, client, 0, 7, 7)
+
+		// L1 has never been compacted (empty destination): should seek from
+		// snapMax+1 rather than TXID 1, skipping the file already captured
+		// in the snapshot.
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 6 || info.MaxTXID != 7 {
+			t.Errorf("TXID range=%d-%d, want 6-7", info.MinTXID, info.MaxTXID)
+		}
+	})
+
+	t.Run("NoSnapshotDefers", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		// No snapshot exists yet. An empty destination must DEFER (ErrNoCompaction)
+		// rather than seek from TXID 1, which would pull the DB-sized base into
+		// the ladder's first compaction. The snapshot and ladder levels run in
+		// independent monitors with no ordering guarantee, so a ladder level can
+		// reach Compact before the snapshot lands; it should wait.
+		createTestLTXFile(t, client, 0, 1, 1)
+		createTestLTXFile(t, client, 0, 2, 2)
+
+		if _, err := compactor.Compact(context.Background(), 1); err != litestream.ErrNoCompaction {
+			t.Errorf("err=%v, want ErrNoCompaction", err)
+		}
+	})
+
+	t.Run("DefersThenProceedsOnceSnapshotLands", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		// L0 base + increment, but no snapshot yet: the first compaction defers.
+		createTestLTXFile(t, client, 0, 1, 1)
+		createTestLTXFile(t, client, 0, 2, 2)
+		if _, err := compactor.Compact(context.Background(), 1); err != litestream.ErrNoCompaction {
+			t.Fatalf("err=%v, want ErrNoCompaction before snapshot exists", err)
+		}
+
+		// Once the snapshot lands (covering the base at TXID 1), the same empty
+		// destination proceeds, seeking from snapMax+1 and skipping the base.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 2 || info.MaxTXID != 2 {
+			t.Errorf("TXID range=%d-%d, want 2-2 (base skipped, seek from snapMax+1)", info.MinTXID, info.MaxTXID)
+		}
+	})
+
+	t.Run("NonEmptyDestinationSkipsPastLeapfroggingSnapshot", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		// A base snapshot must exist for the empty-destination first compaction to
+		// proceed (an empty destination defers until the snapshot lands).
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
+
+		// L1 already has files up through TXID 3 (seeded from snapMax+1 = 2).
+		createTestLTXFile(t, client, 0, 1, 1)
+		createTestLTXFile(t, client, 0, 2, 2)
+		createTestLTXFile(t, client, 0, 3, 3)
+		if _, err := compactor.Compact(context.Background(), 1); err != nil {
+			t.Fatal(err)
+		}
+
+		// A later snapshot leapfrogs past the current L1 head, covering [1,10].
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 10)
+
+		// New L0 increments 4..10 are now redundant (subsumed by the snapshot),
+		// plus fresh increments past the snapshot at 11.
+		for txID := ltx.TXID(4); txID <= 10; txID++ {
+			createTestLTXFile(t, client, 0, txID, txID)
+		}
+		createTestLTXFile(t, client, 0, 11, 11)
+
+		// The seek is max(dstMax, snapMax)+1 = 11: the ladder skips the
+		// snapshot-covered range 4..10 instead of re-writing it, and picks up at
+		// TXID 11. This is the whole point of the policy -- snapshot-covered data
+		// is never dragged back through the ladder.
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.MinTXID != 11 || info.MaxTXID != 11 {
+			t.Errorf("TXID range=%d-%d, want 11-11 (ladder seeks past the leapfrogging snapshot)", info.MinTXID, info.MaxTXID)
+		}
+
+		// L1 is now {[2,3],[11,11]}: the gap [4,10] is spanned by the snapshot
+		// [1,10], which VerifyLevelConsistency must accept.
+		if err := compactor.VerifyLevelConsistency(context.Background(), 1); err != nil {
+			t.Errorf("expected snapshot-covered gap to verify, got: %v", err)
+		}
+	})
+
+	t.Run("LaggingDestinationDoesNotStraddleSnapshotHole", func(t *testing.T) {
+		client := file.NewReplicaClient(t.TempDir())
+		compactor := litestream.NewCompactor(client, slog.Default())
+
+		// Base snapshot covers TXID 1.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
+
+		// L1 has only caught up through TXID 3 (it lags). With the base snapshot at
+		// TXID 1, the first compaction seeks from 2 and produces L1 [2,3].
+		createTestLTXFile(t, client, 0, 1, 1)
+		createTestLTXFile(t, client, 0, 2, 2)
+		createTestLTXFile(t, client, 0, 3, 3)
+		if info, err := compactor.Compact(context.Background(), 1); err != nil {
+			t.Fatal(err)
+		} else if info.MinTXID != 2 || info.MaxTXID != 3 {
+			t.Fatalf("L1 head=%d-%d, want 2-3", info.MinTXID, info.MaxTXID)
+		}
+
+		// A boundary snapshot lands at TXID 5, leaving a HOLE in L0 (no [5,5]
+		// file: that txID went straight to the snapshot level). L0 has a file at
+		// TXID 4 that L1 has not yet consumed, sitting below the snapshot.
+		createTestLTXFile(t, client, 0, 4, 4)
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 5)
+		createTestLTXFile(t, client, 0, 6, 6)
+		createTestLTXFile(t, client, 0, 7, 7)
+
+		// L1 (head=3) lags the snapshot (max=5). A naive seek of dstMax+1 = 4
+		// would read L0 files on BOTH sides of the hole -- {[4,4],[6,6],[7,7]} --
+		// a non-contiguous input that ltx.Compactor rejects. The policy seeks from
+		// max(3,5)+1 = 6 instead, skipping the redundant [4,4] and the hole.
+		info, err := compactor.Compact(context.Background(), 1)
+		if err != nil {
+			t.Fatalf("straddle should be avoided by seeking past the snapshot, got: %v", err)
+		}
+		if info.MinTXID != 6 || info.MaxTXID != 7 {
+			t.Errorf("TXID range=%d-%d, want 6-7 (seek past the boundary-snapshot hole)", info.MinTXID, info.MaxTXID)
+		}
+
+		// L1 is {[2,3],[6,7]}: the gap [4,5] is spanned by the snapshot [1,5].
+		if err := compactor.VerifyLevelConsistency(context.Background(), 1); err != nil {
+			t.Errorf("expected snapshot-covered gap to verify, got: %v", err)
 		}
 	})
 }
@@ -92,8 +250,9 @@ func TestCompactor_CompactClosesPipeOnWriteError(t *testing.T) {
 	client := newEarlyReturnCompactionClient(t.TempDir())
 	compactor := litestream.NewCompactor(client, slog.Default())
 
-	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
 	createTestLTXFile(t, client, 0, 2, 2)
+	createTestLTXFile(t, client, 0, 3, 3)
 	client.failWrites = true
 
 	before := countCompactorPipeWriters()
@@ -123,7 +282,8 @@ func TestCompactor_CompactResumesRemoteSourceAfterDisconnect(t *testing.T) {
 	client := newDisconnectingCompactionClient(t.TempDir(), 16)
 	compactor := litestream.NewCompactor(client, slog.Default())
 
-	createTestLTXFile(t, client, 0, 1, 1)
+	createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
+	createTestLTXFile(t, client, 0, 2, 2)
 
 	info, err := compactor.Compact(context.Background(), 1)
 	if err != nil {
@@ -132,8 +292,8 @@ func TestCompactor_CompactResumesRemoteSourceAfterDisconnect(t *testing.T) {
 	if info.Level != 1 {
 		t.Errorf("Level=%d, want 1", info.Level)
 	}
-	if info.MinTXID != 1 || info.MaxTXID != 1 {
-		t.Errorf("TXID range=%d-%d, want 1-1", info.MinTXID, info.MaxTXID)
+	if info.MinTXID != 2 || info.MaxTXID != 2 {
+		t.Errorf("TXID range=%d-%d, want 2-2", info.MinTXID, info.MaxTXID)
 	}
 
 	var resumed bool
@@ -285,10 +445,11 @@ func TestCompactor_EnforceL0Retention(t *testing.T) {
 		client := file.NewReplicaClient(t.TempDir())
 		compactor := litestream.NewCompactor(client, slog.Default())
 
-		// Create L0 files
-		createTestLTXFile(t, client, 0, 1, 1)
+		// Base in the snapshot at TXID 1; L0 increments from TXID 2.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
 		createTestLTXFile(t, client, 0, 2, 2)
 		createTestLTXFile(t, client, 0, 3, 3)
+		createTestLTXFile(t, client, 0, 4, 4)
 
 		// Compact to L1
 		_, err := compactor.Compact(context.Background(), 1)
@@ -477,11 +638,13 @@ func TestCompactor_EnforceL0Retention_RetentionDisabled(t *testing.T) {
 		return nil
 	}
 
-	// Create L0 files with old timestamps so they're eligible for deletion.
+	// Base in the snapshot at TXID 1; L0 increments (old timestamps so they're
+	// eligible for deletion) from TXID 2.
+	createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
 	oldTime := time.Now().Add(-1 * time.Hour)
-	createTestLTXFileWithTimestamp(t, client, 0, 1, 1, oldTime)
 	createTestLTXFileWithTimestamp(t, client, 0, 2, 2, oldTime)
 	createTestLTXFileWithTimestamp(t, client, 0, 3, 3, oldTime)
+	createTestLTXFileWithTimestamp(t, client, 0, 4, 4, oldTime)
 
 	// Compact to L1 first.
 	_, err := compactor.Compact(context.Background(), 1)
@@ -598,10 +761,11 @@ func TestCompactor_CompactWithVerification(t *testing.T) {
 		compactor := litestream.NewCompactor(client, slog.Default())
 		compactor.VerifyCompaction = true
 
-		// Create contiguous L0 files
-		createTestLTXFile(t, client, 0, 1, 1)
+		// Base in the snapshot at TXID 1; contiguous L0 increments from TXID 2.
+		createTestLTXFile(t, client, litestream.SnapshotLevel, 1, 1)
 		createTestLTXFile(t, client, 0, 2, 2)
 		createTestLTXFile(t, client, 0, 3, 3)
+		createTestLTXFile(t, client, 0, 4, 4)
 
 		// Compact to L1 - should succeed with verification
 		info, err := compactor.Compact(context.Background(), 1)
@@ -611,8 +775,8 @@ func TestCompactor_CompactWithVerification(t *testing.T) {
 		if info.Level != 1 {
 			t.Errorf("Level=%d, want 1", info.Level)
 		}
-		if info.MinTXID != 1 || info.MaxTXID != 3 {
-			t.Errorf("TXID range=%d-%d, want 1-3", info.MinTXID, info.MaxTXID)
+		if info.MinTXID != 2 || info.MaxTXID != 4 {
+			t.Errorf("TXID range=%d-%d, want 2-4", info.MinTXID, info.MaxTXID)
 		}
 	})
 }

--- a/db.go
+++ b/db.go
@@ -595,6 +595,107 @@ func (db *DB) MaxLTX() (minTXID, maxTXID ltx.TXID, err error) {
 	return minTXID, maxTXID, nil
 }
 
+// openLevel0Anchor opens the local level-0 LTX file whose MaxTXID is maxTXID
+// and returns it along with its MinTXID. The file is either an increment
+// ([maxTXID, maxTXID]) or a snapshotting write ([1, maxTXID]); exactly one
+// exists for a given TXID, so we try the increment name first and fall back to
+// the snapshot name. Callers that assumed a [txID, txID] name must use this so
+// they resolve snapshots (tagged [1, txID], whether the initial snapshot or a
+// boundary snapshot) correctly.
+func (db *DB) openLevel0Anchor(maxTXID ltx.TXID) (f *os.File, minTXID ltx.TXID, err error) {
+	minTXID = maxTXID
+	path := db.LTXPath(0, minTXID, maxTXID)
+	f, err = os.Open(path)
+	if os.IsNotExist(err) && maxTXID > 1 {
+		minTXID = 1
+		path = db.LTXPath(0, minTXID, maxTXID)
+		f, err = os.Open(path)
+	}
+	if err != nil {
+		return nil, 0, NewLTXError("open", path, 0, uint64(minTXID), uint64(maxTXID), err)
+	}
+	return f, minTXID, nil
+}
+
+// uploadTarget resolves the local level-0 file the replica should upload next,
+// given the next TXID it needs (fromTXID = its resume position + 1).
+// Snapshotting writes are tagged [1, k] in the local L0 directory (the TX1
+// base and mid-stream boundary snapshots) and go to the remote snapshot
+// level; increments are tagged [k, k] and go to remote L0.
+//
+// Returns the file's MinTXID, its actual MaxTXID (which may exceed fromTXID
+// when a wider snapshot was used), and the destination remote level.
+func (db *DB) uploadTarget(fromTXID ltx.TXID) (minTXID, maxTXID ltx.TXID, remoteLevel int, err error) {
+	// The first write is always the base, so [1,1] is a snapshot; a [1, k]
+	// file for k > 1 is a boundary snapshot. No increment is ever [1, x].
+	if _, err := os.Stat(db.LTXPath(0, 1, fromTXID)); err == nil {
+		return 1, fromTXID, SnapshotLevel, nil
+	}
+	if _, err := os.Stat(db.LTXPath(0, fromTXID, fromTXID)); err == nil {
+		return fromTXID, fromTXID, 0, nil
+	}
+
+	// Neither exact name exists: fall back to the current live snapshot (the
+	// one [1, k] file that survives at a time), which may extend further than
+	// fromTXID and subsumes it.
+	if k, ok := db.currentSnapshotMaxTXID(); ok && k >= fromTXID {
+		return 1, k, SnapshotLevel, nil
+	}
+
+	path := db.LTXPath(0, fromTXID, fromTXID)
+	return 0, 0, 0, NewLTXError("open", path, 0, uint64(fromTXID), uint64(fromTXID), os.ErrNotExist)
+}
+
+// currentSnapshotMaxTXID returns the MaxTXID of the current live snapshot in
+// the local L0 directory (a file tagged [1, k]), if one exists. If more than
+// one such file happens to survive locally at once (the replica hasn't yet
+// confirmed the upload that would let an older one be cleaned up), the widest
+// is used, since it subsumes any narrower one.
+func (db *DB) currentSnapshotMaxTXID() (maxTXID ltx.TXID, ok bool) {
+	ents, err := os.ReadDir(db.LTXLevelDir(0))
+	if err != nil {
+		return 0, false
+	}
+	for _, ent := range ents {
+		min, max, err := ltx.ParseFilename(ent.Name())
+		if err != nil {
+			continue
+		}
+		if min == 1 && max > maxTXID {
+			maxTXID = max
+			ok = true
+		}
+	}
+	return maxTXID, ok
+}
+
+// deleteSupersededLocalSnapshot deletes the local file of a sync-path snapshot
+// the replica has just advanced past. It is called from the replica sync loop
+// immediately after a durable upload, with prevTXID = the replica's position
+// before that upload and (curMinTXID, curMaxTXID) = the file it just uploaded.
+//
+// Because a sync-path snapshot is uploaded to the L9 snapshot level instead of
+// L0, it is not cleaned up as increment LTX files are in EnforceL0RetentionByTime.
+// Thus, once both the snapshot and its succeeding file have been uploaded to the
+// replica, the snapshot file no longer serves a purpose locally and is deleted
+// to reclaim disk space.
+//
+// Deleting only [1, prevTXID] suffices because the contiguous walk visits every
+// superseded snapshot as prevTXID exactly once. Like all local retention, this
+// assumes a single replica walks the L0 directory.
+func (db *DB) deleteSupersededLocalSnapshot(prevTXID, curMinTXID, curMaxTXID ltx.TXID) {
+	if prevTXID == 0 {
+		return // nothing was anchored before this upload
+	}
+	stalePath := db.LTXPath(0, 1, prevTXID)
+	if stalePath == db.LTXPath(0, curMinTXID, curMaxTXID) {
+		return // we just (re)uploaded this exact file; it is still the live anchor
+	}
+	if err := os.Remove(stalePath); err != nil && !os.IsNotExist(err) {
+		db.Logger.Warn("failed to remove superseded local snapshot file", "path", stalePath, "error", err)
+	}
+}
+
 // FileInfo returns the cached file stats for the database file when it was initialized.
 func (db *DB) FileInfo() os.FileInfo {
 	return db.fileInfo
@@ -699,7 +800,11 @@ func (db *DB) SyncStatus(ctx context.Context) (SyncStatus, error) {
 		return SyncStatus{}, fmt.Errorf("local position: %w", err)
 	}
 
-	remotePos, err := db.Replica.calcPos(ctx)
+	// Snapshotting writes (the base and boundary snapshots) live only at the
+	// snapshot level, so the remote position must consider L9 as well as L0 —
+	// otherwise a replica that has uploaded the base but no increments reads as
+	// out of sync.
+	remotePos, err := db.Replica.calcRemotePos(ctx)
 	if err != nil {
 		return SyncStatus{}, fmt.Errorf("remote position: %w", err)
 	}
@@ -1688,18 +1793,20 @@ func (db *DB) verifyWithExecutor(ctx context.Context, exec *syncExecutor) (info 
 		return info, nil // first sync
 	}
 
-	// Determine last WAL offset we save from.
-	ltxPath := db.LTXPath(0, exec.pos.TXID, exec.pos.TXID)
-	ltxFile, err := os.Open(ltxPath)
+	// Determine last WAL offset we save from. The anchor may be a snapshot
+	// tagged [1, TXID] (initial or boundary), so resolve its real range rather
+	// than assuming [TXID, TXID].
+	ltxFile, minTXID, err := db.openLevel0Anchor(exec.pos.TXID)
 	if err != nil {
-		return info, NewLTXError("open", ltxPath, 0, uint64(exec.pos.TXID), uint64(exec.pos.TXID), err)
+		return info, err
 	}
 	defer func() { _ = ltxFile.Close() }()
 
 	dec := ltx.NewDecoder(ltxFile)
 	if err := dec.DecodeHeader(); err != nil {
 		// Decode failure indicates corruption
-		ltxErr := NewLTXError("decode", ltxPath, 0, uint64(exec.pos.TXID), uint64(exec.pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+		ltxPath := db.LTXPath(0, minTXID, exec.pos.TXID)
+		ltxErr := NewLTXError("decode", ltxPath, 0, uint64(minTXID), uint64(exec.pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
 		return info, ltxErr
 	}
 	info.offset = dec.Header().WALOffset + dec.Header().WALSize
@@ -2011,7 +2118,17 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 			s.reason = info.reason
 		})
 
-	filename := db.LTXPath(0, txID, txID)
+	// Snapshotting writes (the initial base and mid-stream boundary snapshots)
+	// are full-DB images. Tag them [1, txID] so the file itself durably marks
+	// it as a snapshot: the replica routes MinTXID==1 files to the remote
+	// snapshot level (L9), and no increment is ever [1, x] because the first
+	// write is always the base. Increments stay [txID, txID]. The file is
+	// still written into the local L0 directory so MaxLTX/Pos find the anchor.
+	minTXID := txID
+	if info.snapshotting {
+		minTXID = 1
+	}
+	filename := db.LTXPath(0, minTXID, txID)
 
 	logArgs := []any{
 		"txid", txID.String(),
@@ -2148,7 +2265,7 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 		Flags:     ltx.HeaderFlagNoChecksum,
 		PageSize:  uint32(db.pageSize),
 		Commit:    commit,
-		MinTXID:   txID,
+		MinTXID:   minTXID,
 		MaxTXID:   txID,
 		Timestamp: timestamp.UnixMilli(),
 		WALOffset: info.offset,
@@ -2245,12 +2362,20 @@ func (db *DB) sync(ctx context.Context, checkpointing bool, exec *syncExecutor, 
 	}
 
 	result.synced = true
-	result.l0FileInfo = &ltx.FileInfo{
-		Level:     0,
-		MinTXID:   txID,
-		MaxTXID:   txID,
-		CreatedAt: time.Now(),
-		Size:      enc.N(),
+	// Only increments advance the L0 max used by the compaction ladder.
+	// Snapshotting writes are recorded at the snapshot level (via the remote
+	// L9 upload), not L0, so the ladder never sees a DB-sized image. Leaving
+	// l0FileInfo nil here keeps maxLTXFileInfos[0] pointing at the last
+	// increment (or empty at bootstrap); the anchor still resolves from the
+	// local L0 directory via MaxLTX/Pos.
+	if !info.snapshotting {
+		result.l0FileInfo = &ltx.FileInfo{
+			Level:     0,
+			MinTXID:   txID,
+			MaxTXID:   txID,
+			CreatedAt: time.Now(),
+			Size:      enc.N(),
+		}
 	}
 
 	encPos := enc.PostApplyPos()
@@ -2769,16 +2894,18 @@ func (db *DB) snapshotWALEndOffset(pos ltx.Pos) (int64, error) {
 		return WALHeaderSize, nil
 	}
 
-	ltxPath := db.LTXPath(0, pos.TXID, pos.TXID)
-	f, err := os.Open(ltxPath)
+	// The anchor may be a snapshot tagged [1, TXID] (initial or boundary);
+	// resolve its real range rather than assuming [TXID, TXID].
+	f, minTXID, err := db.openLevel0Anchor(pos.TXID)
 	if err != nil {
-		return 0, NewLTXError("open", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), err)
+		return 0, err
 	}
 	defer func() { _ = f.Close() }()
 
 	dec := ltx.NewDecoder(f)
 	if err := dec.DecodeHeader(); err != nil {
-		return 0, NewLTXError("decode", ltxPath, 0, uint64(pos.TXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
+		ltxPath := db.LTXPath(0, minTXID, pos.TXID)
+		return 0, NewLTXError("decode", ltxPath, 0, uint64(minTXID), uint64(pos.TXID), fmt.Errorf("%w: %w", ErrLTXCorrupted, err))
 	}
 
 	// Compare WAL headers. If the WAL was restarted since this LTX file was

--- a/db.go
+++ b/db.go
@@ -3415,7 +3415,10 @@ func (db *DB) MaxLTXFileInfo(ctx context.Context, level int) (ltx.FileInfo, erro
 		return ltx.FileInfo{}, fmt.Errorf("cannot determine L%d max ltx file for %q: %w", level, db.Path(), err)
 	}
 
-	db.maxLTXFileInfos.m[level] = &remoteInfo
+	// Only cache a real file. Mirrors the guard in Compactor.MaxLTXFileInfo.
+	if remoteInfo.MaxTXID > 0 {
+		db.maxLTXFileInfos.m[level] = &remoteInfo
+	}
 	return remoteInfo, nil
 }
 

--- a/db.go
+++ b/db.go
@@ -354,9 +354,7 @@ func NewDB(path string) *DB {
 		return info, ok
 	}
 	db.compactor.CacheSetter = func(level int, info *ltx.FileInfo) {
-		db.maxLTXFileInfos.Lock()
-		defer db.maxLTXFileInfos.Unlock()
-		db.maxLTXFileInfos.m[level] = info
+		db.recordMaxLTXFile(level, info)
 	}
 
 	return db
@@ -2028,9 +2026,7 @@ func (db *DB) applySyncResult(state *syncState, result syncResult) {
 		db.pos.Unlock()
 	}
 	if result.l0FileInfo != nil {
-		db.maxLTXFileInfos.Lock()
-		db.maxLTXFileInfos.m[0] = result.l0FileInfo
-		db.maxLTXFileInfos.Unlock()
+		db.recordMaxLTXFile(0, result.l0FileInfo)
 	}
 }
 
@@ -2071,10 +2067,7 @@ func (db *DB) applySyncExecutor(exec *syncExecutor, notify bool) {
 	}
 
 	if exec.l0FileInfo != nil {
-		db.maxLTXFileInfos.Lock()
-		info := *exec.l0FileInfo
-		db.maxLTXFileInfos.m[0] = &info
-		db.maxLTXFileInfos.Unlock()
+		db.recordMaxLTXFile(0, exec.l0FileInfo)
 	}
 
 	db.mu.Lock()
@@ -2559,10 +2552,7 @@ func (db *DB) checkpoint(ctx context.Context, mode string, state *syncState) err
 	db.pos.value = &pos
 	db.pos.Unlock()
 	if exec.l0FileInfo != nil {
-		db.maxLTXFileInfos.Lock()
-		info := *exec.l0FileInfo
-		db.maxLTXFileInfos.m[0] = &info
-		db.maxLTXFileInfos.Unlock()
+		db.recordMaxLTXFile(0, exec.l0FileInfo)
 	}
 	return nil
 }
@@ -3069,9 +3059,7 @@ func (db *DB) Snapshot(ctx context.Context) (*ltx.FileInfo, error) {
 		return info, err
 	}
 
-	db.maxLTXFileInfos.Lock()
-	db.maxLTXFileInfos.m[SnapshotLevel] = info
-	db.maxLTXFileInfos.Unlock()
+	db.recordMaxLTXFile(SnapshotLevel, info)
 
 	return info, nil
 }
@@ -3399,13 +3387,43 @@ func (db *DB) CRC64(ctx context.Context) (uint64, ltx.Pos, error) {
 	return h.Sum64(), exec.pos, nil
 }
 
+// recordMaxLTXFile is the single writer for the maxLTXFileInfos cache. Every
+// path that observes a new max LTX file for a level -- the sync/checkpoint L0
+// writes, the L9 snapshot writes (db.Snapshot and the sync-path base/boundary
+// snapshot upload), the compactor's L1..L8 writes, and the read-through fills
+// from remote -- funnels through here so two invariants hold everywhere:
+//
+//   - Never cache an empty (MaxTXID == 0) result. A read-through fill that
+//     observes an empty level (e.g. a compaction-monitor tick before the base
+//     has finished uploading to L9) must not pin MaxTXID==0 and starve
+//     leveled compaction forever.
+//   - Never regress. L9 has two racing writers -- the snapshot monitor via
+//     db.Snapshot and the replica sync loop via uploadLTXFile -- that are not
+//     mutually serialized, so a lower-TXID writer must not clobber a higher
+//     one. Monotonicity is safe for every level because generation resets clear
+//     the whole map (see ResetLocalState) rather than writing a lower value,
+//     and the L0 error paths delete their entry rather than lowering it.
+//
+// The info is copied so callers may reuse their pointer.
+func (db *DB) recordMaxLTXFile(level int, info *ltx.FileInfo) {
+	if info == nil || info.MaxTXID == 0 {
+		return
+	}
+	db.maxLTXFileInfos.Lock()
+	defer db.maxLTXFileInfos.Unlock()
+	if cur, ok := db.maxLTXFileInfos.m[level]; ok && info.MaxTXID < cur.MaxTXID {
+		return
+	}
+	cp := *info
+	db.maxLTXFileInfos.m[level] = &cp
+}
+
 // MaxLTXFileInfo returns the metadata for the last LTX file in a level.
 // If cached, it will returned the local copy. Otherwise, it fetches from the replica.
 func (db *DB) MaxLTXFileInfo(ctx context.Context, level int) (ltx.FileInfo, error) {
 	db.maxLTXFileInfos.Lock()
-	defer db.maxLTXFileInfos.Unlock()
-
 	info, ok := db.maxLTXFileInfos.m[level]
+	db.maxLTXFileInfos.Unlock()
 	if ok {
 		return *info, nil
 	}
@@ -3415,10 +3433,7 @@ func (db *DB) MaxLTXFileInfo(ctx context.Context, level int) (ltx.FileInfo, erro
 		return ltx.FileInfo{}, fmt.Errorf("cannot determine L%d max ltx file for %q: %w", level, db.Path(), err)
 	}
 
-	// Only cache a real file. Mirrors the guard in Compactor.MaxLTXFileInfo.
-	if remoteInfo.MaxTXID > 0 {
-		db.maxLTXFileInfos.m[level] = &remoteInfo
-	}
+	db.recordMaxLTXFile(level, &remoteInfo)
 	return remoteInfo, nil
 }
 

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -3753,7 +3753,9 @@ func TestApplySyncResult(t *testing.T) {
 		db.maxLTXFileInfos.Lock()
 		got := db.maxLTXFileInfos.m[0]
 		db.maxLTXFileInfos.Unlock()
-		if got != info {
+		// recordMaxLTXFile copies the info defensively, so compare by value
+		// rather than pointer identity.
+		if got == nil || *got != *info {
 			t.Fatalf("l0FileInfo=%v, want %v", got, info)
 		}
 	})

--- a/db_internal_test.go
+++ b/db_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1686,14 +1687,20 @@ func TestDB_MonitorRetriesAndRecoversFromLTXStagingDiskFull(t *testing.T) {
 
 	diskFull.Store(false)
 
+	// The base (TXID 1) is a snapshotting write, uploaded to the remote
+	// snapshot level (l9) rather than remote L0, so both must be counted.
 	remoteLTXCount := func() int {
-		entries, err := os.ReadDir(filepath.Join(replicaDir, "l0"))
-		if os.IsNotExist(err) {
-			return 0
-		} else if err != nil {
-			t.Fatalf("read replica ltx dir: %v", err)
+		var n int
+		for _, level := range []string{"l0", "l9"} {
+			entries, err := os.ReadDir(filepath.Join(replicaDir, level))
+			if os.IsNotExist(err) {
+				continue
+			} else if err != nil {
+				t.Fatalf("read replica ltx dir: %v", err)
+			}
+			n += len(entries)
 		}
-		return len(entries)
+		return n
 	}
 
 	waitFor("automatic recovery", func() bool {
@@ -1789,6 +1796,19 @@ func TestDB_L0RetentionMetrics(t *testing.T) {
 	defer sqldb.Close()
 
 	if _, err := sqldb.Exec(`CREATE TABLE t (id INT, data TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Replica.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// The base must be captured in a snapshot before an empty L1's first
+	// compaction: Compact defers (ErrNoCompaction) until a snapshot exists,
+	// rather than pulling the DB-sized base into L1's first file.
+	if _, err := db.Snapshot(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3079,14 +3099,33 @@ func TestDB_Sync_CompactionValidAfterGrowthAndCheckpoint(t *testing.T) {
 	}
 	t.Logf("final txid=%d", pos.TXID)
 
-	var readers []io.ReadCloser
-	for txid := ltx.TXID(1); txid <= pos.TXID; txid++ {
-		path := db.LTXPath(0, txid, txid)
-		f, err := os.Open(path)
+	// Build the restore chain by walking backward from the current position,
+	// resolving each anchor the same way production code does (openLevel0Anchor),
+	// to construct the history of increments ([txid, txid]) and snapshots
+	// ([1,txid]).
+	type ltxFile struct {
+		min, max ltx.TXID
+		path     string
+	}
+	var files []ltxFile
+	for max := pos.TXID; max > 0; {
+		f, min, err := db.openLevel0Anchor(max)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
+			t.Fatal(err)
+		}
+		files = append(files, ltxFile{min: min, max: max, path: f.Name()})
+		f.Close()
+		if min <= 1 {
+			break
+		}
+		max = min - 1
+	}
+
+	var readers []io.ReadCloser
+	// files were appended newest-first; reverse to oldest-first for the compactor.
+	for _, lf := range slices.Backward(files) {
+		f, err := os.Open(lf.path)
+		if err != nil {
 			t.Fatal(err)
 		}
 		readers = append(readers, f)
@@ -3759,7 +3798,18 @@ func TestVerifyAndSync_DelaysStateMutationUntilApply(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The first sync above is the base (a snapshotting write): it doesn't
+	// populate maxLTXFileInfos[0], since snapshotting writes are recorded at
+	// the snapshot level, not L0. A genuine increment is needed so the L0
+	// cache this test inspects below is populated.
 	if _, err := sqldb.Exec(`INSERT INTO t VALUES (2, 'after')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqldb.Exec(`INSERT INTO t VALUES (3, 'after2')`); err != nil {
 		t.Fatal(err)
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -220,6 +220,15 @@ func TestDB_Sync(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Reconnecting to the same remote target on reopen (below) is the
+		// realistic restart scenario -- calcPos recovers the resume position
+		// from that target's own listing, so no historical local file (e.g. a
+		// superseded snapshot's local copy, already cleaned up once uploaded)
+		// is ever needed. A fresh, unrelated remote target would need the full
+		// history replayed from TXID 1, which is a distinct, unsupported
+		// scenario this test isn't about.
+		replicaClient := db.Replica.Client
+
 		if err := db.Close(context.Background()); err != nil {
 			t.Fatal(err)
 		} else if err := sqldb.Close(); err != nil {
@@ -231,8 +240,9 @@ func TestDB_Sync(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Reopen the managed database.
+		// Reopen the managed database, reconnecting to the same remote target.
 		db = testingutil.MustOpenDBAt(t, db.Path())
+		db.Replica.Client = replicaClient
 		defer testingutil.MustCloseDB(t, db)
 
 		// Re-sync and ensure new generation has been created.
@@ -413,6 +423,16 @@ func TestDB_Compact(t *testing.T) {
 		if err := db.Sync(context.Background()); err != nil {
 			t.Fatal(err)
 		}
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// The base (TXID 1) must be captured in a snapshot before an empty L1's
+		// first compaction: Compact defers (ErrNoCompaction) until a snapshot
+		// exists, rather than pulling the DB-sized base into L1's first file.
+		if _, err := db.Snapshot(t.Context()); err != nil {
+			t.Fatal(err)
+		}
 
 		if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
 			t.Fatal(err)
@@ -436,7 +456,7 @@ func TestDB_Compact(t *testing.T) {
 		if got, want := info.Level, 1; got != want {
 			t.Fatalf("Level=%v, want %v", got, want)
 		}
-		if got, want := info.MinTXID, ltx.TXID(1); got != want {
+		if got, want := info.MinTXID, ltx.TXID(2); got != want {
 			t.Fatalf("MinTXID=%s, want %s", got, want)
 		}
 		if got, want := info.MaxTXID, ltx.TXID(2); got != want {
@@ -455,6 +475,16 @@ func TestDB_Compact(t *testing.T) {
 		if err := db.Sync(context.Background()); err != nil {
 			t.Fatal(err)
 		}
+		if err := db.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// The base (TXID 1) must be captured in a snapshot before an empty L1's
+		// first compaction: Compact defers (ErrNoCompaction) until a snapshot
+		// exists, rather than pulling the DB-sized base into L1's first file.
+		if _, err := db.Snapshot(t.Context()); err != nil {
+			t.Fatal(err)
+		}
 
 		if _, err := sqldb.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
 			t.Fatal(err)
@@ -471,10 +501,10 @@ func TestDB_Compact(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Compact to L1:1-2
+		// Compact to L1:2-2 (base at TXID 1 is skipped: already in the snapshot)
 		if info, err := db.Compact(t.Context(), 1); err != nil {
 			t.Fatal(err)
-		} else if got, want := ltx.FormatFilename(info.MinTXID, info.MaxTXID), `0000000000000001-0000000000000002.ltx`; got != want {
+		} else if got, want := ltx.FormatFilename(info.MinTXID, info.MaxTXID), `0000000000000002-0000000000000002.ltx`; got != want {
 			t.Fatalf("Filename=%s, want %s", got, want)
 		}
 
@@ -496,12 +526,14 @@ func TestDB_Compact(t *testing.T) {
 			t.Fatalf("Filename=%s, want %s", got, want)
 		}
 
-		// Compact to L2:1-3
+		// Compact to L2:2-3 (empty L2 also seeks past the snapshot at TXID 1,
+		// pulling both L1 files -- [2,2] and [3,3] -- which both start at or
+		// after snapMax+1)
 		if info, err := db.Compact(t.Context(), 2); err != nil {
 			t.Fatal(err)
 		} else if got, want := info.Level, 2; got != want {
 			t.Fatalf("Level=%v, want %v", got, want)
-		} else if got, want := ltx.FormatFilename(info.MinTXID, info.MaxTXID), `0000000000000001-0000000000000003.ltx`; got != want {
+		} else if got, want := ltx.FormatFilename(info.MinTXID, info.MaxTXID), `0000000000000002-0000000000000003.ltx`; got != want {
 			t.Fatalf("Filename=%s, want %s", got, want)
 		}
 	})
@@ -891,6 +923,16 @@ func TestDB_EnforceL0RetentionByTime_RetentionDisabled(t *testing.T) {
 	} else if err := db.Sync(t.Context()); err != nil {
 		t.Fatal(err)
 	}
+
+	// The base (TXID 1, above) must be captured in a snapshot before an empty
+	// L1's first compaction: Compact defers (ErrNoCompaction) until a snapshot
+	// exists. Snapshotting right after the base (rather than after the loop
+	// below) leaves TXID 2-4 as genuine increments for L1 to compact. db.Snapshot
+	// reads the live DB directly, so this doesn't need db.Replica.Sync first.
+	if _, err := db.Snapshot(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
 	for i := 0; i < 3; i++ {
 		if _, err := sqldb.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (?)`, i); err != nil {
 			t.Fatal(err)
@@ -924,7 +966,8 @@ func TestDB_EnforceL0RetentionByTime_RetentionDisabled(t *testing.T) {
 		t.Fatalf("expected at least 2 L0 files, got %d", beforeCount)
 	}
 
-	// Compact L0 to L1 so files become eligible for L0 retention.
+	// Compact L0 to L1 so files become eligible for L0 retention. The base was
+	// already captured in a snapshot above.
 	store := litestream.NewStore([]*litestream.DB{db}, litestream.DefaultCompactionLevels)
 	if _, err := store.CompactDB(t.Context(), db, &litestream.CompactionLevel{Level: 1, Interval: time.Nanosecond}); err != nil {
 		t.Fatal(err)
@@ -1058,6 +1101,18 @@ func TestCompaction_PreservesLastTimestamp(t *testing.T) {
 		if err := db.Replica.Sync(ctx); err != nil {
 			t.Fatalf("sync replica: %v", err)
 		}
+
+		// The base (TXID 1, the first iteration above) must be captured in a
+		// snapshot before an empty L1's first compaction: Compact defers
+		// (ErrNoCompaction) until a snapshot exists, rather than pulling the
+		// DB-sized base into L1's first file. Snapshotting right after the base
+		// (rather than after the whole loop) leaves TXID 2-10 as genuine
+		// increments for L1 to compact.
+		if i == 0 {
+			if _, err := db.Snapshot(ctx); err != nil {
+				t.Fatalf("snapshot: %v", err)
+			}
+		}
 	}
 
 	// Record the last L0 file timestamp before compaction
@@ -1179,16 +1234,32 @@ func TestDB_EnforceRetentionByTXID_LocalCleanup(t *testing.T) {
 		if err != nil {
 			t.Fatalf("get max ltx: %v", err)
 		}
-		localPath := db.LTXPath(0, minTXID, maxTXID)
-		firstBatchL0Files = append(firstBatchL0Files, localFile{
-			path:    localPath,
-			minTXID: minTXID,
-			maxTXID: maxTXID,
-		})
+		// The base (i == 0, TXID 1) is a snapshotting write: its local file is
+		// proactively removed by the replica once superseded by the next
+		// upload (see the cleanup in Replica.syncOnce), since its data already
+		// lives durably at the remote snapshot level and no anchor ever needs
+		// it again locally. It is never visible to EnforceRetentionByTXID
+		// (level 0, ...), which only sees files present in the remote L0
+		// listing. So only genuine increments (i >= 1) are tracked here as
+		// files that retention is responsible for.
+		if i > 0 {
+			localPath := db.LTXPath(0, minTXID, maxTXID)
+			firstBatchL0Files = append(firstBatchL0Files, localFile{
+				path:    localPath,
+				minTXID: minTXID,
+				maxTXID: maxTXID,
+			})
+		}
 
 		if err := db.Replica.Sync(ctx); err != nil {
 			t.Fatalf("sync replica batch1 %d: %v", i, err)
 		}
+	}
+
+	// The base's local file is proactively cleaned up once superseded -- it
+	// never lingers for EnforceRetentionByTXID to find.
+	if _, err := os.Stat(db.LTXPath(0, 1, 1)); !os.IsNotExist(err) {
+		t.Fatalf("base local file should have been proactively removed once superseded")
 	}
 
 	for _, lf := range firstBatchL0Files {
@@ -1267,6 +1338,17 @@ func TestDB_EnforceL0RetentionByTime(t *testing.T) {
 		}
 		if err := db.Replica.Sync(ctx); err != nil {
 			t.Fatalf("sync replica %d: %v", i, err)
+		}
+
+		// The base (TXID 1, the first iteration above) must be captured in a
+		// snapshot before an empty L1's first compaction: Compact defers
+		// (ErrNoCompaction) until a snapshot exists. Snapshotting right after the
+		// base (rather than after the whole loop) leaves TXID 2-3 as genuine
+		// increments for L1 to compact.
+		if i == 0 {
+			if _, err := db.Snapshot(ctx); err != nil {
+				t.Fatalf("snapshot: %v", err)
+			}
 		}
 	}
 

--- a/replica.go
+++ b/replica.go
@@ -1046,8 +1046,24 @@ func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileIn
 
 // fillFollowGap attempts to bridge a gap in level 0 files by searching
 // higher compaction levels for a file that covers the missing TXID range.
+//
+// The ladder levels (1..SnapshotLevel-1) are tried first, in order, preferring
+// the smallest contiguous forward step. If none of them can advance, we fall
+// back to the newest L9 snapshot that extends past currentTXID: snapshots are
+// full-DB images written directly to SnapshotLevel and Compact deliberately
+// seeks past them, leaving holes in the ladder that only a snapshot covers.
+// This mirrors CalcRestorePlan, which seeds from the snapshot before layering
+// ladder levels on top. Without it, a follower parked inside such a hole (its
+// L0 files pruned by retention) stalls silently.
 func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.TXID, gapMinTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
 	currentTXID := afterTXID
+
+	// sawAhead records whether we observed data past currentTXID that we could
+	// not reach contiguously. A caller-supplied gap (gapMinTXID > afterTXID+1,
+	// e.g. an L0 file ahead) is already such evidence; ladder scans below add to
+	// it. If we finish without advancing while sawAhead is set, the follower is
+	// genuinely stalled rather than merely caught up, and we warn.
+	sawAhead := gapMinTXID > afterTXID+1
 
 	for level := 1; level < SnapshotLevel; level++ {
 		itr, err := r.Client.LTXFiles(ctx, level, 0, false)
@@ -1070,6 +1086,9 @@ func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.T
 
 			// Skip if there's a gap at this level too.
 			if info.MinTXID > currentTXID+1 {
+				if info.MaxTXID > currentTXID {
+					sawAhead = true
+				}
 				break
 			}
 
@@ -1105,7 +1124,49 @@ func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.T
 		}
 	}
 
+	// The ladder could not advance. Fall back to the newest snapshot that
+	// extends past currentTXID, then let the ladder resume on the next poll.
+	bridgedTXID, err := r.fillFollowGapFromSnapshot(ctx, f, currentTXID, pageSize)
+	if err != nil {
+		return currentTXID, err
+	}
+	currentTXID = bridgedTXID
+
+	// Still stuck with known data ahead: the follower is stalled, not caught up.
+	if currentTXID == afterTXID && sawAhead {
+		r.Logger().Warn("follow: unable to bridge gap; follower stalled",
+			"current_txid", currentTXID, "gap_min_txid", gapMinTXID)
+	}
+
 	return currentTXID, nil
+}
+
+// fillFollowGapFromSnapshot bridges a follow-mode gap using the newest L9
+// snapshot whose coverage extends past afterTXID. Applying a snapshot is a
+// full-DB image write (applyLTXFile truncates to the snapshot's page count),
+// which advances the follower to the snapshot's TXID so the ladder can resume.
+// Returns the (possibly unchanged) TXID reached; afterTXID when no snapshot can
+// help.
+func (r *Replica) fillFollowGapFromSnapshot(ctx context.Context, f *os.File, afterTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
+	// The newest snapshot is the one with the highest MaxTXID, so "newest
+	// snapshot that advances us" is simply the max snapshot when it clears
+	// afterTXID. MaxLTXFileInfo returns a zero-valued FileInfo (MaxTXID == 0)
+	// when no snapshot exists, which the guard below handles.
+	snapshot, err := r.MaxLTXFileInfo(ctx, SnapshotLevel)
+	if err != nil {
+		return afterTXID, fmt.Errorf("max snapshot ltx file: %w", err)
+	}
+	if snapshot.MaxTXID <= afterTXID {
+		return afterTXID, nil
+	}
+
+	if err := r.applyLTXFile(ctx, f, &snapshot, pageSize); err != nil {
+		return afterTXID, fmt.Errorf(
+			"apply gap-fill snapshot (level=%d, min=%s, max=%s): %w",
+			snapshot.Level, snapshot.MinTXID, snapshot.MaxTXID, err,
+		)
+	}
+	return snapshot.MaxTXID, nil
 }
 
 // RestoreV3 restores from a v0.3.x format backup.

--- a/replica.go
+++ b/replica.go
@@ -275,6 +275,14 @@ func (r *Replica) uploadLTXFile(ctx context.Context, localLevel, remoteLevel int
 		"maxTXID", info.MaxTXID,
 		"size", info.Size)
 
+	// Snapshot uploads (the base and boundary snapshots, routed to L9) must
+	// refresh the DB's cached snapshot-level max, consistent with db.Snapshot
+	if remoteLevel == SnapshotLevel {
+		r.db.maxLTXFileInfos.Lock()
+		r.db.maxLTXFileInfos.m[SnapshotLevel] = info
+		r.db.maxLTXFileInfos.Unlock()
+	}
+
 	// Track current position
 	//replicaWALIndexGaugeVec.WithLabelValues(r.db.Path(), r.Name()).Set(float64(rd.Pos().Index))
 	//replicaWALOffsetGaugeVec.WithLabelValues(r.db.Path(), r.Name()).Set(float64(rd.Pos().Offset))

--- a/replica.go
+++ b/replica.go
@@ -276,11 +276,9 @@ func (r *Replica) uploadLTXFile(ctx context.Context, localLevel, remoteLevel int
 		"size", info.Size)
 
 	// Snapshot uploads (the base and boundary snapshots, routed to L9) must
-	// refresh the DB's cached snapshot-level max, consistent with db.Snapshot
+	// refresh the DB's cached snapshot-level max, consistent with db.Snapshot.
 	if remoteLevel == SnapshotLevel {
-		r.db.maxLTXFileInfos.Lock()
-		r.db.maxLTXFileInfos.m[SnapshotLevel] = info
-		r.db.maxLTXFileInfos.Unlock()
+		r.db.recordMaxLTXFile(SnapshotLevel, info)
 	}
 
 	// Track current position

--- a/replica.go
+++ b/replica.go
@@ -204,7 +204,7 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 		))
 
 	// Replicate all L0 LTX files since last replica position.
-	for txID, syncedFileN := r.Pos().TXID+1, 0; txID <= dpos.TXID; txID = r.Pos().TXID + 1 {
+	for fromTXID, syncedFileN := r.Pos().TXID+1, 0; fromTXID <= dpos.TXID; fromTXID = r.Pos().TXID + 1 {
 		if maxSyncLTXFiles > 0 && syncedFileN >= maxSyncLTXFiles {
 			result.limited = true
 			// Uploads succeeded, so record sync health; otherwise a
@@ -219,12 +219,24 @@ func (r *Replica) syncOnce(ctx context.Context, maxSyncLTXFiles int) (result rep
 		if err := ctx.Err(); err != nil {
 			return result, context.Cause(ctx)
 		}
-		if err := r.uploadLTXFile(ctx, 0, txID, txID); err != nil {
+		// Upload incremental L0 files to L0, and snapshots to L9.
+		prevTXID := r.Pos().TXID
+		minTXID, maxTXID, remoteLevel, err := r.db.uploadTarget(fromTXID)
+		if err != nil {
 			return result, err
 		}
-		r.SetPos(ltx.Pos{TXID: txID})
+		if err := r.uploadLTXFile(ctx, 0, remoteLevel, minTXID, maxTXID); err != nil {
+			return result, err
+		}
+		r.SetPos(ltx.Pos{TXID: maxTXID})
 		result.synced = true
 		syncedFileN++
+
+		// Delete the local file of any sync-path snapshot we've now advanced past
+		// (the initial snapshot or a boundary snapshot). Its bytes are durably at
+		// remote L9; its local L0-dir copy is only staging + anchor state that no
+		// retention path owns.
+		r.db.deleteSupersededLocalSnapshot(prevTXID, minTXID, maxTXID)
 	}
 
 	// Record successful sync for heartbeat monitoring.
@@ -245,15 +257,15 @@ func (r *Replica) lockSync(ctx context.Context) error {
 	return nil
 }
 
-func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID ltx.TXID) (err error) {
-	filename := r.db.LTXPath(level, minTXID, maxTXID)
+func (r *Replica) uploadLTXFile(ctx context.Context, localLevel, remoteLevel int, minTXID, maxTXID ltx.TXID) (err error) {
+	filename := r.db.LTXPath(localLevel, minTXID, maxTXID)
 	f, err := os.Open(filename)
 	if err != nil {
-		return NewLTXError("open", filename, level, uint64(minTXID), uint64(maxTXID), err)
+		return NewLTXError("open", filename, localLevel, uint64(minTXID), uint64(maxTXID), err)
 	}
 	defer func() { _ = f.Close() }()
 
-	info, err := r.Client.WriteLTXFile(ctx, level, minTXID, maxTXID, f)
+	info, err := r.Client.WriteLTXFile(ctx, remoteLevel, minTXID, maxTXID, f)
 	if err != nil {
 		return fmt.Errorf("write ltx file: %w", err)
 	}
@@ -270,13 +282,38 @@ func (r *Replica) uploadLTXFile(ctx context.Context, level int, minTXID, maxTXID
 	return nil
 }
 
-// calcPos returns the last position saved to the replica for level 0.
+// calcPos returns the last position saved to the replica for level 0. This is
+// the replica sync loop's resume point: it stays L0-only so every increment is
+// still uploaded to L0 (preserving point-in-time restore granularity) even when
+// a snapshot at L9 already covers a higher TXID. Re-encountering a snapshot TXID
+// is harmless -- uploadTarget re-routes it to L9 idempotently.
 func (r *Replica) calcPos(ctx context.Context) (pos ltx.Pos, err error) {
 	info, err := r.MaxLTXFileInfo(ctx, 0)
 	if err != nil {
 		return pos, fmt.Errorf("max ltx file: %w", err)
 	}
 	return ltx.Pos{TXID: info.MaxTXID}, nil
+}
+
+// calcRemotePos returns the highest TXID durably present in the replica across
+// the increment level (L0) and the snapshot level (L9). Snapshotting writes --
+// the base and boundary snapshots -- are stored only at the snapshot level, so a
+// replica that has uploaded the base but no increments is still fully caught up.
+// Used for reporting replication status, not for the sync loop's resume point.
+func (r *Replica) calcRemotePos(ctx context.Context) (pos ltx.Pos, err error) {
+	l0, err := r.MaxLTXFileInfo(ctx, 0)
+	if err != nil {
+		return pos, fmt.Errorf("max l0 ltx file: %w", err)
+	}
+	snap, err := r.MaxLTXFileInfo(ctx, SnapshotLevel)
+	if err != nil {
+		return pos, fmt.Errorf("max snapshot ltx file: %w", err)
+	}
+	txID := l0.MaxTXID
+	if snap.MaxTXID > txID {
+		txID = snap.MaxTXID
+	}
+	return ltx.Pos{TXID: txID}, nil
 }
 
 // MaxLTXFileInfo returns metadata about the last LTX file for a given level.

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -146,7 +146,7 @@ func TestReplica_UploadLTXFile_OpenErrorReturnsLTXError(t *testing.T) {
 		db := NewDB(filepath.Join(t.TempDir(), "test.db"))
 		r := NewReplicaWithClient(db, &followTestReplicaClient{})
 
-		err := r.uploadLTXFile(context.Background(), 0, 1, 1)
+		err := r.uploadLTXFile(context.Background(), 0, 0, 1, 1)
 		if err == nil {
 			t.Fatal("expected error for missing LTX file")
 		}
@@ -174,7 +174,7 @@ func TestReplica_UploadLTXFile_OpenErrorReturnsLTXError(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err := r.uploadLTXFile(context.Background(), 0, 1, 1)
+		err := r.uploadLTXFile(context.Background(), 0, 0, 1, 1)
 		if err == nil {
 			t.Fatal("expected error for permission denied")
 		}

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -116,6 +116,156 @@ func TestReplica_ApplyNewLTXFiles_LevelZeroEmptyFallsBackToCompaction(t *testing
 	}
 }
 
+// TestReplica_ApplyNewLTXFiles_BridgesSnapshotHole reproduces the follow-mode
+// stall reported against the compaction-based-snapshot branch. Snapshots are
+// written to L9 and Compact seeks past them, so a ladder level can cover only
+// part of the history (here L1 = [6,12]) while the range [1,5] lives solely in
+// the L9 snapshot. With the follower's L0 files pruned by retention, the only
+// way past TXID 5 is the snapshot. A follower parked at TXID 3 must bridge the
+// hole via L9 and then let the ladder resume, ultimately reaching 12.
+func TestReplica_ApplyNewLTXFiles_BridgesSnapshotHole(t *testing.T) {
+	const pageSize = 4096
+
+	l1Info := &ltx.FileInfo{Level: 1, MinTXID: 6, MaxTXID: 12}
+	snapInfo := &ltx.FileInfo{Level: SnapshotLevel, MinTXID: 1, MaxTXID: 5}
+
+	fixtures := map[string][]byte{
+		ltxFixtureKey(l1Info.Level, l1Info.MinTXID, l1Info.MaxTXID): mustBuildIncrementalLTX(t, l1Info.MinTXID, l1Info.MaxTXID, pageSize, 1, 0xE5),
+		ltxFixtureKey(snapInfo.Level, snapInfo.MinTXID, snapInfo.MaxTXID): mustBuildSnapshotLTX(t, snapInfo.MinTXID, snapInfo.MaxTXID, pageSize, [][]byte{
+			newSQLiteHeaderPage(pageSize),
+			bytes.Repeat([]byte{0xF6}, pageSize),
+		}),
+	}
+
+	client := &followTestReplicaClient{}
+	client.LTXFilesFunc = func(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {
+		var all []*ltx.FileInfo
+		switch level {
+		case 0:
+			all = nil // pruned by retention
+		case 1:
+			all = []*ltx.FileInfo{l1Info}
+		case SnapshotLevel:
+			all = []*ltx.FileInfo{snapInfo}
+		}
+		infos := make([]*ltx.FileInfo, 0, len(all))
+		for _, info := range all {
+			if info.MinTXID >= seek {
+				infos = append(infos, info)
+			}
+		}
+		return ltx.NewFileInfoSliceIterator(infos), nil
+	}
+	client.OpenLTXFileFunc = func(_ context.Context, level int, minTXID, maxTXID ltx.TXID, _, _ int64) (io.ReadCloser, error) {
+		data, ok := fixtures[ltxFixtureKey(level, minTXID, maxTXID)]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+
+	r := NewReplicaWithClient(nil, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	// First poll bridges the hole via the L9 snapshot, reaching its TXID.
+	got, err := r.applyNewLTXFiles(context.Background(), f, 3, pageSize)
+	if err != nil {
+		t.Fatalf("apply new ltx files (poll 1): %v", err)
+	}
+	if got != 5 {
+		t.Fatalf("poll 1 txid=%s, want %s", got, ltx.TXID(5))
+	}
+
+	// Second poll resumes the ladder from L1 and catches up.
+	got, err = r.applyNewLTXFiles(context.Background(), f, got, pageSize)
+	if err != nil {
+		t.Fatalf("apply new ltx files (poll 2): %v", err)
+	}
+	if got != 12 {
+		t.Fatalf("poll 2 txid=%s, want %s", got, ltx.TXID(12))
+	}
+}
+
+// TestReplica_ApplyNewLTXFiles_StallWarnsWhenUnbridgeable verifies that a
+// follower with data ahead it genuinely cannot reach (a ladder hole with no
+// covering snapshot) makes no progress and emits a WARN, rather than stalling
+// silently.
+func TestReplica_ApplyNewLTXFiles_StallWarnsWhenUnbridgeable(t *testing.T) {
+	const pageSize = 4096
+
+	l1Info := &ltx.FileInfo{Level: 1, MinTXID: 6, MaxTXID: 12}
+
+	client := &followTestReplicaClient{}
+	client.LTXFilesFunc = func(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {
+		var all []*ltx.FileInfo
+		if level == 1 {
+			all = []*ltx.FileInfo{l1Info}
+		}
+		infos := make([]*ltx.FileInfo, 0, len(all))
+		for _, info := range all {
+			if info.MinTXID >= seek {
+				infos = append(infos, info)
+			}
+		}
+		return ltx.NewFileInfoSliceIterator(infos), nil
+	}
+	client.OpenLTXFileFunc = func(_ context.Context, _ int, _, _ ltx.TXID, _, _ int64) (io.ReadCloser, error) {
+		return nil, os.ErrNotExist
+	}
+
+	var logs bytes.Buffer
+	db := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	db.Logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	r := NewReplicaWithClient(db, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	got, err := r.applyNewLTXFiles(context.Background(), f, 3, pageSize)
+	if err != nil {
+		t.Fatalf("apply new ltx files: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("txid=%s, want %s (no progress)", got, ltx.TXID(3))
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("follower stalled")) {
+		t.Fatalf("expected stall WARN, got logs: %q", logs.String())
+	}
+}
+
+// TestReplica_ApplyNewLTXFiles_CaughtUpDoesNotWarn ensures the stall WARN does
+// not fire on the steady-state idle path, where L0 is empty simply because the
+// follower is already at the head with no data ahead.
+func TestReplica_ApplyNewLTXFiles_CaughtUpDoesNotWarn(t *testing.T) {
+	const pageSize = 4096
+
+	client := &followTestReplicaClient{}
+	client.LTXFilesFunc = func(_ context.Context, _ int, _ ltx.TXID, _ bool) (ltx.FileIterator, error) {
+		return ltx.NewFileInfoSliceIterator(nil), nil
+	}
+	client.OpenLTXFileFunc = func(_ context.Context, _ int, _, _ ltx.TXID, _, _ int64) (io.ReadCloser, error) {
+		return nil, os.ErrNotExist
+	}
+
+	var logs bytes.Buffer
+	db := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	db.Logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	r := NewReplicaWithClient(db, client)
+	f := mustCreateWritableDBFile(t)
+	defer func() { _ = f.Close() }()
+
+	got, err := r.applyNewLTXFiles(context.Background(), f, 12, pageSize)
+	if err != nil {
+		t.Fatalf("apply new ltx files: %v", err)
+	}
+	if got != 12 {
+		t.Fatalf("txid=%s, want %s (unchanged)", got, ltx.TXID(12))
+	}
+	if bytes.Contains(logs.Bytes(), []byte("follower stalled")) {
+		t.Fatalf("unexpected stall WARN on idle path: %q", logs.String())
+	}
+}
+
 func TestReplica_ApplyNewLTXFiles_IteratorCloseError(t *testing.T) {
 	client := &followTestReplicaClient{}
 	client.LTXFilesFunc = func(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {

--- a/replica_test.go
+++ b/replica_test.go
@@ -41,8 +41,14 @@ func TestReplica_Sync(t *testing.T) {
 
 	t.Logf("position after sync: %s", dpos.String())
 
+	// Reuse db.Replica (swapping in a client this test can inspect directly)
+	// rather than attaching a second, independent Replica to the same DB: only
+	// one Replica is ever meant to walk a DB's local L0 directory forward (see
+	// uploadTarget's local-file cleanup), and db.Replica already exists as a
+	// required field from MustOpenDBs.
 	c := file.NewReplicaClient(t.TempDir())
-	r := litestream.NewReplicaWithClient(db, c)
+	db.Replica.Client = c
+	r := db.Replica
 
 	if err := r.Sync(context.Background()); err != nil {
 		t.Fatal(err)
@@ -50,8 +56,10 @@ func TestReplica_Sync(t *testing.T) {
 
 	t.Logf("second sync")
 
-	// Verify we synced checkpoint page to WAL.
-	rd, err := c.OpenLTXFile(context.Background(), 0, dpos.TXID, dpos.TXID, 0, 0)
+	// Verify we synced checkpoint page to WAL. The initial sync is a
+	// snapshotting write (the base), tagged [1, dpos.TXID] and routed to the
+	// remote snapshot level rather than remote L0.
+	rd, err := c.OpenLTXFile(context.Background(), litestream.SnapshotLevel, 1, dpos.TXID, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2107,9 +2115,15 @@ func TestReplica_Restore_Follow(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Reuse db.Replica (swapping in a client this test can inspect directly)
+	// rather than attaching a second, independent Replica to the same DB: only
+	// one Replica is ever meant to walk a DB's local L0 directory forward (see
+	// uploadTarget's local-file cleanup), and db.Replica already exists as a
+	// required field from MustOpenDBs.
 	replicaDir := t.TempDir()
 	c := file.NewReplicaClient(replicaDir)
-	r := litestream.NewReplicaWithClient(db, c)
+	db.Replica.Client = c
+	r := db.Replica
 
 	if err := r.Sync(ctx); err != nil {
 		t.Fatal(err)
@@ -2266,9 +2280,15 @@ func TestReplica_Restore_Follow_WriteTXIDFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Reuse db.Replica (swapping in a client this test can inspect directly)
+	// rather than attaching a second, independent Replica to the same DB: only
+	// one Replica is ever meant to walk a DB's local L0 directory forward (see
+	// uploadTarget's local-file cleanup), and db.Replica already exists as a
+	// required field from MustOpenDBs.
 	replicaDir := t.TempDir()
 	c := file.NewReplicaClient(replicaDir)
-	r := litestream.NewReplicaWithClient(db, c)
+	db.Replica.Client = c
+	r := db.Replica
 	if err := r.Sync(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -2376,9 +2396,15 @@ func TestReplica_Restore_Follow_CrashRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Reuse db.Replica (swapping in a client this test can inspect directly)
+	// rather than attaching a second, independent Replica to the same DB: only
+	// one Replica is ever meant to walk a DB's local L0 directory forward (see
+	// uploadTarget's local-file cleanup), and db.Replica already exists as a
+	// required field from MustOpenDBs.
 	replicaDir := t.TempDir()
 	c := file.NewReplicaClient(replicaDir)
-	r := litestream.NewReplicaWithClient(db, c)
+	db.Replica.Client = c
+	r := db.Replica
 	if err := r.Sync(ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/store.go
+++ b/store.go
@@ -789,6 +789,15 @@ func (s *Store) CompactDB(ctx context.Context, db *DB, lvl *CompactionLevel) (*l
 		if err != nil {
 			return nil, fmt.Errorf("fetch db position: %w", err)
 		}
+		// The base (TXID 1) is the sync path's responsibility: it writes the
+		// initial full-DB image and the replica uploads it to the snapshot
+		// level. The monitor only produces periodic snapshots once the DB has
+		// advanced past the base (pos > 1). Standing down at pos <= 1 avoids
+		// a concurrent second full-DB read that would otherwise race the sync
+		// path's base capture.
+		if pos.TXID <= 1 {
+			return nil, ErrNoCompaction
+		}
 		if dstInfo.MaxTXID != 0 && dstInfo.MaxTXID >= pos.TXID {
 			return nil, ErrNoCompaction
 		}

--- a/store_test.go
+++ b/store_test.go
@@ -107,6 +107,18 @@ func TestStore_CompactDB(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// The base (TXID 1, above) is the sync path's own responsibility: the
+		// first sync is a snapshotting write, tagged [1,1] locally, and the
+		// replica upload routes it to the remote snapshot level automatically.
+		// A further increment is needed for L1 to compact.
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (200)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
 		_, err := s.CompactDB(t.Context(), db0, levels[1])
 		require.NoError(t, err)
 
@@ -137,6 +149,13 @@ func TestStore_CompactDB(t *testing.T) {
 		}
 		s := litestream.NewStore([]*litestream.DB{db0}, levels)
 		s.CompactionMonitorEnabled = false
+		// The base write below lands at the snapshot level immediately (via the
+		// replica upload), so it counts against the SnapshotInterval throttle for
+		// the manual compaction below. Use a short-but-nonzero interval: long
+		// enough that the two manual calls below (executed back-to-back, no
+		// sleep) reliably land within the same interval window, short enough
+		// that sleeping past it (below) reliably clears the base's recency.
+		s.SnapshotInterval = 200 * time.Millisecond
 		if err := s.Open(t.Context()); err != nil {
 			t.Fatal(err)
 		}
@@ -152,6 +171,20 @@ func TestStore_CompactDB(t *testing.T) {
 		} else if err := db0.Replica.Sync(t.Context()); err != nil {
 			t.Fatal(err)
 		}
+
+		// The base (TXID 1, above) is the sync path's own responsibility and is
+		// already at the snapshot level; the monitor stands down at pos <= 1.
+		// Advance past the base so the monitor has a periodic snapshot to make.
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (200)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clear the base's recency against the interval throttle above.
+		time.Sleep(2 * s.SnapshotInterval)
 
 		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != nil {
 			t.Fatal(err)
@@ -189,13 +222,27 @@ func TestStore_CompactDB(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// The base (TXID 1, above) is itself a snapshotting write and the replica
+		// upload routes it to the snapshot level automatically -- that's the
+		// first SnapshotLevel write. The monitor stands down at pos <= 1, so
+		// advance past the base before exercising its periodic-snapshot path.
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (200)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
 		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrNoCompaction) {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if got, want := client.writeCount(), 1; got != want {
+		// One SnapshotLevel write for the base (via the replica upload) and one
+		// for the periodic snapshot above; the no-progress retry adds no more.
+		if got, want := client.writeCount(), 2; got != want {
 			t.Fatalf("WriteLTXFile count=%d, want %d", got, want)
 		}
 	})

--- a/store_test.go
+++ b/store_test.go
@@ -190,10 +190,16 @@ func TestStore_CompactDB(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Re-compacting immediately should return an error that there's nothing to compact.
-		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrCompactionTooEarly) {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		// Re-compacting immediately should indicate there is nothing new to
+		// snapshot. This is ErrCompactionTooEarly (the just-written snapshot is
+		// newer than the interval boundary) or ErrNoCompaction (we crossed an
+		// interval boundary between the two calls, so PrevCompactionAt truncated
+		// past the snapshot's timestamp). Both mean "no new snapshot"; which one
+		// surfaces is a boundary-truncation race, same as the L1 subtest above.
+		_, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel())
+		require.True(t,
+			errors.Is(err, litestream.ErrCompactionTooEarly) || errors.Is(err, litestream.ErrNoCompaction),
+			"expected ErrCompactionTooEarly or ErrNoCompaction, got: %v", err)
 	})
 
 	t.Run("SnapshotNoProgress", func(t *testing.T) {
@@ -269,6 +275,64 @@ func TestStore_CompactDB(t *testing.T) {
 		// immediately at startup before db.Sync() has been called.
 		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrDBNotReady) {
 			t.Fatalf("expected ErrDBNotReady, got: %v", err)
+		}
+	})
+
+	// Regression: an empty snapshot level observed by a compaction-monitor tick
+	// (which happens on every fresh generation: the snapshot monitor fires at
+	// startup, before the sync path has finished uploading the base to L9) must
+	// not permanently starve leveled compaction. Previously db.MaxLTXFileInfo
+	// cached the empty (MaxTXID==0) snapshot-level result; leveled compaction
+	// reads snapInfo from that cache and returns ErrNoCompaction whenever
+	// snapInfo.MaxTXID==0, so with the snapshot monitor on a 30-day interval and
+	// the sync path never refreshing the cache, the ladder wedged forever. On a
+	// large DB the base upload reliably lags the startup tick, so it never
+	// recovered (observed in prod: L0 grew unbounded, L1/L2/L3 stayed empty).
+	t.Run("EmptySnapshotLevelDoesNotStarveCompaction", func(t *testing.T) {
+		db0, sqldb0 := testingutil.MustOpenDBs(t)
+		defer testingutil.MustCloseDBs(t, db0, sqldb0)
+
+		levels := litestream.CompactionLevels{
+			{Level: 0},
+			{Level: 1, Interval: time.Nanosecond},
+		}
+		s := litestream.NewStore([]*litestream.DB{db0}, levels)
+		s.CompactionMonitorEnabled = false
+		if err := s.Open(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close(t.Context())
+
+		// Write the base locally but do NOT upload yet (remote L9 is still empty,
+		// exactly as it is while a large base is mid-upload).
+		if _, err := sqldb0.ExecContext(t.Context(), `CREATE TABLE t (id INT);`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (100)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Snapshot-monitor tick against the still-empty remote snapshot level. It
+		// stands down at pos<=1, but it must not poison the snapshot-level cache.
+		if _, err := s.CompactDB(t.Context(), db0, s.SnapshotLevel()); !errors.Is(err, litestream.ErrNoCompaction) {
+			t.Fatalf("expected ErrNoCompaction from base-only snapshot tick, got: %v", err)
+		}
+
+		// Advance past the base and upload: base -> L9, increment -> L0.
+		if _, err := sqldb0.ExecContext(t.Context(), `INSERT INTO t (id) VALUES (200)`); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		} else if err := db0.Replica.Sync(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+
+		// L0->L1 compaction must now proceed: the base exists at L9, so
+		// snapInfo.MaxTXID>0 and there is an L0 increment to roll up.
+		if _, err := s.CompactDB(t.Context(), db0, levels[1]); err != nil {
+			t.Fatalf("L1 compaction starved after empty-snapshot-level tick: %v", err)
 		}
 	})
 }

--- a/tests/integration/directory_watcher_helpers.go
+++ b/tests/integration/directory_watcher_helpers.go
@@ -185,20 +185,13 @@ func WaitForDatabaseInReplica(t *testing.T, replicaPath, dbPath string, timeout 
 			}
 
 			// Check if this directory matches the database name and has LTX files
+			// at any compaction level (see ltxFilesAllLevels).
 			if info.IsDir() && filepath.Base(path) == dbName {
-				ltxDir := filepath.Join(path, "ltx", "0")
-				if _, err := os.Stat(ltxDir); err == nil {
-					entries, err := os.ReadDir(ltxDir)
-					if err == nil {
-						for _, entry := range entries {
-							if strings.HasSuffix(entry.Name(), ".ltx") {
-								relPath, _ := filepath.Rel(replicaPath, path)
-								t.Logf("Database %s detected in replica at %s (found %s)", dbName, relPath, entry.Name())
-								found = true
-								return nil
-							}
-						}
-					}
+				if matches := ltxFilesAllLevels(path); len(matches) > 0 {
+					relPath, _ := filepath.Rel(replicaPath, path)
+					t.Logf("Database %s detected in replica at %s (found %s)", dbName, relPath, filepath.Base(matches[0]))
+					found = true
+					return nil
 				}
 			}
 			return nil
@@ -256,9 +249,8 @@ func CountDatabasesInReplica(replicaPath string) (int, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		// Check if this database directory has LTX files
-		ltxDir := filepath.Join(replicaPath, entry.Name(), "ltx", "0")
-		if countLTXFiles(ltxDir) > 0 {
+		// Count a database as replicated if it has LTX files at any level.
+		if len(ltxFilesAllLevels(filepath.Join(replicaPath, entry.Name()))) > 0 {
 			count++
 		}
 	}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -425,12 +425,7 @@ func (db *TestDB) GetDatabaseSize() (int64, error) {
 }
 
 func (db *TestDB) GetReplicaFileCount() (int, error) {
-	ltxPath := filepath.Join(db.ReplicaPath, "ltx", "0")
-	files, err := filepath.Glob(filepath.Join(ltxPath, "*.ltx"))
-	if err != nil {
-		return 0, err
-	}
-	return len(files), nil
+	return len(ltxFilesAllLevels(db.ReplicaPath)), nil
 }
 
 func (db *TestDB) WaitForReplicaFiles(minFiles int, timeout time.Duration) (int, error) {
@@ -509,12 +504,30 @@ func (db *TestDB) WaitForSnapshots(timeout time.Duration) error {
 	}
 }
 
+// countLTXFiles counts .ltx files directly within a single level directory
+// (e.g. <db>/ltx/0). Callers that need to distinguish levels -- such as
+// asserting a base snapshot at ltx/9 separately from an increment at ltx/0 --
+// rely on this per-directory precision.
 func countLTXFiles(dir string) int {
 	matches, err := filepath.Glob(filepath.Join(dir, "*.ltx"))
 	if err != nil {
 		return 0
 	}
 	return len(matches)
+}
+
+// ltxFilesAllLevels returns the .ltx files under a database's replica directory
+// across every compaction level (dbReplicaDir/ltx/*/*.ltx). A database's initial
+// state is captured as a base snapshot uploaded directly to the snapshot level
+// (ltx/9); only later increments appear at ltx/0 and compactions at ltx/1+. Use
+// this whenever the question is merely "has this database been replicated at
+// all", independent of level.
+func ltxFilesAllLevels(dbReplicaDir string) []string {
+	matches, err := filepath.Glob(filepath.Join(dbReplicaDir, "ltx", "*", "*.ltx"))
+	if err != nil {
+		return nil
+	}
+	return matches
 }
 
 func GetTestDuration(t *testing.T, defaultDuration time.Duration) time.Duration {


### PR DESCRIPTION
# Upload sync snapshots directly to L9 to eliminate unnecessary Compaction overhead

## Summary

Sync snapshots — the initial base at TXID 1 and mid-stream boundary snapshots
taken at checkpoint boundaries — are now uploaded directly to the L9 snapshot
level, instead of landing in L0 and being pulled up through the compaction
ladder. This keeps DB-sized full images out of the L0→L1→L2→L3 ladder entirely.

## Background

Every write, including a snapshot, previously landed in L0, and compaction
re-materialized that whole DB-sized image into each ladder level in turn:

- On a fresh generation, a ~120 GB database gets written roughly 5× — the L0
  base, the L9 snapshot, and again into L1, L2, and L3, each spanning
  `MinTXID=1`.
- Large compactions are resource intensive, resulting in memory issues such
  as #1477 and necessitating mitigations such as serializing them (#1479).
  This in aggregate results in monopolizing the DB for long stretches (order
  of an hour per generation on large DBs) while L0 files pile up.
- This repeats on every restart that mints a new generation.

Fixes #1510

## Approach

Let the sync path own snapshot capture and route the bytes straight to the L9
snapshot level, so the compaction ladder never sees a full-DB image. Snapshots
remain visible to restore (at L9) and continue to serve as the local resume
anchor, but they no longer participate in the ladder.

Supporting components are updated to understand the new semantics:
- **replication** distinguishes between snapshots (MinLTX = 1) and increments
  (MinLTX = MaxLTX) and uploads them to the appropriate level
- sync snapshots are locally deleted after their next file has been uploaded,
  since they are otherwise no longer tracked by L0 retention
- **compaction** avoids doing the initial `[1,1]` snapshot so as to eliminate
  redundant snapshotting when a generation begins. All levels instead wait for
  an L9 snapshot to exist and then compact LTX files after it.
- **restore following** checks the L9 level when encountering a gap
  (it previously only consulted up to L8)

## Reviewer's guide

The diff is ~255 lines of production change across 4 files and ~429 lines of
test change across 6. The tests are mechanical fallout (see Testing), so reading
the production code first is enough to understand the change. Suggested order —
it follows a snapshot's life from capture to reclamation:

1. **`db.go` — `sync()`** (the origin). A snapshotting write is tagged
   `[1, txID]` and leaves `l0FileInfo` nil. _Check:_ the `[1, k]` marker is
   unambiguous (no increment is ever `[1, x]`) and snapshots no longer advance
   the L0 ladder max.
2. **`db.go` — `uploadTarget`, `openLevel0Anchor`, `currentSnapshotMaxTXID`**
   (resolution). How a `[1, k]` file is recognized and how the anchor is
   resolved when the name isn't `[txID, txID]`. _Check:_ the ordering in
   `uploadTarget` (snapshot name tried first — the two collide at `fromTXID==1`)
   and the cold-resume fallback to the live snapshot.
3. **`replica.go` — `syncOnce`, `uploadLTXFile`** (routing). `MinTXID==1` →
   remote L9, increments → remote L0; the loop advances by the file's actual
   `MaxTXID`. _Check:_ re-encountering a snapshot TXID is idempotent.
4. **`compactor.go` — `Compact`, `VerifyLevelConsistency`** (the ladder skips
   snapshots). _Check:_ `seekTXID = max(dstMax, snapMax) + 1`, the require-a-
   snapshot guard, and that a snapshot-spanned gap is accepted (loaded lazily).
5. **`store.go` — `CompactDB`** (monitor stand-down). _Check:_ the snapshot
   monitor stands down at `pos <= 1` so it can't race the base capture.
6. **`replica.go`/`db.go` — `calcRemotePos` vs `calcPos`, `SyncStatus`**
   (reporting). _Check:_ status uses `max(L0, L9)` while the resume cursor stays
   L0-only.
7. **`db.go` — `deleteSupersededLocalSnapshot`** (reclamation). _Check:_ the
   single-`[1, prevTXID]`-delete argument and the single-replica assumption.

For the test churn, the two files worth actually reading are `compactor_test.go`
(the gap-spanned-by-snapshot verification and the seek behavior) and
`store_test.go` (the snapshot-monitor stand-down and base auto-delivery). The
rest is find-and-replace: removing now-redundant manual snapshot seeds and
updating expected TXID ranges / remote-level counts.

## Changes

### Snapshot capture and tagging (`sync`)

- Snapshotting writes are tagged `[1, txID]` (`MinTXID=1`) in the local L0
  directory; increments stay `[txID, txID]`. The `[1, k]` tag is a durable,
  stateless marker of "this is a snapshot" that survives restart — no increment
  is ever `[1, x]`, because the first write is always the base.
- Snapshotting writes no longer set `l0FileInfo`, so they don't advance the L0
  max the compaction ladder reads. The local file is still written to the L0
  directory so `MaxLTX`/`Pos` continue to find the anchor.

### Upload routing (`Replica.syncOnce`, `uploadTarget`)

- The upload loop resolves each file through `DB.uploadTarget`: files tagged
  `MinTXID=1` upload to remote L9, increments upload to remote L0.
- `openLevel0Anchor` / `currentSnapshotMaxTXID` resolve the local `[1, k]`
  anchor for the verify, WAL-offset, and cold-resume paths that previously
  assumed a `[txID, txID]` filename.

### Compaction (`Compactor.Compact`, `VerifyLevelConsistency`)

- `Compact` seeks past the newest snapshot: `max(dstMax, snapMax) + 1`. A
  snapshot at L9 leaves a "hole" in the lower levels; seeking past it means the
  hole is skipped rather than mistaken for a gap.
- `Compact` requires an initial snapshot to exist before it will compact — a
  ladder with no snapshot to anchor it is unrestorable.
- `VerifyLevelConsistency` accepts a TXID gap when an L9 snapshot spans it
  (loaded lazily, so the common gapless path makes no extra request).

### Snapshot monitor stand-down (`Store.CompactDB`)

- The snapshot-level `CompactDB` stands down at `pos <= 1`. The base is the sync
  path's responsibility; standing down avoids a concurrent second full-DB read
  racing the sync path's base capture.

### Position reporting (`calcRemotePos` vs `calcPos`)

- Snapshots live only at L9, so a replica that has uploaded the base but no
  increments is fully caught up. `SyncStatus` now reports remote position via
  `calcRemotePos` = `max(L0 max, L9 max)`, so a boundary snapshot with no
  trailing increment doesn't read as lag.
- `calcPos` stays L0-only: it is the sync loop's resume cursor, and keeping it
  on L0 preserves point-in-time-restore granularity (every increment is still
  uploaded to L0 even when a snapshot at L9 already covers a higher TXID).
  Re-encountering a snapshot TXID is harmless — `uploadTarget` re-routes it to
  L9 idempotently.

### Local disk reclamation (`deleteSupersededLocalSnapshot`)

- Because a sync-path snapshot uploads to L9, remote-listing-driven L0 retention
  never sees it, so it would otherwise never be reclaimed locally. Once the
  replica has advanced past a snapshot (its bytes durable at L9 and its
  succeeding file uploaded), its local file is deleted to reclaim disk.
- Deleting only `[1, prevTXID]` suffices because the contiguous walk visits
  every superseded snapshot as `prevTXID` exactly once. Like all local
  retention, this assumes a single replica walks the L0 directory.

## Invariants and assumptions

- **Single replica per DB.** All local-retention paths already assume one
  consumer walks the local L0 directory (`DB.Replica` is a singular field with
  no fan-out). `deleteSupersededLocalSnapshot` makes the same assumption; a
  second independent replica sharing these files is not a supported
  configuration.
- **`[1, k]` as a stateless snapshot marker.** No increment is ever `[1, x]`, so
  the filename alone durably distinguishes a snapshot from an increment across
  restarts, with no side metadata to keep in sync.

## Testing

- `go test ./...` passes.
- `go test -race -count=5 .` passes.
- The test diff is largely mechanical: snapshots are now auto-delivered to L9 by
  the sync path, so tests that previously seeded a snapshot by hand or asserted
  `[txID, txID]` names / L0-only remote counts were updated accordingly.

## Out of scope

While running the suite under `-race`, we hit a pre-existing, unrelated data
race in `FuzzRestoreWithMissingCompactedFile`. `git diff` confirms this change
does not touch the affected code. `Store.Close()` closes each `DB` before it
cancels its own context and waits for the compaction-monitor goroutines to stop,
so a monitor can still be mid-`db.Snapshot()` (reading `db.f`) at the moment
`db.Close()` nils it out under a separate lock. It's a shutdown-ordering bug
worth a separate issue/PR, but it is independent of this change and not
addressed here.
