### PR TITLE
docs(contributing): give the soak command a timeout it can pass under

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,8 @@ before merging:
 go build -o bin/litestream ./cmd/litestream
 go build -o bin/litestream-test ./cmd/litestream-test
 
-# Run the behavioral test suite
-go test -tags 'integration,soak' -run TestLTXBehavior -short -v ./tests/integration/
+# Run the behavioral test suite (~11m15s with -short)
+go test -tags 'integration,soak' -run TestLTXBehavior -short -v -timeout 20m ./tests/integration/
 ```
 
 This verifies LTX files are the right size and frequency, snapshots aren't excessive,


### PR DESCRIPTION
## Description

The soak command in `CONTRIBUTING.md` runs for about 11m15s under Go's default 10 minute timeout, so it always ends in `panic: test timed out`. This adds `-timeout 20m` and notes the runtime in the adjacent comment. Two lines, documentation only.

## Motivation and Context

No issue; found while following the contributing docs.

`-run TestLTXBehavior` is an unanchored regex, so it selects both tests in `tests/integration/ltx_behavior_test.go`:

```
tests/integration/ltx_behavior_test.go:24:func TestLTXBehavior
tests/integration/ltx_behavior_test.go:54:func TestLTXBehavior_NoExcessiveSnapshots
```

Running the documented command verbatim on a clean `main` at 4ed7a308:

```
FAIL	github.com/benbjohnson/litestream/tests/integration	600.030s
```

600s is the default `go test` timeout, and the run ends in a timeout panic with a goroutine dump. The same command with a raised timeout passes, and shows where the time goes:

```
--- PASS: TestLTXBehavior (505.37s)
    --- PASS: TestLTXBehavior/low-volume (168.21s)
    --- PASS: TestLTXBehavior/high-volume (168.37s)
    --- PASS: TestLTXBehavior/burst-volume (168.79s)
--- PASS: TestLTXBehavior_NoExcessiveSnapshots (168.52s)
ok	github.com/benbjohnson/litestream/tests/integration	673.915s
```

11m14s against a 10m budget. Nothing is wrong with the tests; the documented invocation just has no room to finish.

I left the pattern unanchored deliberately. Anchoring it to `TestLTXBehavior$` would also make the command pass, but it would silently stop running `TestLTXBehavior_NoExcessiveSnapshots`, which the current command does at least attempt and which the surrounding text describes ("snapshots aren't excessive").

20m is ~1.8x the measured runtime. Most of that runtime is fixed rather than machine dependent: `ProfileDuration` returns a flat 2 minutes per profile in short mode, so roughly 8 of the 11 minutes are load windows that take the same wall-clock time anywhere, and only the remaining setup, verification and restore work varies with the machine.

## How Has This Been Tested?

`golang:1.25` container, clean `main` at 4ed7a308, as a non-root user, after building the required binaries:

```bash
go build -o bin/litestream ./cmd/litestream
go build -o bin/litestream-test ./cmd/litestream-test

# before: FAIL at 600.030s, panic: test timed out
go test -tags 'integration,soak' -run TestLTXBehavior -short -v ./tests/integration/

# after: ok at 673.915s
go test -tags 'integration,soak' -run TestLTXBehavior -short -v -timeout 20m ./tests/integration/
```

Also ran `gofmt -l .`, `go vet ./...` and `go test ./...` on the branch; all clean, as expected for a change that touches no Go files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`) — both clean; no Go files are touched
- [x] I have tested my changes (`go test ./...`) — passes, plus the before/after soak runs above
- [x] I have updated the documentation accordingly (if needed) — the documentation is the change

---

This contribution was claude-assisted. I ran the commands above and am responsible for the change.
