### PR TITLE
fix(gs): GCP context cancelled error

### DIFF
--- a/store.go
+++ b/store.go
@@ -181,7 +181,7 @@ func (s *Store) Open(ctx context.Context) error {
 			}
 
 			if db.Replica != nil && db.Replica.Client != nil {
-				if err := db.Replica.Client.Init(initCtx); err != nil {
+				if err := db.Replica.Client.Init(s.ctx); err != nil {
 					return fmt.Errorf("initialize replica client for %q: %w", db.Path(), err)
 				}
 			}

--- a/store_test.go
+++ b/store_test.go
@@ -76,6 +76,40 @@ func TestStore_Open_InitErrorDoesNotOpenDBs(t *testing.T) {
 	}
 }
 
+func TestStore_Open_InitContextNotCancelled(t *testing.T) {
+	initCtxCh := make(chan context.Context, 1)
+	db := litestream.NewDB(filepath.Join(t.TempDir(), "db"))
+	db.MonitorInterval = 0
+	db.Replica = litestream.NewReplicaWithClient(db, &mock.ReplicaClient{
+		InitFunc: func(ctx context.Context) error {
+			initCtxCh <- ctx
+			return nil
+		},
+	})
+
+	store := litestream.NewStore([]*litestream.DB{db}, litestream.CompactionLevels{{Level: 0}})
+	store.CompactionMonitorEnabled = false
+	if err := store.Open(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close(t.Context())
+
+	select {
+	case ctx := <-initCtxCh:
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("context passed to replica client Init() cancelled during Open: %v", err)
+		}
+		// Leave time for initGroup.Wait() to return and cancel its derived
+		// context; the client's context must remain usable.
+		time.Sleep(10 * time.Millisecond)
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("context passed to replica client Init() cancelled after Open: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replica client Init() never called")
+	}
+}
+
 func TestStore_CompactDB(t *testing.T) {
 	t.Run("L1", func(t *testing.T) {
 		db0, sqldb0 := testingutil.MustOpenDBs(t)


### PR DESCRIPTION
## Description

Fix GCP bug introduced in 59c1b25 before v0.5.16 release. The errgroup context is canceled the instant Wait() returns, so the GCS client's token source was bound to a dead context — breaking all writes.

I found this when trying to replicate a fresh database to my Google Storage Bucket for the first time.

Initialise with the store's context instead, which lives until Store.Close().

## Motivation and Context
Fixes #1512

```
time=2026-09-11T21:07:53.306+01:00 level=INFO msg=litestream version=0.5.17 level=""
time=2026-09-11T21:07:53.307+01:00 level=INFO msg="initialized db" path=/tmp/cc6.db
time=2026-09-11T21:07:53.307+01:00 level=INFO msg="replicating to" type=gs sync-interval=1s bucket=running-cafe-staging-litestream path=cc6
time=2026-09-11T21:07:53.307+01:00 level=INFO msg="syncing database" path=/tmp/cc6.db
time=2026-09-11T21:07:53.308+01:00 level=INFO msg="replication complete, litestream shutting down"
time=2026-09-11T21:07:53.308+01:00 level=INFO msg="litestream shut down"
Error: sync database /tmp/cc6.db: check database behind replica: get replica position: Get "https://storage.googleapis.com/storage/v1/b/running-cafe-staging-litestream/o?alt=json&delimiter=&endOffset=&includeTrailingDelimiter=false&matchGlob=&pageToken=&prefix=cc6%2Fltx%2F0%2F&prettyPrint=false&projection=full&startOffset=&versions=false": Post "https://oauth2.googleapis.com/token": context canceled
```

## How Has This Been Tested?

replicate to my bucket against 0.5.14 worked, 0.5.17 failed, my version also works. :)

## Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project (`go fmt`, `go vet`)
- [x] I have tested my changes (`go test ./...`)
- [x] I have updated the documentation accordingly (if needed)
