### PR TITLE
fix(python): use version-independent wheel tags

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -10,6 +10,19 @@ on:
 
 name: Commit
 jobs:
+  python-wheel-test:
+    name: Python Wheel Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install setuptools wheel packaging
+      - run: python packages/python/scripts/test_wheel.py
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/packages/python/scripts/rename_wheel.py
+++ b/packages/python/scripts/rename_wheel.py
@@ -7,6 +7,7 @@ Usage: python rename_wheel.py <wheel_dir> <platform_tag>
 """
 import glob
 import os
+import subprocess
 import sys
 
 
@@ -20,15 +21,14 @@ def main():
         sys.exit(1)
 
     for wheel in wheels:
-        parts = os.path.basename(wheel).split("-")
-        # Wheel filename: {name}-{ver}-{python}-{abi}-{platform}.whl
-        parts[-1] = f"{platform_tag}.whl"
-        parts[-2] = "none"
-        parts[-3] = "cp38.cp39.cp310.cp311.cp312.cp313"
-        new_name = "-".join(parts)
-        new_path = os.path.join(wheel_dir, new_name)
-        os.rename(wheel, new_path)
-        print(f"Renamed: {os.path.basename(wheel)} -> {new_name}")
+        subprocess.run(
+            [
+                sys.executable, "-m", "wheel", "tags",
+                "--python-tag=py3", "--abi-tag=none",
+                f"--platform-tag={platform_tag}", "--remove", wheel,
+            ],
+            check=True,
+        )
 
 
 if __name__ == "__main__":

--- a/packages/python/scripts/test_wheel.py
+++ b/packages/python/scripts/test_wheel.py
@@ -1,0 +1,83 @@
+import email
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from packaging.tags import Tag, compatible_tags
+from packaging.utils import parse_wheel_filename
+from wheel.wheelfile import WheelFile
+
+
+PACKAGE_DIR = Path(__file__).resolve().parents[1]
+PLATFORMS = (
+    "manylinux_2_35_x86_64",
+    "manylinux_2_35_aarch64",
+    "macosx_11_0_x86_64",
+    "macosx_11_0_arm64",
+)
+
+
+class WheelTest(unittest.TestCase):
+    def test_release_wheel(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            shutil.copytree(
+                PACKAGE_DIR,
+                source,
+                ignore=shutil.ignore_patterns("build", "dist", "*.egg-info", "__pycache__"),
+            )
+            payload = b"test SQLite shared library"
+            (source / "litestream_vfs" / "litestream-vfs.so").write_bytes(payload)
+            subprocess.run(
+                [sys.executable, "setup.py", "bdist_wheel"],
+                cwd=source,
+                env={**os.environ, "LITESTREAM_VERSION": "0.0.0"},
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            original, = (source / "dist").glob("*.whl")
+            for platform in PLATFORMS:
+                with self.subTest(platform=platform):
+                    wheel_dir = root / platform
+                    wheel_dir.mkdir()
+                    shutil.copy2(original, wheel_dir)
+                    subprocess.run(
+                        [sys.executable, str(PACKAGE_DIR / "scripts" / "rename_wheel.py"),
+                         str(wheel_dir), platform],
+                        check=True,
+                    )
+                    wheel, = wheel_dir.glob("*.whl")
+                    _, _, _, tags = parse_wheel_filename(wheel.name)
+                    self.assertEqual(tags, {Tag("py3", "none", platform)})
+                    for version in ((3, 8), (3, 13), (3, 14), (3, 15)):
+                        self.assertTrue(tags.intersection(compatible_tags(version, platforms=[platform])))
+                    with WheelFile(wheel) as archive:
+                        metadata_path, = (name for name in archive.namelist() if name.endswith(".dist-info/WHEEL"))
+                        metadata = email.message_from_bytes(archive.read(metadata_path))
+                        self.assertEqual(metadata.get_all("Tag"), [f"py3-none-{platform}"])
+                        self.assertEqual(metadata["Root-Is-Purelib"], "false")
+                        self.assertFalse(any("_noop" in name for name in archive.namelist()))
+                        self.assertEqual(archive.read("litestream_vfs/litestream-vfs.so"), payload)
+                        for name in archive.namelist():
+                            archive.read(name)
+                    print(f"Verified: {wheel.name}")
+
+    def test_empty_wheel_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                [sys.executable, str(PACKAGE_DIR / "scripts" / "rename_wheel.py"), tmp, PLATFORMS[0]],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("No wheels found", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -1,5 +1,11 @@
 import os
-from setuptools import setup, Extension
+from setuptools import setup, Distribution
+
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
+
 
 setup(
     name="litestream-vfs",
@@ -11,7 +17,7 @@ setup(
     license="Apache-2.0",
     packages=["litestream_vfs"],
     package_data={"litestream_vfs": ["*.so", "*.dylib"]},
-    ext_modules=[Extension("litestream_vfs._noop", ["litestream_vfs/noop.c"])],
+    distclass=BinaryDistribution,
     python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Description

Build Python VFS wheels with `py3-none-<platform>` compatibility tags so Python 3.14, 3.15, and future Python 3 releases can install them without updating a CPython version list. Keep the existing platform restrictions and Python >=3.8 requirement.

The wrapper loads a SQLite extension through `sqlite3.Connection.load_extension`; the VFS library does not use the Python C API. Stop compiling the unused CPython `_noop` module that previously forced platform tagging, and mark the distribution as containing native binaries instead. Use the standard wheel retagging command to update the filename, internal WHEEL metadata, and RECORD hashes together. `abi3` is unnecessary because the library does not use CPython's stable ABI.

Scope is Python packaging and its regression check; VFS behavior, platform build targets, and publishing triggers are unchanged.

## Motivation and Context

Fixes #1518. Related to #1147 and its packaging implementation #1148.

The old build produces `cp38.cp39.cp310.cp311.cp312.cp313-none-<platform>` filenames, excluding newer Python versions. Its filename-only rename also leaves the original CPython tags inside the archive. The new regression check failed for all four platforms before the fix.

## How Has This Been Tested?

- `python packages/python/scripts/test_wheel.py` (with setuptools, wheel, and packaging installed): passes on Python 3.12 and 3.14. Builds actual wheel archives and checks filename tags, internal metadata, RECORD integrity, bundled library preservation, absence of `_noop`, and compatibility with Python 3.8, 3.13, 3.14, and 3.15. Added this check to PR CI.
- Inspected produced filenames for all four release platforms:
  - `litestream_vfs-0.0.0-py3-none-manylinux_2_35_x86_64.whl`
  - `litestream_vfs-0.0.0-py3-none-manylinux_2_35_aarch64.whl`
  - `litestream_vfs-0.0.0-py3-none-macosx_11_0_x86_64.whl`
  - `litestream_vfs-0.0.0-py3-none-macosx_11_0_arm64.whl`
- `make vfs-darwin-arm64`, package the resulting dylib with `python setup.py bdist_wheel`, then `python scripts/rename_wheel.py dist macosx_11_0_arm64`: installed the resulting wheel and successfully called `litestream_vfs.load(sqlite3.connect(':memory:'))` on Python 3.14.6 and 3.15.0a8. Also verified pip's Python 3.15 target resolution. Other platform packaging checks use a fixture payload; native runtime loading was tested on macOS arm64.
- Changed packaging source coverage: 100% (21/21 statements).
- `go build ./...` and `pre-commit run --all-files`: pass.
- `golangci-lint run --new-from-rev=1be2782`: no new findings. Full standalone lint reports 51 existing findings in unchanged Go code; the repository's pre-commit lint checks pass.
- `govulncheck ./...`: no reachable vulnerabilities.
- `go test -race ./...`: all packages except the CLI package pass locally. On macOS arm64 with both Go 1.27.1 and the pinned Go 1.26.8, the unchanged `TestLTXCommand_UsageOmitsReplicaFlag` times out after 10 minutes while its stdout-capture helper blocks in `os.File.Write`. CI's complete Linux unit suite passes. No Go source is changed in this PR.

All applicable PR CI checks pass, including Python Wheel Test, platform builds, lint, unit tests, storage integration tests, and the LTX behavioral gate.

No tags pushed and no packages published.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`) — CI passes; local race-run limitation noted above
- [x] I have updated the documentation accordingly (if needed)
