### PR TITLE
fix(follow): warn when follow mode cannot advance past a gap

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -831,13 +831,14 @@ func (r *Replica) follow(ctx context.Context, outputPath string, lastTXID ltx.TX
 	defer ticker.Stop()
 
 	var consecutiveErrors int
+	var stallTXID ltx.TXID // position at which a follow gap was last reported
 	for {
 		select {
 		case <-ctx.Done():
 			r.Logger().Info("follow mode stopped")
 			return nil
 		case <-ticker.C:
-			newTXID, err := r.applyNewLTXFiles(ctx, f, lastTXID, pageSize)
+			newTXID, err := r.applyNewLTXFiles(ctx, f, lastTXID, pageSize, &stallTXID)
 			if err != nil {
 				if ctx.Err() != nil {
 					r.Logger().Info("follow mode stopped")
@@ -862,7 +863,7 @@ func (r *Replica) follow(ctx context.Context, outputPath string, lastTXID ltx.TX
 // applyNewLTXFiles polls for new LTX files and applies them to the database.
 // It starts from level 0 and falls back to higher levels if there are gaps
 // (e.g., level 0 files were compacted away).
-func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
+func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID ltx.TXID, pageSize uint32, stallTXID *ltx.TXID) (ltx.TXID, error) {
 	currentTXID := afterTXID
 
 	// Poll level 0 for the most recent incremental files.
@@ -888,7 +889,7 @@ func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID lt
 
 		// If there's a gap, try to fill it from higher compaction levels.
 		if info.MinTXID > currentTXID+1 {
-			bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, info.MinTXID, pageSize)
+			bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, info.MinTXID, pageSize, stallTXID)
 			if err != nil {
 				return closeLevel0(err)
 			}
@@ -899,6 +900,7 @@ func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID lt
 				continue
 			}
 			if info.MinTXID > currentTXID+1 {
+				r.reportFollowGap(ctx, stallTXID, currentTXID, info.MinTXID)
 				return closeLevel0(nil)
 			}
 		}
@@ -925,7 +927,7 @@ func (r *Replica) applyNewLTXFiles(ctx context.Context, f *os.File, afterTXID lt
 	}
 
 	if !sawLevel0 {
-		bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, currentTXID+1, pageSize)
+		bridgedTXID, err := r.fillFollowGap(ctx, f, currentTXID, currentTXID+1, pageSize, stallTXID)
 		if err != nil {
 			return currentTXID, err
 		}
@@ -1001,8 +1003,9 @@ func (r *Replica) applyLTXFile(ctx context.Context, f *os.File, info *ltx.FileIn
 
 // fillFollowGap attempts to bridge a gap in level 0 files by searching
 // higher compaction levels for a file that covers the missing TXID range.
-func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.TXID, gapMinTXID ltx.TXID, pageSize uint32) (ltx.TXID, error) {
+func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.TXID, gapMinTXID ltx.TXID, pageSize uint32, stallTXID *ltx.TXID) (ltx.TXID, error) {
 	currentTXID := afterTXID
+	var unreachableTXID ltx.TXID
 
 	for level := 1; level < SnapshotLevel; level++ {
 		itr, err := r.Client.LTXFiles(ctx, level, 0, false)
@@ -1025,6 +1028,9 @@ func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.T
 
 			// Skip if there's a gap at this level too.
 			if info.MinTXID > currentTXID+1 {
+				if unreachableTXID == 0 {
+					unreachableTXID = info.MinTXID
+				}
 				break
 			}
 
@@ -1060,7 +1066,28 @@ func (r *Replica) fillFollowGap(ctx context.Context, f *os.File, afterTXID ltx.T
 		}
 	}
 
+	// No level bridged the gap but files exist beyond our position, so the
+	// follower cannot advance without operator intervention.
+	if unreachableTXID != 0 {
+		r.reportFollowGap(ctx, stallTXID, currentTXID, unreachableTXID)
+	}
+
 	return currentTXID, nil
+}
+
+// reportFollowGap warns that follow mode has no path from its current position
+// to the next available LTX file. stallTXID holds the position last reported by
+// the caller's follow loop; the follower retries every interval and its position
+// is monotonic, so reporting per position logs the condition once when it is
+// entered rather than on every poll. Stays silent during shutdown (see #235).
+func (r *Replica) reportFollowGap(ctx context.Context, stallTXID *ltx.TXID, currentTXID, nextTXID ltx.TXID) {
+	if ctx.Err() != nil || *stallTXID == currentTXID {
+		return
+	}
+	*stallTXID = currentTXID
+
+	r.Logger().Warn("follow: no ltx file available at current position, follower is not advancing",
+		"txid", currentTXID, "next_txid", nextTXID)
 }
 
 // RestoreV3 restores from a v0.3.x format backup.

--- a/replica_internal_test.go
+++ b/replica_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ func TestReplica_ApplyNewLTXFiles_FillGapWithOverlappingCompactedFile(t *testing
 	f := mustCreateWritableDBFile(t)
 	defer func() { _ = f.Close() }()
 
-	got, err := r.applyNewLTXFiles(context.Background(), f, 150, pageSize)
+	got, err := r.applyNewLTXFiles(context.Background(), f, 150, pageSize, new(ltx.TXID))
 	if err != nil {
 		t.Fatalf("apply new ltx files: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestReplica_ApplyNewLTXFiles_LevelZeroEmptyFallsBackToCompaction(t *testing
 	f := mustCreateWritableDBFile(t)
 	defer func() { _ = f.Close() }()
 
-	got, err := r.applyNewLTXFiles(context.Background(), f, 10, pageSize)
+	got, err := r.applyNewLTXFiles(context.Background(), f, 10, pageSize, new(ltx.TXID))
 	if err != nil {
 		t.Fatalf("apply new ltx files: %v", err)
 	}
@@ -132,7 +133,7 @@ func TestReplica_ApplyNewLTXFiles_IteratorCloseError(t *testing.T) {
 	f := mustCreateWritableDBFile(t)
 	defer func() { _ = f.Close() }()
 
-	_, err := r.applyNewLTXFiles(context.Background(), f, 10, 4096)
+	_, err := r.applyNewLTXFiles(context.Background(), f, 10, 4096, new(ltx.TXID))
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -541,5 +542,95 @@ func TestApplyLTXFile_MultiplePages(t *testing.T) {
 		if i > 0 && !bytes.Equal(readBuf, pages[i]) {
 			t.Fatalf("page %d data mismatch", i+1)
 		}
+	}
+}
+
+func TestReplica_ApplyNewLTXFiles_UnreachableGapWarnsOnce(t *testing.T) {
+	const pageSize = 4096
+
+	for _, tt := range []struct {
+		name         string
+		level0       []*ltx.FileInfo
+		level1       []*ltx.FileInfo
+		cancelled    bool
+		wantWarnings int
+	}{
+		// The gap is visible in the level 0 listing itself.
+		{
+			name:         "GapInLevel0",
+			level0:       []*ltx.FileInfo{{Level: 0, MinTXID: 200, MaxTXID: 200}},
+			wantWarnings: 1,
+		},
+		// Level 0 has been compacted away entirely; the gap is only visible at
+		// a higher level.
+		{
+			name:         "NoLevel0Files",
+			level1:       []*ltx.FileInfo{{Level: 1, MinTXID: 200, MaxTXID: 250}},
+			wantWarnings: 1,
+		},
+		// Shutdown must stay quiet (see TestReplica_ContextCancellationNoLogs).
+		{
+			name:      "CancelledContext",
+			level0:    []*ltx.FileInfo{{Level: 0, MinTXID: 200, MaxTXID: 200}},
+			cancelled: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &followTestReplicaClient{}
+			client.LTXFilesFunc = func(_ context.Context, level int, seek ltx.TXID, _ bool) (ltx.FileIterator, error) {
+				var all []*ltx.FileInfo
+				switch level {
+				case 0:
+					all = tt.level0
+				case 1:
+					all = tt.level1
+				}
+
+				infos := make([]*ltx.FileInfo, 0, len(all))
+				for _, info := range all {
+					if info.MinTXID >= seek {
+						infos = append(infos, info)
+					}
+				}
+				return ltx.NewFileInfoSliceIterator(infos), nil
+			}
+
+			var logBuf bytes.Buffer
+			db := NewDB(filepath.Join(t.TempDir(), "follower.db"))
+			db.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			r := NewReplicaWithClient(db, client)
+			f := mustCreateWritableDBFile(t)
+			defer func() { _ = f.Close() }()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancelled {
+				cancel()
+			}
+
+			// Poll several times from the same position, as the follow loop does
+			// on every interval, carrying the same stall state it carries.
+			// Nothing bridges the gap, so the position never advances and the
+			// condition must be reported exactly once.
+			stallTXID := new(ltx.TXID)
+			for i := 0; i < 3; i++ {
+				got, err := r.applyNewLTXFiles(ctx, f, 100, pageSize, stallTXID)
+				if err != nil {
+					t.Fatalf("apply new ltx files: %v", err)
+				}
+				if got != 100 {
+					t.Fatalf("txid=%s, want %s", got, ltx.TXID(100))
+				}
+			}
+
+			logs := logBuf.String()
+			if n := strings.Count(logs, "level=WARN"); n != tt.wantWarnings {
+				t.Fatalf("warnings=%d, want %d, logs=%q", n, tt.wantWarnings, logs)
+			}
+			if tt.wantWarnings > 0 && !strings.Contains(logs, "next_txid=00000000000000c8") {
+				t.Fatalf("expected next txid in warning, logs=%q", logs)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`restore -f` can stop making progress permanently while logging nothing. This makes the condition visible. It does not change which gaps can be bridged.

## Problem

When follow mode cannot bridge a gap from its current position, `applyNewLTXFiles` returns the unchanged TXID and a `nil` error. Back in `follow()`, a nil error with `newTXID == lastTXID` takes neither the error branch nor the `newTXID > lastTXID` branch, so nothing is logged on that iteration, or any later one, since nothing in the loop changes. The follower stays alive, keeps polling, and keeps serving reads from a database that never changes again. A restart resumes from the `-txid` sidecar and stops at the same TXID, while a plain `litestream restore` from the same replica succeeds.

A follower stalled this way, at `-follow-interval 1s`, with `LOG_LEVEL=trace`:

```
level=INFO msg="resuming follow mode from crash recovery" txid=0000000000000004
level=INFO msg="entering follow mode" txid=0000000000000004 interval=1s
level=INFO msg="follow mode stopped"
error/warning lines: 0
```

Sixty seconds of polling, frontier advancing the whole time, zero ERROR or WARN lines. Full investigation, a self-contained reproduction, and the level-by-level analysis are in #1515.

## Solution

Report the condition once per position rather than once per poll.

The position is monotonic, so keying the report on it logs when the state is *entered* rather than on every tick. Both silent exits are covered: the gap seen in the level 0 listing, and the no-level-0-files-at-all path. A fix to only the first leaves the second silent.

**Why a WARN and not a returned error.** `follow()` already increments `consecutiveErrors`, logs, and continues, but nothing consumes that counter: there is no threshold and no bail-out. So returning an error here would not change behaviour, it would only produce an ERROR line every `-follow-interval` forever, trading silence for a permanent error stream. `docs/PATTERNS.md` warns against "just logging" where continuing risks corrupting state; that is not this case, since a stalled follower is idle rather than advancing on bad data. If you would rather this terminate the follower or trip a threshold, that is a behaviour change I am happy to make instead; it just seemed like your call, not mine.

Reporting stays silent when the context is already cancelled, so shutdown remains quiet (#235, `TestReplica_ContextCancellationNoLogs`).

## Scope

**In scope:**
- Surfacing the unbridgeable-gap condition in follow mode, once per position.
- Test coverage for both silent exits and for the cancelled-context case.

**Not in scope:**
- Changing which gaps can be bridged. `fillFollowGap` still searches levels 1..8 and still does not consult snapshots. Whether that bound should change is a separate decision with real consequences (it would admit a full-database file where an incremental one would have served, under `applyLTXFile`'s exclusive lock, interacting with #1268), and I have deliberately not touched it.
- Any change to restore, compaction, or the replica sync path.

## Test Plan

```bash
go test -race -count=1 -run 'TestReplica_ApplyNewLTXFiles' ./
go test -race ./...
```

New: `TestReplica_ApplyNewLTXFiles_UnreachableGapWarnsOnce`, covering
- `GapInLevel0`: gap visible in the level 0 listing; warns once across repeated polls
- `NoLevel0Files`: level 0 compacted away entirely; the other silent exit
- `CancelledContext`: stays silent during shutdown

Verified on this branch: `gofmt`/`goimports` clean, `go vet ./...` clean, `staticcheck` clean, `go test -race ./...` passing.

## Related

- Fixes #1515
- Related to #1514. That PR makes the compaction ladder skip TXIDs a snapshot covers and relaxes `VerifyLevelConsistency` to accept the resulting hole, on the grounds that restore seeds from the snapshot. `follow` does not read the snapshot level, so on that branch a follower can reach this stall with nothing missing from the replica. Details in #1515.
- #1270 is a different root cause (a TOCTOU race that fails loudly), adjacent in remedy only.

---

This contribution was AI-assisted. I have reviewed the diff and am responsible for it.
